### PR TITLE
Add visualization of code DAGs

### DIFF
--- a/python/src/carabiner_worker/formatter.py
+++ b/python/src/carabiner_worker/formatter.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import os
+import re
+import sys
+from typing import List, Sequence, TextIO
+
+RESET = "\033[0m"
+
+STYLE_CODES = {
+    "bold": "\033[1m",
+    "dim": "\033[2m",
+    "red": "\033[31m",
+    "green": "\033[32m",
+    "yellow": "\033[33m",
+    "blue": "\033[34m",
+    "magenta": "\033[35m",
+    "cyan": "\033[36m",
+    "white": "\033[37m",
+}
+
+_TAG_PATTERN = re.compile(r"\[(/?)([a-zA-Z]+)?\]")
+
+
+def supports_color(stream: TextIO) -> bool:
+    """Return True if the provided stream likely supports ANSI colors."""
+
+    if os.environ.get("NO_COLOR"):
+        return False
+    if os.environ.get("FORCE_COLOR"):
+        return True
+    isatty = getattr(stream, "isatty", None)
+    if callable(isatty) and isatty():
+        if sys.platform != "win32":
+            return True
+        return bool(
+            os.environ.get("ANSICON")
+            or os.environ.get("WT_SESSION")
+            or os.environ.get("TERM_PROGRAM")
+        )
+    return False
+
+
+class Formatter:
+    """
+    Very small markup formatter inspired by Rich's tag syntax. We want to minimize our python client
+    dependencies to just grpc+standard library.
+
+    """
+
+    def __init__(self, enable_colors: bool) -> None:
+        self._enable_colors = enable_colors
+
+    @property
+    def enable_colors(self) -> bool:
+        return self._enable_colors
+
+    def format(self, text: str) -> str:
+        if not text:
+            return text
+        return _apply_markup(text, self._enable_colors)
+
+    def apply_styles(self, text: str, styles: Sequence[str]) -> str:
+        """Wrap text with markup tags for the provided style sequence."""
+
+        if not styles:
+            return text
+        opening = "".join(f"[{style}]" for style in styles)
+        closing = "".join(f"[/{style}]" for style in reversed(styles))
+        return f"{opening}{text}{closing}"
+
+
+def _apply_markup(text: str, enable_colors: bool) -> str:
+    if not enable_colors:
+        return _TAG_PATTERN.sub("", text)
+    result: List[str] = []
+    stack: List[str] = []
+    index = 0
+    for match in _TAG_PATTERN.finditer(text):
+        result.append(text[index : match.start()])
+        is_closing = match.group(1) == "/"
+        tag_name = match.group(2)
+        if tag_name is None:
+            if is_closing:
+                if stack:
+                    stack.clear()
+                    result.append(RESET)
+            else:
+                result.append(match.group(0))
+            index = match.end()
+            continue
+        if is_closing:
+            if tag_name in stack:
+                while stack:
+                    name = stack.pop()
+                    result.append(RESET)
+                    if name == tag_name:
+                        break
+                if stack:
+                    result.append("".join(STYLE_CODES[name] for name in stack))
+            index = match.end()
+            continue
+        code = STYLE_CODES.get(tag_name)
+        if code is None:
+            result.append(match.group(0))
+        else:
+            stack.append(tag_name)
+            result.append(code)
+        index = match.end()
+    result.append(text[index:])
+    if stack:
+        result.append(RESET)
+    return "".join(result)

--- a/python/tests/test_formatter.py
+++ b/python/tests/test_formatter.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import io
+
+import pytest
+
+from carabiner_worker.formatter import Formatter, supports_color
+
+
+class DummyStream(io.StringIO):
+    def __init__(self, *, is_tty: bool) -> None:
+        super().__init__()
+        self._is_tty = is_tty
+
+    def isatty(self) -> bool:  # type: ignore[override]
+        return self._is_tty
+
+
+def test_formatter_strips_tags_when_disabled() -> None:
+    formatter = Formatter(enable_colors=False)
+    assert formatter.format("hello [bold]world[/bold]") == "hello world"
+
+
+def test_formatter_applies_basic_styles() -> None:
+    formatter = Formatter(enable_colors=True)
+    styled = formatter.format("[bold]hello[/bold][/]")
+    assert "\033[1m" in styled
+    assert styled.endswith("\033[0m")
+
+
+def test_supports_color_honors_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    stream = DummyStream(is_tty=False)
+    monkeypatch.setenv("FORCE_COLOR", "1")
+    assert supports_color(stream) is True
+    monkeypatch.delenv("FORCE_COLOR", raising=False)
+    monkeypatch.setenv("NO_COLOR", "1")
+    assert supports_color(DummyStream(is_tty=True)) is False

--- a/python/tests/test_workflow.py
+++ b/python/tests/test_workflow.py
@@ -115,8 +115,9 @@ def test_workflow_visualize_outputs_ascii_summary() -> None:
     output = VisualizationWorkflow.visualize(stream=buffer)
     assert buffer.getvalue().rstrip("\n") == output
 
-    # print to stdout so we can visualize it
-    sys.stdout.write(output)
+    # print to stdout so we can visualize it - we write it to stdout directly because
+    # stringio has tty=False so it doesn't support colors
+    VisualizationWorkflow.visualize(stream=sys.stdout)
     sys.stdout.flush()
 
     module_line = f"Workflow: {VisualizationWorkflow.__module__}.{VisualizationWorkflow.__name__}"
@@ -135,3 +136,15 @@ def test_workflow_visualize_outputs_ascii_summary() -> None:
     assert "node_2: viz_store_value" in output
     assert "      - identifier: 'alpha'" in output
     assert "      - result: transformed" in output
+
+
+class _TtyBuffer(io.StringIO):
+    def isatty(self) -> bool:  # type: ignore[override]
+        return True
+
+
+def test_workflow_visualize_placeholders_dim() -> None:
+    buffer = _TtyBuffer()
+    VisualizationWorkflow.visualize(stream=buffer)
+    output = buffer.getvalue()
+    assert "\u001b[2m    guard       : -\u001b[0m" in output


### PR DESCRIPTION
It's sometimes helpful to visualize how your DAG is going to look like in your own project _while_ implementing your workflow. This helps catch failures in parsing or tracking some logic that we don't yet support in carabiner. We provide a new `.visualize()` attribute of workflows that will pretty print this parsed graph as ascii.