### PR TITLE
Allow duplicate action names across modules

### DIFF
--- a/python/src/rappel/actions.py
+++ b/python/src/rappel/actions.py
@@ -70,9 +70,10 @@ def action(
         if not inspect.iscoroutinefunction(target):
             raise TypeError(f"action '{target.__name__}' must be defined with 'async def'")
         action_name = name or target.__name__
-        registry.register(action_name, target)
+        action_module = target.__module__
+        registry.register(action_module, action_name, target)
         target.__rappel_action_name__ = action_name
-        target.__rappel_action_module__ = target.__module__
+        target.__rappel_action_module__ = action_module
         return target
 
     if func is not None:

--- a/python/src/rappel/registry.py
+++ b/python/src/rappel/registry.py
@@ -8,33 +8,66 @@ AsyncAction = Callable[..., Awaitable[Any]]
 
 @dataclass
 class _ActionEntry:
+    module: str
     name: str
     func: AsyncAction
 
 
+def _make_key(module: str, name: str) -> str:
+    """Create a registry key from module and action name."""
+    return f"{module}:{name}"
+
+
 class ActionRegistry:
-    """In-memory registry of user-defined actions."""
+    """In-memory registry of user-defined actions.
+
+    Actions are keyed by (module, name), allowing the same action name
+    to be used in different modules.
+    """
 
     def __init__(self) -> None:
         self._actions: dict[str, _ActionEntry] = {}
         self._lock = RLock()
 
-    def register(self, name: str, func: AsyncAction) -> None:
-        with self._lock:
-            if name in self._actions:
-                raise ValueError(f"action '{name}' already registered")
-            self._actions[name] = _ActionEntry(name=name, func=func)
+    def register(self, module: str, name: str, func: AsyncAction) -> None:
+        """Register an action with its module and name.
 
-    def get(self, name: str) -> Optional[AsyncAction]:
+        Args:
+            module: The Python module containing the action.
+            name: The action name (from @action decorator).
+            func: The async function to execute.
+
+        Raises:
+            ValueError: If an action with the same module:name is already registered.
+        """
+        key = _make_key(module, name)
         with self._lock:
-            entry = self._actions.get(name)
+            if key in self._actions:
+                raise ValueError(f"action '{module}:{name}' already registered")
+            self._actions[key] = _ActionEntry(module=module, name=name, func=func)
+
+    def get(self, module: str, name: str) -> Optional[AsyncAction]:
+        """Look up an action by module and name.
+
+        Args:
+            module: The Python module containing the action.
+            name: The action name.
+
+        Returns:
+            The action function if found, None otherwise.
+        """
+        key = _make_key(module, name)
+        with self._lock:
+            entry = self._actions.get(key)
             return entry.func if entry else None
 
     def names(self) -> list[str]:
+        """Return all registered action keys (module:name format)."""
         with self._lock:
             return sorted(self._actions.keys())
 
     def reset(self) -> None:
+        """Clear all registered actions."""
         with self._lock:
             self._actions.clear()
 

--- a/python/src/rappel/workflow_runtime.py
+++ b/python/src/rappel/workflow_runtime.py
@@ -43,18 +43,18 @@ async def execute_action(dispatch: pb2.ActionDispatch) -> ActionExecutionResult:
     action_name = dispatch.action_name
     module_name = dispatch.module_name
 
-    # Import the module if specified
+    # Import the module if specified (this registers actions via @action decorator)
     if module_name:
         import importlib
 
         importlib.import_module(module_name)
 
-    # Get the action handler
-    handler = registry.get(action_name)
+    # Get the action handler using both module and name
+    handler = registry.get(module_name, action_name)
     if handler is None:
         return ActionExecutionResult(
             result=None,
-            exception=KeyError(f"action '{action_name}' not registered"),
+            exception=KeyError(f"action '{module_name}:{action_name}' not registered"),
         )
 
     # Deserialize kwargs

--- a/python/tests/test_registry.py
+++ b/python/tests/test_registry.py
@@ -19,7 +19,8 @@ def test_action_decorator_accepts_async_functions() -> None:
     async def sample() -> str:
         return "ok"
 
-    assert "sample" in action_registry.names()
+    # Registry keys are now module:name format
+    assert f"{__name__}:sample" in action_registry.names()
 
 
 def test_action_decorator_rejects_sync_functions() -> None:
@@ -28,3 +29,50 @@ def test_action_decorator_rejects_sync_functions() -> None:
 
     with pytest.raises(TypeError):
         action(cast(Any, sync_func))
+
+
+def test_registry_allows_same_name_different_modules() -> None:
+    """Test that actions with the same name can coexist in different modules."""
+
+    async def action_one() -> str:
+        return "from module_a"
+
+    async def action_two() -> str:
+        return "from module_b"
+
+    # Register same action name under different modules
+    action_registry.register("module_a", "process", action_one)
+    action_registry.register("module_b", "process", action_two)
+
+    # Both should be retrievable independently
+    handler_a = action_registry.get("module_a", "process")
+    handler_b = action_registry.get("module_b", "process")
+
+    assert handler_a is action_one
+    assert handler_b is action_two
+    assert handler_a is not handler_b
+
+    # Names should show both registrations
+    names = action_registry.names()
+    assert "module_a:process" in names
+    assert "module_b:process" in names
+
+
+def test_registry_rejects_duplicate_in_same_module() -> None:
+    """Test that duplicate action names in the same module raise an error."""
+
+    async def action_one() -> str:
+        return "first"
+
+    async def action_two() -> str:
+        return "second"
+
+    action_registry.register("my_module", "duplicate", action_one)
+
+    with pytest.raises(ValueError, match="my_module:duplicate.*already registered"):
+        action_registry.register("my_module", "duplicate", action_two)
+
+
+def test_registry_get_returns_none_for_unknown() -> None:
+    """Test that get returns None for unregistered actions."""
+    assert action_registry.get("unknown_module", "unknown_action") is None

--- a/python/tests/test_workflow_runtime.py
+++ b/python/tests/test_workflow_runtime.py
@@ -61,8 +61,8 @@ def _build_action_dispatch(
 
 def test_execute_action_with_kwargs() -> None:
     """Test executing an action with resolved kwargs."""
-    if action_registry.get("multiply") is None:
-        action_registry.register("multiply", multiply)
+    if action_registry.get(__name__, "multiply") is None:
+        action_registry.register(__name__, "multiply", multiply)
 
     dispatch = _build_action_dispatch(
         action_name="multiply",
@@ -79,8 +79,8 @@ def test_execute_action_with_kwargs() -> None:
 
 def test_execute_action_resolves_dependencies() -> None:
     """Test executing an action with injected dependencies."""
-    if action_registry.get("with_dependency") is None:
-        action_registry.register("with_dependency", with_dependency)
+    if action_registry.get(__name__, "with_dependency") is None:
+        action_registry.register(__name__, "with_dependency", with_dependency)
 
     dispatch = _build_action_dispatch(
         action_name="with_dependency",
@@ -97,8 +97,8 @@ def test_execute_action_resolves_dependencies() -> None:
 
 def test_execute_action_handles_error() -> None:
     """Test that action errors are captured in the result."""
-    if action_registry.get("failing_action") is None:
-        action_registry.register("failing_action", failing_action)
+    if action_registry.get(__name__, "failing_action") is None:
+        action_registry.register(__name__, "failing_action", failing_action)
 
     dispatch = _build_action_dispatch(
         action_name="failing_action",


### PR DESCRIPTION
Our previous action registry enforced unique action names by parameterizing the action dictionary on function names. We modify that approach here to take (module, fn_name) together for uniqueness. We were already using the module before to dynamically call importlib before we try to run the actions - so this change can be relatively minor.