### PR TITLE
Standardize db env

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,7 @@ jobs:
 
       - name: Run tests with coverage
         env:
-          DATABASE_URL: postgresql://mountaineer:mountaineer@localhost:5432/mountaineer_daemons
+          RAPPEL_DATABASE_URL: postgresql://mountaineer:mountaineer@localhost:5432/mountaineer_daemons
         run: make rust-coverage
 
       - name: Upload Rust coverage LCOV
@@ -181,7 +181,7 @@ jobs:
 
       - name: Rust tests with coverage
         env:
-          DATABASE_URL: postgresql://mountaineer:mountaineer@localhost:5432/mountaineer_daemons
+          RAPPEL_DATABASE_URL: postgresql://mountaineer:mountaineer@localhost:5432/mountaineer_daemons
         run: make rust-coverage
 
       - name: Upload main Python coverage XML
@@ -310,7 +310,7 @@ jobs:
 
       - name: Run benchmarks on PR branch
         env:
-          DATABASE_URL: postgresql://mountaineer:mountaineer@localhost:5432/mountaineer_daemons
+          RAPPEL_DATABASE_URL: postgresql://mountaineer:mountaineer@localhost:5432/mountaineer_daemons
         run: uv run scripts/run_benchmarks.py single --format json --output benchmark-pr.json
 
       - name: Save benchmark code diff
@@ -370,7 +370,7 @@ jobs:
 
       - name: Run benchmarks on main branch
         env:
-          DATABASE_URL: postgresql://mountaineer:mountaineer@localhost:5432/mountaineer_daemons
+          RAPPEL_DATABASE_URL: postgresql://mountaineer:mountaineer@localhost:5432/mountaineer_daemons
         run: uv run scripts/run_benchmarks.py single --format json --output benchmark-main.json
 
       - name: Upload main benchmark results
@@ -462,7 +462,7 @@ jobs:
 
       - name: Run integration tests
         env:
-          DATABASE_URL: postgresql://mountaineer:mountaineer@localhost:5432/mountaineer_daemons
+          RAPPEL_DATABASE_URL: postgresql://mountaineer:mountaineer@localhost:5432/mountaineer_daemons
         run: cargo test --test integration_test -- --nocapture
 
   example-app-tests:

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ These are the primary environment parameters that you'll likely want to customiz
 
 | Environment Variable | Description | Default | Example |
 |---------------------|-------------|---------|---------|
-| `DATABASE_URL` | PostgreSQL connection string for the rappel server | (required on bridge &workers ) | `postgresql://user:pass@localhost:5433/rappel` |
+| `RAPPEL_DATABASE_URL` | PostgreSQL connection string for the rappel server | (required on bridge &workers ) | `postgresql://user:pass@localhost:5433/rappel` |
 | `RAPPEL_WORKER_COUNT` | Number of Python worker processes | `num_cpus` | `8` |
 | `RAPPEL_CONCURRENT_PER_WORKER` | Max concurrent actions per worker | `10` | `20` |
 | `RAPPEL_USER_MODULE` | Python module preloaded into each worker | none | `my_app.actions` |

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -28,7 +28,7 @@ Key runtime data:
 
 The `start-workers` binary polls for the work to be done. Launch this a single
 time for each physical worker node you have in your cluster. Worker processes read their
-configuration from `DATABASE_URL` plus optional `RAPPEL_*` environment
+configuration from `RAPPEL_DATABASE_URL` plus optional `RAPPEL_*` environment
 variables (poll interval, batch size, worker count, etc.) so the loop can be
 tuned per deployment without CLI flags. The dispatcher shares a single
 `Database` handle with the worker bridge, repeatedly calls `dispatch_actions()`

--- a/example_app/Makefile
+++ b/example_app/Makefile
@@ -30,7 +30,7 @@ docker-test:
 	@timeout 60 sh -c 'until $(COMPOSE_CMD) logs --tail=50 daemons 2>&1 | grep -q "python worker pool started"; do sleep 1; done' || (echo "Daemons never reported ready" && $(COMPOSE_CMD) logs daemons || true; $(COMPOSE_CMD) down -v; exit 1)
 	@set -e; \
 	TEST_EXIT_CODE=0; \
-	timeout $(DOCKER_TEST_TIMEOUT) $(COMPOSE_CMD) run --rm -e DATABASE_URL=postgresql://rappel:rappel@postgres:5432/rappel_example webapp uv run --active pytest -vvv || TEST_EXIT_CODE=$$?; \
+	timeout $(DOCKER_TEST_TIMEOUT) $(COMPOSE_CMD) run --rm -e RAPPEL_DATABASE_URL=postgresql://rappel:rappel@postgres:5432/rappel_example webapp uv run --active pytest -vvv || TEST_EXIT_CODE=$$?; \
 	echo ""; \
 	echo "=== Daemon Logs ==="; \
 	$(COMPOSE_CMD) logs --tail=$(DOCKER_LOG_TAIL) daemons || true; \

--- a/example_app/docker-compose.yml
+++ b/example_app/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       postgres:
         condition: service_healthy
     environment:
-      DATABASE_URL: postgresql://rappel:rappel@postgres:5432/rappel_example
+      RAPPEL_DATABASE_URL: postgresql://rappel:rappel@postgres:5432/rappel_example
       RAPPEL_USER_MODULE: example_app.workflows
       RAPPEL_WORKER_COUNT: 2
       RAPPEL_LOG_LEVEL: debug
@@ -45,7 +45,7 @@ services:
       daemons:
         condition: service_started
     environment:
-      DATABASE_URL: postgresql://rappel:rappel@postgres:5432/rappel_example
+      RAPPEL_DATABASE_URL: postgresql://rappel:rappel@postgres:5432/rappel_example
       RAPPEL_LOG_LEVEL: debug
     ports:
       - "8000:8000"

--- a/example_app/src/example_app/web.py
+++ b/example_app/src/example_app/web.py
@@ -289,9 +289,9 @@ class ResetResponse(BaseModel):
 @app.post("/api/reset", response_model=ResetResponse)
 async def reset_database() -> ResetResponse:
     """Reset workflow-related tables for a clean slate. Development use only."""
-    database_url = os.environ.get("DATABASE_URL")
+    database_url = os.environ.get("RAPPEL_DATABASE_URL")
     if not database_url:
-        return ResetResponse(success=False, message="DATABASE_URL not configured")
+        return ResetResponse(success=False, message="RAPPEL_DATABASE_URL not configured")
 
     try:
         conn = await asyncpg.connect(database_url)

--- a/scripts/run_benchmarks.py
+++ b/scripts/run_benchmarks.py
@@ -423,12 +423,13 @@ FORMATTERS: dict[str, OutputFormatter] = {
 def reset_database():
     """Reset the database tables for clean benchmark runs."""
     db_url = os.environ.get(
-        "DATABASE_URL", "postgresql://mountaineer:mountaineer@localhost:5432/mountaineer_daemons"
+        "RAPPEL_DATABASE_URL",
+        "postgresql://mountaineer:mountaineer@localhost:5432/mountaineer_daemons",
     )
 
     match = re.match(r"postgresql://([^:]+):([^@]+)@([^:]+):(\d+)/(.+)", db_url)
     if not match:
-        print(f"Warning: Could not parse DATABASE_URL: {db_url}", file=sys.stderr)
+        print(f"Warning: Could not parse RAPPEL_DATABASE_URL: {db_url}", file=sys.stderr)
         return
 
     user, password, host, port, dbname = match.groups()

--- a/src/bin/benchmark.rs
+++ b/src/bin/benchmark.rs
@@ -467,7 +467,7 @@ async fn main() -> Result<()> {
         .init();
 
     // Connect to database
-    let database_url = env::var("DATABASE_URL").unwrap_or_else(|_| {
+    let database_url = env::var("RAPPEL_DATABASE_URL").unwrap_or_else(|_| {
         "postgresql://mountaineer:mountaineer@localhost:5432/mountaineer_daemons".to_string()
     });
     let pool_size = (args.hosts * args.workers_per_host * 2).max(20);

--- a/src/bin/rappel-bridge.rs
+++ b/src/bin/rappel-bridge.rs
@@ -5,7 +5,7 @@
 //! - gRPC server for Python worker connections
 //!
 //! Configuration is via environment variables:
-//! - DATABASE_URL: PostgreSQL connection string (required)
+//! - RAPPEL_DATABASE_URL: PostgreSQL connection string (required)
 //! - RAPPEL_HTTP_ADDR: HTTP server bind address (default: 127.0.0.1:24117)
 //! - RAPPEL_GRPC_ADDR: gRPC server bind address (default: HTTP port + 1)
 

--- a/src/bin/run_workflow.rs
+++ b/src/bin/run_workflow.rs
@@ -605,7 +605,7 @@ async fn main() -> Result<()> {
     }
 
     // Connect to database with a short timeout
-    let database_url = env::var("DATABASE_URL").unwrap_or_else(|_| {
+    let database_url = env::var("RAPPEL_DATABASE_URL").unwrap_or_else(|_| {
         "postgresql://mountaineer:mountaineer@localhost:5432/mountaineer_daemons".to_string()
     });
     eprintln!(
@@ -624,7 +624,7 @@ async fn main() -> Result<()> {
         anyhow!(
             "Database connection timed out after 5 seconds.\n\
          Please ensure PostgreSQL is running and accessible at: {}\n\
-         You can set DATABASE_URL environment variable to override.",
+         You can set RAPPEL_DATABASE_URL environment variable to override.",
             database_url
         )
     })?

--- a/src/bin/start-workers.rs
+++ b/src/bin/start-workers.rs
@@ -8,7 +8,7 @@
 //! - Optionally starts the web dashboard for monitoring
 //!
 //! Configuration is via environment variables:
-//! - DATABASE_URL: PostgreSQL connection string (required)
+//! - RAPPEL_DATABASE_URL: PostgreSQL connection string (required)
 //! - RAPPEL_USER_MODULE: Python module to preload
 //! - RAPPEL_WORKER_COUNT: Number of workers (default: num_cpus)
 //! - RAPPEL_BATCH_SIZE: Actions per poll cycle (default: 100)

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,7 @@
 //! Configuration loading from environment variables.
 //!
 //! Uses the following environment variables:
-//! - `DATABASE_URL`: PostgreSQL connection string (required)
+//! - `RAPPEL_DATABASE_URL`: PostgreSQL connection string (required)
 //! - `RAPPEL_HTTP_ADDR`: HTTP server bind address (default: 127.0.0.1:24117)
 //! - `RAPPEL_GRPC_ADDR`: gRPC server bind address (default: HTTP port + 1)
 //! - `RAPPEL_BASE_PORT`: Base port for singleton server probing (default: 24117)
@@ -112,8 +112,8 @@ impl Config {
         // Load .env file if it exists
         dotenvy::dotenv().ok();
 
-        let database_url =
-            env::var("DATABASE_URL").context("DATABASE_URL environment variable is required")?;
+        let database_url = env::var("RAPPEL_DATABASE_URL")
+            .context("RAPPEL_DATABASE_URL environment variable is required")?;
 
         let http_addr =
             env::var("RAPPEL_HTTP_ADDR").unwrap_or_else(|_| "127.0.0.1:24117".to_string());
@@ -202,7 +202,7 @@ impl Config {
 ///
 /// # Panics
 ///
-/// Panics if configuration loading fails (e.g., missing required DATABASE_URL).
+/// Panics if configuration loading fails (e.g., missing required RAPPEL_DATABASE_URL).
 pub fn get_config() -> Config {
     CONFIG
         .get_or_init(|| {
@@ -246,7 +246,7 @@ pub fn reset_config() {
 /// Get the database URL from environment
 pub fn database_url() -> Result<String> {
     dotenvy::dotenv().ok();
-    env::var("DATABASE_URL").context("DATABASE_URL environment variable is required")
+    env::var("RAPPEL_DATABASE_URL").context("RAPPEL_DATABASE_URL environment variable is required")
 }
 
 #[cfg(test)]

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -9,9 +9,9 @@
 //!
 //! # Connection
 //!
-//! Set the `DATABASE_URL` environment variable to your PostgreSQL connection string:
+//! Set the `RAPPEL_DATABASE_URL` environment variable to your PostgreSQL connection string:
 //! ```text
-//! DATABASE_URL=postgresql://user:password@localhost:5432/rappel
+//! RAPPEL_DATABASE_URL=postgresql://user:password@localhost:5432/rappel
 //! ```
 
 mod webapp;

--- a/src/server_webapp.rs
+++ b/src/server_webapp.rs
@@ -1647,7 +1647,7 @@ mod tests {
 
     // ========================================================================
     // HTTP Route Tests (require database)
-    // These tests require DATABASE_URL to be set and run with serial_test
+    // These tests require RAPPEL_DATABASE_URL to be set and run with serial_test
     // to avoid conflicts with other database tests.
     // ========================================================================
 
@@ -1658,8 +1658,8 @@ mod tests {
 
     async fn test_db() -> Database {
         dotenvy::dotenv().ok();
-        let url =
-            std::env::var("DATABASE_URL").expect("DATABASE_URL must be set for integration tests");
+        let url = std::env::var("RAPPEL_DATABASE_URL")
+            .expect("RAPPEL_DATABASE_URL must be set for integration tests");
         Database::connect(&url)
             .await
             .expect("failed to connect to database")

--- a/tests/integration_harness.rs
+++ b/tests/integration_harness.rs
@@ -288,12 +288,12 @@ pub struct IntegrationHarness {
 impl IntegrationHarness {
     /// Create a new test harness with the given configuration.
     ///
-    /// Returns `None` if DATABASE_URL is not set (skips test).
+    /// Returns `None` if RAPPEL_DATABASE_URL is not set (skips test).
     pub async fn new(config: HarnessConfig<'_>) -> Result<Option<Self>> {
-        let database_url = match env::var("DATABASE_URL") {
+        let database_url = match env::var("RAPPEL_DATABASE_URL") {
             Ok(url) => url,
             Err(_) => {
-                eprintln!("skipping integration test: DATABASE_URL not set");
+                eprintln!("skipping integration test: RAPPEL_DATABASE_URL not set");
                 return Ok(None);
             }
         };

--- a/tests/schedule_test.rs
+++ b/tests/schedule_test.rs
@@ -74,10 +74,10 @@ async fn create_test_workflow(database: &Database, name: &str) -> Result<Workflo
 async fn test_schedule_database_operations() -> Result<()> {
     let _ = tracing_subscriber::fmt::try_init();
 
-    let database_url = match env::var("DATABASE_URL") {
+    let database_url = match env::var("RAPPEL_DATABASE_URL") {
         Ok(url) => url,
         Err(_) => {
-            eprintln!("skipping test: DATABASE_URL not set");
+            eprintln!("skipping test: RAPPEL_DATABASE_URL not set");
             return Ok(());
         }
     };
@@ -221,10 +221,10 @@ async fn test_schedule_database_operations() -> Result<()> {
 async fn test_scheduler_creates_instance() -> Result<()> {
     let _ = tracing_subscriber::fmt::try_init();
 
-    let database_url = match env::var("DATABASE_URL") {
+    let database_url = match env::var("RAPPEL_DATABASE_URL") {
         Ok(url) => url,
         Err(_) => {
-            eprintln!("skipping test: DATABASE_URL not set");
+            eprintln!("skipping test: RAPPEL_DATABASE_URL not set");
             return Ok(());
         }
     };
@@ -358,10 +358,10 @@ async fn test_scheduler_creates_instance() -> Result<()> {
 async fn test_list_schedules_grpc_endpoint() -> Result<()> {
     let _ = tracing_subscriber::fmt::try_init();
 
-    let database_url = match env::var("DATABASE_URL") {
+    let database_url = match env::var("RAPPEL_DATABASE_URL") {
         Ok(url) => url,
         Err(_) => {
-            eprintln!("skipping test: DATABASE_URL not set");
+            eprintln!("skipping test: RAPPEL_DATABASE_URL not set");
             return Ok(());
         }
     };

--- a/tests/timeout_retry_test.rs
+++ b/tests/timeout_retry_test.rs
@@ -17,10 +17,10 @@ use rappel::{BackoffKind, Database, NewAction, WorkflowInstanceId, WorkflowVersi
 
 /// Helper to create a test database connection.
 async fn setup_db() -> Option<Database> {
-    let database_url = match env::var("DATABASE_URL") {
+    let database_url = match env::var("RAPPEL_DATABASE_URL") {
         Ok(url) => url,
         Err(_) => {
-            eprintln!("skipping test: DATABASE_URL not set");
+            eprintln!("skipping test: RAPPEL_DATABASE_URL not set");
             return None;
         }
     };


### PR DESCRIPTION
`DATABASE_URL` might conflict with the user-space env convention for applications in rust. We standardize the database to use our `RAPPEL` prefix to avoid this conflict.

Rust tests are failing but this is just for the main branch coverage since we updated the env variable it's using in CI too.