### PR TITLE
Make action registration idempotent

### DIFF
--- a/python/src/rappel/registry.py
+++ b/python/src/rappel/registry.py
@@ -29,6 +29,32 @@ class ActionRegistry:
         self._actions: dict[str, _ActionEntry] = {}
         self._lock = RLock()
 
+    def _source_fingerprint(self, func: AsyncAction) -> tuple[str | None, str | None]:
+        func_any: Any = func
+        try:
+            code = func_any.__code__
+        except AttributeError:
+            return (None, None)
+        try:
+            qualname = func_any.__qualname__
+        except AttributeError:
+            qualname = None
+        filename = code.co_filename
+        if not isinstance(filename, str):
+            filename = None
+        if qualname is not None and not isinstance(qualname, str):
+            qualname = None
+        return (filename, qualname)
+
+    def _is_same_action_definition(self, existing: AsyncAction, new: AsyncAction) -> bool:
+        if existing is new:
+            return True
+        existing_fingerprint = self._source_fingerprint(existing)
+        new_fingerprint = self._source_fingerprint(new)
+        if existing_fingerprint == (None, None) or new_fingerprint == (None, None):
+            return False
+        return existing_fingerprint == new_fingerprint
+
     def register(self, module: str, name: str, func: AsyncAction) -> None:
         """Register an action with its module and name.
 
@@ -38,11 +64,16 @@ class ActionRegistry:
             func: The async function to execute.
 
         Raises:
-            ValueError: If an action with the same module:name is already registered.
+            ValueError: If an action with the same module:name is already registered
+                with a different implementation.
         """
         key = _make_key(module, name)
         with self._lock:
-            if key in self._actions:
+            existing = self._actions.get(key)
+            if existing is not None:
+                if self._is_same_action_definition(existing.func, func):
+                    self._actions[key] = _ActionEntry(module=module, name=name, func=func)
+                    return
                 raise ValueError(f"action '{module}:{name}' already registered")
             self._actions[key] = _ActionEntry(module=module, name=name, func=func)
 

--- a/python/tests/test_registry.py
+++ b/python/tests/test_registry.py
@@ -73,6 +73,27 @@ def test_registry_rejects_duplicate_in_same_module() -> None:
         action_registry.register("my_module", "duplicate", action_two)
 
 
+def test_registry_allows_reregistration_of_same_definition() -> None:
+    filename = "fake_module.py"
+    module_name = "fake_module"
+
+    source_one = "async def demo() -> int:\n    return 1\n"
+    globals_one: dict[str, Any] = {"__name__": module_name, "__file__": filename}
+    exec(compile(source_one, filename, "exec"), globals_one)
+    func_one = globals_one["demo"]
+
+    action_registry.register(module_name, "demo", func_one)
+
+    source_two = "async def demo() -> int:\n    return 2\n"
+    globals_two: dict[str, Any] = {"__name__": module_name, "__file__": filename}
+    exec(compile(source_two, filename, "exec"), globals_two)
+    func_two = globals_two["demo"]
+
+    assert func_one is not func_two
+    action_registry.register(module_name, "demo", func_two)
+    assert action_registry.get(module_name, "demo") is func_two
+
+
 def test_registry_get_returns_none_for_unknown() -> None:
     """Test that get returns None for unregistered actions."""
     assert action_registry.get("unknown_module", "unknown_action") is None


### PR DESCRIPTION
If a rare situation occurs where an action is re-registered with the same code, we should allow it to be registered again. This _shouldn't_ happen with a normally succeeding importlib import, but there are chances that if one import fails and we capture an action registration before we're done parsing the file - and then re-import later - we might have a stale action registration of the same exact value that raises. This PR fixes that case.