### PR TITLE
Increase serialization support for UUIDs

### DIFF
--- a/python/src/rappel/serialization.py
+++ b/python/src/rappel/serialization.py
@@ -1,6 +1,11 @@
 import dataclasses
 import importlib
 import traceback
+from base64 import b64encode
+from datetime import date, datetime, time, timedelta
+from decimal import Decimal
+from enum import Enum
+from pathlib import PurePath
 from typing import Any
 from uuid import UUID
 
@@ -59,6 +64,44 @@ def _to_argument_value(value: Any) -> pb2.WorkflowArgumentValue:
     if isinstance(value, UUID):
         # Serialize UUID as string primitive
         argument.primitive.CopyFrom(_serialize_primitive(str(value)))
+        return argument
+    if isinstance(value, datetime):
+        # Serialize datetime as ISO format string
+        argument.primitive.CopyFrom(_serialize_primitive(value.isoformat()))
+        return argument
+    if isinstance(value, date):
+        # Serialize date as ISO format string (must come after datetime check)
+        argument.primitive.CopyFrom(_serialize_primitive(value.isoformat()))
+        return argument
+    if isinstance(value, time):
+        # Serialize time as ISO format string
+        argument.primitive.CopyFrom(_serialize_primitive(value.isoformat()))
+        return argument
+    if isinstance(value, timedelta):
+        # Serialize timedelta as total seconds
+        argument.primitive.CopyFrom(_serialize_primitive(value.total_seconds()))
+        return argument
+    if isinstance(value, Decimal):
+        # Serialize Decimal as string to preserve precision
+        argument.primitive.CopyFrom(_serialize_primitive(str(value)))
+        return argument
+    if isinstance(value, Enum):
+        # Serialize Enum as its value
+        return _to_argument_value(value.value)
+    if isinstance(value, bytes):
+        # Serialize bytes as base64 string
+        argument.primitive.CopyFrom(_serialize_primitive(b64encode(value).decode("ascii")))
+        return argument
+    if isinstance(value, PurePath):
+        # Serialize Path as string
+        argument.primitive.CopyFrom(_serialize_primitive(str(value)))
+        return argument
+    if isinstance(value, (set, frozenset)):
+        # Serialize sets as lists
+        argument.list_value.SetInParent()
+        for item in value:
+            item_value = argument.list_value.items.add()
+            item_value.CopyFrom(_to_argument_value(item))
         return argument
     if isinstance(value, BaseException):
         argument.exception.type = value.__class__.__name__

--- a/python/tests/test_workflow_runtime.py
+++ b/python/tests/test_workflow_runtime.py
@@ -2,7 +2,11 @@
 
 import asyncio
 from dataclasses import dataclass as python_dataclass
+from datetime import date, datetime, time, timedelta, timezone
+from decimal import Decimal
+from pathlib import Path
 from typing import Annotated
+from uuid import UUID
 
 from pydantic import BaseModel
 
@@ -10,7 +14,7 @@ from proto import messages_pb2 as pb2
 from rappel import registry as action_registry
 from rappel.actions import action
 from rappel.dependencies import Depend
-from rappel.workflow_runtime import ActionExecutionResult, execute_action
+from rappel.workflow_runtime import ActionExecutionResult, _coerce_value, execute_action
 
 
 @action
@@ -238,3 +242,116 @@ def test_execute_action_coerces_dict_to_dataclass() -> None:
     assert isinstance(result, ActionExecutionResult)
     assert result.exception is None, f"Unexpected exception: {result.exception}"
     assert result.result == 7  # 3 + 4
+
+
+# ---- Tests for primitive type coercion ----
+
+
+def test_coerce_uuid_from_string() -> None:
+    """Test that UUID strings are coerced to UUID objects."""
+    uuid_str = "12345678-1234-5678-1234-567812345678"
+    result = _coerce_value(uuid_str, UUID)
+    assert isinstance(result, UUID)
+    assert str(result) == uuid_str
+
+
+def test_coerce_datetime_from_string() -> None:
+    """Test that ISO datetime strings are coerced to datetime objects."""
+    dt = datetime(2024, 1, 15, 10, 30, 45, tzinfo=timezone.utc)
+    result = _coerce_value(dt.isoformat(), datetime)
+    assert isinstance(result, datetime)
+    assert result == dt
+
+
+def test_coerce_date_from_string() -> None:
+    """Test that ISO date strings are coerced to date objects."""
+    d = date(2024, 1, 15)
+    result = _coerce_value(d.isoformat(), date)
+    assert isinstance(result, date)
+    assert result == d
+
+
+def test_coerce_time_from_string() -> None:
+    """Test that ISO time strings are coerced to time objects."""
+    t = time(10, 30, 45)
+    result = _coerce_value(t.isoformat(), time)
+    assert isinstance(result, time)
+    assert result == t
+
+
+def test_coerce_timedelta_from_seconds() -> None:
+    """Test that numeric values are coerced to timedelta objects."""
+    td = timedelta(hours=2, minutes=30)
+    result = _coerce_value(td.total_seconds(), timedelta)
+    assert isinstance(result, timedelta)
+    assert result == td
+
+
+def test_coerce_decimal_from_string() -> None:
+    """Test that string values are coerced to Decimal objects."""
+    d = Decimal("123.456789012345678901234567890")
+    result = _coerce_value(str(d), Decimal)
+    assert isinstance(result, Decimal)
+    assert result == d
+
+
+def test_coerce_bytes_from_base64() -> None:
+    """Test that base64 strings are coerced to bytes."""
+    from base64 import b64encode
+
+    data = b"hello world"
+    result = _coerce_value(b64encode(data).decode("ascii"), bytes)
+    assert isinstance(result, bytes)
+    assert result == data
+
+
+def test_coerce_path_from_string() -> None:
+    """Test that strings are coerced to Path objects."""
+    p = Path("/usr/local/bin")
+    result = _coerce_value(str(p), Path)
+    assert isinstance(result, Path)
+    assert result == p
+
+
+def test_coerce_list_of_uuids() -> None:
+    """Test that list[UUID] coerces string items to UUIDs."""
+    uuid_strs = [
+        "12345678-1234-5678-1234-567812345678",
+        "87654321-4321-8765-4321-876543218765",
+    ]
+    result = _coerce_value(uuid_strs, list[UUID])
+    assert isinstance(result, list)
+    assert all(isinstance(u, UUID) for u in result)
+    assert [str(u) for u in result] == uuid_strs
+
+
+def test_coerce_set_of_datetimes() -> None:
+    """Test that set[datetime] coerces list of ISO strings to set of datetimes."""
+    dt1 = datetime(2024, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
+    dt2 = datetime(2024, 1, 16, 11, 0, 0, tzinfo=timezone.utc)
+    result = _coerce_value([dt1.isoformat(), dt2.isoformat()], set[datetime])
+    assert isinstance(result, set)
+    assert all(isinstance(d, datetime) for d in result)
+    assert result == {dt1, dt2}
+
+
+def test_coerce_dict_with_uuid_values() -> None:
+    """Test that dict[str, UUID] coerces string values to UUIDs."""
+    uuid_str = "12345678-1234-5678-1234-567812345678"
+    result = _coerce_value({"user_id": uuid_str}, dict[str, UUID])
+    assert isinstance(result, dict)
+    assert isinstance(result["user_id"], UUID)
+    assert str(result["user_id"]) == uuid_str
+
+
+def test_coerce_preserves_already_correct_type() -> None:
+    """Test that values already of the correct type are preserved."""
+    uuid_obj = UUID("12345678-1234-5678-1234-567812345678")
+    result = _coerce_value(uuid_obj, UUID)
+    assert result is uuid_obj
+
+
+def test_coerce_none_returns_none() -> None:
+    """Test that None values are preserved."""
+    result = _coerce_value(None, UUID)
+    assert result is None


### PR DESCRIPTION
We've only had support for basic primitives as return types or requiring serialization through a pydantic data model. This PR expands support for primitive types that can be handled natively, and switches pydantic to the better suited "json" encoding type so we're able to properly insert the outputs into our SQL column.