### PR TITLE
Allow any input parameters for workflow

### DIFF
--- a/python/src/rappel/workflow.py
+++ b/python/src/rappel/workflow.py
@@ -60,7 +60,7 @@ class Workflow:
     _ir_lock: ClassVar[RLock] = RLock()
     _workflow_version_id: ClassVar[Optional[str]] = None
 
-    async def run(self) -> Any:
+    async def run(self, *args: Any, **kwargs: Any) -> Any:
         raise NotImplementedError
 
     async def run_action(


### PR DESCRIPTION
We have arg and kwarg parsing logic working correctly for some time now. But we need to update the type signature of the workflow run to make client typehinters happy.