### PR TITLE
Reject duplicate schedules

### DIFF
--- a/python/src/rappel/__init__.py
+++ b/python/src/rappel/__init__.py
@@ -10,7 +10,11 @@ from .actions import (
     serialize_result_payload,
 )
 from .dependencies import Depend, provide_dependencies
-from .exceptions import ExhaustedRetries, ExhaustedRetriesError
+from .exceptions import (
+    ExhaustedRetries,
+    ExhaustedRetriesError,
+    ScheduleAlreadyExistsError,
+)
 from .ir_builder import UnsupportedPatternError, build_workflow_ir
 from .registry import registry
 from .schedule import (
@@ -45,6 +49,7 @@ __all__ = [
     "bridge",
     "ExhaustedRetries",
     "ExhaustedRetriesError",
+    "ScheduleAlreadyExistsError",
     "UnsupportedPatternError",
     # Schedule functions
     "schedule_workflow",

--- a/python/src/rappel/exceptions.py
+++ b/python/src/rappel/exceptions.py
@@ -9,3 +9,10 @@ class ExhaustedRetriesError(Exception):
 
 
 ExhaustedRetries = ExhaustedRetriesError
+
+
+class ScheduleAlreadyExistsError(Exception):
+    """Raised when a schedule name is already registered."""
+
+    def __init__(self, message: str | None = None) -> None:
+        super().__init__(message or "schedule already exists")


### PR DESCRIPTION
The `upsert` we're doing on the scheduled payload is confusing - and can lead to unintended behavior if the user keeps upserting on the same scheduled name and pushing back the initial scheduled date. This PR chooses to raise in this case instead.