### PR TITLE
Structured types for action return values

### DIFF
--- a/src/bin/benchmark.rs
+++ b/src/bin/benchmark.rs
@@ -25,7 +25,7 @@ use tracing::{error, info};
 
 use rappel::{
     Database, PythonWorkerConfig, PythonWorkerPool, WorkerBridgeServer, WorkflowInstanceId,
-    WorkflowVersionId, proto, validate_program,
+    WorkflowValue, WorkflowVersionId, proto, validate_program,
 };
 
 const BENCHMARK_WORKFLOW_MODULE: &str = include_str!("../../tests/fixtures/benchmark_workflow.py");
@@ -555,6 +555,11 @@ async fn main() -> Result<()> {
         serde_json::Value::Number(args.complexity.into()),
     );
 
+    let workflow_inputs: HashMap<String, WorkflowValue> = initial_inputs
+        .iter()
+        .map(|(key, value)| (key.clone(), WorkflowValue::from_json(value)))
+        .collect();
+
     // Create multiple simulated hosts, each with its own runner + worker pool
     let mut hosts: Vec<(
         Arc<rappel::DAGRunner>,
@@ -598,7 +603,7 @@ async fn main() -> Result<()> {
         if host_id == 0 {
             for instance_id in &instance_ids {
                 runner
-                    .start_instance(*instance_id, initial_inputs.clone())
+                    .start_instance(*instance_id, workflow_inputs.clone())
                     .await?;
             }
         }

--- a/src/db/worker.rs
+++ b/src/db/worker.rs
@@ -1375,7 +1375,7 @@ impl Database {
             .bind(instance_id.0)
             .bind(&write.target_node_id)
             .bind(&write.variable_name)
-            .bind(&write.value)
+            .bind(write.value.to_json())
             .bind(&write.source_node_id)
             .bind(write.spread_index)
             .execute(&mut *tx)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,7 @@ pub mod schedule;
 pub mod server_client;
 pub mod server_webapp;
 pub mod server_worker;
+pub mod value;
 pub mod worker;
 
 // Configuration
@@ -54,6 +55,7 @@ pub use db::{
 // Worker infrastructure
 pub use messages::{MessageError, ast as ir_ast, proto, workflow_arguments_to_json};
 pub use server_worker::{WorkerBridgeChannels, WorkerBridgeServer};
+pub use value::WorkflowValue;
 pub use worker::{
     ActionDispatchPayload, PythonWorker, PythonWorkerConfig, PythonWorkerPool, RoundTripMetrics,
 };

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -74,18 +74,7 @@ pub fn workflow_argument_value_to_json(value: &proto::WorkflowArgumentValue) -> 
 
     match &value.kind {
         Some(Kind::Primitive(p)) => primitive_to_json(p),
-        Some(Kind::Basemodel(bm)) => {
-            // Flatten the basemodel: put __type__ alongside fields, not in a nested "data" wrapper
-            let mut obj = match optional_workflow_dict_to_json(&bm.data) {
-                serde_json::Value::Object(map) => map,
-                _ => serde_json::Map::new(),
-            };
-            obj.insert(
-                "__type__".to_string(),
-                json!(format!("{}.{}", bm.module, bm.name)),
-            );
-            serde_json::Value::Object(obj)
-        }
+        Some(Kind::Basemodel(bm)) => optional_workflow_dict_to_json(&bm.data),
         Some(Kind::Exception(e)) => {
             json!({
                 "__exception__": {

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,0 +1,332 @@
+use std::collections::HashMap;
+
+use serde_json::Value as JsonValue;
+
+use crate::messages::proto;
+
+#[derive(Debug, Clone)]
+pub enum WorkflowValue {
+    Null,
+    Bool(bool),
+    Int(i64),
+    Float(f64),
+    String(String),
+    List(Vec<WorkflowValue>),
+    Tuple(Vec<WorkflowValue>),
+    Dict(HashMap<String, WorkflowValue>),
+    Exception {
+        exc_type: String,
+        module: String,
+        message: String,
+        traceback: String,
+    },
+}
+
+impl WorkflowValue {
+    pub fn from_proto(value: &proto::WorkflowArgumentValue) -> Self {
+        use proto::primitive_workflow_argument::Kind as PrimitiveKind;
+        use proto::workflow_argument_value::Kind;
+
+        match &value.kind {
+            Some(Kind::Primitive(p)) => match &p.kind {
+                Some(PrimitiveKind::IntValue(i)) => WorkflowValue::Int(*i),
+                Some(PrimitiveKind::DoubleValue(f)) => WorkflowValue::Float(*f),
+                Some(PrimitiveKind::StringValue(s)) => WorkflowValue::String(s.clone()),
+                Some(PrimitiveKind::BoolValue(b)) => WorkflowValue::Bool(*b),
+                Some(PrimitiveKind::NullValue(_)) => WorkflowValue::Null,
+                None => WorkflowValue::Null,
+            },
+            Some(Kind::ListValue(list)) => {
+                WorkflowValue::List(list.items.iter().map(WorkflowValue::from_proto).collect())
+            }
+            Some(Kind::TupleValue(tuple)) => {
+                WorkflowValue::Tuple(tuple.items.iter().map(WorkflowValue::from_proto).collect())
+            }
+            Some(Kind::DictValue(dict)) => {
+                let mut entries = HashMap::new();
+                for entry in &dict.entries {
+                    let value = entry
+                        .value
+                        .as_ref()
+                        .map(WorkflowValue::from_proto)
+                        .unwrap_or(WorkflowValue::Null);
+                    entries.insert(entry.key.clone(), value);
+                }
+                WorkflowValue::Dict(entries)
+            }
+            Some(Kind::Basemodel(model)) => {
+                let mut data = HashMap::new();
+                if let Some(dict) = &model.data {
+                    for entry in &dict.entries {
+                        let value = entry
+                            .value
+                            .as_ref()
+                            .map(WorkflowValue::from_proto)
+                            .unwrap_or(WorkflowValue::Null);
+                        data.insert(entry.key.clone(), value);
+                    }
+                }
+                WorkflowValue::Dict(data)
+            }
+            Some(Kind::Exception(exc)) => WorkflowValue::Exception {
+                exc_type: exc.r#type.clone(),
+                module: exc.module.clone(),
+                message: exc.message.clone(),
+                traceback: exc.traceback.clone(),
+            },
+            None => WorkflowValue::Null,
+        }
+    }
+
+    pub fn to_proto(&self) -> proto::WorkflowArgumentValue {
+        use proto::workflow_argument_value::Kind;
+
+        let kind = match self {
+            WorkflowValue::Null => Kind::Primitive(proto::PrimitiveWorkflowArgument {
+                kind: Some(proto::primitive_workflow_argument::Kind::NullValue(0)),
+            }),
+            WorkflowValue::Bool(b) => Kind::Primitive(proto::PrimitiveWorkflowArgument {
+                kind: Some(proto::primitive_workflow_argument::Kind::BoolValue(*b)),
+            }),
+            WorkflowValue::Int(i) => Kind::Primitive(proto::PrimitiveWorkflowArgument {
+                kind: Some(proto::primitive_workflow_argument::Kind::IntValue(*i)),
+            }),
+            WorkflowValue::Float(f) => Kind::Primitive(proto::PrimitiveWorkflowArgument {
+                kind: Some(proto::primitive_workflow_argument::Kind::DoubleValue(*f)),
+            }),
+            WorkflowValue::String(s) => Kind::Primitive(proto::PrimitiveWorkflowArgument {
+                kind: Some(proto::primitive_workflow_argument::Kind::StringValue(
+                    s.clone(),
+                )),
+            }),
+            WorkflowValue::List(items) => Kind::ListValue(proto::WorkflowListArgument {
+                items: items.iter().map(WorkflowValue::to_proto).collect(),
+            }),
+            WorkflowValue::Tuple(items) => Kind::TupleValue(proto::WorkflowTupleArgument {
+                items: items.iter().map(WorkflowValue::to_proto).collect(),
+            }),
+            WorkflowValue::Dict(entries) => {
+                let entries = entries
+                    .iter()
+                    .map(|(key, value)| proto::WorkflowArgument {
+                        key: key.clone(),
+                        value: Some(value.to_proto()),
+                    })
+                    .collect();
+                Kind::DictValue(proto::WorkflowDictArgument { entries })
+            }
+            WorkflowValue::Exception {
+                exc_type,
+                module,
+                message,
+                traceback,
+            } => Kind::Exception(proto::WorkflowErrorValue {
+                r#type: exc_type.clone(),
+                module: module.clone(),
+                message: message.clone(),
+                traceback: traceback.clone(),
+            }),
+        };
+
+        proto::WorkflowArgumentValue { kind: Some(kind) }
+    }
+
+    pub fn from_json(value: &JsonValue) -> Self {
+        match value {
+            JsonValue::Null => WorkflowValue::Null,
+            JsonValue::Bool(b) => WorkflowValue::Bool(*b),
+            JsonValue::Number(n) => {
+                if let Some(i) = n.as_i64() {
+                    WorkflowValue::Int(i)
+                } else if let Some(f) = n.as_f64() {
+                    WorkflowValue::Float(f)
+                } else {
+                    WorkflowValue::Null
+                }
+            }
+            JsonValue::String(s) => WorkflowValue::String(s.clone()),
+            JsonValue::Array(arr) => {
+                WorkflowValue::List(arr.iter().map(WorkflowValue::from_json).collect())
+            }
+            JsonValue::Object(obj) => {
+                if let Some(exception) = Self::exception_from_json(obj) {
+                    return exception;
+                }
+
+                let mut entries = HashMap::new();
+                for (key, value) in obj {
+                    entries.insert(key.clone(), WorkflowValue::from_json(value));
+                }
+                WorkflowValue::Dict(entries)
+            }
+        }
+    }
+
+    pub fn to_json(&self) -> JsonValue {
+        match self {
+            WorkflowValue::Null => JsonValue::Null,
+            WorkflowValue::Bool(b) => JsonValue::Bool(*b),
+            WorkflowValue::Int(i) => JsonValue::Number((*i).into()),
+            WorkflowValue::Float(f) => serde_json::Number::from_f64(*f)
+                .map(JsonValue::Number)
+                .unwrap_or(JsonValue::Null),
+            WorkflowValue::String(s) => JsonValue::String(s.clone()),
+            WorkflowValue::List(items) => {
+                JsonValue::Array(items.iter().map(WorkflowValue::to_json).collect())
+            }
+            WorkflowValue::Tuple(items) => {
+                JsonValue::Array(items.iter().map(WorkflowValue::to_json).collect())
+            }
+            WorkflowValue::Dict(entries) => {
+                let map = entries
+                    .iter()
+                    .map(|(key, value)| (key.clone(), value.to_json()))
+                    .collect();
+                JsonValue::Object(map)
+            }
+            WorkflowValue::Exception {
+                exc_type,
+                module,
+                message,
+                traceback,
+            } => {
+                let exc_obj = serde_json::json!({
+                    "type": exc_type,
+                    "module": module,
+                    "message": message,
+                    "traceback": traceback,
+                });
+                serde_json::json!({
+                    "__exception__": exc_obj
+                })
+            }
+        }
+    }
+
+    pub fn is_truthy(&self) -> bool {
+        match self {
+            WorkflowValue::Null => false,
+            WorkflowValue::Bool(b) => *b,
+            WorkflowValue::Int(i) => *i != 0,
+            WorkflowValue::Float(f) => *f != 0.0,
+            WorkflowValue::String(s) => !s.is_empty(),
+            WorkflowValue::List(items) => !items.is_empty(),
+            WorkflowValue::Tuple(items) => !items.is_empty(),
+            WorkflowValue::Dict(entries) => !entries.is_empty(),
+            WorkflowValue::Exception { .. } => true,
+        }
+    }
+
+    pub fn as_i64(&self) -> Option<i64> {
+        match self {
+            WorkflowValue::Int(i) => Some(*i),
+            WorkflowValue::Float(f) => Some(*f as i64),
+            _ => None,
+        }
+    }
+
+    pub fn as_f64(&self) -> Option<f64> {
+        match self {
+            WorkflowValue::Int(i) => Some(*i as f64),
+            WorkflowValue::Float(f) => Some(*f),
+            _ => None,
+        }
+    }
+
+    pub fn as_list(&self) -> Option<&Vec<WorkflowValue>> {
+        match self {
+            WorkflowValue::List(items) => Some(items),
+            WorkflowValue::Tuple(items) => Some(items),
+            _ => None,
+        }
+    }
+
+    pub fn as_dict(&self) -> Option<&HashMap<String, WorkflowValue>> {
+        match self {
+            WorkflowValue::Dict(entries) => Some(entries),
+            _ => None,
+        }
+    }
+
+    pub fn to_key_string(&self) -> String {
+        match self {
+            WorkflowValue::Null => "null".to_string(),
+            WorkflowValue::Bool(b) => b.to_string(),
+            WorkflowValue::Int(i) => i.to_string(),
+            WorkflowValue::Float(f) => f.to_string(),
+            WorkflowValue::String(s) => s.clone(),
+            WorkflowValue::List(_) => "[list]".to_string(),
+            WorkflowValue::Tuple(_) => "[tuple]".to_string(),
+            WorkflowValue::Dict(_) => "{dict}".to_string(),
+            WorkflowValue::Exception { exc_type, .. } => exc_type.clone(),
+        }
+    }
+
+    fn exception_from_json(obj: &serde_json::Map<String, JsonValue>) -> Option<WorkflowValue> {
+        match obj.get("__exception__") {
+            Some(JsonValue::Object(exc_obj)) => {
+                let exc_type = exc_obj.get("type").and_then(|v| v.as_str())?;
+                let module = exc_obj.get("module").and_then(|v| v.as_str()).unwrap_or("");
+                let message = exc_obj
+                    .get("message")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("");
+                let traceback = exc_obj
+                    .get("traceback")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("");
+                Some(WorkflowValue::Exception {
+                    exc_type: exc_type.to_string(),
+                    module: module.to_string(),
+                    message: message.to_string(),
+                    traceback: traceback.to_string(),
+                })
+            }
+            Some(JsonValue::Bool(true)) => {
+                let exc_type = obj.get("type").and_then(|v| v.as_str())?;
+                let module = obj.get("module").and_then(|v| v.as_str()).unwrap_or("");
+                let message = obj.get("message").and_then(|v| v.as_str()).unwrap_or("");
+                let traceback = obj.get("traceback").and_then(|v| v.as_str()).unwrap_or("");
+                Some(WorkflowValue::Exception {
+                    exc_type: exc_type.to_string(),
+                    module: module.to_string(),
+                    message: message.to_string(),
+                    traceback: traceback.to_string(),
+                })
+            }
+            _ => None,
+        }
+    }
+}
+
+impl PartialEq for WorkflowValue {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (WorkflowValue::Null, WorkflowValue::Null) => true,
+            (WorkflowValue::Bool(a), WorkflowValue::Bool(b)) => a == b,
+            (WorkflowValue::Int(a), WorkflowValue::Int(b)) => a == b,
+            (WorkflowValue::Float(a), WorkflowValue::Float(b)) => a == b,
+            (WorkflowValue::Int(a), WorkflowValue::Float(b)) => (*a as f64) == *b,
+            (WorkflowValue::Float(a), WorkflowValue::Int(b)) => *a == (*b as f64),
+            (WorkflowValue::String(a), WorkflowValue::String(b)) => a == b,
+            (WorkflowValue::List(a), WorkflowValue::List(b)) => a == b,
+            (WorkflowValue::Tuple(a), WorkflowValue::Tuple(b)) => a == b,
+            (WorkflowValue::Dict(a), WorkflowValue::Dict(b)) => a == b,
+            (
+                WorkflowValue::Exception {
+                    exc_type: at,
+                    module: am,
+                    message: amsg,
+                    traceback: atb,
+                },
+                WorkflowValue::Exception {
+                    exc_type: bt,
+                    module: bm,
+                    message: bmsg,
+                    traceback: btb,
+                },
+            ) => at == bt && am == bm && amsg == bmsg && atb == btb,
+            _ => false,
+        }
+    }
+}


### PR DESCRIPTION
Our json handling code in the rust layer has gotten progressively more complex (and prone to bugs) by introducing custom types like Exceptions. This results in us having to access values in the dag/ast layer with brittle key access that can't be compile time validated. This PR switches our logic to rust types that can be more easily verified.