### PR TITLE
Recycle workers when above threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ These are the primary environment parameters that you'll likely want to customiz
 | `RAPPEL_CONCURRENT_PER_WORKER` | Max concurrent actions per worker | `10` | `20` |
 | `RAPPEL_USER_MODULE` | Python module preloaded into each worker | none | `my_app.actions` |
 | `RAPPEL_POLL_INTERVAL_MS` | Poll interval for the dispatch loop (ms) | `100` | `50` |
+| `RAPPEL_MAX_ACTION_LIFECYCLE` | Max actions per worker before recycling (see below) | none (no limit) | `1000` |
 | `RAPPEL_WEBAPP_ENABLED` | Enable the web dashboard | `false` | `true` |
 | `RAPPEL_WEBAPP_ADDR` | Web dashboard bind address | `0.0.0.0:24119` | `0.0.0.0:8080` |
 
@@ -161,6 +162,14 @@ We expect that you won't need to modify the following env parameters, but we pro
 | `RAPPEL_HTTP_ADDR` | HTTP bind address for `rappel-bridge` | `127.0.0.1:24117` | `0.0.0.0:24117` |
 | `RAPPEL_GRPC_ADDR` | gRPC bind address for `rappel-bridge` | HTTP port + 1 | `0.0.0.0:24118` |
 | `RAPPEL_BATCH_SIZE` | Max actions fetched per poll | `workers * concurrent_per_worker` | `200` |
+
+### Worker Recycling
+
+The `RAPPEL_MAX_ACTION_LIFECYCLE` setting controls how many actions a Python worker process can execute before being automatically recycled (shut down and replaced with a fresh process). This can help mitigate memory leaks in third-party libraries that may accumulate memory over time.
+
+When a worker reaches its action limit, rappel spawns a replacement worker before retiring the old one. Any in-flight actions on the old worker will complete normally before the process terminates. This ensures zero downtime during recycling.
+
+By default, this is set to `None` (no limit), meaning workers run indefinitely. If you notice memory growth in your workers over time, try setting this to a value like `1000` or `10000` depending on your action characteristics.
 
 ## Philosophy
 

--- a/python/tests/fixtures/__init__.py
+++ b/python/tests/fixtures/__init__.py
@@ -1,0 +1,1 @@
+# Test fixtures for integration tests

--- a/python/tests/fixtures/test_actions.py
+++ b/python/tests/fixtures/test_actions.py
@@ -1,0 +1,21 @@
+"""Test actions for integration tests."""
+
+from rappel.actions import action
+
+
+@action
+async def greet(name: str) -> str:
+    """Simple greeting action for testing."""
+    return f"Hello, {name}!"
+
+
+@action
+async def add(a: int, b: int) -> int:
+    """Simple addition action for testing."""
+    return a + b
+
+
+@action
+async def echo(message: str) -> str:
+    """Echo action that returns the input."""
+    return message

--- a/src/bin/benchmark.rs
+++ b/src/bin/benchmark.rs
@@ -580,6 +580,7 @@ async fn main() -> Result<()> {
                 worker_config,
                 args.workers_per_host as usize,
                 Arc::clone(&worker_bridge),
+                None, // max_action_lifecycle - not used in benchmarks
             )
             .await?,
         );

--- a/src/bin/run_workflow.rs
+++ b/src/bin/run_workflow.rs
@@ -718,6 +718,7 @@ async fn main() -> Result<()> {
             worker_config,
             args.workers as usize,
             Arc::clone(&worker_bridge),
+            None, // max_action_lifecycle - not used in run_workflow
         )
         .await?,
     );

--- a/src/bin/start-workers.rs
+++ b/src/bin/start-workers.rs
@@ -49,6 +49,7 @@ async fn main() -> Result<()> {
         batch_size = config.batch_size,
         poll_interval_ms = config.poll_interval_ms,
         user_module = ?config.user_module,
+        max_action_lifecycle = ?config.max_action_lifecycle,
         "starting worker pool"
     );
 
@@ -75,6 +76,7 @@ async fn main() -> Result<()> {
             worker_config,
             config.worker_count,
             Arc::clone(&worker_bridge),
+            config.max_action_lifecycle,
         )
         .await?,
     );

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,6 +10,7 @@
 //! - `RAPPEL_POLL_INTERVAL_MS`: Dispatcher poll interval (default: 100)
 //! - `RAPPEL_BATCH_SIZE`: Actions to dispatch per poll (default: worker_count * concurrent_per_worker)
 //! - `RAPPEL_USER_MODULE`: Python module to preload in workers (optional)
+//! - `RAPPEL_MAX_ACTION_LIFECYCLE`: Max actions per worker before recycling (default: None, no limit)
 //! - `RAPPEL_WEBAPP_ENABLED`: Enable webapp dashboard (default: false)
 //! - `RAPPEL_WEBAPP_ADDR`: Webapp bind address (default: 0.0.0.0:24119)
 
@@ -60,6 +61,10 @@ pub struct Config {
 
     /// Python module to preload in workers
     pub user_module: Option<String>,
+
+    /// Maximum number of actions a worker can execute before being recycled.
+    /// None means no limit (workers run indefinitely).
+    pub max_action_lifecycle: Option<u64>,
 
     /// Webapp configuration
     pub webapp: WebappConfig,
@@ -154,6 +159,10 @@ impl Config {
 
         let user_module = env::var("RAPPEL_USER_MODULE").ok();
 
+        let max_action_lifecycle = env::var("RAPPEL_MAX_ACTION_LIFECYCLE")
+            .ok()
+            .and_then(|s| s.parse().ok());
+
         let webapp = WebappConfig::from_env();
 
         Ok(Self {
@@ -166,6 +175,7 @@ impl Config {
             poll_interval_ms,
             batch_size,
             user_module,
+            max_action_lifecycle,
             webapp,
         })
     }
@@ -185,6 +195,7 @@ impl Config {
             poll_interval_ms: 50,
             batch_size: (worker_count * concurrent_per_worker) as i32,
             user_module: None,
+            max_action_lifecycle: None,
             webapp: WebappConfig::default(),
         }
     }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -966,7 +966,7 @@ impl WorkQueueHandler {
         };
 
         // Get worker and send
-        let worker = Arc::clone(&self.worker_pool.workers()[worker_idx]);
+        let worker = self.worker_pool.get_worker(worker_idx).await;
         let delivery_token = action.delivery_token;
         let in_flight_tracker = Arc::clone(&self.in_flight);
         let slot_tracker = Arc::clone(&self.slot_tracker);
@@ -975,7 +975,7 @@ impl WorkQueueHandler {
         tokio::spawn(async move {
             match worker.send_action(dispatch).await {
                 Ok(metrics) => {
-                    worker_pool.record_completion(worker_idx);
+                    worker_pool.record_completion(worker_idx, Arc::clone(&worker_pool));
                     // Get in-flight info and release slot
                     let in_flight_action = {
                         let mut tracker = in_flight_tracker.lock().await;

--- a/tests/integration_harness.rs
+++ b/tests/integration_harness.rs
@@ -385,8 +385,9 @@ impl IntegrationHarness {
             user_modules: vec![config.user_module.to_string()],
             extra_python_paths: vec![python_env.path().to_path_buf()],
         };
-        let worker_pool =
-            Arc::new(PythonWorkerPool::new(worker_config, 1, Arc::clone(&worker_bridge)).await?);
+        let worker_pool = Arc::new(
+            PythonWorkerPool::new(worker_config, 1, Arc::clone(&worker_bridge), None).await?,
+        );
         info!("worker pool ready");
 
         // Create DAGRunner with the proper components

--- a/tests/schedule_test.rs
+++ b/tests/schedule_test.rs
@@ -299,7 +299,7 @@ async fn test_scheduler_creates_instance() -> Result<()> {
 
     // Create worker pool with 1 worker (minimum required)
     let worker_pool =
-        Arc::new(PythonWorkerPool::new(worker_config, 1, Arc::clone(&worker_bridge)).await?);
+        Arc::new(PythonWorkerPool::new(worker_config, 1, Arc::clone(&worker_bridge), None).await?);
 
     let runner = Arc::new(DAGRunner::new(
         runner_config,


### PR DESCRIPTION
Help control memory leaks in 3rd party python libraries by optionally
recycling worker processes after some threshold of work.