### PR TITLE
Enforce return exception for gather to match IR

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,13 @@ class WelcomeEmailWorkflow(Workflow):
         users = await fetch_users(user_ids)
         active_users = [user for user in users if user.active]
 
-        results = await asyncio.gather(*[
-            send_email(to=user.email, subject="Welcome")
-            for user in active_users
-        ])
+        results = await asyncio.gather(
+            *[
+                send_email(to=user.email, subject="Welcome")
+                for user in active_users
+            ],
+            return_exceptions=True,
+        )
         
         return results
 ```
@@ -106,7 +109,8 @@ Workflows can get much more complex than the example above:
         profile, settings, history = await asyncio.gather(
             fetch_profile(user_id=user_id),
             fetch_settings(user_id=user_id),
-            fetch_purchase_history(user_id=user_id)
+            fetch_purchase_history(user_id=user_id),
+            return_exceptions=True,
         ) 
 
         # wait before sending email

--- a/example_app/src/example_app/workflows.py
+++ b/example_app/src/example_app/workflows.py
@@ -430,6 +430,7 @@ class ParallelMathWorkflow(Workflow):
         factorial_value, fib_value = await asyncio.gather(
             compute_factorial(number),
             compute_fibonacci(number),
+            return_exceptions=True,
         )
         # Fan in: combine results
         result = await summarize_math(
@@ -1016,7 +1017,8 @@ class SpreadEmptyCollectionWorkflow(Workflow):
     async def run(self, items: list[str]) -> SpreadEmptyResult:
         # Spread over items - may be empty!
         results = await asyncio.gather(
-            *[process_spread_item(item=item) for item in items]
+            *[process_spread_item(item=item) for item in items],
+            return_exceptions=True,
         )
 
         return await build_spread_empty_result(results=results)
@@ -1084,10 +1086,13 @@ class NoOpWorkflow(Workflow):
     async def run(self, indices: list[int], complexity: int = 0) -> NoOpResult:
         _ = complexity
 
-        stage1 = await asyncio.gather(*[
-            noop_int(value=i)
-            for i in indices
-        ])
+        stage1 = await asyncio.gather(
+            *[
+                noop_int(value=i)
+                for i in indices
+            ],
+            return_exceptions=True,
+        )
 
         processed: list[int] = []
         for value in stage1:
@@ -1097,10 +1102,13 @@ class NoOpWorkflow(Workflow):
                 result = await noop_int(value=value)
             processed.append(result)
 
-        tagged = await asyncio.gather(*[
-            noop_tag_from_value(value=value)
-            for value in processed
-        ])
+        tagged = await asyncio.gather(
+            *[
+                noop_tag_from_value(value=value)
+                for value in processed
+            ],
+            return_exceptions=True,
+        )
 
         return await noop_combine(items=tagged)
 

--- a/python/tests/fixtures_gather/gather_listcomp.py
+++ b/python/tests/fixtures_gather/gather_listcomp.py
@@ -15,13 +15,14 @@ async def process_item(item: str, multiplier: int) -> str:
 class GatherListCompWorkflow(Workflow):
     """Gather with starred list comprehension for parallel fan-out.
 
-    Pattern: await asyncio.gather(*[action(x) for x in items])
+    Pattern: await asyncio.gather(*[action(x) for x in items], return_exceptions=True)
     This is a common idiom for parallel processing of collections.
     """
 
-    async def run(self, items: list, multiplier: int) -> list[str]:
+    async def run(self, items: list, multiplier: int) -> list[str | BaseException]:
         # Starred list comprehension - fan out over items
         results = await asyncio.gather(
-            *[process_item(item=item, multiplier=multiplier) for item in items]
+            *[process_item(item=item, multiplier=multiplier) for item in items],
+            return_exceptions=True,
         )
         return results

--- a/python/tests/fixtures_gather/gather_nested.py
+++ b/python/tests/fixtures_gather/gather_nested.py
@@ -17,8 +17,9 @@ async def fetch_b() -> int:
 
 
 @action
-async def combine(values: tuple[int, int]) -> int:
-    return sum(values)
+async def combine(values: tuple[int | BaseException, int | BaseException]) -> int:
+    numeric_values = [value for value in values if isinstance(value, int)]
+    return sum(numeric_values)
 
 
 @workflow
@@ -30,6 +31,7 @@ class GatherNestedWorkflow(Workflow):
         results = await asyncio.gather(
             fetch_a(),
             fetch_b(),
+            return_exceptions=True,
         )
         # Fan-in
         total = await combine(values=results)

--- a/python/tests/fixtures_gather/gather_run_action_spread.py
+++ b/python/tests/fixtures_gather/gather_run_action_spread.py
@@ -26,7 +26,7 @@ class GatherRunActionSpreadWorkflow(Workflow):
     Pattern: await asyncio.gather(*[
         self.run_action(action(x), retry=..., timeout=...)
         for x in items
-    ])
+    ], return_exceptions=True)
     """
 
     async def run(self, items: list) -> str:
@@ -39,6 +39,7 @@ class GatherRunActionSpreadWorkflow(Workflow):
                     timeout=timedelta(seconds=30),
                 )
                 for item in items
-            ]
+            ],
+            return_exceptions=True,
         )
         return await combine_results(results=results)

--- a/python/tests/fixtures_gather/gather_simple.py
+++ b/python/tests/fixtures_gather/gather_simple.py
@@ -20,9 +20,10 @@ async def action_b() -> int:
 class GatherSimpleWorkflow(Workflow):
     """Simple gather of two actions."""
 
-    async def run(self) -> int:
+    async def run(self) -> tuple[int | BaseException, int | BaseException]:
         a, b = await asyncio.gather(
             action_a(),
             action_b(),
+            return_exceptions=True,
         )
-        return a + b
+        return a, b

--- a/python/tests/fixtures_gather/gather_to_variable.py
+++ b/python/tests/fixtures_gather/gather_to_variable.py
@@ -25,10 +25,13 @@ async def fetch_value_3() -> str:
 class GatherToVariableWorkflow(Workflow):
     """Gather results assigned to a single variable (list/tuple)."""
 
-    async def run(self) -> tuple[str, str, str]:
+    async def run(
+        self,
+    ) -> tuple[str | BaseException, str | BaseException, str | BaseException]:
         results = await asyncio.gather(
             fetch_value_1(),
             fetch_value_2(),
             fetch_value_3(),
+            return_exceptions=True,
         )
         return results

--- a/python/tests/fixtures_gather/gather_tuple_unpack.py
+++ b/python/tests/fixtures_gather/gather_tuple_unpack.py
@@ -27,7 +27,9 @@ async def compute_fibonacci(n: int) -> int:
 
 
 @action
-async def summarize_math(factorial_value: int, fib_value: int) -> str:
+async def summarize_math(
+    factorial_value: int | BaseException, fib_value: int | BaseException
+) -> str:
     """Summarize the computed values."""
     return f"factorial={factorial_value}, fibonacci={fib_value}"
 
@@ -41,6 +43,7 @@ class GatherTupleUnpackWorkflow(Workflow):
         factorial_value, fib_value = await asyncio.gather(
             compute_factorial(n=5),
             compute_fibonacci(n=10),
+            return_exceptions=True,
         )
         # Use the unpacked values
         summary = await summarize_math(

--- a/python/tests/fixtures_gather/gather_unsupported_variable.py
+++ b/python/tests/fixtures_gather/gather_unsupported_variable.py
@@ -14,12 +14,12 @@ class GatherUnsupportedVariableWorkflow(Workflow):
     data flow analysis to understand what's in the tasks list.
     """
 
-    async def run(self, count: int) -> list[int]:
+    async def run(self, count: int) -> list[int | BaseException]:
         # Build up tasks list in a loop - NOT SUPPORTED
         tasks = []
         for i in range(count):
             tasks.append(i)
 
         # Spread the variable - this should raise an error
-        results = await asyncio.gather(*tasks)
+        results = await asyncio.gather(*tasks, return_exceptions=True)
         return results

--- a/python/tests/fixtures_gather/gather_with_args.py
+++ b/python/tests/fixtures_gather/gather_with_args.py
@@ -20,9 +20,10 @@ async def compute_cube(n: int) -> int:
 class GatherWithArgsWorkflow(Workflow):
     """Gather actions that take arguments."""
 
-    async def run(self, value: int) -> tuple[int, int]:
+    async def run(self, value: int) -> tuple[int | BaseException, int | BaseException]:
         square, cube = await asyncio.gather(
             compute_square(n=value),
             compute_cube(n=value),
+            return_exceptions=True,
         )
         return square, cube

--- a/tests/fixtures/benchmark_workflow.py
+++ b/tests/fixtures/benchmark_workflow.py
@@ -318,10 +318,13 @@ class BenchmarkFanOutWorkflow(Workflow):
         complexity: int = 100,
     ) -> dict[str, Any]:
         # Fan-out: compute hashes in parallel over the range
-        hashes = await asyncio.gather(*[
-            compute_hash_for_index(index=i, complexity=complexity)
-            for i in indices
-        ])
+        hashes = await asyncio.gather(
+            *[
+                compute_hash_for_index(index=i, complexity=complexity)
+                for i in indices
+            ],
+            return_exceptions=True,
+        )
 
         # Process each hash sequentially with conditional logic
         processed = []
@@ -366,10 +369,13 @@ class BenchmarkPureFanOutWorkflow(Workflow):
         complexity: int = 100,
     ) -> dict[str, Any]:
         # Pure fan-out: compute ALL hashes in parallel
-        hash_results = await asyncio.gather(*[
-            compute_hash_for_index(index=i, complexity=complexity)
-            for i in indices
-        ])
+        hash_results = await asyncio.gather(
+            *[
+                compute_hash_for_index(index=i, complexity=complexity)
+                for i in indices
+            ],
+            return_exceptions=True,
+        )
 
         # Fan-in: aggregate with a single action (no sequential processing)
         # Note: hash_results from gather is already a list that can be passed directly
@@ -404,10 +410,13 @@ class BenchmarkQueueNoopWorkflow(Workflow):
         _ = complexity
 
         # Fan-out: noop actions in parallel
-        stage1 = await asyncio.gather(*[
-            noop_int(value=i)
-            for i in indices
-        ])
+        stage1 = await asyncio.gather(
+            *[
+                noop_int(value=i)
+                for i in indices
+            ],
+            return_exceptions=True,
+        )
 
         # Sequential loop with conditional branch
         processed = []
@@ -419,10 +428,13 @@ class BenchmarkQueueNoopWorkflow(Workflow):
             processed.append(result)
 
         # Fan-out: tag values and fan-in summary
-        tagged = await asyncio.gather(*[
-            noop_tag_from_value(value=value)
-            for value in processed
-        ])
+        tagged = await asyncio.gather(
+            *[
+                noop_tag_from_value(value=value)
+                for value in processed
+            ],
+            return_exceptions=True,
+        )
 
         summary = await noop_combine(items=tagged)
         return summary

--- a/tests/fixtures/complete_feature_workflow.py
+++ b/tests/fixtures/complete_feature_workflow.py
@@ -133,12 +133,14 @@ class CompleteFeatureWorkflow(Workflow):
         status_a, status_b = await asyncio.gather(
             check_status_a(service="alpha"),
             check_status_b(service="beta"),
+            return_exceptions=True,
         )
 
         # 3. Spread action (parallel iteration over a collection)
-        processed = await asyncio.gather(*[
-            process_item(item=x) for x in items
-        ])
+        processed = await asyncio.gather(
+            *[process_item(item=x) for x in items],
+            return_exceptions=True,
+        )
 
         # 4. For loop with single action per iteration
         for i, item in enumerate(processed):

--- a/tests/fixtures/integration_loop.py
+++ b/tests/fixtures/integration_loop.py
@@ -22,7 +22,11 @@ async def finalize_payload(items: list[str]) -> str:
 @workflow
 class LoopWorkflow(Workflow):
     async def run(self) -> str:
-        seeds = await asyncio.gather(load_item(name="alpha"), load_item(name="beta"))
+        seeds = await asyncio.gather(
+            load_item(name="alpha"),
+            load_item(name="beta"),
+            return_exceptions=True,
+        )
         outputs = []
         for seed in seeds:
             local_value = f"{seed}-local"

--- a/tests/fixtures/integration_loop_accum.py
+++ b/tests/fixtures/integration_loop_accum.py
@@ -27,7 +27,11 @@ async def finalize_payload(items: list[str]) -> str:
 @workflow
 class LoopAccumWorkflow(Workflow):
     async def run(self) -> str:
-        seeds = await asyncio.gather(load_item(name="alpha"), load_item(name="beta"))
+        seeds = await asyncio.gather(
+            load_item(name="alpha"),
+            load_item(name="beta"),
+            return_exceptions=True,
+        )
         outputs: list[str] = []
         for seed in seeds:
             index = len(outputs)

--- a/tests/fixtures/integration_multi_action_loop.py
+++ b/tests/fixtures/integration_multi_action_loop.py
@@ -43,6 +43,7 @@ class MultiActionLoopWorkflow(Workflow):
             load_order(order_id="A"),
             load_order(order_id="B"),
             load_order(order_id="C"),
+            return_exceptions=True,
         )
 
         # Process each order with multiple actions per iteration

--- a/tests/fixtures/integration_parallel_block.py
+++ b/tests/fixtures/integration_parallel_block.py
@@ -30,7 +30,11 @@ class ParallelBlockWorkflow(Workflow):
         await asyncio.gather(
             record_event(name="alpha"),
             record_event(name="beta"),
+            return_exceptions=True,
         )
-        await asyncio.gather(*[record_event(name=item) for item in ["gamma", "delta"]])
+        await asyncio.gather(
+            *[record_event(name=item) for item in ["gamma", "delta"]],
+            return_exceptions=True,
+        )
         events = await snapshot_events()
         return await format_events(events=events)

--- a/tests/fixtures/integration_parallel_fn.py
+++ b/tests/fixtures/integration_parallel_fn.py
@@ -37,6 +37,7 @@ class ParallelFnWorkflow(Workflow):
         doubled, tripled = await asyncio.gather(
             self.helper_double(n=value),
             self.helper_triple(n=value),
+            return_exceptions=True,
         )
         # Sum the results
         total = await add(x=doubled, y=tripled)

--- a/tests/fixtures/integration_parallel_math.py
+++ b/tests/fixtures/integration_parallel_math.py
@@ -58,6 +58,7 @@ class ParallelMathWorkflow(Workflow):
         factorial_value, fib_value = await asyncio.gather(
             compute_factorial(number),
             compute_fibonacci(number),
+            return_exceptions=True,
         )
         return await summarize_math(
             input_number=number,

--- a/tests/fixtures/integration_run_action_spread.py
+++ b/tests/fixtures/integration_run_action_spread.py
@@ -33,6 +33,7 @@ class RunActionSpreadWorkflow(Workflow):
                     timeout=timedelta(seconds=30),
                 )
                 for item in items
-            ]
+            ],
+            return_exceptions=True,
         )
         return await combine_results(results=results)

--- a/tests/fixtures/integration_spread_from_action.py
+++ b/tests/fixtures/integration_spread_from_action.py
@@ -29,5 +29,8 @@ async def combine_results(results: list[str]) -> str:
 class SpreadFromActionWorkflow(Workflow):
     async def run(self, include_items: bool) -> str:
         items = await fetch_items(include_items=include_items)
-        results = await asyncio.gather(*[process_item(item=item) for item in items])
+        results = await asyncio.gather(
+            *[process_item(item=item) for item in items],
+            return_exceptions=True,
+        )
         return await combine_results(results=results)

--- a/tests/fixtures/integration_spread_helper_input.py
+++ b/tests/fixtures/integration_spread_helper_input.py
@@ -32,7 +32,8 @@ class SpreadHelperInputWorkflow(Workflow):
         ready = await check_ready()
         if ready:
             results = await asyncio.gather(
-                *[process_item(item=item) for item in items]
+                *[process_item(item=item) for item in items],
+                return_exceptions=True,
             )
             return results
         return []

--- a/tests/fixtures/integration_spread_loop.py
+++ b/tests/fixtures/integration_spread_loop.py
@@ -28,14 +28,18 @@ class SpreadLoopWorkflow(Workflow):
         totals = []
         for item in items:
             results = await asyncio.gather(
-                *[identity(value=value) for value in [item, item + 1]]
+                *[identity(value=value) for value in [item, item + 1]],
+                return_exceptions=True,
             )
             total = await sum_values(values=results)
             totals = totals + [total]
 
         empties = []
         for _item in items:
-            results = await asyncio.gather(*[identity(value=value) for value in []])
+            results = await asyncio.gather(
+                *[identity(value=value) for value in []],
+                return_exceptions=True,
+            )
             empties = empties + [0]
 
         return await format_results(totals=totals, empties=empties)

--- a/tests/fixtures/loop_workflow.py
+++ b/tests/fixtures/loop_workflow.py
@@ -28,7 +28,10 @@ class LoopWorkflow(Workflow):
 
     async def run(self, items: list) -> str:
         # Process all items in parallel using gather
-        processed = await asyncio.gather(*[process_item(item=item) for item in items])
+        processed = await asyncio.gather(
+            *[process_item(item=item) for item in items],
+            return_exceptions=True,
+        )
 
         # Join all results
         final = await join_results(processed)

--- a/tests/fixtures/parallel_workflow.py
+++ b/tests/fixtures/parallel_workflow.py
@@ -33,6 +33,7 @@ class ParallelWorkflow(Workflow):
         doubled, squared = await asyncio.gather(
             compute_double(value),
             compute_square(value),
+            return_exceptions=True,
         )
         # Fan in: combine results
         result = await combine_results(doubled=doubled, squared=squared)


### PR DESCRIPTION
Technically, a vanilla asyncio.gather is unsupported by the rappel IR because we will run every action and return errors into this payload before running the next stage. We append our python parser to reflect this situation and better map the semantics of python native and the IR.