### PR TITLE
Reload DAG

### DIFF
--- a/migrations/0029_rename_dag_hash_to_ir_hash.sql
+++ b/migrations/0029_rename_dag_hash_to_ir_hash.sql
@@ -1,0 +1,5 @@
+-- Rename dag_hash to ir_hash for clarity (it's actually the IR hash, not DAG hash)
+ALTER TABLE workflow_versions RENAME COLUMN dag_hash TO ir_hash;
+
+-- Update the unique constraint name to match
+ALTER INDEX workflow_versions_workflow_name_dag_hash_key RENAME TO workflow_versions_workflow_name_ir_hash_key;

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -211,7 +211,7 @@ impl BackoffKind {
 pub struct WorkflowVersion {
     pub id: Uuid,
     pub workflow_name: String,
-    pub dag_hash: String,
+    pub ir_hash: String,
     pub program_proto: Vec<u8>,
     pub concurrent: bool,
     pub created_at: DateTime<Utc>,
@@ -222,7 +222,7 @@ pub struct WorkflowVersion {
 pub struct WorkflowVersionSummary {
     pub id: Uuid,
     pub workflow_name: String,
-    pub dag_hash: String,
+    pub ir_hash: String,
     pub concurrent: bool,
     pub created_at: DateTime<Utc>,
 }

--- a/src/db/worker.rs
+++ b/src/db/worker.rs
@@ -32,20 +32,20 @@ impl Database {
     pub async fn upsert_workflow_version(
         &self,
         workflow_name: &str,
-        dag_hash: &str,
+        ir_hash: &str,
         program_proto: &[u8],
         concurrent: bool,
     ) -> DbResult<WorkflowVersionId> {
         let row = sqlx::query(
             r#"
-            INSERT INTO workflow_versions (workflow_name, dag_hash, program_proto, concurrent)
+            INSERT INTO workflow_versions (workflow_name, ir_hash, program_proto, concurrent)
             VALUES ($1, $2, $3, $4)
-            ON CONFLICT (workflow_name, dag_hash) DO UPDATE SET workflow_name = EXCLUDED.workflow_name
+            ON CONFLICT (workflow_name, ir_hash) DO UPDATE SET workflow_name = EXCLUDED.workflow_name
             RETURNING id
             "#,
         )
         .bind(workflow_name)
-        .bind(dag_hash)
+        .bind(ir_hash)
         .bind(program_proto)
         .bind(concurrent)
         .fetch_one(&self.pool)
@@ -59,7 +59,7 @@ impl Database {
     pub async fn get_workflow_version(&self, id: WorkflowVersionId) -> DbResult<WorkflowVersion> {
         let version = sqlx::query_as::<_, WorkflowVersion>(
             r#"
-            SELECT id, workflow_name, dag_hash, program_proto, concurrent, created_at
+            SELECT id, workflow_name, ir_hash, program_proto, concurrent, created_at
             FROM workflow_versions
             WHERE id = $1
             "#,

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -298,7 +298,7 @@ async fn load_initial_scope(db: &Database, instance_id: WorkflowInstanceId) -> R
 
 /// Cache for DAGs loaded from workflow versions.
 ///
-/// Since workflow versions are immutable (content-addressed by dag_hash),
+/// Since workflow versions are immutable (content-addressed by ir_hash),
 /// we can cache them indefinitely. The cache stores Arc<DAG> which can be
 /// used to create DAGHelper instances on-demand.
 pub struct DAGCache {

--- a/templates/workflow.html
+++ b/templates/workflow.html
@@ -6,9 +6,16 @@
 {% block content %}
 <section class="space-y-4">
     <a href="/workflows" class="text-xs uppercase tracking-[0.4em] text-zinc-500 transition hover:text-zinc-700 dark:hover:text-zinc-300">&larr; Back to all workflows</a>
-    <div class="space-y-2">
-        <h1 class="text-3xl font-semibold tracking-tight text-zinc-900 dark:text-white">{{ workflow.name }}</h1>
-        <p class="text-sm text-zinc-600 dark:text-zinc-400">Workflow version #{{ workflow.id }}</p>
+    <div class="flex items-start justify-between gap-4">
+        <div class="space-y-2">
+            <h1 class="text-3xl font-semibold tracking-tight text-zinc-900 dark:text-white">{{ workflow.name }}</h1>
+            <p class="text-sm text-zinc-600 dark:text-zinc-400">Workflow version #{{ workflow.id }}</p>
+        </div>
+        <form method="POST" action="/workflows/{{ workflow.id }}/delete" class="shrink-0" onsubmit="return confirm('Are you sure you want to delete this workflow version? This will force a re-registration of the IR on next run. This action cannot be undone.');">
+            <button type="submit" class="rounded-lg bg-red-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-red-500">
+                Delete Version
+            </button>
+        </form>
     </div>
     <dl class="grid gap-4 rounded-2xl border border-zinc-200 dark:border-zinc-900 bg-zinc-100 dark:bg-zinc-900/40 p-6 sm:grid-cols-2">
         <div>


### PR DESCRIPTION
Our workflow definitions are unique based on the IR that's passed in. In rare cases we want to re-compute the DAG with the latest implemented version, in situations where we fix the underlying graph that's constructed but the IR does not change.