### PR TITLE
Lock rust toolchain to 1.93.1 (current stable)

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.93.1"
+components = ["rustfmt", "clippy"]
+profile = "minimal"


### PR DESCRIPTION
We want to lock to a particular rust version just like we lock everything else