### PR TITLE
Refactor observability to use cfg instead of features

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,8 +47,9 @@ Run the Rust benchmark harness (defaults to `--count 1000`) via:
 $ make benchmark
 ```
 
-`make benchmark` builds with `--features trace`, writes a tracing-chrome file, and prints
-a pyinstrument-style summary via `scripts/parse_chrome_trace.py`. Override the trace path
+`make benchmark` builds with `RUSTFLAGS="--cfg waymark_observability_trace"`,
+writes a tracing-chrome file, and prints a pyinstrument-style summary
+via `scripts/parse_chrome_trace.py`. Override the trace path
 with `BENCH_TRACE=...`, the summary size with `BENCH_TRACE_TOP=...`, or benchmark args with
 `BENCH_ARGS="--count 200 --batch-size 50"`. Set `BENCH_RELEASE=1` to run the benchmark binary
 from the release profile. `make benchmark-trace` is an alias if you want the explicit target
@@ -64,7 +65,7 @@ This opens a tmux session with the benchmark on the left and `tokio-console` on 
 `make benchmark-console` requires tmux, and `tokio-console` must be installed (`cargo install
 tokio-console --locked`). Tokio console also requires building with
 `RUSTFLAGS="--cfg tokio_unstable"`, which the make target sets by default (override with
-`BENCH_RUSTFLAGS=...`). The console listens on `127.0.0.1:6669` by default; override with
+`BENCH_CONSOLE_RUSTFLAGS=...`). The console listens on `127.0.0.1:6669` by default; override with
 `TOKIO_CONSOLE_BIND`. This is a tokio-console socket, not an HTTP endpoint, so it won’t
 load in a browser. If tokio-console shows "RECONNECTING", reinstall it so the client/server
 protocols match. We track the latest `console-subscriber` (0.5.x), while the CLI is still
@@ -72,7 +73,7 @@ protocols match. We track the latest `console-subscriber` (0.5.x), while the CLI
 
 Stream benchmark output directly into our parser to summarize throughput and latency samples:
 
-```bash
+````bash
 $ cargo run --bin waymark-benchmark -- \
   --messages 100000 \
   --payload 1024 \
@@ -90,7 +91,7 @@ $ cargo run --bin bench_instances -- \
   --payload-size 1024 \
   --concurrency 64 \
   --workers 4
-```
+````
 
 Add `--json` to the parser if you prefer JSON output.
 
@@ -100,6 +101,7 @@ Add `--json` to the parser if you prefer JSON output.
 
 Integration fixtures are run by the Rust entrypoint binary `crates/bin/integration-test`.
 It runs curated fixtures from `tests/waymark-integration-tests` and checks parity:
+
 - Baseline execution via direct inline Python workflow logic
 - Runtime execution via Rust DAG execution + in-memory backend
 - Runtime execution via Rust DAG execution + Postgres backend
@@ -122,6 +124,7 @@ cargo run --bin waymark-integration-test -- --backends in-memory
 ```
 
 Prereqs:
+
 - No manual Postgres startup is required for the default test harness configuration.
 - Ensure `uv` is installed and `.venv` is prepared (`uv sync`)
 

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,8 @@ BENCH_TRACE_PREFIX ?= $(BENCH_TRACE:.json=)
 BENCH_TRACE_TOP ?= 30
 BENCH_CONSOLE_BIND ?= 127.0.0.1:6669
 BENCH_CONSOLE_ARGS ?= --observe
-BENCH_RUSTFLAGS ?= --cfg tokio_unstable
+BENCH_CONSOLE_RUSTFLAGS ?= --cfg waymark_observability_trace
+BENCH_RUSTFLAGS ?= --cfg tokio_unstable --cfg waymark_observability_trace
 BENCH_CONCURRENCY_SWEEP ?= 25 100 250 1000
 BENCH_RELEASE ?= 0
 BENCH_PROFILE_FLAG := $(if $(filter 1 true yes,$(BENCH_RELEASE)),--release,)
@@ -93,11 +94,11 @@ benchmark-console:
 	tmux attach -t waymark-benchmark
 
 benchmark-console-run:
-	TOKIO_CONSOLE_BIND="$(BENCH_CONSOLE_BIND)" RUSTFLAGS="$(BENCH_RUSTFLAGS)" cargo build $(BENCH_PROFILE_FLAG) --bin waymark-benchmark --features observability
-	TOKIO_CONSOLE_BIND="$(BENCH_CONSOLE_BIND)" RUSTFLAGS="$(BENCH_RUSTFLAGS)" $(BENCH_BIN) $(BENCH_CONSOLE_ARGS) $(BENCH_ARGS)
+	TOKIO_CONSOLE_BIND="$(BENCH_CONSOLE_BIND)" RUSTFLAGS="$(BENCH_RUSTFLAGS) $(BENCH_CONSOLE_RUSTFLAGS)" cargo build $(BENCH_PROFILE_FLAG) --bin waymark-benchmark
+	TOKIO_CONSOLE_BIND="$(BENCH_CONSOLE_BIND)" RUSTFLAGS="$(BENCH_RUSTFLAGS) $(BENCH_CONSOLE_RUSTFLAGS)" $(BENCH_BIN) $(BENCH_CONSOLE_ARGS) $(BENCH_ARGS)
 
 benchmark-trace:
-	cargo build $(BENCH_PROFILE_FLAG) --bin waymark-benchmark --features trace
+	RUSTFLAGS="$(BENCH_RUSTFLAGS)" cargo build $(BENCH_PROFILE_FLAG) --bin waymark-benchmark
 	@for max in $(BENCH_CONCURRENCY_SWEEP); do \
 		trace_file="$(BENCH_TRACE_PREFIX)-$${max}.json"; \
 		echo "=== BENCH: max_concurrent_instances=$${max} ==="; \

--- a/crates/bin/benchmark/Cargo.toml
+++ b/crates/bin/benchmark/Cargo.toml
@@ -26,7 +26,3 @@ sqlx = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tracing = { workspace = true }
 uuid = { workspace = true }
-
-[features]
-trace = ["waymark-observability-setup/trace"]
-observability = ["waymark-observability-setup/tokio-console"]

--- a/crates/lib/backend-postgres/Cargo.toml
+++ b/crates/lib/backend-postgres/Cargo.toml
@@ -34,6 +34,3 @@ prost = { workspace = true }
 serial_test = { workspace = true }
 waymark-test-support = { workspace = true }
 waymark-ir-parser = { workspace = true }
-
-[features]
-trace = []

--- a/crates/lib/observability-macros/build.rs
+++ b/crates/lib/observability-macros/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("cargo::rustc-check-cfg=cfg(waymark_observability_trace)");
+}

--- a/crates/lib/observability-macros/src/lib.rs
+++ b/crates/lib/observability-macros/src/lib.rs
@@ -5,12 +5,20 @@ use syn::{ItemFn, parse_macro_input};
 #[proc_macro_attribute]
 pub fn obs(args: TokenStream, input: TokenStream) -> TokenStream {
     let mut item = parse_macro_input!(input as ItemFn);
-    let attr = if args.is_empty() {
-        syn::parse_quote!(#[cfg_attr(feature = "trace", ::waymark_observability::__inner::tracing::instrument(skip_all))])
-    } else {
-        let args = proc_macro2::TokenStream::from(args);
-        syn::parse_quote!(#[cfg_attr(feature = "trace", ::waymark_observability::__inner::tracing::instrument(#args))])
-    };
-    item.attrs.push(attr);
+    handle_item(args, &mut item);
     TokenStream::from(quote!(#item))
 }
+
+#[cfg(waymark_observability_trace)]
+fn handle_item(args: TokenStream, item: &mut ItemFn) {
+    let attr = if args.is_empty() {
+        syn::parse_quote!(#[::waymark_observability::__inner::tracing::instrument(skip_all)])
+    } else {
+        let args = proc_macro2::TokenStream::from(args);
+        syn::parse_quote!(#[::waymark_observability::__inner::tracing::instrument(#args)])
+    };
+    item.attrs.push(attr);
+}
+
+#[cfg(not(waymark_observability_trace))]
+fn handle_item(_args: TokenStream, _item: &mut ItemFn) {}

--- a/crates/lib/observability-setup/Cargo.toml
+++ b/crates/lib/observability-setup/Cargo.toml
@@ -3,13 +3,13 @@ name = "waymark-observability-setup"
 version.workspace = true
 edition = "2024"
 
-[features]
-default = ["trace"]
+[package.metadata.docs.rs]
+rustdoc-args = ["--cfg", "waymark_observability_trace", "--cfg", "waymark_observability_tokio_console"]
+rustc-args = ["--cfg", "waymark_observability_trace", "--cfg", "waymark_observability_tokio_console"]
 
-trace = ["dep:tracing-subscriber", "dep:tracing-chrome"]
-tokio-console = ["dep:console-subscriber"]
+[target.'cfg(waymark_observability_trace)'.dependencies]
+tracing-subscriber = { workspace = true }
+tracing-chrome = { workspace = true }
 
-[dependencies]
-console-subscriber = { workspace = true, optional = true }
-tracing-chrome = { workspace = true, optional = true }
-tracing-subscriber = { workspace = true, optional = true }
+[target.'cfg(waymark_observability_tokio_console)'.dependencies]
+console-subscriber = { workspace = true }

--- a/crates/lib/observability-setup/build.rs
+++ b/crates/lib/observability-setup/build.rs
@@ -1,0 +1,5 @@
+fn main() {
+    println!(
+        "cargo::rustc-check-cfg=cfg(waymark_observability_trace,waymark_observability_tokio_console)"
+    );
+}

--- a/crates/lib/observability-setup/src/impl.rs
+++ b/crates/lib/observability-setup/src/impl.rs
@@ -37,7 +37,7 @@ pub fn init(options: ObservabilityOptions) {
         (None, None)
     };
 
-    #[cfg(feature = "tokio-console")]
+    #[cfg(waymark_observability_tokio_console)]
     {
         let console_layer = options.console.then(|| {
             console_subscriber::ConsoleLayer::builder()
@@ -52,11 +52,11 @@ pub fn init(options: ObservabilityOptions) {
             eprintln!("tracing init failed: {err}");
         }
     }
-    #[cfg(not(feature = "tokio-console"))]
+    #[cfg(not(waymark_observability_tokio_console))]
     {
         if options.console {
             eprintln!(
-                "tokio-console disabled. Rebuild with --features observability to enable it."
+                "tokio-console disabled. Rebuild with `--cfg waymark_observability_tokio_console` to enable it."
             );
         }
         if let Err(err) = tracing_subscriber::registry().with(chrome_layer).try_init() {

--- a/crates/lib/observability-setup/src/lib.rs
+++ b/crates/lib/observability-setup/src/lib.rs
@@ -4,8 +4,8 @@ mod common;
 
 pub use self::common::*;
 
-#[cfg_attr(feature = "trace", path = "impl.rs")]
-#[cfg_attr(not(feature = "trace"), path = "mock.rs")]
+#[cfg_attr(waymark_observability_trace, path = "impl.rs")]
+#[cfg_attr(not(waymark_observability_trace), path = "mock.rs")]
 mod r#impl;
 
 pub use self::r#impl::*;

--- a/crates/lib/observability-setup/src/mock.rs
+++ b/crates/lib/observability-setup/src/mock.rs
@@ -1,7 +1,7 @@
 use crate::ObservabilityOptions;
 
 pub fn init(_options: ObservabilityOptions) {
-    eprintln!("Tracing disabled. Rebuild with --features trace or --features observability.");
+    eprintln!("Tracing disabled. Rebuild with `--cfg waymark_observability_trace`.");
 }
 
 pub fn flush() {}

--- a/crates/lib/observability/test/sample.rs
+++ b/crates/lib/observability/test/sample.rs
@@ -1,0 +1,4 @@
+use waymark_observability::obs;
+
+#[obs]
+fn myfn() {}

--- a/crates/lib/runner-state/Cargo.toml
+++ b/crates/lib/runner-state/Cargo.toml
@@ -11,6 +11,3 @@ thiserror = { workspace = true }
 uuid = { workspace = true }
 waymark-dag = { workspace = true }
 waymark-proto = { workspace = true }
-
-[features]
-trace = []

--- a/crates/lib/runner/Cargo.toml
+++ b/crates/lib/runner/Cargo.toml
@@ -4,7 +4,7 @@ version.workspace = true
 edition = "2024"
 
 [dependencies]
-chrono = { workspace = true, features = ["serde"]  }
+chrono = { workspace = true, features = ["serde"] }
 rustc-hash = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
@@ -19,6 +19,3 @@ tracing = { workspace = true }
 [dev-dependencies]
 waymark-ir-parser = { workspace = true }
 waymark-backend-memory = { workspace = true }
-
-[features]
-trace = []

--- a/crates/waymark/Cargo.toml
+++ b/crates/waymark/Cargo.toml
@@ -46,10 +46,6 @@ tonic = { version = "0.11", features = ["transport"] }
 tracing = "0.1"
 console-subscriber = { version = "0.5", optional = true }
 
-[features]
-trace = ["waymark-observability-setup/trace"]
-observability = ["trace", "dep:console-subscriber"]
-
 [dev-dependencies]
 waymark-backend-fault-injection = { workspace = true }
 waymark-backend-memory = { workspace = true }


### PR DESCRIPTION
To build with observability now: `RUSTFLAGS="--cfg waymark_observability_trace" cargo clippy -p waymark`

I've also adjusted `Makefile` for benches, and `CONTRIBUTING.md`