### PR TITLE
Finalize the waymark crate separation into multiple crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3330,10 +3330,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "waymark"
-version = "0.1.0"
-
-[[package]]
 name = "waymark-backend-fault-injection"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "3"
-members = ["crates/lib/*", "crates/bin/*", "crates/waymark"]
+members = ["crates/lib/*", "crates/bin/*"]
 
 [workspace.package]
 version = "0.1.0"

--- a/crates/waymark/Cargo.toml
+++ b/crates/waymark/Cargo.toml
@@ -1,9 +1,0 @@
-
-[package]
-name = "waymark"
-version.workspace = true
-edition = "2024"
-
-[dependencies]
-
-[dev-dependencies]

--- a/crates/waymark/src/lib.rs
+++ b/crates/waymark/src/lib.rs
@@ -1,1 +1,0 @@
-//! Waymark - worker pool infrastructure plus the core IR/runtime port.


### PR DESCRIPTION
Goes in after #225.

This PR finally removes the `waymark` crate.

Before we wrap this up, we will need to do a a pass on dependency graph optimization. There are no unused dependencies in the crates, but there might be some `dependencies` that should be `dev-dependencies`. I'll make a quick pass to verify the crates for this.

Then, next up:
- bringup composition, runloop refactor and rewiring how tasks are spawned and managed

After that, on the general code quality improvements track (i.e. not related to runloop refactors):
- overhaul of bin targets runtime bootstrap (logging, observability setup, etc)
- subsystem newtypes introduction (to discuss)
- reconsider the use of dyn traits
- error types correction (move to having specific errors versus generic errors); also `anyhow` drop