### PR TITLE
Correct crate features

### DIFF
--- a/crates/bin/start-workers/Cargo.toml
+++ b/crates/bin/start-workers/Cargo.toml
@@ -18,6 +18,6 @@ prost = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }
 sqlx = { workspace = true }
-tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "signal"] }
 tokio-util = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }

--- a/crates/lib/worker-inline/Cargo.toml
+++ b/crates/lib/worker-inline/Cargo.toml
@@ -5,6 +5,6 @@ version.workspace = true
 
 [dependencies]
 serde_json = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["rt-multi-thread", "sync"] }
 waymark-observability = { workspace = true }
 waymark-worker-core = { workspace = true }

--- a/crates/lib/worker-metrics/Cargo.toml
+++ b/crates/lib/worker-metrics/Cargo.toml
@@ -4,5 +4,5 @@ edition = "2024"
 version.workspace = true
 
 [dependencies]
-chrono = { workspace = true }
+chrono = { workspace = true, default-features = false, features = ["clock"] }
 uuid = { workspace = true }

--- a/crates/lib/worker-remote/Cargo.toml
+++ b/crates/lib/worker-remote/Cargo.toml
@@ -9,7 +9,7 @@ futures-core = { workspace = true }
 prost = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true,  features = ["process"] }
 tokio-stream = { workspace = true, features = ["net"] }
 tonic = { workspace = true }
 tracing = { workspace = true }

--- a/crates/lib/worker-status-reporter/Cargo.toml
+++ b/crates/lib/worker-status-reporter/Cargo.toml
@@ -4,8 +4,8 @@ edition = "2024"
 version.workspace = true
 
 [dependencies]
-chrono = { workspace = true }
-tokio = { workspace = true }
+chrono = { workspace = true, default-features = false, features = ["clock"] }
+tokio = { workspace = true, features = ["macros", "time"] }
 tokio-util = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }


### PR DESCRIPTION
This PR correct issues with features that occur when crates are used standalone. Normal operations don't catch it because our usual compilation flows expands features from all crates in the build target first, and then compiles crates with the full set of all enabled features.

I've used `cargo hack check --feature-powerset --no-dev-deps` to check all crates separately. We have an issue to track adding this check to CI - but this is a manual pass to unblock #223.