### PR TITLE
Reduce code duplication via waymark-ir-conversions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3753,6 +3753,7 @@ dependencies = [
  "waymark-core-backend",
  "waymark-dag",
  "waymark-dag-builder",
+ "waymark-ir-conversions",
  "waymark-ir-parser",
  "waymark-observability",
  "waymark-proto",
@@ -3769,6 +3770,7 @@ dependencies = [
  "thiserror",
  "uuid",
  "waymark-dag",
+ "waymark-ir-conversions",
  "waymark-proto",
 ]
 

--- a/crates/lib/ir-conversions/src/lib.rs
+++ b/crates/lib/ir-conversions/src/lib.rs
@@ -62,3 +62,30 @@ pub fn literal_from_json_value(value: &serde_json::Value) -> ir::Expr {
         },
     }
 }
+
+pub fn literal_to_json_value(lit: &ir::Literal) -> serde_json::Value {
+    match lit.value.as_ref() {
+        Some(ir::literal::Value::IntValue(value)) => serde_json::Value::Number((*value).into()),
+        Some(ir::literal::Value::FloatValue(value)) => serde_json::Number::from_f64(*value)
+            .map(serde_json::Value::Number)
+            .unwrap_or(serde_json::Value::Null),
+        Some(ir::literal::Value::StringValue(value)) => serde_json::Value::String(value.clone()),
+        Some(ir::literal::Value::BoolValue(value)) => serde_json::Value::Bool(*value),
+        Some(ir::literal::Value::IsNone(_)) => serde_json::Value::Null,
+        None => serde_json::Value::Null,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn literal_to_json_value_happy_path() {
+        let lit = ir::Literal {
+            value: Some(ir::literal::Value::IntValue(7)),
+        };
+        assert_eq!(literal_to_json_value(&lit), json!(7));
+    }
+}

--- a/crates/lib/runner-state/Cargo.toml
+++ b/crates/lib/runner-state/Cargo.toml
@@ -10,4 +10,5 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 uuid = { workspace = true }
 waymark-dag = { workspace = true }
+waymark-ir-conversions = { workspace = true }
 waymark-proto = { workspace = true }

--- a/crates/lib/runner-state/src/state.rs
+++ b/crates/lib/runner-state/src/state.rs
@@ -14,6 +14,7 @@ use waymark_dag::{
     ActionCallNode, AggregatorNode, AssignmentNode, DAG, DAGNode, EdgeType, FnCallNode, JoinNode,
     ReturnNode, SleepNode,
 };
+use waymark_ir_conversions::literal_to_json_value;
 use waymark_proto::ast as ir;
 
 /// Raised when the runner state cannot be updated safely.
@@ -1172,7 +1173,7 @@ impl RunnerState {
     ) -> Result<ValueExpr, RunnerStateError> {
         match expr.kind.as_ref() {
             Some(ir::expr::Kind::Literal(lit)) => Ok(ValueExpr::Literal(LiteralValue {
-                value: literal_value(lit),
+                value: literal_to_json_value(lit),
             })),
             Some(ir::expr::Kind::Variable(var)) => {
                 if let Some(scope) = local_scope
@@ -1788,23 +1789,6 @@ fn format_literal(value: &serde_json::Value) -> String {
             serde_json::to_string(value).unwrap_or_else(|_| format!("\"{value}\""))
         }
         _ => value.to_string(),
-    }
-}
-
-/// Convert an IR literal into a Python value.
-///
-/// Example IR:
-/// - Literal(int_value=3) -> 3
-pub fn literal_value(lit: &ir::Literal) -> serde_json::Value {
-    match lit.value.as_ref() {
-        Some(ir::literal::Value::IntValue(value)) => serde_json::Value::Number((*value).into()),
-        Some(ir::literal::Value::FloatValue(value)) => serde_json::Number::from_f64(*value)
-            .map(serde_json::Value::Number)
-            .unwrap_or(serde_json::Value::Null),
-        Some(ir::literal::Value::StringValue(value)) => serde_json::Value::String(value.clone()),
-        Some(ir::literal::Value::BoolValue(value)) => serde_json::Value::Bool(*value),
-        Some(ir::literal::Value::IsNone(_)) => serde_json::Value::Null,
-        None => serde_json::Value::Null,
     }
 }
 

--- a/crates/lib/runner/Cargo.toml
+++ b/crates/lib/runner/Cargo.toml
@@ -12,6 +12,7 @@ uuid = { workspace = true }
 waymark-dag = { workspace = true }
 waymark-proto = { workspace = true }
 waymark-observability = { workspace = true }
+waymark-ir-conversions = { workspace = true }
 waymark-runner-state = { workspace = true }
 waymark-core-backend = { workspace = true }
 

--- a/crates/lib/runner/src/expression_evaluator.rs
+++ b/crates/lib/runner/src/expression_evaluator.rs
@@ -6,12 +6,12 @@ use serde_json::Value;
 use uuid::Uuid;
 
 use waymark_dag::{DAGEdge, EdgeType};
+use waymark_ir_conversions::literal_to_json_value;
 use waymark_observability::obs;
 use waymark_proto::ast as ir;
 use waymark_runner_state::{
     ActionCallSpec, ActionResultValue, BinaryOpValue, DictEntryValue, DictValue, DotValue,
     FunctionCallValue, IndexValue, ListValue, LiteralValue, UnaryOpValue, VariableValue,
-    literal_value,
     value_visitor::{ValueExpr, ValueExprEvaluator},
 };
 
@@ -22,7 +22,7 @@ impl RunnerExecutor {
     pub(super) fn expr_to_value(expr: &ir::Expr) -> Result<ValueExpr, RunnerExecutorError> {
         match expr.kind.as_ref() {
             Some(ir::expr::Kind::Literal(lit)) => Ok(ValueExpr::Literal(LiteralValue {
-                value: literal_value(lit),
+                value: literal_to_json_value(lit),
             })),
             Some(ir::expr::Kind::Variable(var)) => Ok(ValueExpr::Variable(VariableValue {
                 name: var.name.clone(),


### PR DESCRIPTION
This PR consolidates the code that is related to the proto-to-json literal conversions at `waymark-ir-conversions`, and reuses it tree-wide instead of various reimplementations.

There is a bigger discussion to have with regard to:
- use of JSON and specifically `serde_json::Value` as an internal model (suboptimal?)
- use of protobuf-generated types as an internal model (also suboptimal?)
- there are way too many "foreign" types that represent/model the same concepts: we should consider rewriting the system without using protobuf-generated types & json, and only keep the conversion into those at the relevant transport boundaries; otherwise we can't have guarding new-types and, more generally, type-safe code; there are good ways to share the transport data-schemas that won't cause so much inconvenience at the code level
- introduction of the newtypes (as mentioned above) for primitives, and more heavy use of the type-system
- maybe we should make a full-blown grammar and lexer (see https://github.com/pest-parser/pest and https://github.com/rust-bakery/nom), and separate ast from the ir