### PR TITLE
Runloop: initial refactor of the runloop errors

### DIFF
--- a/crates/lib/runloop/src/lib.rs
+++ b/crates/lib/runloop/src/lib.rs
@@ -15,4 +15,4 @@ mod shard;
 
 use self::error_value::error_value;
 
-pub use self::runloop::{RunLoop, RunLoopConfig, RunLoopError};
+pub use self::runloop::{Error as RunLoopError, RunLoop, RunLoopConfig};

--- a/crates/lib/runloop/src/runloop.rs
+++ b/crates/lib/runloop/src/runloop.rs
@@ -53,7 +53,7 @@ mod lock_utils;
 
 /// Raised when the run loop cannot coordinate execution.
 #[derive(Debug, thiserror::Error)]
-pub enum RunLoopError {
+pub enum Error {
     #[error("{0}")]
     Message(String),
     #[error(transparent)]
@@ -61,7 +61,7 @@ pub enum RunLoopError {
     #[error(transparent)]
     WorkerPool(#[from] WorkerPoolError),
     #[error(transparent)]
-    RunnerExecutor(#[from] RunnerExecutorError),
+    RunnerExecutor(RunnerExecutorError),
 }
 
 #[derive(Clone, Debug)]
@@ -198,8 +198,8 @@ impl RunLoop {
     }
 
     #[obs]
-    pub async fn run(&mut self) -> Result<(), RunLoopError> {
-        self.worker_pool.launch().await?;
+    pub async fn run(&mut self) -> Result<(), Error> {
+        self.worker_pool.launch().await.map_err(Error::WorkerPool)?;
 
         let (event_tx, mut event_rx) = mpsc::unbounded_channel::<shard::Event>();
         let mut shard_senders: Vec<std_mpsc::Sender<shard::Command>> =
@@ -215,9 +215,7 @@ impl RunLoop {
                 .stack_size(128 * 1024 * 1024 /* 128 MB */)
                 .spawn(move || shard::run_executor_shard(shard_id, backend, cmd_rx, event_tx))
                 .map_err(|err| {
-                    RunLoopError::Message(format!(
-                        "failed to spawn executor shard {shard_id}: {err}"
-                    ))
+                    Error::Message(format!("failed to spawn executor shard {shard_id}: {err}"))
                 })?;
             shard_senders.push(cmd_tx);
             shard_handles.push(handle);
@@ -409,7 +407,7 @@ impl RunLoop {
                 }
                 CoordinatorEvent::Instance(queued_instances_polling::Message::Error(err)) => {
                     warn!(error = %err, "runloop exiting: instance poller backend error");
-                    break 'runloop Err(RunLoopError::Backend(err));
+                    break 'runloop Err(Error::Backend(err));
                 }
                 CoordinatorEvent::Shard(event) => match event {
                     shard::Event::Step(step) => all_steps.push(step),
@@ -449,7 +447,7 @@ impl RunLoop {
                     }
                     queued_instances_polling::Message::Error(err) => {
                         warn!(error = %err, "runloop exiting: instance poller backend error");
-                        break 'runloop Err(RunLoopError::Backend(err));
+                        break 'runloop Err(Error::Backend(err));
                     }
                 }
             }
@@ -513,10 +511,13 @@ impl RunLoop {
                     // put the error into the "dumb" unified error.
                     let error = match error {
                         parts::step_persist_acks::Error::StepsPersistFailed(run_loop_error) => {
-                            RunLoopError::Message(run_loop_error)
+                            Error::Message(run_loop_error)
                         }
-                        parts::step_persist_acks::Error::StepsPersisted(run_loop_error) => {
-                            run_loop_error
+                        parts::step_persist_acks::Error::StepsPersisted(steps_persisted_error) => {
+                            match steps_persisted_error {
+                                parts::step_persist_acks::StepsPersistedError::EvictInstances(backend_error) => backend_error.into(),
+                                parts::step_persist_acks::StepsPersistedError::ApplyConfirmedStep(worker_pool_error) => worker_pool_error.into(),
+                            }
                         }
                     };
                     break 'runloop Err(error);
@@ -579,6 +580,16 @@ impl RunLoop {
                     // For now we reduce all the extra useful information to just
                     // put the error into the "dumb" unified error.
                     let parts::new_instances::Error::Hydrate(error) = error;
+                    let error = match error {
+                        ops::hydrate_instances::Error::GetWorkflowVersions(backend_error) => {
+                            backend_error.into()
+                        }
+                        err @ ops::hydrate_instances::Error::IrProgramDecode { .. }
+                        | err @ ops::hydrate_instances::Error::ConvertToDag { .. }
+                        | err @ ops::hydrate_instances::Error::WorkflowCacheGetNone { .. } => {
+                            Error::Message(err.to_string())
+                        }
+                    };
                     break 'runloop Err(error);
                 }
             }
@@ -616,7 +627,7 @@ impl RunLoop {
                     // put the error into the "dumb" unified error.
                     let error = match error {
                         err @ parts::steps::Error::SubmittingPersistBatch => {
-                            RunLoopError::Message(err.to_string())
+                            Error::Message(err.to_string())
                         }
                     };
                     break 'runloop Err(error);
@@ -646,7 +657,7 @@ impl RunLoop {
                     // For now we reduce all the extra useful information to just
                     // put the error into the "dumb" unified error.
                     let parts::deferred_instances::Error::EvictInstance(error) = error;
-                    break 'runloop Err(error);
+                    break 'runloop Err(error.into());
                 }
             }
 
@@ -660,7 +671,7 @@ impl RunLoop {
                     })
                     .await
             {
-                break 'runloop Err(err);
+                break 'runloop Err(err.into());
             }
         };
 
@@ -694,7 +705,7 @@ impl RunLoop {
             })
             .await
         {
-            run_result = Err(err);
+            run_result = Err(err.into());
         }
 
         for sender in shard_senders {

--- a/crates/lib/runloop/src/runloop/ops/apply_confirmed_step.rs
+++ b/crates/lib/runloop/src/runloop/ops/apply_confirmed_step.rs
@@ -14,7 +14,7 @@ use waymark_runner::SleepRequest;
 use crate::{
     commit_barrier::CommitBarrier,
     instance_lock_heartbeat,
-    runloop::{InflightActionDispatch, RunLoopError, SleepWake},
+    runloop::{InflightActionDispatch, SleepWake},
     shard,
 };
 
@@ -61,7 +61,9 @@ pub struct Params<'a, WorkerPool: ?Sized> {
 /// - Spawns background sleep timers that trigger wake events when ready
 ///
 /// The `skip_sleep` flag is used during testing/debugging to immediately wake all sleeps.
-pub fn run<WorkerPool>(params: Params<'_, WorkerPool>) -> Result<(), RunLoopError>
+pub fn run<WorkerPool>(
+    params: Params<'_, WorkerPool>,
+) -> Result<(), waymark_worker_core::WorkerPoolError>
 where
     WorkerPool: ?Sized + waymark_worker_core::BaseWorkerPool,
 {

--- a/crates/lib/runloop/src/runloop/ops/apply_confirmed_step/tests.rs
+++ b/crates/lib/runloop/src/runloop/ops/apply_confirmed_step/tests.rs
@@ -9,7 +9,7 @@ use waymark_worker_core::{ActionRequest, WorkerPoolError};
 use crate::commit_barrier::CommitBarrier;
 use crate::instance_lock_heartbeat;
 use crate::runloop::test_support::{MockWorkerPool, assert_no_extra_worker_pool_calls};
-use crate::runloop::{InflightActionDispatch, RunLoopError, SleepWake};
+use crate::runloop::{InflightActionDispatch, SleepWake};
 use crate::shard;
 
 struct TestHarness {
@@ -155,13 +155,8 @@ async fn queue_error_is_returned() {
         .returning(|_| Err(WorkerPoolError::new("MockQueueError", "mock queue failure")));
 
     let err = super::run(harness.params(step)).expect_err("queue should fail");
-    match err {
-        RunLoopError::WorkerPool(pool_err) => {
-            assert_eq!(pool_err.kind, "MockQueueError");
-            assert_eq!(pool_err.message, "mock queue failure");
-        }
-        _ => panic!("expected worker pool error"),
-    }
+    assert_eq!(err.kind, "MockQueueError");
+    assert_eq!(err.message, "mock queue failure");
 
     assert_no_extra_worker_pool_calls(&mut harness.worker_pool);
 }

--- a/crates/lib/runloop/src/runloop/ops/evict_instances.rs
+++ b/crates/lib/runloop/src/runloop/ops/evict_instances.rs
@@ -4,11 +4,7 @@ use chrono::{DateTime, Utc};
 use uuid::Uuid;
 use waymark_runner::SleepRequest;
 
-use crate::{
-    instance_lock_heartbeat,
-    runloop::{InflightActionDispatch, RunLoopError},
-    shard,
-};
+use crate::{instance_lock_heartbeat, runloop::InflightActionDispatch, shard};
 
 pub struct Params<'a, CoreBackend: ?Sized> {
     /// Maps each active instance/executor to the shard currently responsible for it.
@@ -45,7 +41,9 @@ pub struct Params<'a, CoreBackend: ?Sized> {
 ///
 /// Eviction occurs when instances have exceeded error thresholds, resource limits,
 /// or are explicitly terminated by callers.
-pub async fn run<CoreBackend>(params: Params<'_, CoreBackend>) -> Result<(), RunLoopError>
+pub async fn run<CoreBackend>(
+    params: Params<'_, CoreBackend>,
+) -> Result<(), waymark_backends_core::BackendError>
 where
     CoreBackend: ?Sized + waymark_core_backend::CoreBackend,
 {

--- a/crates/lib/runloop/src/runloop/ops/flush_instances_done.rs
+++ b/crates/lib/runloop/src/runloop/ops/flush_instances_done.rs
@@ -1,7 +1,5 @@
 use waymark_core_backend::InstanceDone;
 
-use crate::runloop::RunLoopError;
-
 #[cfg(test)]
 mod tests;
 
@@ -20,7 +18,9 @@ pub struct Params<'a, CoreBackend: ?Sized> {
 ///
 /// This ensures that the runloop's in-memory instance state accurately reflects
 /// the authoritative backend state, even if the runloop crashes.
-pub async fn run<CoreBackend>(params: Params<'_, CoreBackend>) -> Result<(), RunLoopError>
+pub async fn run<CoreBackend>(
+    params: Params<'_, CoreBackend>,
+) -> Result<(), waymark_backends_core::BackendError>
 where
     CoreBackend: ?Sized + waymark_core_backend::CoreBackend,
 {

--- a/crates/lib/runloop/src/runloop/ops/hydrate_instances.rs
+++ b/crates/lib/runloop/src/runloop/ops/hydrate_instances.rs
@@ -4,8 +4,6 @@ use uuid::Uuid;
 use waymark_core_backend::QueuedInstance;
 use waymark_proto::ast as ir;
 
-use crate::runloop::RunLoopError;
-
 pub struct Params<'a, WorkflowRegistryBackend: ?Sized> {
     /// Cache of workflow DAGs keyed by workflow version ID to avoid repeated hydration work.
     pub workflow_cache: &'a mut HashMap<Uuid, Arc<waymark_dag::DAG>>,
@@ -13,6 +11,21 @@ pub struct Params<'a, WorkflowRegistryBackend: ?Sized> {
     pub registry_backend: &'a WorkflowRegistryBackend,
     /// Claimed instances that need DAG references attached before shard execution.
     pub instances: &'a mut [QueuedInstance],
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("get workflow versions: {0}")]
+    GetWorkflowVersions(#[source] waymark_backends_core::BackendError),
+
+    #[error("invalid workflow IR: {0}")]
+    IrProgramDecode(#[source] prost::DecodeError),
+
+    #[error("invalid workflow DAG: {0}")]
+    ConvertToDag(#[source] waymark_dag::DagConversionError),
+
+    #[error("workflow version not found: {workflow_version_id}")]
+    WorkflowCacheGetNone { workflow_version_id: uuid::Uuid },
 }
 
 /// Loads and caches workflow DAG definitions for instances.
@@ -28,7 +41,7 @@ pub struct Params<'a, WorkflowRegistryBackend: ?Sized> {
 /// Caching avoids repeated fetches for workflows used by multiple instances.
 pub async fn run<WorkflowRegistryBackend>(
     params: Params<'_, WorkflowRegistryBackend>,
-) -> Result<(), RunLoopError>
+) -> Result<(), Error>
 where
     WorkflowRegistryBackend: ?Sized + waymark_workflow_registry_backend::WorkflowRegistryBackend,
 {
@@ -51,12 +64,11 @@ where
         let versions = registry_backend
             .get_workflow_versions(&missing)
             .await
-            .map_err(RunLoopError::Backend)?;
+            .map_err(Error::GetWorkflowVersions)?;
         for version in versions {
             let program = <ir::Program as prost::Message>::decode(&version.program_proto[..])
-                .map_err(|err| RunLoopError::Message(format!("invalid workflow IR: {err}")))?;
-            let dag = waymark_dag_builder::convert_to_dag(&program)
-                .map_err(|err| RunLoopError::Message(format!("invalid workflow DAG: {err}")))?;
+                .map_err(Error::IrProgramDecode)?;
+            let dag = waymark_dag_builder::convert_to_dag(&program).map_err(Error::ConvertToDag)?;
             workflow_cache.insert(version.id, Arc::new(dag));
         }
     }
@@ -64,11 +76,8 @@ where
     for instance in instances.iter_mut() {
         let dag = workflow_cache
             .get(&instance.workflow_version_id)
-            .ok_or_else(|| {
-                RunLoopError::Message(format!(
-                    "workflow version not found: {}",
-                    instance.workflow_version_id
-                ))
+            .ok_or_else(|| Error::WorkflowCacheGetNone {
+                workflow_version_id: instance.workflow_version_id,
             })?;
         instance.dag = Some(Arc::clone(dag));
     }

--- a/crates/lib/runloop/src/runloop/parts/deferred_instances.rs
+++ b/crates/lib/runloop/src/runloop/parts/deferred_instances.rs
@@ -41,7 +41,7 @@ pub struct Params<'a, CoreBackend: ?Sized> {
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error("evict instance: {0}")]
-    EvictInstance(#[source] crate::RunLoopError),
+    EvictInstance(#[source] waymark_backends_core::BackendError),
 }
 
 /// Evicts instances that have been sleeping too long.

--- a/crates/lib/runloop/src/runloop/parts/new_instances.rs
+++ b/crates/lib/runloop/src/runloop/parts/new_instances.rs
@@ -58,7 +58,7 @@ pub struct Params<'a, WorkflowRegistryBackend: ?Sized> {
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error("hydrate: {0}")]
-    Hydrate(#[source] crate::RunLoopError),
+    Hydrate(#[source] super::ops::hydrate_instances::Error),
 }
 
 /// Registers new instances into the runloop and initializes their state.

--- a/crates/lib/runloop/src/runloop/parts/step_persist_acks.rs
+++ b/crates/lib/runloop/src/runloop/parts/step_persist_acks.rs
@@ -21,7 +21,7 @@ mod tests;
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error("steps persted: {0}")]
-    StepsPersisted(#[source] crate::RunLoopError),
+    StepsPersisted(StepsPersistedError),
 
     #[error("steps persist failed: {0}")]
     StepsPersistFailed(String),
@@ -180,9 +180,18 @@ struct StepsPersistedParams<'a, CoreBackend: ?Sized, WorkerPool: ?Sized> {
     pub lock_statuses: Vec<InstanceLockStatus>,
 }
 
+#[derive(Debug, thiserror::Error)]
+pub enum StepsPersistedError {
+    #[error("evict instances: {0}")]
+    EvictInstances(#[source] waymark_backends_core::BackendError),
+
+    #[error("apply confirmed step: {0}")]
+    ApplyConfirmedStep(#[source] waymark_worker_core::WorkerPoolError),
+}
+
 async fn handle_steps_persisted<CoreBackend, WorkerPool>(
     params: StepsPersistedParams<'_, CoreBackend, WorkerPool>,
-) -> Result<(), crate::RunLoopError>
+) -> Result<(), StepsPersistedError>
 where
     CoreBackend: ?Sized + waymark_core_backend::CoreBackend,
     WorkerPool: ?Sized + waymark_worker_core::BaseWorkerPool,
@@ -229,7 +238,9 @@ where
             instance_ids: &evict_ids_vec,
         };
 
-        super::ops::evict_instances::run(params).await?;
+        super::ops::evict_instances::run(params)
+            .await
+            .map_err(StepsPersistedError::EvictInstances)?;
     }
     for step in batch.steps {
         if !batch.instance_ids.contains(&step.executor_id) {
@@ -257,7 +268,8 @@ where
             skip_sleep,
             step,
         };
-        super::ops::apply_confirmed_step::run(params)?;
+        super::ops::apply_confirmed_step::run(params)
+            .map_err(StepsPersistedError::ApplyConfirmedStep)?;
     }
 
     for instance_id in batch.instance_ids {

--- a/crates/lib/runloop/src/shard/executor.rs
+++ b/crates/lib/runloop/src/shard/executor.rs
@@ -6,7 +6,7 @@ use waymark_core_backend::InstanceDone;
 use waymark_runner::{RunnerExecutor, replay_variables};
 use waymark_worker_core::{ActionCompletion, ActionRequest};
 
-use crate::{RunLoopError, error_value};
+use crate::error_value;
 
 pub(super) struct Executor {
     pub executor_id: Uuid,
@@ -26,16 +26,41 @@ impl Executor {
             completed: false,
         }
     }
+}
 
-    pub fn start(&mut self) -> Result<super::Step, RunLoopError> {
-        let step = self.executor.increment(&[self.entry_node])?;
-        self.apply_step(step)
+#[derive(Debug, thiserror::Error)]
+pub enum StartError {
+    #[error("increment: {0}")]
+    Increment(#[source] waymark_runner::RunnerExecutorError),
+
+    #[error("apply step: {0}")]
+    ApplyStep(#[source] ApplyStepError),
+}
+
+impl Executor {
+    pub fn start(&mut self) -> Result<super::Step, StartError> {
+        let step = self
+            .executor
+            .increment(&[self.entry_node])
+            .map_err(StartError::Increment)?;
+        self.apply_step(step).map_err(StartError::ApplyStep)
     }
+}
 
+#[derive(Debug, thiserror::Error)]
+pub enum HandleCompletionsError {
+    #[error("increment: {0}")]
+    Increment(#[source] waymark_runner::RunnerExecutorError),
+
+    #[error("apply step: {0}")]
+    ApplyStep(#[source] ApplyStepError),
+}
+
+impl Executor {
     pub fn handle_completions(
         &mut self,
         completions: Vec<ActionCompletion>,
-    ) -> Result<Option<super::Step>, RunLoopError> {
+    ) -> Result<Option<super::Step>, HandleCompletionsError> {
         let mut finished_nodes = Vec::new();
         for completion in completions {
             self.executor
@@ -46,14 +71,31 @@ impl Executor {
         if finished_nodes.is_empty() {
             return Ok(None);
         }
-        let step = self.executor.increment(&finished_nodes)?;
-        Ok(Some(self.apply_step(step)?))
+        let step = self
+            .executor
+            .increment(&finished_nodes)
+            .map_err(HandleCompletionsError::Increment)?;
+        let step = self
+            .apply_step(step)
+            .map_err(HandleCompletionsError::ApplyStep)?;
+        Ok(Some(step))
     }
+}
 
+#[derive(Debug, thiserror::Error)]
+pub enum HandleWakeError {
+    #[error("increment: {0}")]
+    Increment(#[source] waymark_runner::RunnerExecutorError),
+
+    #[error("apply step: {0}")]
+    ApplyStep(#[source] ApplyStepError),
+}
+
+impl Executor {
     pub fn handle_wake(
         &mut self,
         node_ids: Vec<Uuid>,
-    ) -> Result<Option<super::Step>, RunLoopError> {
+    ) -> Result<Option<super::Step>, HandleWakeError> {
         let mut finished_nodes = Vec::new();
         for node_id in node_ids {
             if self.executor.state().nodes.contains_key(&node_id) {
@@ -64,32 +106,57 @@ impl Executor {
         if finished_nodes.is_empty() {
             return Ok(None);
         }
-        let step = self.executor.increment(&finished_nodes)?;
-        Ok(Some(self.apply_step(step)?))
+        let step = self
+            .executor
+            .increment(&finished_nodes)
+            .map_err(HandleWakeError::Increment)?;
+        let step = self.apply_step(step).map_err(HandleWakeError::ApplyStep)?;
+        Ok(Some(step))
     }
+}
+#[derive(Debug, thiserror::Error)]
+pub enum ApplyStepError {
+    #[error("action node missing action spec")]
+    NoActionSpec,
 
+    #[error("resolve action kwargs: {0}")]
+    ResolveActionKwargs(#[source] waymark_runner::RunnerExecutorError),
+
+    #[error("action timeout seconds: {0}")]
+    ActionTimeoutSeconds(#[source] waymark_runner::RunnerExecutorError),
+
+    #[error("invalid negative action attempt for node {node_id}: {action_attempt}")]
+    NegativeAction {
+        node_id: uuid::Uuid,
+        action_attempt: i32,
+    },
+}
+
+impl Executor {
     fn apply_step(
         &mut self,
         step: waymark_runner::ExecutorStep,
-    ) -> Result<super::Step, RunLoopError> {
+    ) -> Result<super::Step, ApplyStepError> {
         let mut actions = Vec::new();
         let mut sleep_requests = Vec::new();
         for action in &step.actions {
-            let action_spec = action.action.clone().ok_or_else(|| {
-                RunLoopError::Message("action node missing action spec".to_string())
-            })?;
+            let action_spec = action.action.clone().ok_or(ApplyStepError::NoActionSpec)?;
             if self.inflight.contains(&action.node_id) {
                 continue;
             }
             let kwargs = self
                 .executor
-                .resolve_action_kwargs(action.node_id, &action_spec)?;
-            let timeout_seconds = self.executor.action_timeout_seconds(action.node_id)?;
+                .resolve_action_kwargs(action.node_id, &action_spec)
+                .map_err(ApplyStepError::ResolveActionKwargs)?;
+            let timeout_seconds = self
+                .executor
+                .action_timeout_seconds(action.node_id)
+                .map_err(ApplyStepError::ActionTimeoutSeconds)?;
             let attempt_number = u32::try_from(action.action_attempt).map_err(|_| {
-                RunLoopError::Message(format!(
-                    "invalid negative action attempt for node {}",
-                    action.node_id
-                ))
+                ApplyStepError::NegativeAction {
+                    node_id: action.node_id,
+                    action_attempt: action.action_attempt,
+                }
             })?;
             actions.push(ActionRequest {
                 executor_id: self.executor_id,

--- a/crates/lib/runloop/src/shard/run.rs
+++ b/crates/lib/runloop/src/shard/run.rs
@@ -8,7 +8,31 @@ use tracing::{debug, warn};
 use uuid::Uuid;
 use waymark_worker_core::ActionCompletion;
 
-use crate::{RunLoopError, shard};
+use crate::shard;
+
+#[derive(Debug, thiserror::Error)]
+pub enum AssignInstancesError {
+    #[error("queued instance missing runner state")]
+    QueuedInstanceMissingRunnerState,
+
+    #[error("queued instance missing workflow DAG")]
+    QueuedInstanceMissingWorkflowDag,
+
+    #[error("start: {0}")]
+    Start(#[source] super::executor::StartError),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("assign instances: {0}")]
+    AssignInstances(AssignInstancesError),
+
+    #[error("action completions: {0}")]
+    ActionCompletions(super::executor::HandleCompletionsError),
+
+    #[error("wake: {0}")]
+    Wake(super::executor::HandleWakeError),
+}
 
 pub fn run_executor_shard(
     shard_id: usize,
@@ -21,7 +45,7 @@ pub fn run_executor_shard(
     let send_instance_failed =
         |executor_id: Uuid,
          entry_node: Uuid,
-         err: RunLoopError,
+         err: Error,
          sender: &mpsc::UnboundedSender<shard::Event>| {
             let _ = sender.send(shard::Event::InstanceFailed {
                 executor_id,
@@ -49,34 +73,31 @@ pub fn run_executor_shard(
                             "replacing active executor state for reclaimed instance"
                         );
                     }
-                    let state = match instance.state {
-                        Some(state) => state,
-                        None => {
-                            send_instance_failed(
-                                instance.instance_id,
-                                instance.entry_node,
-                                RunLoopError::Message(
-                                    "queued instance missing runner state".to_string(),
-                                ),
-                                &sender,
-                            );
-                            continue;
-                        }
+
+                    let Some(state) = instance.state else {
+                        send_instance_failed(
+                            instance.instance_id,
+                            instance.entry_node,
+                            Error::AssignInstances(
+                                AssignInstancesError::QueuedInstanceMissingRunnerState,
+                            ),
+                            &sender,
+                        );
+                        continue;
                     };
-                    let dag = match instance.dag {
-                        Some(dag) => dag,
-                        None => {
-                            send_instance_failed(
-                                instance.instance_id,
-                                instance.entry_node,
-                                RunLoopError::Message(
-                                    "queued instance missing workflow DAG".to_string(),
-                                ),
-                                &sender,
-                            );
-                            continue;
-                        }
+
+                    let Some(dag) = instance.dag else {
+                        send_instance_failed(
+                            instance.instance_id,
+                            instance.entry_node,
+                            Error::AssignInstances(
+                                AssignInstancesError::QueuedInstanceMissingWorkflowDag,
+                            ),
+                            &sender,
+                        );
+                        continue;
                     };
+
                     let mut executor = waymark_runner::RunnerExecutor::new(
                         dag,
                         state,
@@ -84,6 +105,7 @@ pub fn run_executor_shard(
                         Some(backend.clone()),
                     );
                     executor.set_instance_id(instance.instance_id);
+
                     let mut owner =
                         shard::Executor::new(instance.instance_id, executor, instance.entry_node);
                     let step = match owner.start() {
@@ -92,7 +114,7 @@ pub fn run_executor_shard(
                             send_instance_failed(
                                 instance.instance_id,
                                 instance.entry_node,
-                                err,
+                                Error::AssignInstances(AssignInstancesError::Start(err)),
                                 &sender,
                             );
                             continue;
@@ -130,7 +152,12 @@ pub fn run_executor_shard(
                         Err(err) => {
                             let entry_node = owner.entry_node;
                             executors.remove(&executor_id);
-                            send_instance_failed(executor_id, entry_node, err, &sender);
+                            send_instance_failed(
+                                executor_id,
+                                entry_node,
+                                Error::ActionCompletions(err),
+                                &sender,
+                            );
                             continue;
                         }
                     };
@@ -163,7 +190,12 @@ pub fn run_executor_shard(
                         Err(err) => {
                             let entry_node = owner.entry_node;
                             executors.remove(&executor_id);
-                            send_instance_failed(executor_id, entry_node, err, &sender);
+                            send_instance_failed(
+                                executor_id,
+                                entry_node,
+                                Error::Wake(err),
+                                &sender,
+                            );
                             continue;
                         }
                     };


### PR DESCRIPTION
This PR applies semantic error structuring to the inner errors that we aim to expose; we don't address the nature of the `RunLoopError` just yet - but we cover a lot of prerequisites here.

This piece of work was needed to eliminate a common dependency - unlocking further separation of the code.