### PR TITLE
Drop support for dyn-clones for core backend

### DIFF
--- a/crates/bin/bridge/src/main.rs
+++ b/crates/bin/bridge/src/main.rs
@@ -166,10 +166,6 @@ impl InMemoryBackend {
 
 #[async_trait]
 impl CoreBackend for InMemoryBackend {
-    fn clone_box(&self) -> Box<dyn CoreBackend> {
-        Box::new(self.clone())
-    }
-
     async fn save_graphs(
         &self,
         claim: LockClaim,

--- a/crates/lib/backend-fault-injection/src/lib.rs
+++ b/crates/lib/backend-fault-injection/src/lib.rs
@@ -48,10 +48,6 @@ impl FaultInjectingBackend {
 
 #[async_trait::async_trait]
 impl CoreBackend for FaultInjectingBackend {
-    fn clone_box(&self) -> Box<dyn CoreBackend> {
-        Box::new(self.clone())
-    }
-
     async fn save_graphs(
         &self,
         claim: LockClaim,

--- a/crates/lib/backend-memory/src/core_backend.rs
+++ b/crates/lib/backend-memory/src/core_backend.rs
@@ -8,10 +8,6 @@ use waymark_core_backend::{
 
 #[async_trait::async_trait]
 impl waymark_core_backend::CoreBackend for crate::MemoryBackend {
-    fn clone_box(&self) -> Box<dyn waymark_core_backend::CoreBackend> {
-        Box::new(self.clone())
-    }
-
     async fn save_graphs(
         &self,
         claim: LockClaim,

--- a/crates/lib/backend-postgres/src/core.rs
+++ b/crates/lib/backend-postgres/src/core.rs
@@ -845,10 +845,6 @@ impl PostgresBackend {
 
 #[async_trait::async_trait]
 impl waymark_core_backend::CoreBackend for PostgresBackend {
-    fn clone_box(&self) -> Box<dyn waymark_core_backend::CoreBackend> {
-        Box::new(self.clone())
-    }
-
     async fn save_graphs(
         &self,
         claim: waymark_core_backend::LockClaim,

--- a/crates/lib/core-backend/src/lib.rs
+++ b/crates/lib/core-backend/src/lib.rs
@@ -11,8 +11,6 @@ pub use self::data::*;
 /// Abstract persistence backend for runner state.
 #[async_trait::async_trait]
 pub trait CoreBackend: Send + Sync {
-    fn clone_box(&self) -> Box<dyn CoreBackend>;
-
     /// Persist updated execution graphs.
     async fn save_graphs(
         &self,
@@ -49,10 +47,4 @@ pub trait CoreBackend: Send + Sync {
 
     /// Insert queued instances for run-loop consumption.
     async fn queue_instances(&self, instances: &[QueuedInstance]) -> BackendResult<()>;
-}
-
-impl Clone for Box<dyn CoreBackend> {
-    fn clone(&self) -> Self {
-        self.clone_box()
-    }
 }


### PR DESCRIPTION
`dyn`-clones are not used anywhere, so it makes sense to remove them. We'll be moving away from `dyn`-traits and moving towards the generics as part of the efforts to improve type-safety.