### PR TITLE
Refactor and place send_with_stop in specialized utils crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -816,6 +816,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -836,6 +847,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -3806,6 +3818,7 @@ dependencies = [
  "waymark-proto",
  "waymark-runner",
  "waymark-runner-state",
+ "waymark-utils-tokio-channel",
  "waymark-worker-core",
  "waymark-worker-inline",
  "waymark-workflow-registry-backend",
@@ -3997,6 +4010,24 @@ version = "0.1.0"
 dependencies = [
  "sqlx",
  "waymark-support-integration",
+]
+
+[[package]]
+name = "waymark-utils-futures"
+version = "0.1.0"
+dependencies = [
+ "futures-util",
+ "thiserror",
+]
+
+[[package]]
+name = "waymark-utils-tokio-channel"
+version = "0.1.0"
+dependencies = [
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "waymark-utils-futures",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,8 @@ waymark-scheduler-loop = { path = "crates/lib/scheduler-loop" }
 waymark-smoke-sources = { path = "crates/lib/smoke-sources" }
 waymark-support-integration = { path = "crates/lib/support-integration" }
 waymark-support-test = { path = "crates/lib/support-test" }
+waymark-utils-futures = { path = "crates/lib/utils-futures" }
+waymark-utils-tokio-channel = { path = "crates/lib/utils-tokio-channel" }
 waymark-webapp-backend = { path = "crates/lib/webapp-backend" }
 waymark-webapp-bringup = { path = "crates/lib/webapp-bringup" }
 waymark-webapp-config = { path = "crates/lib/webapp-config" }
@@ -62,6 +64,7 @@ clap = "4.5"
 console-subscriber = "0.5"
 cron = "0.12"
 futures-core = "0.3"
+futures-util = "0.3"
 http-body-util = "0.1"
 mockall = "0.14"
 proc-macro2 = "1"

--- a/crates/lib/runloop/Cargo.toml
+++ b/crates/lib/runloop/Cargo.toml
@@ -12,6 +12,7 @@ waymark-dag-builder = { workspace = true }
 waymark-observability = { workspace = true }
 waymark-proto = { workspace = true }
 waymark-runner = { workspace = true }
+waymark-utils-tokio-channel = { workspace = true }
 waymark-worker-core = { workspace = true }
 waymark-workflow-registry-backend = { workspace = true }
 

--- a/crates/lib/runloop/src/completions_polling/loop.rs
+++ b/crates/lib/runloop/src/completions_polling/loop.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use tracing::{debug, info};
 use waymark_worker_core::ActionCompletion;
 
-use crate::channel_utils::send_with_stop;
+use waymark_utils_tokio_channel::send_with_stop;
 
 pub struct Params<WorkerPool>
 where

--- a/crates/lib/runloop/src/lib.rs
+++ b/crates/lib/runloop/src/lib.rs
@@ -4,7 +4,6 @@ mod available_instance_slots;
 mod commit_barrier;
 mod runloop;
 
-mod channel_utils;
 mod error_value;
 
 mod completions_polling;

--- a/crates/lib/runloop/src/queued_instances_polling/loop.rs
+++ b/crates/lib/runloop/src/queued_instances_polling/loop.rs
@@ -5,9 +5,9 @@ use chrono::Utc;
 use tracing::{debug, info};
 use uuid::Uuid;
 use waymark_core_backend::{LockClaim, QueuedInstanceBatch};
+use waymark_utils_tokio_channel::send_with_stop;
 
 use crate::available_instance_slots;
-use crate::channel_utils::send_with_stop;
 
 pub struct Params<CoreBackend>
 where

--- a/crates/lib/runloop/src/runloop/parts/steps.rs
+++ b/crates/lib/runloop/src/runloop/parts/steps.rs
@@ -1,8 +1,9 @@
 use std::collections::HashSet;
 
 use uuid::Uuid;
+use waymark_utils_tokio_channel::send_with_stop;
 
-use crate::{channel_utils::send_with_stop, commit_barrier::CommitBarrier, persist, shard};
+use crate::{commit_barrier::CommitBarrier, persist, shard};
 
 #[cfg(test)]
 mod tests;

--- a/crates/lib/utils-futures/Cargo.toml
+++ b/crates/lib/utils-futures/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "waymark-utils-futures"
+edition = "2024"
+version.workspace = true
+publish.workspace = true
+
+[dependencies]
+futures-util = { workspace = true }
+thiserror = { workspace = true }

--- a/crates/lib/utils-futures/src/lib.rs
+++ b/crates/lib/utils-futures/src/lib.rs
@@ -1,0 +1,5 @@
+pub mod with_cancellation;
+pub mod with_race_callback;
+
+pub use self::with_cancellation::with_cancellation;
+pub use self::with_race_callback::with_race_callback;

--- a/crates/lib/utils-futures/src/with_cancellation.rs
+++ b/crates/lib/utils-futures/src/with_cancellation.rs
@@ -1,0 +1,27 @@
+use futures_util::future::Either;
+
+pub async fn with_cancellation<PayloadFut, CancellationSignalFut>(
+    payload_fut: PayloadFut,
+    cancellation_signal_fut: CancellationSignalFut,
+) -> Result<PayloadFut::Output, CancelledError<PayloadFut>>
+where
+    PayloadFut: Future + Unpin,
+    CancellationSignalFut: Future<Output = ()>,
+{
+    let cancellation_signal_fut = std::pin::pin!(cancellation_signal_fut);
+
+    let either = futures_util::future::select(payload_fut, cancellation_signal_fut).await;
+    match either {
+        Either::Left((payload_outcome, _)) => Ok(payload_outcome),
+        Either::Right(((), payload_fut)) => Err(CancelledError { payload_fut }),
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("cancelled")]
+pub struct CancelledError<PayloadFut> {
+    /// The payload future provided in the error in case the caller decides
+    /// to resume polling it.
+    /// Can also be dropped for actual cancellation.
+    pub payload_fut: PayloadFut,
+}

--- a/crates/lib/utils-futures/src/with_race_callback.rs
+++ b/crates/lib/utils-futures/src/with_race_callback.rs
@@ -1,0 +1,22 @@
+use futures_util::future::Either;
+
+pub async fn with_race_callback<PayloadFut, RaceFut>(
+    payload_fut: PayloadFut,
+    race_fut: RaceFut,
+    callback_fn: impl FnOnce(),
+) -> PayloadFut::Output
+where
+    PayloadFut: Future + Unpin,
+    RaceFut: Future<Output = ()>,
+{
+    let race_fut = std::pin::pin!(race_fut);
+
+    let either = futures_util::future::select(payload_fut, race_fut).await;
+    match either {
+        Either::Left((payload_outcome, _)) => payload_outcome,
+        Either::Right(((), payload_fut)) => {
+            callback_fn();
+            payload_fut.await
+        }
+    }
+}

--- a/crates/lib/utils-tokio-channel/Cargo.toml
+++ b/crates/lib/utils-tokio-channel/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "waymark-utils-tokio-channel"
+edition = "2024"
+version.workspace = true
+publish.workspace = true
+
+[dependencies]
+waymark-utils-futures = { workspace = true }
+
+tokio = { workspace = true, features = ["time", "sync"] }
+tracing = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tokio-util = { workspace = true }

--- a/crates/lib/utils-tokio-channel/src/lib.rs
+++ b/crates/lib/utils-tokio-channel/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod send_with_stop;
+
+pub use self::send_with_stop::send_with_stop;

--- a/crates/lib/utils-tokio-channel/src/send_with_stop.rs
+++ b/crates/lib/utils-tokio-channel/src/send_with_stop.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use tracing::{info, warn};
+use waymark_utils_futures::{with_cancellation, with_race_callback};
 
 /// Sends an item into a bounded channel while racing against a cancellation token.
 ///
@@ -12,41 +12,42 @@ use tracing::{info, warn};
 /// the cancellation future, guaranteeing the task can exit cleanly. It also warns if the
 /// send is pending for more than 2 seconds, surfacing backpressure during normal operation.
 #[tracing::instrument(skip_all, fields(kind))]
-pub async fn send_with_stop<T>(
+pub async fn send_with_stop<T, CancellationSignalFut>(
     tx: &tokio::sync::mpsc::Sender<T>,
     item: T,
-    stop: tokio_util::sync::WaitForCancellationFuture<'_>,
+    stop: CancellationSignalFut,
     #[allow(unused_variables)] kind: &'static str, // used in tracing span
-) -> Result<(), SendWithStopError<T>> {
-    let mut send_fut = std::pin::pin!(tx.send(item));
-    let mut stop = std::pin::pin!(stop);
+) -> Result<(), Error<T>>
+where
+    CancellationSignalFut: Future<Output = ()>,
+{
+    let fut = tx.send(item);
 
-    let mut warned = false;
-    loop {
-        tokio::select! {
-            res = &mut send_fut => {
-                return match res {
-                    Ok(val) => Ok(val),
-                    Err(err) => {
-                        warn!("receiver dropped");
-                        Err(SendWithStopError::Send(err))
-                    }
-                }
-            }
-            _ = &mut stop => {
-                info!("sender stop notified during send");
-                return Err(SendWithStopError::Stop);
-            }
-            _ = tokio::time::sleep(Duration::from_secs(2)), if !warned => {
-                warn!("send pending >2s");
-                warned = true;
-            }
+    let fut = std::pin::pin!(fut);
+    let fut = with_race_callback(fut, tokio::time::sleep(Duration::from_secs(2)), || {
+        tracing::warn!("send pending >2s")
+    });
+
+    let fut = std::pin::pin!(fut);
+    let fut = with_cancellation(fut, stop);
+
+    let result = fut.await;
+
+    match result {
+        Ok(Ok(val)) => Ok(val),
+        Ok(Err(send_error)) => {
+            tracing::warn!("receiver dropped");
+            Err(Error::ReceiverDropped(send_error))
+        }
+        Err(with_cancellation::CancelledError { .. }) => {
+            tracing::info!("sender stop notified during send");
+            return Err(Error::Stop);
         }
     }
 }
 
-pub enum SendWithStopError<T> {
-    Send(tokio::sync::mpsc::error::SendError<T>),
+pub enum Error<T> {
+    ReceiverDropped(tokio::sync::mpsc::error::SendError<T>),
     Stop,
 }
 
@@ -74,7 +75,7 @@ mod tests {
             .expect("send task should complete")
             .expect("send task should not panic");
         assert!(
-            matches!(sent, Err(SendWithStopError::Stop)),
+            matches!(sent, Err(Error::Stop)),
             "send should abort when stop is notified"
         );
 
@@ -89,7 +90,7 @@ mod tests {
         let shutdown_token = tokio_util::sync::CancellationToken::new();
         let sent = send_with_stop(&tx, 99, shutdown_token.cancelled(), "test message").await;
         assert!(
-            matches!(sent, Err(SendWithStopError::Stop)),
+            matches!(sent, Err(Error::ReceiverDropped(_))),
             "send should fail when receiver is dropped"
         );
     }


### PR DESCRIPTION
This PR sets up the pattern for util crates.

Goes in after https://github.com/piercefreeman/waymark/pull/256.