### PR TITLE
Proper impls for send_with_stop error

### DIFF
--- a/crates/lib/utils-tokio-channel/src/send_with_stop.rs
+++ b/crates/lib/utils-tokio-channel/src/send_with_stop.rs
@@ -51,6 +51,33 @@ pub enum Error<T> {
     Stop,
 }
 
+impl<T> core::fmt::Debug for Error<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ReceiverDropped(arg0) => f.debug_tuple("ReceiverDropped").field(arg0).finish(),
+            Self::Stop => write!(f, "Stop"),
+        }
+    }
+}
+
+impl<T> core::fmt::Display for Error<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ReceiverDropped(_) => write!(f, "receiver dropped"),
+            Self::Stop => write!(f, "stop"),
+        }
+    }
+}
+
+impl<T> core::error::Error for Error<T> {
+    fn cause(&self) -> Option<&dyn std::error::Error> {
+        match self {
+            Self::ReceiverDropped(val) => Some(val as _),
+            Self::Stop => None,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
We don't use `thiserror` here cause we need ti eliminate certain trait bounds. It doesn't do that; there are other crates that do it (`derive_more`), but we can consider it later.