### PR TITLE
Switch to AsyncFnMut at waymark-tick-loop

### DIFF
--- a/crates/lib/runloop/src/queued_instances_polling/loop.rs
+++ b/crates/lib/runloop/src/queued_instances_polling/loop.rs
@@ -39,55 +39,53 @@ where
         queued_instance_tx,
     } = params;
 
-    let available_instance_slots_tracker = available_instance_slots_tracker.as_ref();
-    let core_backend = core_backend.as_ref();
-    let queued_instance_tx = &queued_instance_tx;
-    let shutdown_token = &shutdown_token;
+    let tick_fn = {
+        let shutdown_token = shutdown_token.clone();
+        async move || {
+            let available_slots = available_instance_slots_tracker.get();
+            let Some(batch_size) = std::num::NonZeroUsize::new(available_slots) else {
+                return Ok(());
+            };
 
-    let tick_fn = || async move {
-        let available_slots = available_instance_slots_tracker.get();
-        let Some(batch_size) = std::num::NonZeroUsize::new(available_slots) else {
-            return Ok(());
-        };
+            let lock_expires_at = Utc::now()
+                + chrono::Duration::from_std(lock_ttl.get())
+                    .unwrap_or_else(|_| chrono::Duration::seconds(0));
+            let batch = core_backend
+                .poll_queued_instances(
+                    batch_size,
+                    LockClaim {
+                        lock_uuid,
+                        lock_expires_at,
+                    },
+                )
+                .await;
 
-        let lock_expires_at = Utc::now()
-            + chrono::Duration::from_std(lock_ttl.get())
-                .unwrap_or_else(|_| chrono::Duration::seconds(0));
-        let batch = core_backend
-            .poll_queued_instances(
-                batch_size,
-                LockClaim {
-                    lock_uuid,
-                    lock_expires_at,
+            let message = match batch {
+                Ok(instances) => {
+                    let count = instances.len();
+                    tracing::debug!(count, "polled queued instances");
+                    super::Message::Batch { instances }
+                }
+                Err(error) => match error.kind() {
+                    waymark_core_backend::poll_queued_instances::ErrorKind::NoInstances => {
+                        // No instances were obtained.
+                        tracing::trace!(?error, "no instances from core backend");
+                        super::Message::Pending
+                    }
+                    waymark_core_backend::poll_queued_instances::ErrorKind::Internal => {
+                        super::Message::Error(error)
+                    }
                 },
+            };
+
+            send_with_stop(
+                &queued_instance_tx,
+                message,
+                shutdown_token.cancelled(),
+                "instance message",
             )
-            .await;
-
-        let message = match batch {
-            Ok(instances) => {
-                let count = instances.len();
-                tracing::debug!(count, "polled queued instances");
-                super::Message::Batch { instances }
-            }
-            Err(error) => match error.kind() {
-                waymark_core_backend::poll_queued_instances::ErrorKind::NoInstances => {
-                    // No instances were obtained.
-                    tracing::trace!(?error, "no instances from core backend");
-                    super::Message::Pending
-                }
-                waymark_core_backend::poll_queued_instances::ErrorKind::Internal => {
-                    super::Message::Error(error)
-                }
-            },
-        };
-
-        send_with_stop(
-            queued_instance_tx,
-            message,
-            shutdown_token.cancelled(),
-            "instance message",
-        )
-        .await
+            .await
+        }
     };
 
     let tick_interval = poll_interval.map(|poll_interval| {

--- a/crates/lib/tick-loop/src/lib.rs
+++ b/crates/lib/tick-loop/src/lib.rs
@@ -25,12 +25,11 @@ pub enum Error<TickError> {
     Tick(TickError),
 }
 
-pub async fn run<TickFn, TickFut, TickError>(
+pub async fn run<'f, TickFn, TickError>(
     params: Params<TickFn>,
 ) -> Result<core::convert::Infallible, Error<TickError>>
 where
-    TickFn: FnMut() -> TickFut,
-    TickFut: Future<Output = Result<(), TickError>>,
+    TickFn: AsyncFnMut() -> Result<(), TickError> + 'f,
     TickError: core::fmt::Debug,
 {
     let Params {


### PR DESCRIPTION
Goes in after #266.

This PR changes how `waymark-tick-loop` captures the `tick_fn` such that borrow checker has visibility into the async closure lifetime.