### PR TITLE
Make the instance poller wait for the available slots rather than skip the tick

### DIFF
--- a/crates/lib/runloop/src/available_instance_slots.rs
+++ b/crates/lib/runloop/src/available_instance_slots.rs
@@ -2,12 +2,13 @@
 
 #![deny(missing_docs, clippy::missing_docs_in_private_items)]
 
-use std::{num::NonZeroUsize, sync::atomic::AtomicUsize};
+use std::num::NonZeroUsize;
 
 /// [`Calc`] encapsulates the notion of the available instance slots.
 /// It is responsible for providing the computations necessary to obtain
 /// the amount of available instance slots based on the max concurrent
 /// instances.
+#[derive(Debug)]
 pub struct Calc {
     /// The max amount of concurrent instances.
     /// At least one instance is required.
@@ -19,25 +20,23 @@ pub struct Calc {
 ///
 /// It also provides access to the available instance slots in an atomic and
 /// thread-safe way.
+#[derive(Debug)]
 pub struct Tracker {
     /// Calculation logic and parameters for computing the available slots.
     pub calc: Calc,
 
+    /// The handle for updating the available slots.
+    tx: tokio::sync::watch::Sender<usize>,
+}
+
+/// Read handle for observing available instance slots.
+#[derive(Debug, Clone)]
+pub struct Reader {
     /// The materialized copy of the pre-computed available slots value.
-    pub available_slots: AtomicUsize,
+    rx: tokio::sync::watch::Receiver<usize>,
 }
 
 impl Calc {
-    /// Get the amount of available slots by discounting the active instances
-    /// from the max number of instances.
-    /// Saturates to `0` if `active_instances` exceeds
-    /// the configured `max_concurrent_instances`.
-    pub fn discounting_active_saturating(&self, active_instances: usize) -> usize {
-        self.max_concurrent_instances
-            .get()
-            .saturating_sub(active_instances)
-    }
-
     /// Get the amount of available slots by discounting the active instances
     /// from the max number of instances.
     /// Returns `None` if `active_instances` exceeds
@@ -49,50 +48,74 @@ impl Calc {
     }
 }
 
+/// Errors that can happen while updating the tracked slot count.
+#[derive(Debug, thiserror::Error)]
+pub enum UpdateError {
+    /// Active instances exceed configured capacity.
+    #[error("the amount of active instances exceed the capacity")]
+    ExceedsCapacity,
+
+    /// All reader handles were dropped so updates cannot be published.
+    #[error("all readers have been dropped")]
+    NoReaders,
+}
+
+/// Indicates the tracker side was dropped while waiting for updates.
+#[derive(Debug, thiserror::Error)]
+#[error("tracker has been dropped")]
+pub struct TrackerGoneError;
+
 impl Tracker {
     /// Create a new tracker with no active instances.
-    pub fn from_scratch(calc: Calc) -> Self {
+    pub fn from_scratch(calc: Calc) -> (Self, Reader) {
         // Should always succeed.
         Self::with_active_instances(calc, 0).unwrap()
     }
 
     /// Create a new tracker with the specified amount of active instances.
-    pub fn with_active_instances(calc: Calc, active_instances: usize) -> Option<Self> {
+    pub fn with_active_instances(calc: Calc, active_instances: usize) -> Option<(Self, Reader)> {
         let available_slots = calc.discounting_active_checked(active_instances)?;
-        let available_slots = AtomicUsize::new(available_slots);
-        Some(Self {
-            calc,
-            available_slots,
-        })
-    }
 
-    /// Store raw available slots value.
-    fn store_raw(&self, available_slots: usize) {
-        self.available_slots
-            .store(available_slots, std::sync::atomic::Ordering::SeqCst);
+        let (tx, rx) = tokio::sync::watch::channel(available_slots);
+
+        let tracker = Self { calc, tx };
+
+        let reader = Reader { rx };
+
+        Some((tracker, reader))
     }
 
     /// Update the available slots by discounting the provided active instances
     /// value.
     /// Returns `None` if the number of active instances exceeds the capacity.
-    #[allow(dead_code)]
-    pub fn update_checked(&self, active_instances: usize) -> Option<()> {
-        let available_slots = self.calc.discounting_active_checked(active_instances)?;
-        self.store_raw(available_slots);
-        Some(())
-    }
+    pub fn update(&self, active_instances: usize) -> Result<(), UpdateError> {
+        let available_slots = self
+            .calc
+            .discounting_active_checked(active_instances)
+            .ok_or(UpdateError::ExceedsCapacity)?;
 
-    /// Update the available slots by discounting the provided active instances
-    /// value.
-    /// Saturates to `0` if the number of active instances exceeds the capacity.
-    pub fn update_saturating(&self, active_instances: usize) {
-        let available_slots = self.calc.discounting_active_saturating(active_instances);
-        self.store_raw(available_slots);
+        self.tx
+            .send(available_slots)
+            .map_err(|_| UpdateError::NoReaders)
     }
+}
 
-    /// Get the currently stored value of available instance slot amount.
-    pub fn get(&self) -> usize {
-        self.available_slots
-            .load(std::sync::atomic::Ordering::SeqCst)
+impl Reader {
+    /// Wait until at least one instance slot is available.
+    pub async fn wait_available(&mut self) -> Result<NonZeroUsize, TrackerGoneError> {
+        let val = {
+            let val_ref = self
+                .rx
+                .wait_for(|available| *available > 0)
+                .await
+                .map_err(|_| TrackerGoneError)?;
+
+            *val_ref
+        };
+
+        // Guaranteed to be nonzero by the `wait_for` predicate above.
+        let val = NonZeroUsize::new(val).unwrap();
+
+        Ok(val)
     }
 }

--- a/crates/lib/runloop/src/queued_instances_polling/loop.rs
+++ b/crates/lib/runloop/src/queued_instances_polling/loop.rs
@@ -14,7 +14,7 @@ where
 {
     pub shutdown_token: tokio_util::sync::CancellationToken,
     pub core_backend: Arc<CoreBackend>,
-    pub available_instance_slots_tracker: Arc<available_instance_slots::Tracker>,
+    pub available_instance_slots_reader: available_instance_slots::Reader,
     pub poll_interval: Option<NonZeroDuration>,
     pub lock_uuid: Uuid,
     pub lock_ttl: NonZeroDuration,
@@ -22,6 +22,15 @@ where
 }
 
 pub type BackendErrorFor<T> = <T as waymark_core_backend::CoreBackend>::PollQueuedInstancesError;
+
+#[derive(thiserror::Error)]
+enum Error<T> {
+    #[error("waiting for available instance slots: {0}")]
+    WaitForAvailableInstanceSlots(available_instance_slots::TrackerGoneError),
+
+    #[error("sending message: {0}")]
+    SendWithStop(send_with_stop::Error<T>),
+}
 
 pub async fn run<CoreBackend>(params: Params<CoreBackend, BackendErrorFor<CoreBackend>>)
 where
@@ -32,7 +41,7 @@ where
     let Params {
         shutdown_token,
         core_backend,
-        available_instance_slots_tracker,
+        mut available_instance_slots_reader,
         poll_interval,
         lock_ttl,
         lock_uuid,
@@ -42,10 +51,10 @@ where
     let tick_fn = {
         let shutdown_token = shutdown_token.clone();
         async move || {
-            let available_slots = available_instance_slots_tracker.get();
-            let Some(batch_size) = std::num::NonZeroUsize::new(available_slots) else {
-                return Ok(());
-            };
+            let batch_size = available_instance_slots_reader
+                .wait_available()
+                .await
+                .map_err(Error::WaitForAvailableInstanceSlots)?;
 
             let lock_expires_at = Utc::now()
                 + chrono::Duration::from_std(lock_ttl.get())
@@ -85,6 +94,7 @@ where
                 "instance message",
             )
             .await
+            .map_err(Error::SendWithStop)
         }
     };
 
@@ -104,4 +114,16 @@ where
     .await;
 
     tracing::error!(?error, "queued instances loop terminated");
+}
+
+impl<T> core::fmt::Debug for Error<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::WaitForAvailableInstanceSlots(arg0) => f
+                .debug_tuple("WaitForAvailableInstanceSlots")
+                .field(arg0)
+                .finish(),
+            Self::SendWithStop(arg0) => f.debug_tuple("SendWithStop").field(arg0).finish(),
+        }
+    }
 }

--- a/crates/lib/runloop/src/runloop.rs
+++ b/crates/lib/runloop/src/runloop.rs
@@ -107,7 +107,8 @@ where
     core_backend: Arc<CoreBackend>,
     registry_backend: Arc<RegistryBackend>,
     workflow_cache: HashMap<Uuid, Arc<DAG>>,
-    available_instance_slot_tracker: Arc<crate::available_instance_slots::Tracker>,
+    available_instance_slots_tracker: Arc<crate::available_instance_slots::Tracker>,
+    available_instance_slots_reader: crate::available_instance_slots::Reader,
     instance_done_batch_size: NonZeroUsize,
     poll_interval: Option<NonZeroDuration>,
     persistence_interval: Option<NonZeroDuration>,
@@ -179,9 +180,9 @@ where
             .instance_done_batch_size
             .unwrap_or(config.max_concurrent_instances);
 
-        let available_instance_slot_tracker =
+        let (available_instance_slots_tracker, available_instance_slots_reader) =
             crate::available_instance_slots::Tracker::from_scratch(available_instance_slots_calc);
-        let available_instance_slot_tracker = Arc::new(available_instance_slot_tracker);
+        let available_instance_slots_tracker = Arc::new(available_instance_slots_tracker);
 
         let worker_pool = worker_pool.into();
         let backend = backend.into();
@@ -195,7 +196,8 @@ where
             core_backend,
             registry_backend,
             workflow_cache: HashMap::new(),
-            available_instance_slot_tracker,
+            available_instance_slots_tracker,
+            available_instance_slots_reader,
             instance_done_batch_size,
             poll_interval: config.poll_interval,
             persistence_interval: config.persistence_interval,
@@ -228,8 +230,11 @@ where
     CoreBackend::PollQueuedInstancesError: Send + Sync + 'static,
 {
     fn store_available_instance_slots(&self, active_instances: usize) {
-        self.available_instance_slot_tracker
-            .update_saturating(active_instances);
+        // TODO: fix error handling later
+        let _ = self
+            .available_instance_slots_tracker
+            .update(active_instances);
+
         if let Some(gauge) = &self.active_instance_gauge {
             gauge.store(active_instances, Ordering::SeqCst);
         }
@@ -309,7 +314,7 @@ where
             let params = queued_instances_polling::r#loop::Params {
                 shutdown_token: self.shutdown_token.clone(),
                 core_backend: self.core_backend.clone(),
-                available_instance_slots_tracker: Arc::clone(&self.available_instance_slot_tracker),
+                available_instance_slots_reader: self.available_instance_slots_reader.clone(),
                 poll_interval: self.poll_interval,
                 lock_uuid: self.lock_uuid,
                 lock_ttl: self.lock_ttl,


### PR DESCRIPTION
Goes in after #257.

This PR addresses the issue of spinlock when the polling interval is not set (now `None` and before - when it was zero).

This makes sure we don't stress the tokio runtime threads while there are no available instance slots.