### PR TITLE
Take self by-value at Runloop::run

### DIFF
--- a/crates/bin/benchmark/src/main.rs
+++ b/crates/bin/benchmark/src/main.rs
@@ -329,7 +329,7 @@ async fn run_benchmark(
     println!("Queued {total} instances across {} IR jobs", cases.len());
 
     let worker_pool = InlineWorkerPool::new(action_registry());
-    let mut runloop = RunLoop::new(
+    let runloop = RunLoop::new(
         worker_pool,
         backend.clone(),
         RunLoopConfig {

--- a/crates/bin/bridge/src/bridge_service.rs
+++ b/crates/bin/bridge/src/bridge_service.rs
@@ -280,7 +280,7 @@ impl proto::workflow_service_server::WorkflowService for BridgeService {
             };
 
             runtime.block_on(async move {
-                let mut runloop = RunLoop::new(
+                let runloop = RunLoop::new(
                     worker_pool,
                     backend,
                     RunLoopConfig {

--- a/crates/bin/fuzzer/src/harness.rs
+++ b/crates/bin/fuzzer/src/harness.rs
@@ -48,7 +48,7 @@ pub async fn run_case(case_index: usize, case: &GeneratedCase) -> Result<()> {
         .push_back(queued);
 
     let worker_pool = InlineWorkerPool::new(action_registry());
-    let mut runloop = RunLoop::new(
+    let runloop = RunLoop::new(
         worker_pool,
         backend.clone(),
         RunLoopConfig {

--- a/crates/bin/integration-test/src/main.rs
+++ b/crates/bin/integration-test/src/main.rs
@@ -574,7 +574,7 @@ where
     <B as CoreBackend>::PollQueuedInstancesError: Send + Sync + 'static,
     <B as CoreBackend>::PollQueuedInstancesError: core::error::Error,
 {
-    let mut runloop = RunLoop::new(
+    let runloop = RunLoop::new(
         worker_pool,
         backend,
         RunLoopConfig {

--- a/crates/bin/smoke/src/main.rs
+++ b/crates/bin/smoke/src/main.rs
@@ -111,7 +111,7 @@ async fn run_program_smoke(case: &SmokeCase, worker_pool: RemoteWorkerPool) -> R
         .queue_template_node(&entry_node, None)
         .map_err(|err| anyhow!(err.0))?;
 
-    let mut runloop = RunLoop::new(
+    let runloop = RunLoop::new(
         worker_pool,
         backend.clone(),
         RunLoopConfig {

--- a/crates/bin/start-workers/src/main.rs
+++ b/crates/bin/start-workers/src/main.rs
@@ -185,7 +185,7 @@ async fn main() -> Result<()> {
 
     // Run the runloop.
     let lock_uuid = Uuid::new_v4();
-    let mut runloop = waymark_runloop::RunLoop::new_with_shutdown(
+    let runloop = waymark_runloop::RunLoop::new_with_shutdown(
         remote_pool.clone(),
         backend.clone(),
         RunLoopConfig {

--- a/crates/lib/runloop/src/runloop.rs
+++ b/crates/lib/runloop/src/runloop.rs
@@ -237,7 +237,7 @@ where
 {
     #[obs]
     pub async fn run(
-        &mut self,
+        mut self,
     ) -> Result<(), Error<queued_instances_polling::r#loop::BackendErrorFor<CoreBackend>>> {
         self.worker_pool.launch().await.map_err(Error::WorkerPool)?;
 

--- a/crates/lib/runloop/tests/integration.rs
+++ b/crates/lib/runloop/tests/integration.rs
@@ -99,7 +99,7 @@ fn main(input: [x], output: [y]):
     );
     let worker_pool = waymark_worker_inline::InlineWorkerPool::new(actions);
 
-    let mut runloop = RunLoop::new(
+    let runloop = RunLoop::new(
         worker_pool,
         backend.clone(),
         RunLoopConfig {
@@ -180,7 +180,7 @@ fn main(input: [x], output: [y]):
     );
     let worker_pool = waymark_worker_inline::InlineWorkerPool::new(actions);
 
-    let mut runloop = RunLoop::new(
+    let runloop = RunLoop::new(
         worker_pool,
         backend.clone(),
         RunLoopConfig {
@@ -317,7 +317,7 @@ fn main(input: [x], output: [y]):
     );
     let worker_pool = waymark_worker_inline::InlineWorkerPool::new(actions);
 
-    let mut runloop = RunLoop::new(
+    let runloop = RunLoop::new(
         worker_pool,
         backend.clone(),
         RunLoopConfig {
@@ -406,7 +406,7 @@ fn main(input: [], output: [y]):
     );
     let worker_pool = waymark_worker_inline::InlineWorkerPool::new(actions);
 
-    let mut runloop = RunLoop::new(
+    let runloop = RunLoop::new(
         worker_pool,
         backend.clone(),
         RunLoopConfig {
@@ -519,7 +519,7 @@ fn main(input: [x], output: [y]):
         .expect("register workflow version");
 
     let worker_pool = waymark_worker_inline::InlineWorkerPool::new(HashMap::new());
-    let mut runloop = RunLoop::new(
+    let runloop = RunLoop::new(
         worker_pool,
         backend.clone(),
         RunLoopConfig {
@@ -668,7 +668,7 @@ fn main(input: [limit], output: [result]):
     );
     let worker_pool = waymark_worker_inline::InlineWorkerPool::new(actions);
 
-    let mut runloop = RunLoop::new(
+    let runloop = RunLoop::new(
         worker_pool,
         backend.clone(),
         RunLoopConfig {
@@ -729,7 +729,7 @@ async fn test_runloop_reproduces_no_progress_with_continued_queue_growth() {
     let worker_pool = waymark_worker_inline::InlineWorkerPool::new(HashMap::new());
     let shutdown_token = tokio_util::sync::CancellationToken::new();
 
-    let mut runloop = RunLoop::new_with_shutdown(
+    let runloop = RunLoop::new_with_shutdown(
         worker_pool,
         backend.clone(),
         default_test_config(Uuid::new_v4()),
@@ -864,7 +864,7 @@ fn main(input: [x], output: [y]):
         .expect("register workflow version");
 
     let worker_pool = waymark_worker_inline::InlineWorkerPool::new(HashMap::new());
-    let mut runloop = RunLoop::new(
+    let runloop = RunLoop::new(
         worker_pool,
         backend.clone(),
         default_test_config(Uuid::new_v4()),
@@ -959,7 +959,7 @@ fn main(input: [], output: [result]):
         }),
     );
     let worker_pool = waymark_worker_inline::InlineWorkerPool::new(actions);
-    let mut runloop = RunLoop::new(
+    let runloop = RunLoop::new(
         worker_pool,
         backend.clone(),
         default_test_config(Uuid::new_v4()),
@@ -1042,7 +1042,7 @@ fn main(input: [], output: [result]):
         Arc::new(|_kwargs| Box::pin(async move { Ok(Value::Number(7.into())) })),
     );
     let worker_pool = waymark_worker_inline::InlineWorkerPool::new(actions);
-    let mut runloop = RunLoop::new(
+    let runloop = RunLoop::new(
         worker_pool,
         backend.clone(),
         default_test_config(Uuid::new_v4()),


### PR DESCRIPTION
Goes in after #269 

This PR concludes trimming runloop impls.

The next steps for runloop refactor is extracting the `new` impl and inline `spawns` into separate bringup code crate(s). After that we get to refactoring task management across the full executables.