### PR TITLE
Cancel shutdown token on runloop exit [crit]

### DIFF
--- a/crates/bin/start-workers/src/main.rs
+++ b/crates/bin/start-workers/src/main.rs
@@ -201,7 +201,10 @@ async fn main() -> Result<()> {
         },
         shutdown_token.child_token(),
     );
-    let result = runloop.run().await;
+    let result = {
+        let _guard = shutdown_token.drop_guard();
+        runloop.run().await
+    };
     match result {
         Ok(_) => {
             warn!("runloop exited cleanly (unexpected)");


### PR DESCRIPTION
This PR fixes a critical issue of the runloop exit not leading to shutdown.

This is a temporary correction for a critical issue in the runtime behavior, and a proper overhaul of the task management and tracking is planned for the near future - this is the reason this fix doesn't contain new regressions tests.