### PR TITLE
Add raw config logging target

### DIFF
--- a/crates/bin/start-workers/src/main.rs
+++ b/crates/bin/start-workers/src/main.rs
@@ -66,6 +66,8 @@ async fn main() -> Result<()> {
     // Load configuration and announce startup.
     let config = WorkerConfig::from_env()?;
 
+    tracing::debug!(target: "raw-config", ?config, "raw config");
+
     info!(
         worker_count = config.worker_count,
         concurrent_per_worker = config.concurrent_per_worker,


### PR DESCRIPTION
This would allow doing `RUST_LOG=info,raw-config=debug` to print the debug fmt of the config to the logs.