### PR TITLE
Support list merging by star unpacking

### DIFF
--- a/crates/lib/runloop/tests/integration.rs
+++ b/crates/lib/runloop/tests/integration.rs
@@ -1011,6 +1011,84 @@ fn main(input: [], output: [result]):
 }
 
 #[tokio::test]
+async fn test_runloop_executes_list_merge_reassignment() {
+    let source = r#"
+fn main(input: [], output: [result]):
+    left = [1, 2]
+    right = [3, 4]
+    left = left + right
+    left = left + [5]
+    result = left
+    return result
+"#;
+    let program = parse_program(source.trim()).expect("parse program");
+    let program_proto = program.encode_to_vec();
+    let ir_hash = format!("{:x}", Sha256::digest(&program_proto));
+    let dag = Arc::new(convert_to_dag(&program).expect("convert to dag"));
+
+    let mut state = RunnerState::new(Some(Arc::clone(&dag)), None, None, false);
+    let entry_node = dag
+        .entry_node
+        .as_ref()
+        .expect("DAG entry node not found")
+        .clone();
+    let entry_exec = state
+        .queue_template_node(&entry_node, None)
+        .expect("queue entry node");
+
+    let queue = Arc::new(Mutex::new(VecDeque::new()));
+    let backend = MemoryBackend::with_queue(queue.clone());
+    let workflow_version_id = backend
+        .upsert_workflow_version(&WorkflowRegistration {
+            workflow_name: "test_list_merge_reassignment".to_string(),
+            workflow_version: ir_hash.clone(),
+            ir_hash,
+            program_proto,
+            concurrent: false,
+        })
+        .await
+        .expect("register workflow version");
+
+    let worker_pool = waymark_worker_inline::InlineWorkerPool::new(HashMap::new());
+    let runloop = RunLoop::new(
+        worker_pool,
+        backend.clone(),
+        default_test_config(LockId::new_uuid_v4()),
+    );
+    let instance_id = InstanceId::new_uuid_v4();
+    queue.lock().expect("queue lock").push_back(QueuedInstance {
+        workflow_version_id,
+        schedule_id: None,
+        dag: None,
+        entry_node: entry_exec.node_id,
+        state: Some(state),
+        action_results: HashMap::new(),
+        instance_id,
+        scheduled_at: None,
+    });
+
+    runloop.run().await.expect("runloop");
+
+    let instances_done = backend.instances_done();
+    assert_eq!(instances_done.len(), 1);
+    assert_eq!(instances_done[0].executor_id, instance_id);
+    let output = instances_done[0].result.clone().expect("instance result");
+    let Value::Object(map) = output.0 else {
+        panic!("expected output object");
+    };
+    assert_eq!(
+        map.get("result"),
+        Some(&Value::Array(vec![
+            Value::Number(1.into()),
+            Value::Number(2.into()),
+            Value::Number(3.into()),
+            Value::Number(4.into()),
+            Value::Number(5.into()),
+        ]))
+    );
+}
+
+#[tokio::test]
 async fn test_runloop_marks_instance_failed_with_attribute_error() {
     let source = r#"
 fn main(input: [], output: [result]):

--- a/crates/lib/runner/src/action_done_status.rs
+++ b/crates/lib/runner/src/action_done_status.rs
@@ -5,7 +5,9 @@ pub fn for_exception(value: &ExecutionException) -> ActionAttemptStatus {
     match waymark_synthetic_exception::Type::from_value(&value.0) {
         Some(waymark_synthetic_exception::Type::ExecutorResume)
         | Some(waymark_synthetic_exception::Type::ActionTimeout) => ActionAttemptStatus::TimedOut,
-        None => ActionAttemptStatus::Failed,
+        Some(waymark_synthetic_exception::Type::RunnerExecutorError) | None => {
+            ActionAttemptStatus::Failed
+        }
     }
 }
 
@@ -47,6 +49,15 @@ mod tests {
         let value = ExecutionException(serde_json::json!({
             "type": "TimeoutError",
             "message": "user action raised timeout",
+        }));
+        assert_eq!(for_exception(&value), ActionAttemptStatus::Failed);
+    }
+
+    #[test]
+    fn test_action_done_status_for_runner_executor_error_is_failed() {
+        let value = ExecutionException(serde_json::json!({
+            "type": "RunnerExecutorError",
+            "message": "inline node failed",
         }));
         assert_eq!(for_exception(&value), ActionAttemptStatus::Failed);
     }

--- a/crates/lib/runner/src/executor.rs
+++ b/crates/lib/runner/src/executor.rs
@@ -1729,7 +1729,7 @@ fn main(input: [], output: [result]):
         assert!(step.updates.is_none());
 
         let terminal_error = executor.terminal_error().cloned().expect("terminal error");
-        let Value::Object(error_obj) = &terminal_error.0 else {
+        let Value::Object(_) = &terminal_error.0 else {
             panic!("expected error payload object");
         };
         assert_eq!(

--- a/crates/lib/runner/src/executor.rs
+++ b/crates/lib/runner/src/executor.rs
@@ -1729,17 +1729,21 @@ fn main(input: [], output: [result]):
         assert!(step.updates.is_none());
 
         let terminal_error = executor.terminal_error().cloned().expect("terminal error");
+        let Value::Object(error_obj) = &terminal_error.0 else {
+            panic!("expected error payload object");
+        };
         assert_eq!(
-            terminal_error.get("type"),
+            error_obj.get("type"),
             Some(&Value::String("ExecutionError".to_string()))
         );
-        let message = terminal_error
+        let message = error_obj
             .get("message")
             .and_then(Value::as_str)
             .expect("error message");
         assert!(
             RunnerStateError::is_node_limit_exceeded_message(message),
-            "unexpected terminal error: {terminal_error}"
+            "unexpected terminal error: {:?}",
+            terminal_error
         );
     }
 

--- a/python/src/waymark/ir_builder.py
+++ b/python/src/waymark/ir_builder.py
@@ -3709,6 +3709,56 @@ def _expr_to_ir(
                 return result_expr
 
     if isinstance(expr, ast.List):
+        if any(isinstance(element, ast.Starred) for element in expr.elts):
+            segments: list[ir.Expr] = []
+            buffered_elements: list[ir.Expr] = []
+
+            def flush_buffered_elements() -> None:
+                if not buffered_elements:
+                    return
+                segments.append(ir.Expr(list=ir.ListExpr(elements=list(buffered_elements))))
+                buffered_elements.clear()
+
+            for element in expr.elts:
+                if isinstance(element, ast.Starred):
+                    flush_buffered_elements()
+                    starred_value = _expr_to_ir(
+                        element.value,
+                        model_converter=model_converter,
+                        enum_resolver=enum_resolver,
+                        exception_class_resolver=exception_class_resolver,
+                    )
+                    if not starred_value:
+                        return None
+                    segments.append(starred_value)
+                    continue
+
+                value = _expr_to_ir(
+                    element,
+                    model_converter=model_converter,
+                    enum_resolver=enum_resolver,
+                    exception_class_resolver=exception_class_resolver,
+                )
+                if not value:
+                    return None
+                buffered_elements.append(value)
+
+            flush_buffered_elements()
+            if not segments:
+                result.list.CopyFrom(ir.ListExpr(elements=[]))
+                return result
+
+            combined = segments[0]
+            for segment in segments[1:]:
+                combined = ir.Expr(
+                    binary_op=ir.BinaryOp(
+                        left=combined,
+                        op=ir.BinaryOperator.BINARY_OP_ADD,
+                        right=segment,
+                    )
+                )
+            return combined
+
         elements = [
             _expr_to_ir(
                 e,

--- a/python/tests/test_ir_builder.py
+++ b/python/tests/test_ir_builder.py
@@ -1868,6 +1868,17 @@ class TestReturnStatements:
 class TestAugmentedAssignment:
     """Test augmented assignment (+=, -=, etc.)."""
 
+    def _find_binary_assignment(self, program: ir.Program, target: str) -> ir.Assignment | None:
+        func = program.functions[0]
+        for stmt in func.body.statements:
+            if (
+                stmt.HasField("assignment")
+                and target in stmt.assignment.targets
+                and stmt.assignment.value.HasField("binary_op")
+            ):
+                return stmt.assignment
+        return None
+
     def test_plus_equals_assignment(self) -> None:
         """Test: x += 1 is converted to x = x + 1."""
         from waymark import action, workflow
@@ -1898,6 +1909,96 @@ class TestAugmentedAssignment:
         assert aug_assign is not None, "Should have augmented assignment"
         assert aug_assign.targets == ["x"], "Target should be 'x'"
         assert aug_assign.value.binary_op.op == ir.BinaryOperator.BINARY_OP_ADD, "Op should be ADD"
+
+    def test_plus_equals_list_merge_assignment(self) -> None:
+        """Test: left += right is converted to left = left + right."""
+        from waymark import workflow
+        from waymark.workflow import Workflow
+
+        @workflow
+        class PlusEqualsListMergeWorkflow(Workflow):
+            async def run(self, left: list[int], right: list[int]) -> list[int]:
+                left += right
+                return left
+
+        program = PlusEqualsListMergeWorkflow.workflow_ir()
+        assignment = self._find_binary_assignment(program, "left")
+
+        assert assignment is not None, "Should have binary assignment for left"
+        binary = assignment.value.binary_op
+        assert binary.op == ir.BinaryOperator.BINARY_OP_ADD
+        assert binary.left.variable.name == "left"
+        assert binary.right.variable.name == "right"
+
+    def test_explicit_list_merge_assignment(self) -> None:
+        """Test: left = left + right remains an add binary op in IR."""
+        from waymark import workflow
+        from waymark.workflow import Workflow
+
+        @workflow
+        class ExplicitListMergeWorkflow(Workflow):
+            async def run(self, left: list[int], right: list[int]) -> list[int]:
+                left = left + right
+                return left
+
+        program = ExplicitListMergeWorkflow.workflow_ir()
+        assignment = self._find_binary_assignment(program, "left")
+
+        assert assignment is not None, "Should have binary assignment for left"
+        binary = assignment.value.binary_op
+        assert binary.op == ir.BinaryOperator.BINARY_OP_ADD
+        assert binary.left.variable.name == "left"
+        assert binary.right.variable.name == "right"
+
+    def test_starred_list_merge_assignment(self) -> None:
+        """Test: [*left, *right] lowers to list concatenation IR."""
+        from waymark import workflow
+        from waymark.workflow import Workflow
+
+        @workflow
+        class StarredListMergeWorkflow(Workflow):
+            async def run(self, left: list[int], right: list[int]) -> list[int]:
+                merged = [*left, *right]
+                return merged
+
+        program = StarredListMergeWorkflow.workflow_ir()
+        assignment = self._find_binary_assignment(program, "merged")
+
+        assert assignment is not None, "Should have binary assignment for merged"
+        binary = assignment.value.binary_op
+        assert binary.op == ir.BinaryOperator.BINARY_OP_ADD
+        assert binary.left.variable.name == "left"
+        assert binary.right.variable.name == "right"
+
+    def test_starred_list_merge_with_literal_segments(self) -> None:
+        """Test: [0, *left, 5, *right] becomes chained list additions."""
+        from waymark import workflow
+        from waymark.workflow import Workflow
+
+        @workflow
+        class MixedStarredListMergeWorkflow(Workflow):
+            async def run(self, left: list[int], right: list[int]) -> list[int]:
+                merged = [0, *left, 5, *right]
+                return merged
+
+        program = MixedStarredListMergeWorkflow.workflow_ir()
+        assignment = self._find_binary_assignment(program, "merged")
+
+        assert assignment is not None, "Should have binary assignment for merged"
+
+        def count_adds(expr: ir.Expr) -> int:
+            if not expr.HasField("binary_op"):
+                return 0
+            return 1 + count_adds(expr.binary_op.left) + count_adds(expr.binary_op.right)
+
+        assert count_adds(assignment.value) == 3
+        outer = assignment.value.binary_op
+        assert outer.right.variable.name == "right"
+        middle = outer.left.binary_op
+        assert middle.right.list.elements[0].literal.int_value == 5
+        inner = middle.left.binary_op
+        assert inner.left.list.elements[0].literal.int_value == 0
+        assert inner.right.variable.name == "left"
 
 
 class TestExpressionTypes:

--- a/python/tests/test_pytest_in_memory_runtime.py
+++ b/python/tests/test_pytest_in_memory_runtime.py
@@ -29,6 +29,17 @@ class SleepWorkflow(Workflow):
         return "done"
 
 
+@workflow
+class ListMergeSyntaxWorkflow(Workflow):
+    async def run(self) -> list[int]:
+        left = [1, 2]
+        right = [3, 4]
+        left += right
+        left = left + [5]
+        left = [0, *left, *right]
+        return left
+
+
 def test_pytest_runtime_raises_for_unhandled_action_failure() -> None:
     with pytest.raises(RuntimeError, match="workflow failed") as exc_info:
         asyncio.run(UnhandledFailureWorkflow().run())
@@ -43,3 +54,9 @@ def test_pytest_runtime_skips_sleep_nodes() -> None:
 
     assert result == "done"
     assert elapsed < 5.0
+
+
+def test_pytest_runtime_executes_list_merge_syntax_variants() -> None:
+    result = asyncio.run(ListMergeSyntaxWorkflow().run())
+
+    assert result == [0, 1, 2, 3, 4, 5, 3, 4]


### PR DESCRIPTION
We've supported list merging in Python for some time with the syntax `x = y + z` where x, y, and z are both lists. But this PR adds support for the alternative Python syntaxes that are also used to merge lists:

- `left += right`
- `merged = [*left, *right]`
- Mixed starred list literals like `merged = [0, *left, 5, *right]`

Under the hood, starred list literals are lowered into chained list concatenation IR, so they reuse the existing list merge execution path instead of introducing a separate runtime behavior.