### PR TITLE
Refactor hydration and how the dag is kept alongisde the instances

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4153,7 +4153,6 @@ dependencies = [
  "serde",
  "uuid",
  "waymark-backends-core",
- "waymark-dag",
  "waymark-ids",
  "waymark-runner-executor-core",
  "waymark-runner-state",

--- a/crates/bin/benchmark/src/main.rs
+++ b/crates/bin/benchmark/src/main.rs
@@ -168,7 +168,6 @@ fn build_instance(case: &BenchmarkCase, workflow_version_id: Uuid) -> QueuedInst
     QueuedInstance {
         workflow_version_id,
         schedule_id: None,
-        dag: None,
         entry_node: entry_exec.node_id,
         state: Some(state),
         action_results: HashMap::new(),

--- a/crates/bin/bridge/src/bridge_service.rs
+++ b/crates/bin/bridge/src/bridge_service.rs
@@ -629,7 +629,6 @@ fn build_queued_instance(
     Ok(QueuedInstance {
         workflow_version_id,
         schedule_id: None,
-        dag: None,
         entry_node: entry_exec.node_id,
         state: Some(state),
         action_results: HashMap::new(),

--- a/crates/bin/fuzzer/src/harness.rs
+++ b/crates/bin/fuzzer/src/harness.rs
@@ -145,7 +145,6 @@ fn build_instance(
     Ok(QueuedInstance {
         workflow_version_id,
         schedule_id: None,
-        dag: None,
         entry_node: entry_exec.node_id,
         state: Some(state),
         action_results: HashMap::new(),

--- a/crates/bin/integration-test/src/main.rs
+++ b/crates/bin/integration-test/src/main.rs
@@ -634,7 +634,6 @@ fn build_queued_instance(
     Ok(QueuedInstance {
         workflow_version_id,
         schedule_id: None,
-        dag: None,
         entry_node: entry_exec.node_id,
         state: Some(state),
         action_results: HashMap::new(),

--- a/crates/bin/smoke/src/main.rs
+++ b/crates/bin/smoke/src/main.rs
@@ -134,7 +134,6 @@ async fn run_program_smoke(case: &SmokeCase, worker_pool: RemoteWorkerPool) -> R
     queue.lock().expect("queue lock").push_back(QueuedInstance {
         workflow_version_id,
         schedule_id: None,
-        dag: None,
         entry_node: entry_exec.node_id,
         state: Some(state),
         action_results: HashMap::new(),

--- a/crates/bin/soak-harness/src/flow.rs
+++ b/crates/bin/soak-harness/src/flow.rs
@@ -409,7 +409,6 @@ fn build_instance(
     Ok(QueuedInstance {
         workflow_version_id: workflow.workflow_version_id,
         schedule_id: None,
-        dag: None,
         entry_node: entry_node.node_id,
         state: Some(state),
         action_results: HashMap::new(),

--- a/crates/lib/backend-postgres/src/core.rs
+++ b/crates/lib/backend-postgres/src/core.rs
@@ -1184,7 +1184,6 @@ mod tests {
         QueuedInstance {
             workflow_version_id: Uuid::new_v4(),
             schedule_id: None,
-            dag: None,
             entry_node,
             state: Some(sample_runner_state()),
             action_results: HashMap::new(),
@@ -1324,7 +1323,6 @@ mod tests {
         let queued = QueuedInstance {
             workflow_version_id,
             schedule_id: None,
-            dag: None,
             entry_node,
             state: Some(sample_runner_state()),
             action_results: HashMap::new(),

--- a/crates/lib/backend-postgres/src/webapp.rs
+++ b/crates/lib/backend-postgres/src/webapp.rs
@@ -1466,7 +1466,6 @@ fn build_queued_instance(
     Ok(QueuedInstance {
         workflow_version_id,
         schedule_id: None,
-        dag: None,
         entry_node: entry_exec.node_id,
         state: Some(state),
         action_results: HashMap::new(),

--- a/crates/lib/core-backend/Cargo.toml
+++ b/crates/lib/core-backend/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2024"
 
 [dependencies]
 waymark-backends-core = { workspace = true }
-waymark-dag = { workspace = true }
 waymark-ids = { workspace = true }
 waymark-runner-executor-core = { workspace = true }
 waymark-runner-state = { workspace = true }

--- a/crates/lib/core-backend/src/data.rs
+++ b/crates/lib/core-backend/src/data.rs
@@ -2,15 +2,11 @@
 // have specified in our database/Postgres backend, but not 1:1. It's better for
 // us to internally convert within the given backend
 
-use std::{
-    collections::{HashMap, HashSet},
-    sync::Arc,
-};
+use std::collections::{HashMap, HashSet};
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
-use waymark_dag::DAG;
 use waymark_runner_executor_core::{
     ExecutionException, ExecutionSuccess, UncheckedExecutionResult,
 };
@@ -24,8 +20,6 @@ pub struct QueuedInstance {
     pub workflow_version_id: Uuid,
     #[serde(default)]
     pub schedule_id: Option<Uuid>,
-    #[serde(skip, default)]
-    pub dag: Option<Arc<DAG>>,
     pub entry_node: ExecutionId,
     pub state: Option<RunnerState>,
     #[serde(

--- a/crates/lib/runloop/src/hydrated_instance.rs
+++ b/crates/lib/runloop/src/hydrated_instance.rs
@@ -1,0 +1,10 @@
+use std::sync::Arc;
+
+use waymark_core_backend::QueuedInstance;
+use waymark_dag::DAG;
+
+#[derive(Debug)]
+pub struct HydratedInstance {
+    pub instance: QueuedInstance,
+    pub dag: Arc<DAG>,
+}

--- a/crates/lib/runloop/src/lib.rs
+++ b/crates/lib/runloop/src/lib.rs
@@ -7,6 +7,7 @@ mod runloop;
 mod error_value;
 
 mod completions_polling;
+mod hydrated_instance;
 mod instance_lock_heartbeat;
 mod persist;
 mod queued_instances_polling;

--- a/crates/lib/runloop/src/runloop.rs
+++ b/crates/lib/runloop/src/runloop.rs
@@ -681,11 +681,19 @@ where
                     // put the error into the "dumb" unified error.
                     let parts::new_instances::Error::Hydrate(error) = error;
                     let error = match error {
-                        ops::hydrate_instances::Error::GetWorkflowVersions(backend_error) => {
-                            backend_error.into()
-                        }
-                        err @ ops::hydrate_instances::Error::IrProgramDecode { .. }
-                        | err @ ops::hydrate_instances::Error::ConvertToDag { .. }
+                        ops::hydrate_instances::Error::CacheMissingDags(
+                            ops::hydrate_instances::CacheMissingDagsError::GetWorkflowVersions(
+                                backend_error,
+                            ),
+                        ) => backend_error.into(),
+                        err @ ops::hydrate_instances::Error::CacheMissingDags(
+                            ops::hydrate_instances::CacheMissingDagsError::IrProgramDecode {
+                                ..
+                            },
+                        )
+                        | err @ ops::hydrate_instances::Error::CacheMissingDags(
+                            ops::hydrate_instances::CacheMissingDagsError::ConvertToDag { .. },
+                        )
                         | err @ ops::hydrate_instances::Error::WorkflowCacheGetNone { .. } => {
                             Error::Message(err.to_string())
                         }

--- a/crates/lib/runloop/src/runloop.rs
+++ b/crates/lib/runloop/src/runloop.rs
@@ -25,7 +25,6 @@ use crate::{error_value, persist, queued_instances_polling, shard};
 use waymark_ids::{ExecutionId, InstanceId, LockId};
 use waymark_metrics_util::Val as MetricsVal;
 
-use waymark_dag::DAG;
 use waymark_observability::obs;
 use waymark_runner::{RunnerExecutorError, SleepRequest};
 use waymark_worker_core::{ActionCompletion, WorkerPoolError};
@@ -54,6 +53,9 @@ mod ops {
 }
 
 mod lock_utils;
+pub mod workflow_dag_cache;
+
+use self::workflow_dag_cache::WorkflowDagCache;
 
 /// Raised when the run loop cannot coordinate execution.
 #[derive(Debug, thiserror::Error)]
@@ -111,7 +113,7 @@ where
     worker_pool: Arc<WorkerPool>,
     core_backend: Arc<CoreBackend>,
     registry_backend: Arc<RegistryBackend>,
-    workflow_cache: HashMap<Uuid, Arc<DAG>>,
+    workflow_cache: WorkflowDagCache,
     available_instances_updater: AvailableInstancesUpdater,
     available_instance_slots_reader: crate::available_instance_slots::Reader,
     instance_done_batch_size: NonZeroUsize,
@@ -204,7 +206,7 @@ where
             worker_pool,
             core_backend,
             registry_backend,
-            workflow_cache: HashMap::new(),
+            workflow_cache: WorkflowDagCache::default(),
             available_instances_updater,
             available_instance_slots_reader,
             instance_done_batch_size,
@@ -681,18 +683,14 @@ where
                     // put the error into the "dumb" unified error.
                     let parts::new_instances::Error::Hydrate(error) = error;
                     let error = match error {
-                        ops::hydrate_instances::Error::CacheMissingDags(
-                            ops::hydrate_instances::CacheMissingDagsError::GetWorkflowVersions(
-                                backend_error,
-                            ),
+                        ops::hydrate_instances::Error::WorkflowDagCachePopulate(
+                            workflow_dag_cache::PopulateError::GetWorkflowVersions(backend_error),
                         ) => backend_error.into(),
-                        err @ ops::hydrate_instances::Error::CacheMissingDags(
-                            ops::hydrate_instances::CacheMissingDagsError::IrProgramDecode {
-                                ..
-                            },
+                        err @ ops::hydrate_instances::Error::WorkflowDagCachePopulate(
+                            workflow_dag_cache::PopulateError::IrProgramDecode { .. },
                         )
-                        | err @ ops::hydrate_instances::Error::CacheMissingDags(
-                            ops::hydrate_instances::CacheMissingDagsError::ConvertToDag { .. },
+                        | err @ ops::hydrate_instances::Error::WorkflowDagCachePopulate(
+                            workflow_dag_cache::PopulateError::ConvertToDag { .. },
                         )
                         | err @ ops::hydrate_instances::Error::WorkflowCacheGetNone { .. } => {
                             Error::Message(err.to_string())

--- a/crates/lib/runloop/src/runloop/ops/hydrate_instances.rs
+++ b/crates/lib/runloop/src/runloop/ops/hydrate_instances.rs
@@ -1,8 +1,14 @@
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 
+use nonempty_collections::{IntoNonEmptyIterator as _, NEVec, NonEmptyIterator as _};
 use uuid::Uuid;
 use waymark_core_backend::QueuedInstance;
 use waymark_proto::ast as ir;
+
+use crate::hydrated_instance::HydratedInstance;
 
 pub struct Params<'a, WorkflowRegistryBackend: ?Sized> {
     /// Cache of workflow DAGs keyed by workflow version ID to avoid repeated hydration work.
@@ -10,19 +16,13 @@ pub struct Params<'a, WorkflowRegistryBackend: ?Sized> {
     /// Backend used to fetch workflow definitions that are missing from the local cache.
     pub registry_backend: &'a WorkflowRegistryBackend,
     /// Claimed instances that need DAG references attached before shard execution.
-    pub instances: &'a mut [QueuedInstance],
+    pub instances: NEVec<QueuedInstance>,
 }
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    #[error("get workflow versions: {0}")]
-    GetWorkflowVersions(#[source] waymark_backends_core::BackendError),
-
-    #[error("invalid workflow IR: {0}")]
-    IrProgramDecode(#[source] prost::DecodeError),
-
-    #[error("invalid workflow DAG: {0}")]
-    ConvertToDag(#[source] waymark_dag_builder::DagConversionError),
+    #[error("caching missing DAGs: {0}")]
+    CacheMissingDags(#[source] CacheMissingDagsError),
 
     #[error("workflow version not found: {workflow_version_id}")]
     WorkflowCacheGetNone { workflow_version_id: uuid::Uuid },
@@ -41,7 +41,7 @@ pub enum Error {
 /// Caching avoids repeated fetches for workflows used by multiple instances.
 pub async fn run<WorkflowRegistryBackend>(
     params: Params<'_, WorkflowRegistryBackend>,
-) -> Result<(), Error>
+) -> Result<NEVec<HydratedInstance>, Error>
 where
     WorkflowRegistryBackend: ?Sized + waymark_workflow_registry_backend::WorkflowRegistryBackend,
 {
@@ -51,35 +51,78 @@ where
         instances,
     } = params;
 
-    let mut missing = Vec::new();
-    for instance in instances.iter() {
-        if !workflow_cache.contains_key(&instance.workflow_version_id) {
-            missing.push(instance.workflow_version_id);
-        }
-    }
-    missing.sort();
-    missing.dedup();
+    cache_missing_dags(
+        registry_backend,
+        workflow_cache,
+        instances
+            .iter()
+            .map(|instance| instance.workflow_version_id),
+    )
+    .await
+    .map_err(Error::CacheMissingDags)?;
 
-    if !missing.is_empty() {
-        let versions = registry_backend
-            .get_workflow_versions(&missing)
-            .await
-            .map_err(Error::GetWorkflowVersions)?;
-        for version in versions {
-            let program = <ir::Program as prost::Message>::decode(&version.program_proto[..])
-                .map_err(Error::IrProgramDecode)?;
-            let dag = waymark_dag_builder::convert_to_dag(&program).map_err(Error::ConvertToDag)?;
-            workflow_cache.insert(version.id, Arc::new(dag));
-        }
-    }
-
-    for instance in instances.iter_mut() {
+    let hydrate_instance = |instance: QueuedInstance| -> Result<HydratedInstance, _> {
         let dag = workflow_cache
             .get(&instance.workflow_version_id)
             .ok_or_else(|| Error::WorkflowCacheGetNone {
                 workflow_version_id: instance.workflow_version_id,
             })?;
-        instance.dag = Some(Arc::clone(dag));
+        let dag = Arc::clone(dag);
+        Ok(HydratedInstance { dag, instance })
+    };
+
+    let hydrated_instances = instances
+        .into_nonempty_iter()
+        .map(hydrate_instance)
+        .collect::<Result<NEVec<HydratedInstance>, Error>>()?;
+
+    Ok(hydrated_instances)
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum CacheMissingDagsError {
+    #[error("get workflow versions: {0}")]
+    GetWorkflowVersions(#[source] waymark_backends_core::BackendError),
+
+    #[error("invalid workflow IR: {0}")]
+    IrProgramDecode(#[source] prost::DecodeError),
+
+    #[error("invalid workflow DAG: {0}")]
+    ConvertToDag(#[source] waymark_dag_builder::DagConversionError),
+}
+
+async fn cache_missing_dags<WorkflowRegistryBackend>(
+    registry_backend: &WorkflowRegistryBackend,
+    workflow_cache: &mut HashMap<Uuid, Arc<waymark_dag::DAG>>,
+    workflow_version_ids: impl IntoIterator<Item = uuid::Uuid>,
+) -> Result<(), CacheMissingDagsError>
+where
+    WorkflowRegistryBackend: ?Sized + waymark_workflow_registry_backend::WorkflowRegistryBackend,
+{
+    let mut missing = HashSet::new();
+
+    for workflow_version_id in workflow_version_ids {
+        if !workflow_cache.contains_key(&workflow_version_id) {
+            missing.insert(workflow_version_id);
+        }
+    }
+
+    if missing.is_empty() {
+        return Ok(());
+    }
+
+    let missing: Vec<_> = missing.into_iter().collect();
+
+    let versions = registry_backend
+        .get_workflow_versions(&missing)
+        .await
+        .map_err(CacheMissingDagsError::GetWorkflowVersions)?;
+    for version in versions {
+        let program = <ir::Program as prost::Message>::decode(&version.program_proto[..])
+            .map_err(CacheMissingDagsError::IrProgramDecode)?;
+        let dag = waymark_dag_builder::convert_to_dag(&program)
+            .map_err(CacheMissingDagsError::ConvertToDag)?;
+        workflow_cache.insert(version.id, Arc::new(dag));
     }
 
     Ok(())

--- a/crates/lib/runloop/src/runloop/ops/hydrate_instances.rs
+++ b/crates/lib/runloop/src/runloop/ops/hydrate_instances.rs
@@ -1,18 +1,13 @@
-use std::{
-    collections::{HashMap, HashSet},
-    sync::Arc,
-};
+use std::sync::Arc;
 
 use nonempty_collections::{IntoNonEmptyIterator as _, NEVec, NonEmptyIterator as _};
-use uuid::Uuid;
 use waymark_core_backend::QueuedInstance;
-use waymark_proto::ast as ir;
 
-use crate::hydrated_instance::HydratedInstance;
+use crate::{hydrated_instance::HydratedInstance, runloop::WorkflowDagCache};
 
 pub struct Params<'a, WorkflowRegistryBackend: ?Sized> {
     /// Cache of workflow DAGs keyed by workflow version ID to avoid repeated hydration work.
-    pub workflow_cache: &'a mut HashMap<Uuid, Arc<waymark_dag::DAG>>,
+    pub workflow_cache: &'a mut WorkflowDagCache,
     /// Backend used to fetch workflow definitions that are missing from the local cache.
     pub registry_backend: &'a WorkflowRegistryBackend,
     /// Claimed instances that need DAG references attached before shard execution.
@@ -22,7 +17,7 @@ pub struct Params<'a, WorkflowRegistryBackend: ?Sized> {
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error("caching missing DAGs: {0}")]
-    CacheMissingDags(#[source] CacheMissingDagsError),
+    WorkflowDagCachePopulate(#[source] crate::runloop::workflow_dag_cache::PopulateError),
 
     #[error("workflow version not found: {workflow_version_id}")]
     WorkflowCacheGetNone { workflow_version_id: uuid::Uuid },
@@ -51,15 +46,15 @@ where
         instances,
     } = params;
 
-    cache_missing_dags(
-        registry_backend,
-        workflow_cache,
-        instances
-            .iter()
-            .map(|instance| instance.workflow_version_id),
-    )
-    .await
-    .map_err(Error::CacheMissingDags)?;
+    workflow_cache
+        .populate(
+            registry_backend,
+            instances
+                .iter()
+                .map(|instance| instance.workflow_version_id),
+        )
+        .await
+        .map_err(Error::WorkflowDagCachePopulate)?;
 
     let hydrate_instance = |instance: QueuedInstance| -> Result<HydratedInstance, _> {
         let dag = workflow_cache
@@ -77,53 +72,4 @@ where
         .collect::<Result<NEVec<HydratedInstance>, Error>>()?;
 
     Ok(hydrated_instances)
-}
-
-#[derive(Debug, thiserror::Error)]
-pub enum CacheMissingDagsError {
-    #[error("get workflow versions: {0}")]
-    GetWorkflowVersions(#[source] waymark_backends_core::BackendError),
-
-    #[error("invalid workflow IR: {0}")]
-    IrProgramDecode(#[source] prost::DecodeError),
-
-    #[error("invalid workflow DAG: {0}")]
-    ConvertToDag(#[source] waymark_dag_builder::DagConversionError),
-}
-
-async fn cache_missing_dags<WorkflowRegistryBackend>(
-    registry_backend: &WorkflowRegistryBackend,
-    workflow_cache: &mut HashMap<Uuid, Arc<waymark_dag::DAG>>,
-    workflow_version_ids: impl IntoIterator<Item = uuid::Uuid>,
-) -> Result<(), CacheMissingDagsError>
-where
-    WorkflowRegistryBackend: ?Sized + waymark_workflow_registry_backend::WorkflowRegistryBackend,
-{
-    let mut missing = HashSet::new();
-
-    for workflow_version_id in workflow_version_ids {
-        if !workflow_cache.contains_key(&workflow_version_id) {
-            missing.insert(workflow_version_id);
-        }
-    }
-
-    if missing.is_empty() {
-        return Ok(());
-    }
-
-    let missing: Vec<_> = missing.into_iter().collect();
-
-    let versions = registry_backend
-        .get_workflow_versions(&missing)
-        .await
-        .map_err(CacheMissingDagsError::GetWorkflowVersions)?;
-    for version in versions {
-        let program = <ir::Program as prost::Message>::decode(&version.program_proto[..])
-            .map_err(CacheMissingDagsError::IrProgramDecode)?;
-        let dag = waymark_dag_builder::convert_to_dag(&program)
-            .map_err(CacheMissingDagsError::ConvertToDag)?;
-        workflow_cache.insert(version.id, Arc::new(dag));
-    }
-
-    Ok(())
 }

--- a/crates/lib/runloop/src/runloop/parts/new_instances.rs
+++ b/crates/lib/runloop/src/runloop/parts/new_instances.rs
@@ -1,20 +1,21 @@
 use std::{
     collections::{HashMap, HashSet},
     num::NonZeroUsize,
-    sync::Arc,
 };
 
 use chrono::{DateTime, Utc};
 use nonempty_collections::NEVec;
 use tracing::{debug, warn};
-use uuid::Uuid;
 use waymark_core_backend::QueuedInstance;
 use waymark_ids::{ExecutionId, InstanceId, LockId};
 use waymark_runner::SleepRequest;
 
 use crate::{
-    commit_barrier::CommitBarrier, hydrated_instance::HydratedInstance, instance_lock_heartbeat,
-    runloop::InflightActionDispatch, shard,
+    commit_barrier::CommitBarrier,
+    hydrated_instance::HydratedInstance,
+    instance_lock_heartbeat,
+    runloop::{InflightActionDispatch, WorkflowDagCache},
+    shard,
 };
 
 #[cfg(test)]
@@ -43,7 +44,7 @@ pub struct Params<'a, WorkflowRegistryBackend: ?Sized> {
     pub commit_barrier: &'a mut CommitBarrier<shard::Step>,
 
     /// Cache of workflow DAGs keyed by workflow version ID to avoid repeated hydration work.
-    pub workflow_cache: &'a mut HashMap<Uuid, Arc<waymark_dag::DAG>>,
+    pub workflow_cache: &'a mut WorkflowDagCache,
     /// Backend used to fetch workflow definitions that are missing from the local cache.
     pub registry_backend: &'a WorkflowRegistryBackend,
 

--- a/crates/lib/runloop/src/runloop/parts/new_instances.rs
+++ b/crates/lib/runloop/src/runloop/parts/new_instances.rs
@@ -13,7 +13,8 @@ use waymark_ids::{ExecutionId, InstanceId, LockId};
 use waymark_runner::SleepRequest;
 
 use crate::{
-    commit_barrier::CommitBarrier, instance_lock_heartbeat, runloop::InflightActionDispatch, shard,
+    commit_barrier::CommitBarrier, hydrated_instance::HydratedInstance, instance_lock_heartbeat,
+    runloop::InflightActionDispatch, shard,
 };
 
 #[cfg(test)]
@@ -95,24 +96,29 @@ where
         registry_backend,
         next_shard,
         shard_count,
-        mut all_instances,
+        all_instances,
     } = params;
 
     let params = super::ops::hydrate_instances::Params {
         workflow_cache,
         registry_backend,
-        instances: all_instances.as_mut(),
+        instances: all_instances,
     };
 
-    super::ops::hydrate_instances::run(params)
+    let hydrated_instances = super::ops::hydrate_instances::run(params)
         .await
         .map_err(Error::Hydrate)?;
-    debug!(count = all_instances.len(), "hydrated queued instances");
+    debug!(
+        count = hydrated_instances.len(),
+        "hydrated queued instances"
+    );
 
-    let mut by_shard: HashMap<usize, Vec<QueuedInstance>> = HashMap::new();
-    let mut claimed_instance_ids = Vec::with_capacity(all_instances.len().get());
+    let mut by_shard: HashMap<usize, Vec<HydratedInstance>> = HashMap::new();
+    let mut claimed_instance_ids = Vec::with_capacity(hydrated_instances.len().get());
     let mut replaced_instance_ids = Vec::new();
-    for instance in all_instances {
+    for hydrated_instance in hydrated_instances {
+        let instance = &hydrated_instance.instance;
+
         let shard_idx =
             if let Some(existing_shard_idx) = executor_shards.get(&instance.instance_id).copied() {
                 // If an already-active instance reappears from the queue, treat
@@ -134,7 +140,10 @@ where
                 shard_idx
             };
         claimed_instance_ids.push(instance.instance_id);
-        by_shard.entry(shard_idx).or_default().push(instance);
+        by_shard
+            .entry(shard_idx)
+            .or_default()
+            .push(hydrated_instance);
     }
 
     if !replaced_instance_ids.is_empty() {

--- a/crates/lib/runloop/src/runloop/parts/new_instances/tests.rs
+++ b/crates/lib/runloop/src/runloop/parts/new_instances/tests.rs
@@ -150,7 +150,6 @@ fn main(input: [x], output: [y]):
     let result = super::handle(harness.params(NEVec::new(QueuedInstance {
         workflow_version_id,
         schedule_id: None,
-        dag: None,
         entry_node: ExecutionId::new_uuid_v4(),
         state: None,
         action_results: HashMap::new(),
@@ -207,5 +206,5 @@ fn main(input: [x], output: [y]):
         panic!("expected AssignInstances command");
     };
     assert_eq!(batch.len(), 1);
-    assert_eq!(batch[0].instance_id, instance_id);
+    assert_eq!(batch[0].instance.instance_id, instance_id);
 }

--- a/crates/lib/runloop/src/runloop/parts/new_instances/tests.rs
+++ b/crates/lib/runloop/src/runloop/parts/new_instances/tests.rs
@@ -1,5 +1,4 @@
 use std::collections::{HashMap, HashSet};
-use std::sync::Arc;
 
 use nonempty_collections::NEVec;
 use prost::Message;
@@ -12,7 +11,7 @@ use waymark_workflow_registry_backend::{WorkflowRegistration, WorkflowRegistryBa
 
 use crate::commit_barrier::CommitBarrier;
 use crate::instance_lock_heartbeat;
-use crate::runloop::InflightActionDispatch;
+use crate::runloop::{InflightActionDispatch, WorkflowDagCache};
 use crate::shard;
 
 struct TestHarness {
@@ -27,7 +26,7 @@ struct TestHarness {
     pub sleeping_by_instance: HashMap<InstanceId, HashSet<ExecutionId>>,
     pub blocked_until_by_instance: HashMap<InstanceId, chrono::DateTime<chrono::Utc>>,
     pub commit_barrier: CommitBarrier<shard::Step>,
-    pub workflow_cache: HashMap<Uuid, Arc<waymark_dag::DAG>>,
+    pub workflow_cache: WorkflowDagCache,
     pub next_shard: usize,
 }
 
@@ -45,7 +44,7 @@ impl Default for TestHarness {
             sleeping_by_instance: HashMap::new(),
             blocked_until_by_instance: HashMap::new(),
             commit_barrier: CommitBarrier::new(),
-            workflow_cache: HashMap::new(),
+            workflow_cache: WorkflowDagCache::default(),
             next_shard: 0,
         }
     }

--- a/crates/lib/runloop/src/runloop/workflow_dag_cache.rs
+++ b/crates/lib/runloop/src/runloop/workflow_dag_cache.rs
@@ -1,0 +1,70 @@
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
+
+use uuid::Uuid;
+use waymark_proto::ast as ir;
+
+#[derive(Debug, Default)]
+pub struct WorkflowDagCache {
+    map: HashMap<Uuid, Arc<waymark_dag::DAG>>,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum PopulateError {
+    #[error("get workflow versions: {0}")]
+    GetWorkflowVersions(#[source] waymark_backends_core::BackendError),
+
+    #[error("invalid workflow IR: {0}")]
+    IrProgramDecode(#[source] prost::DecodeError),
+
+    #[error("invalid workflow DAG: {0}")]
+    ConvertToDag(#[source] waymark_dag_builder::DagConversionError),
+}
+
+impl WorkflowDagCache {
+    /// Populate the DAG cache for `workflow_version_ids` from
+    /// the `registry_backend`.
+    pub async fn populate<WorkflowRegistryBackend>(
+        &mut self,
+        registry_backend: &WorkflowRegistryBackend,
+        workflow_version_ids: impl IntoIterator<Item = uuid::Uuid>,
+    ) -> Result<(), PopulateError>
+    where
+        WorkflowRegistryBackend:
+            ?Sized + waymark_workflow_registry_backend::WorkflowRegistryBackend,
+    {
+        let mut missing = HashSet::new();
+
+        for workflow_version_id in workflow_version_ids {
+            if !self.map.contains_key(&workflow_version_id) {
+                missing.insert(workflow_version_id);
+            }
+        }
+
+        if missing.is_empty() {
+            return Ok(());
+        }
+
+        let missing: Vec<_> = missing.into_iter().collect();
+
+        let versions = registry_backend
+            .get_workflow_versions(&missing)
+            .await
+            .map_err(PopulateError::GetWorkflowVersions)?;
+        for version in versions {
+            let program = <ir::Program as prost::Message>::decode(&version.program_proto[..])
+                .map_err(PopulateError::IrProgramDecode)?;
+            let dag = waymark_dag_builder::convert_to_dag(&program)
+                .map_err(PopulateError::ConvertToDag)?;
+            self.map.insert(version.id, Arc::new(dag));
+        }
+
+        Ok(())
+    }
+
+    pub fn get(&self, workflow_version_id: &uuid::Uuid) -> Option<&Arc<waymark_dag::DAG>> {
+        self.map.get(workflow_version_id)
+    }
+}

--- a/crates/lib/runloop/src/shard/command.rs
+++ b/crates/lib/runloop/src/shard/command.rs
@@ -1,9 +1,10 @@
-use waymark_core_backend::QueuedInstance;
 use waymark_ids::{ExecutionId, InstanceId};
 use waymark_worker_core::ActionCompletion;
 
+use crate::hydrated_instance::HydratedInstance;
+
 pub enum Command {
-    AssignInstances(Vec<QueuedInstance>),
+    AssignInstances(Vec<HydratedInstance>),
     ActionCompletions(Vec<ActionCompletion>),
     Wake(Vec<ExecutionId>),
     Evict(Vec<InstanceId>),

--- a/crates/lib/runloop/src/shard/run.rs
+++ b/crates/lib/runloop/src/shard/run.rs
@@ -4,15 +4,12 @@ use tracing::{debug, warn};
 use waymark_ids::{ExecutionId, InstanceId};
 use waymark_worker_core::ActionCompletion;
 
-use crate::shard;
+use crate::{hydrated_instance::HydratedInstance, shard};
 
 #[derive(Debug, thiserror::Error)]
 pub enum AssignInstancesError {
     #[error("queued instance missing runner state")]
     QueuedInstanceMissingRunnerState,
-
-    #[error("queued instance missing workflow DAG")]
-    QueuedInstanceMissingWorkflowDag,
 
     #[error("start: {0}")]
     Start(#[source] super::executor::StartError),
@@ -54,13 +51,15 @@ pub fn run_executor_shard(
 
     while let Ok(command) = receiver.recv() {
         match command {
-            shard::Command::AssignInstances(instances) => {
+            shard::Command::AssignInstances(hydrated_instances) => {
                 debug!(
                     shard_id,
-                    count = instances.len(),
+                    count = hydrated_instances.len(),
                     "assigning instances to shard"
                 );
-                for instance in instances {
+                for hydrated_instance in hydrated_instances {
+                    let HydratedInstance { instance, dag } = hydrated_instance;
+
                     // If the same instance id was reclaimed from the DB, we treat
                     // the prior in-memory executor as stale (e.g. stalled) and
                     // replace it with the freshly claimed state.
@@ -78,18 +77,6 @@ pub fn run_executor_shard(
                             instance.entry_node,
                             Error::AssignInstances(
                                 AssignInstancesError::QueuedInstanceMissingRunnerState,
-                            ),
-                            &sender,
-                        );
-                        continue;
-                    };
-
-                    let Some(dag) = instance.dag else {
-                        send_instance_failed(
-                            instance.instance_id,
-                            instance.entry_node,
-                            Error::AssignInstances(
-                                AssignInstancesError::QueuedInstanceMissingWorkflowDag,
                             ),
                             &sender,
                         );

--- a/crates/lib/runloop/tests/integration.rs
+++ b/crates/lib/runloop/tests/integration.rs
@@ -121,7 +121,6 @@ fn main(input: [x], output: [y]):
     queue.lock().expect("queue lock").push_back(QueuedInstance {
         workflow_version_id,
         schedule_id: None,
-        dag: None,
         entry_node: entry_exec.node_id,
         state: Some(state),
         action_results: HashMap::new(),
@@ -227,7 +226,6 @@ fn main(input: [x], output: [y]):
         queue.lock().expect("queue lock").push_back(QueuedInstance {
             workflow_version_id,
             schedule_id: None,
-            dag: None,
             entry_node: entry_exec.node_id,
             state: Some(state),
             action_results: HashMap::new(),
@@ -339,7 +337,6 @@ fn main(input: [x], output: [y]):
     queue.lock().expect("queue lock").push_back(QueuedInstance {
         workflow_version_id,
         schedule_id: None,
-        dag: None,
         entry_node: entry_exec.node_id,
         state: Some(state),
         action_results: HashMap::new(),
@@ -428,7 +425,6 @@ fn main(input: [], output: [y]):
     queue.lock().expect("queue lock").push_back(QueuedInstance {
         workflow_version_id,
         schedule_id: None,
-        dag: None,
         entry_node: entry_exec.node_id,
         state: Some(state),
         action_results: HashMap::new(),
@@ -543,7 +539,6 @@ fn main(input: [x], output: [y]):
     queue.lock().expect("queue lock").push_back(QueuedInstance {
         workflow_version_id,
         schedule_id: None,
-        dag: None,
         entry_node: entry_exec.node_id,
         state: Some(state),
         action_results: HashMap::new(),
@@ -691,7 +686,6 @@ fn main(input: [limit], output: [result]):
     queue.lock().expect("queue lock").push_back(QueuedInstance {
         workflow_version_id,
         schedule_id: None,
-        dag: None,
         entry_node: entry_exec.node_id,
         state: Some(state),
         action_results: HashMap::new(),
@@ -744,7 +738,6 @@ async fn test_runloop_reproduces_no_progress_with_continued_queue_growth() {
             .queue_instances(&[QueuedInstance {
                 workflow_version_id: Uuid::new_v4(),
                 schedule_id: None,
-                dag: None,
                 entry_node: ExecutionId::new_uuid_v4(),
                 state: None,
                 action_results: HashMap::new(),
@@ -881,7 +874,6 @@ fn main(input: [x], output: [y]):
     queue.lock().expect("queue lock").push_back(QueuedInstance {
         workflow_version_id,
         schedule_id: None,
-        dag: None,
         entry_node: action_exec.node_id,
         state: Some(state),
         action_results: HashMap::new(),
@@ -977,7 +969,6 @@ fn main(input: [], output: [result]):
     queue.lock().expect("queue lock").push_back(QueuedInstance {
         workflow_version_id,
         schedule_id: None,
-        dag: None,
         entry_node: entry_exec.node_id,
         state: Some(state),
         action_results: HashMap::new(),
@@ -1059,7 +1050,6 @@ fn main(input: [], output: [result]):
     queue.lock().expect("queue lock").push_back(QueuedInstance {
         workflow_version_id,
         schedule_id: None,
-        dag: None,
         entry_node: entry_exec.node_id,
         state: Some(state),
         action_results: HashMap::new(),
@@ -1139,7 +1129,6 @@ fn main(input: [], output: [result]):
     queue.lock().expect("queue lock").push_back(QueuedInstance {
         workflow_version_id,
         schedule_id: None,
-        dag: None,
         entry_node: entry_exec.node_id,
         state: Some(state),
         action_results: HashMap::new(),

--- a/crates/lib/scheduler-loop/src/lib.rs
+++ b/crates/lib/scheduler-loop/src/lib.rs
@@ -159,7 +159,6 @@ where
         let queued = QueuedInstance {
             workflow_version_id: workflow.version_id,
             schedule_id: Some(schedule.id),
-            dag: None,
             entry_node: entry_exec.node_id,
             state: Some(state),
             action_results: HashMap::new(),


### PR DESCRIPTION
This PR addresses a few issues with how the DAG was managed at runtime.

I have made an observation that while the `dag` was an optional value of `QueuedInstance` it was never used anywhere but a small codepath that worked only with hydrated instances - not stored/loaded in/from the database, not used in the serialization - etc. This was a long-time annoyance, since before I did the audit of accesses to the dag for the purposes of doing this refactor it was unclear whether this was intentional or just a coincidence (although intuitively the contract was quite clear); for implementing the replay feature this was particularly important.

So to avoid any further doubts and to address this long-outstanding issue I've decided to short-list this refactor.

Here we split the `dag` value out of the `QueuedInstance` and add a new type `HydratedInstance` that wraps both `QueuedInstance` and the `dag` - which is not an `Option` anymore and is required to be present. This allowed for elimination of one error class that is now provably guaranteed to be impossible via the type-system (see https://github.com/piercefreeman/waymark/pull/342/changes#diff-c025325f46a7262c47bf26ef0590bad109f4608777c0c7f9f501b5647e5bd802L87-L88).

Notably, this eliminates the `waymark-core-backend` dependency on `waymark-dag` - which was unwanted and should improve the compilation graph.

I'll later consider if the runner state should have the same treatment - but for this for now is enough to reduce the space of possible things to handle / care about at VCR.

---

The essence of this PR is https://github.com/piercefreeman/waymark/pull/342/changes#diff-85a3d501d1ed7f6e67bb6b8455bd31764e6355e10b1b683a24bdad09ce614c68