### PR TITLE
Introduce a proper id type for WorkflowVersionId

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3958,7 +3958,6 @@ version = "0.1.0"
 dependencies = [
  "nonempty-collections",
  "thiserror",
- "uuid",
  "waymark-backends-core",
  "waymark-core-backend",
  "waymark-ids",
@@ -4059,7 +4058,6 @@ dependencies = [
  "sqlx",
  "tokio",
  "tracing",
- "uuid",
  "waymark-backend-postgres",
  "waymark-backend-postgres-migrations",
  "waymark-core-backend",
@@ -4219,7 +4217,6 @@ dependencies = [
  "serde_json",
  "sha2",
  "tokio",
- "uuid",
  "waymark-backend-memory",
  "waymark-core-backend",
  "waymark-dag",
@@ -4282,7 +4279,6 @@ dependencies = [
  "serde_json",
  "sqlx",
  "tokio",
- "uuid",
  "waymark-backend-memory",
  "waymark-backend-postgres",
  "waymark-backend-postgres-migrations",
@@ -4545,7 +4541,6 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
- "uuid",
  "waymark-backend-memory",
  "waymark-core-backend",
  "waymark-dag-builder",
@@ -4566,8 +4561,8 @@ dependencies = [
 name = "waymark-scheduler-loop-core"
 version = "0.1.0"
 dependencies = [
- "uuid",
  "waymark-dag",
+ "waymark-ids",
 ]
 
 [[package]]
@@ -4925,8 +4920,8 @@ dependencies = [
 name = "waymark-workflow-registry-backend"
 version = "0.1.0"
 dependencies = [
- "uuid",
  "waymark-backends-core",
+ "waymark-ids",
 ]
 
 [[package]]

--- a/crates/bin/benchmark/Cargo.toml
+++ b/crates/bin/benchmark/Cargo.toml
@@ -32,4 +32,3 @@ sha2 = { workspace = true }
 sqlx = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tracing = { workspace = true }
-uuid = { workspace = true }

--- a/crates/bin/benchmark/src/main.rs
+++ b/crates/bin/benchmark/src/main.rs
@@ -12,10 +12,9 @@ use rand::seq::SliceRandom;
 use serde_json::Value;
 use sha2::{Digest, Sha256};
 use sqlx::PgPool;
-use uuid::Uuid;
 use waymark_backend_postgres::PostgresBackend;
 use waymark_core_backend::QueuedInstance;
-use waymark_ids::{InstanceId, LockId};
+use waymark_ids::{InstanceId, LockId, WorkflowVersionId};
 use waymark_secret_string::{SecretStr, SecretString};
 use waymark_support_integration::{LOCAL_POSTGRES_DSN, ensure_local_postgres};
 use waymark_workflow_registry_backend::{WorkflowRegistration, WorkflowRegistryBackend as _};
@@ -148,7 +147,7 @@ fn build_cases(base: i64) -> HashMap<String, BenchmarkCase> {
     cases
 }
 
-fn build_instance(case: &BenchmarkCase, workflow_version_id: Uuid) -> QueuedInstance {
+fn build_instance(case: &BenchmarkCase, workflow_version_id: WorkflowVersionId) -> QueuedInstance {
     let mut state = RunnerState::new(Some(Arc::clone(&case.dag)), None, None, false);
     for (name, value) in &case.inputs {
         let expr = literal_from_json_value(value);

--- a/crates/bin/bridge/src/bridge_service.rs
+++ b/crates/bin/bridge/src/bridge_service.rs
@@ -15,7 +15,7 @@ use uuid::Uuid;
 use waymark_backend_memory::MemoryBackend;
 use waymark_core_backend::{InstanceDone, QueuedInstance};
 use waymark_dag_builder::convert_to_dag;
-use waymark_ids::{InstanceId, LockId};
+use waymark_ids::{InstanceId, LockId, WorkflowVersionId};
 use waymark_ir_conversions::literal_from_json_value;
 use waymark_proto::{ast as ir, messages as proto};
 use waymark_runloop::{RunLoop, RunLoopConfig};
@@ -600,7 +600,7 @@ fn find_latest_instance_done(
 
 fn build_queued_instance(
     instance_id: InstanceId,
-    workflow_version_id: Uuid,
+    workflow_version_id: WorkflowVersionId,
     dag: Arc<waymark_dag::DAG>,
     initial_context: Option<proto::WorkflowArguments>,
 ) -> Result<QueuedInstance, String> {

--- a/crates/bin/bridge/src/workflow_store.rs
+++ b/crates/bin/bridge/src/workflow_store.rs
@@ -6,6 +6,7 @@ use uuid::Uuid;
 
 use waymark_backend_postgres::PostgresBackend;
 use waymark_core_backend::QueuedInstance;
+use waymark_ids::WorkflowVersionId;
 use waymark_proto::messages as proto;
 use waymark_runner_executor_core::{ExecutionException, ExecutionSuccess};
 use waymark_secret_string::SecretStr;
@@ -31,7 +32,7 @@ impl WorkflowStore {
     pub async fn upsert_workflow_version(
         &self,
         registration: &proto::WorkflowRegistration,
-    ) -> Result<Uuid> {
+    ) -> Result<WorkflowVersionId> {
         let workflow_version = if registration.workflow_version.is_empty() {
             registration.ir_hash.clone()
         } else {

--- a/crates/bin/fuzzer/Cargo.toml
+++ b/crates/bin/fuzzer/Cargo.toml
@@ -26,7 +26,6 @@ prost = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true }
 tokio = { workspace = true }
-uuid = { workspace = true, features = ["serde", "v4"] }
 
 [lib]
 test = false

--- a/crates/bin/fuzzer/src/harness.rs
+++ b/crates/bin/fuzzer/src/harness.rs
@@ -8,10 +8,9 @@ use anyhow::{Context, Result, bail};
 use prost::Message;
 use serde_json::Value;
 use sha2::{Digest, Sha256};
-use uuid::Uuid;
 use waymark_backend_memory::MemoryBackend;
 use waymark_core_backend::QueuedInstance;
-use waymark_ids::{InstanceId, LockId};
+use waymark_ids::{InstanceId, LockId, WorkflowVersionId};
 use waymark_workflow_registry_backend::{WorkflowRegistration, WorkflowRegistryBackend as _};
 
 use super::generator::GeneratedCase;
@@ -103,7 +102,7 @@ async fn register_workflow(
     case_index: usize,
     backend: &MemoryBackend,
     program: &ir::Program,
-) -> Result<Uuid> {
+) -> Result<WorkflowVersionId> {
     let program_proto = program.encode_to_vec();
     let ir_hash = format!("{:x}", Sha256::digest(&program_proto));
     backend
@@ -120,7 +119,7 @@ async fn register_workflow(
 
 fn build_instance(
     instance_id: InstanceId,
-    workflow_version_id: Uuid,
+    workflow_version_id: WorkflowVersionId,
     dag: Arc<waymark_dag::DAG>,
     base: i64,
 ) -> Result<QueuedInstance> {

--- a/crates/bin/integration-test/Cargo.toml
+++ b/crates/bin/integration-test/Cargo.toml
@@ -31,4 +31,3 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 sqlx = { workspace = true, features = ["runtime-tokio"] }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
-uuid = { workspace = true }

--- a/crates/bin/integration-test/src/main.rs
+++ b/crates/bin/integration-test/src/main.rs
@@ -16,8 +16,7 @@ use clap::Parser;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use sqlx::Row;
-use uuid::Uuid;
-use waymark_ids::{InstanceId, LockId};
+use waymark_ids::{InstanceId, LockId, WorkflowVersionId};
 use waymark_runner_executor_core::{ExecutionException, ExecutionSuccess};
 use waymark_secret_string::SecretString;
 
@@ -609,7 +608,7 @@ where
 
 fn build_queued_instance(
     instance_id: InstanceId,
-    workflow_version_id: Uuid,
+    workflow_version_id: WorkflowVersionId,
     dag: Arc<DAG>,
     kwargs: &HashMap<String, Value>,
 ) -> Result<QueuedInstance> {

--- a/crates/bin/soak-harness/src/diag.rs
+++ b/crates/bin/soak-harness/src/diag.rs
@@ -6,7 +6,7 @@ use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 use serde::Serialize;
 use sqlx::PgPool;
-use uuid::Uuid;
+use waymark_ids::WorkflowVersionId;
 
 use crate::data;
 use crate::flow::HealthSample;
@@ -16,7 +16,7 @@ struct DiagnosticBundle {
     reason: crate::flow::TerminationReason,
     generated_at: DateTime<Utc>,
     workflow_name: String,
-    workflow_version_id: Uuid,
+    workflow_version_id: WorkflowVersionId,
     queue_snapshot: data::QueueSnapshot,
     worker_status: Option<data::WorkerStatusSnapshot>,
     lock_owners: QueryCapture<data::LockOwnerRow>,

--- a/crates/bin/soak-harness/src/setup_workflows.rs
+++ b/crates/bin/soak-harness/src/setup_workflows.rs
@@ -3,10 +3,10 @@ use std::{num::NonZeroUsize, sync::Arc};
 use anyhow::{Context, Result, anyhow};
 use prost::Message as _;
 use sha2::{Digest as _, Sha256};
-use uuid::Uuid;
 use waymark_backend_postgres::PostgresBackend;
 use waymark_dag::DAG;
 use waymark_dag_builder::convert_to_dag;
+use waymark_ids::WorkflowVersionId;
 use waymark_ir_parser::parse_program;
 use waymark_workflow_registry_backend::{WorkflowRegistration, WorkflowRegistryBackend as _};
 
@@ -15,7 +15,7 @@ const DEFAULT_WORKFLOW_NAME: &str = "waymark_soak_timeout_mix_v1";
 #[derive(Debug, Clone)]
 pub struct RegisteredWorkflow {
     pub workflow_name: String,
-    pub workflow_version_id: Uuid,
+    pub workflow_version_id: WorkflowVersionId,
     pub dag: Arc<DAG>,
     pub entry_template_id: String,
 }

--- a/crates/bin/start-workers/src/main.rs
+++ b/crates/bin/start-workers/src/main.rs
@@ -46,7 +46,7 @@ use uuid::Uuid;
 use waymark_backend_postgres::PostgresBackend;
 use waymark_config::WorkerConfig;
 use waymark_dag_builder::convert_to_dag;
-use waymark_ids::LockId;
+use waymark_ids::{LockId, WorkflowVersionId};
 use waymark_nonzero_duration::NonZeroDuration;
 use waymark_proto::ast as ir;
 use waymark_runloop::RunLoopConfig;
@@ -316,7 +316,7 @@ impl waymark_scheduler_loop_core::DagResolver for SchedulerDagResolver {
             return Ok(None);
         };
 
-        let version_id: Uuid = row.get("id");
+        let version_id: WorkflowVersionId = row.get("id");
         let payload: Vec<u8> = row.get("program_proto");
         let program =
             ir::Program::decode(&payload[..]).map_err(SchedulerDagResolverError::DagProtoDecode)?;

--- a/crates/lib/backend-fault-injection/Cargo.toml
+++ b/crates/lib/backend-fault-injection/Cargo.toml
@@ -12,7 +12,6 @@ waymark-workflow-registry-backend = { workspace = true }
 
 nonempty-collections = { workspace = true }
 thiserror = { workspace = true }
-uuid = { workspace = true }
 
 [lib]
 test = false

--- a/crates/lib/backend-fault-injection/src/lib.rs
+++ b/crates/lib/backend-fault-injection/src/lib.rs
@@ -4,12 +4,11 @@ use std::sync::{
 };
 
 use nonempty_collections::NEVec;
-use uuid::Uuid;
 use waymark_backends_core::BackendResult;
 use waymark_core_backend::{
     CoreBackend, GraphUpdate, InstanceDone, InstanceLockStatus, LockClaim, QueuedInstance,
 };
-use waymark_ids::{InstanceId, LockId};
+use waymark_ids::{InstanceId, LockId, WorkflowVersionId};
 use waymark_workflow_registry_backend::{
     WorkflowRegistration, WorkflowRegistryBackend, WorkflowVersion,
 };
@@ -118,11 +117,14 @@ where
     async fn upsert_workflow_version(
         &self,
         registration: &WorkflowRegistration,
-    ) -> BackendResult<Uuid> {
+    ) -> BackendResult<WorkflowVersionId> {
         self.inner.upsert_workflow_version(registration).await
     }
 
-    async fn get_workflow_versions(&self, ids: &[Uuid]) -> BackendResult<Vec<WorkflowVersion>> {
+    async fn get_workflow_versions(
+        &self,
+        ids: &[WorkflowVersionId],
+    ) -> BackendResult<Vec<WorkflowVersion>> {
         self.inner.get_workflow_versions(ids).await
     }
 }

--- a/crates/lib/backend-memory/src/lib.rs
+++ b/crates/lib/backend-memory/src/lib.rs
@@ -22,16 +22,15 @@ use std::collections::{HashMap, VecDeque};
 use std::sync::{Arc, Mutex};
 
 use chrono::{DateTime, Utc};
-use uuid::Uuid;
 
 use waymark_core_backend::{ActionDone, GraphUpdate, InstanceDone, QueuedInstance};
-use waymark_ids::{InstanceId, LockId};
+use waymark_ids::{InstanceId, LockId, WorkflowVersionId};
 use waymark_scheduler_core::{ScheduleId, WorkflowSchedule};
 use waymark_worker_status_backend::WorkerStatusUpdate;
 use waymark_workflow_registry_backend::WorkflowRegistration;
 
 type WorkflowVersionKey = (String, String);
-type WorkflowVersionValue = (Uuid, WorkflowRegistration);
+type WorkflowVersionValue = (WorkflowVersionId, WorkflowRegistration);
 type WorkflowVersionStore = HashMap<WorkflowVersionKey, WorkflowVersionValue>;
 type InstanceLockStore = HashMap<InstanceId, (Option<LockId>, Option<DateTime<Utc>>)>;
 

--- a/crates/lib/backend-memory/src/workflow_registry_backend.rs
+++ b/crates/lib/backend-memory/src/workflow_registry_backend.rs
@@ -1,4 +1,4 @@
-use uuid::Uuid;
+use waymark_ids::WorkflowVersionId;
 use waymark_workflow_registry_backend::{
     BackendError, BackendResult, WorkflowRegistration, WorkflowRegistryBackend, WorkflowVersion,
 };
@@ -7,7 +7,7 @@ impl WorkflowRegistryBackend for crate::MemoryBackend {
     async fn upsert_workflow_version(
         &self,
         registration: &WorkflowRegistration,
-    ) -> BackendResult<Uuid> {
+    ) -> BackendResult<WorkflowVersionId> {
         let mut guard = self
             .workflow_versions
             .lock()
@@ -26,12 +26,15 @@ impl WorkflowRegistryBackend for crate::MemoryBackend {
             return Ok(*id);
         }
 
-        let id = Uuid::new_v4();
+        let id = WorkflowVersionId::new_uuid_v4();
         guard.insert(key, (id, registration.clone()));
         Ok(id)
     }
 
-    async fn get_workflow_versions(&self, ids: &[Uuid]) -> BackendResult<Vec<WorkflowVersion>> {
+    async fn get_workflow_versions(
+        &self,
+        ids: &[WorkflowVersionId],
+    ) -> BackendResult<Vec<WorkflowVersion>> {
         if ids.is_empty() {
             return Ok(Vec::new());
         }

--- a/crates/lib/backend-postgres/src/core.rs
+++ b/crates/lib/backend-postgres/src/core.rs
@@ -12,7 +12,7 @@ use sqlx::{Postgres, QueryBuilder, Row};
 use tracing::warn;
 use uuid::Uuid;
 use waymark_garbage_collector_backend::{GarbageCollectionResult, GarbageCollectorBackend};
-use waymark_ids::{ExecutionId, InstanceId, LockId};
+use waymark_ids::{ExecutionId, InstanceId, LockId, WorkflowVersionId};
 use waymark_runner_executor_core::{ExecutionSuccess, UncheckedExecutionResult};
 use waymark_scheduler_backend::{BackendError, BackendResult};
 use waymark_worker_status_backend::{WorkerStatusBackend, WorkerStatusUpdate};
@@ -135,7 +135,7 @@ impl PostgresBackend {
         if instances.is_empty() {
             return Ok(());
         }
-        let workflow_version_ids: Vec<Uuid> = instances
+        let workflow_version_ids: Vec<WorkflowVersionId> = instances
             .iter()
             .map(|instance| instance.workflow_version_id)
             .collect();
@@ -147,7 +147,7 @@ impl PostgresBackend {
                     "select:workflow_versions_by_id_for_queue_instances"
                 ))
                 .await?;
-        let mut workflow_names_by_version_id: HashMap<Uuid, String> =
+        let mut workflow_names_by_version_id: HashMap<WorkflowVersionId, String> =
             HashMap::with_capacity(workflow_rows.len());
         for row in workflow_rows {
             workflow_names_by_version_id.insert(row.get("id"), row.get("workflow_name"));
@@ -1182,7 +1182,7 @@ mod tests {
 
     fn sample_queued_instance(instance_id: InstanceId, entry_node: ExecutionId) -> QueuedInstance {
         QueuedInstance {
-            workflow_version_id: Uuid::new_v4(),
+            workflow_version_id: WorkflowVersionId::new_uuid_v4(),
             schedule_id: None,
             entry_node,
             state: Some(sample_runner_state()),
@@ -1223,7 +1223,7 @@ mod tests {
 
     async fn insert_workflow_version_row(
         backend: &PostgresBackend,
-        workflow_version_id: Uuid,
+        workflow_version_id: WorkflowVersionId,
         workflow_name: &str,
     ) {
         sqlx::query(
@@ -1283,7 +1283,7 @@ mod tests {
                 .expect("runner count");
         assert_eq!(runner_count, 1);
 
-        let workflow_version_id: Option<Uuid> = sqlx::query_scalar(
+        let workflow_version_id: Option<WorkflowVersionId> = sqlx::query_scalar(
             "SELECT workflow_version_id FROM runner_instances WHERE instance_id = $1",
         )
         .bind(instance_id)
@@ -1317,7 +1317,7 @@ mod tests {
         let backend = setup_backend().await;
         let instance_id = InstanceId::new_uuid_v4();
         let entry_node = ExecutionId::new_uuid_v4();
-        let workflow_version_id = Uuid::new_v4();
+        let workflow_version_id = WorkflowVersionId::new_uuid_v4();
         insert_workflow_version_row(&backend, workflow_version_id, "tests.searchable").await;
 
         let queued = QueuedInstance {

--- a/crates/lib/backend-postgres/src/registry.rs
+++ b/crates/lib/backend-postgres/src/registry.rs
@@ -1,6 +1,6 @@
 use sqlx::Row;
-use uuid::Uuid;
 use waymark_backends_core::{BackendError, BackendResult};
+use waymark_ids::WorkflowVersionId;
 use waymark_timed_future::TimedFutureExt as _;
 use waymark_workflow_registry_backend::{
     WorkflowRegistration, WorkflowRegistryBackend, WorkflowVersion,
@@ -13,7 +13,7 @@ impl WorkflowRegistryBackend for PostgresBackend {
     async fn upsert_workflow_version(
         &self,
         registration: &WorkflowRegistration,
-    ) -> BackendResult<Uuid> {
+    ) -> BackendResult<WorkflowVersionId> {
         let inserted = sqlx::query(
             r#"
             INSERT INTO workflow_versions
@@ -34,7 +34,7 @@ impl WorkflowRegistryBackend for PostgresBackend {
         .await?;
 
         if let Some(row) = inserted {
-            let id: Uuid = row.get("id");
+            let id: WorkflowVersionId = row.get("id");
             return Ok(id);
         }
 
@@ -53,7 +53,7 @@ impl WorkflowRegistryBackend for PostgresBackend {
         ))
         .await?;
 
-        let id: Uuid = row.get("id");
+        let id: WorkflowVersionId = row.get("id");
         let existing_hash: String = row.get("ir_hash");
         if existing_hash != registration.ir_hash {
             return Err(BackendError::Message(format!(
@@ -66,7 +66,10 @@ impl WorkflowRegistryBackend for PostgresBackend {
     }
 
     #[function_name::named]
-    async fn get_workflow_versions(&self, ids: &[Uuid]) -> BackendResult<Vec<WorkflowVersion>> {
+    async fn get_workflow_versions(
+        &self,
+        ids: &[WorkflowVersionId],
+    ) -> BackendResult<Vec<WorkflowVersion>> {
         if ids.is_empty() {
             return Ok(Vec::new());
         }

--- a/crates/lib/backend-postgres/src/webapp.rs
+++ b/crates/lib/backend-postgres/src/webapp.rs
@@ -11,7 +11,7 @@ use waymark_backends_core::{BackendError, BackendResult};
 use waymark_core_backend::{GraphUpdate, QueuedInstance};
 use waymark_dag::{DAGNode, EdgeType};
 use waymark_dag_builder::convert_to_dag;
-use waymark_ids::{ExecutionId, InstanceId};
+use waymark_ids::{ExecutionId, InstanceId, WorkflowVersionId};
 use waymark_ir_conversions::literal_from_json_value;
 use waymark_proto::ast as ir;
 use waymark_runner::replay_action_kwargs;
@@ -539,7 +539,7 @@ impl waymark_webapp_backend::WebappBackend for crate::PostgresBackend {
             ))
         })?;
 
-        let workflow_version_id: Uuid = latest_version.get("id");
+        let workflow_version_id: WorkflowVersionId = latest_version.get("id");
         let program_proto: Vec<u8> = latest_version.get("program_proto");
         let program = ir::Program::decode(&program_proto[..])
             .map_err(|err| BackendError::Message(format!("failed to decode workflow IR: {err}")))?;
@@ -1438,7 +1438,7 @@ fn parse_input_assignment_label(label: &str) -> Option<(&str, &str)> {
 }
 
 fn build_queued_instance(
-    workflow_version_id: Uuid,
+    workflow_version_id: WorkflowVersionId,
     dag: Arc<waymark_dag::DAG>,
     input_payload: &serde_json::Map<String, Value>,
 ) -> BackendResult<QueuedInstance> {
@@ -1935,7 +1935,7 @@ mod tests {
     async fn insert_instance_with_input_graph(
         backend: &PostgresBackend,
         workflow_name: &str,
-        workflow_version_id: Uuid,
+        workflow_version_id: WorkflowVersionId,
     ) -> InstanceId {
         let instance_id = InstanceId::new_uuid_v4();
         let entry_node = ExecutionId::new_uuid_v4();
@@ -1993,7 +1993,10 @@ fn main(input: [items], output: [total]):
         program.encode_to_vec()
     }
 
-    async fn insert_workflow_version(backend: &PostgresBackend, workflow_name: &str) -> Uuid {
+    async fn insert_workflow_version(
+        backend: &PostgresBackend,
+        workflow_name: &str,
+    ) -> WorkflowVersionId {
         WorkflowRegistryBackend::upsert_workflow_version(
             backend,
             &WorkflowRegistration {
@@ -2008,7 +2011,10 @@ fn main(input: [items], output: [total]):
         .expect("insert workflow version")
     }
 
-    async fn insert_loop_workflow_version(backend: &PostgresBackend, workflow_name: &str) -> Uuid {
+    async fn insert_loop_workflow_version(
+        backend: &PostgresBackend,
+        workflow_name: &str,
+    ) -> WorkflowVersionId {
         WorkflowRegistryBackend::upsert_workflow_version(
             backend,
             &WorkflowRegistration {

--- a/crates/lib/core-backend/src/data.rs
+++ b/crates/lib/core-backend/src/data.rs
@@ -12,12 +12,12 @@ use waymark_runner_executor_core::{
 };
 use waymark_runner_state::{ExecutionEdge, ExecutionNode, NodeStatus, RunnerState};
 
-use waymark_ids::{ExecutionId, InstanceId, LockId};
+use waymark_ids::{ExecutionId, InstanceId, LockId, WorkflowVersionId};
 
 /// Queued instance payload for the run loop.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct QueuedInstance {
-    pub workflow_version_id: Uuid,
+    pub workflow_version_id: WorkflowVersionId,
     #[serde(default)]
     pub schedule_id: Option<Uuid>,
     pub entry_node: ExecutionId,

--- a/crates/lib/ids/src/lib.rs
+++ b/crates/lib/ids/src/lib.rs
@@ -131,7 +131,13 @@ macro_rules! uuid_types {
     };
 }
 
-uuid_types![InstanceId, LockId, DispatchToken, ExecutionId];
+uuid_types![
+    InstanceId,
+    LockId,
+    DispatchToken,
+    ExecutionId,
+    WorkflowVersionId
+];
 
 #[deprecated = "use InstanceId instead"]
 pub type ExecutorId = InstanceId;

--- a/crates/lib/runloop/src/runloop/ops/hydrate_instances.rs
+++ b/crates/lib/runloop/src/runloop/ops/hydrate_instances.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use nonempty_collections::{IntoNonEmptyIterator as _, NEVec, NonEmptyIterator as _};
 use waymark_core_backend::QueuedInstance;
+use waymark_ids::WorkflowVersionId;
 
 use crate::{hydrated_instance::HydratedInstance, runloop::WorkflowDagCache};
 
@@ -20,7 +21,9 @@ pub enum Error {
     WorkflowDagCachePopulate(#[source] crate::runloop::workflow_dag_cache::PopulateError),
 
     #[error("workflow version not found: {workflow_version_id}")]
-    WorkflowCacheGetNone { workflow_version_id: uuid::Uuid },
+    WorkflowCacheGetNone {
+        workflow_version_id: WorkflowVersionId,
+    },
 }
 
 /// Loads and caches workflow DAG definitions for instances.

--- a/crates/lib/runloop/src/runloop/workflow_dag_cache.rs
+++ b/crates/lib/runloop/src/runloop/workflow_dag_cache.rs
@@ -3,12 +3,12 @@ use std::{
     sync::Arc,
 };
 
-use uuid::Uuid;
+use waymark_ids::WorkflowVersionId;
 use waymark_proto::ast as ir;
 
 #[derive(Debug, Default)]
 pub struct WorkflowDagCache {
-    map: HashMap<Uuid, Arc<waymark_dag::DAG>>,
+    map: HashMap<WorkflowVersionId, Arc<waymark_dag::DAG>>,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -29,7 +29,7 @@ impl WorkflowDagCache {
     pub async fn populate<WorkflowRegistryBackend>(
         &mut self,
         registry_backend: &WorkflowRegistryBackend,
-        workflow_version_ids: impl IntoIterator<Item = uuid::Uuid>,
+        workflow_version_ids: impl IntoIterator<Item = WorkflowVersionId>,
     ) -> Result<(), PopulateError>
     where
         WorkflowRegistryBackend:
@@ -64,7 +64,7 @@ impl WorkflowDagCache {
         Ok(())
     }
 
-    pub fn get(&self, workflow_version_id: &uuid::Uuid) -> Option<&Arc<waymark_dag::DAG>> {
+    pub fn get(&self, workflow_version_id: &WorkflowVersionId) -> Option<&Arc<waymark_dag::DAG>> {
         self.map.get(workflow_version_id)
     }
 }

--- a/crates/lib/runloop/tests/integration.rs
+++ b/crates/lib/runloop/tests/integration.rs
@@ -5,13 +5,12 @@ use std::time::Duration;
 use prost::Message;
 use serde_json::Value;
 use sha2::{Digest, Sha256};
-use uuid::Uuid;
 
 use waymark_backend_fault_injection::FaultInjectingBackend;
 use waymark_backend_memory::MemoryBackend;
 use waymark_core_backend::{ActionAttemptStatus, CoreBackend, QueuedInstance};
 use waymark_dag_builder::convert_to_dag;
-use waymark_ids::{ExecutionId, InstanceId, LockId};
+use waymark_ids::{ExecutionId, InstanceId, LockId, WorkflowVersionId};
 use waymark_ir_parser::parse_program;
 use waymark_nonzero_duration::NonZeroDuration;
 use waymark_proto::ast as ir;
@@ -736,7 +735,7 @@ async fn test_runloop_reproduces_no_progress_with_continued_queue_growth() {
     for _ in 0..20 {
         backend
             .queue_instances(&[QueuedInstance {
-                workflow_version_id: Uuid::new_v4(),
+                workflow_version_id: WorkflowVersionId::new_uuid_v4(),
                 schedule_id: None,
                 entry_node: ExecutionId::new_uuid_v4(),
                 state: None,

--- a/crates/lib/scheduler-loop-core/Cargo.toml
+++ b/crates/lib/scheduler-loop-core/Cargo.toml
@@ -6,5 +6,4 @@ publish.workspace = true
 
 [dependencies]
 waymark-dag = { workspace = true }
-
-uuid = { workspace = true }
+waymark-ids = { workspace = true }

--- a/crates/lib/scheduler-loop-core/src/lib.rs
+++ b/crates/lib/scheduler-loop-core/src/lib.rs
@@ -1,12 +1,12 @@
 use std::future::Future;
 use std::sync::Arc;
 
-use uuid::Uuid;
 use waymark_dag::DAG;
+use waymark_ids::WorkflowVersionId;
 
 #[derive(Clone)]
 pub struct WorkflowDag {
-    pub version_id: Uuid,
+    pub version_id: WorkflowVersionId,
     pub dag: Arc<DAG>,
 }
 

--- a/crates/lib/scheduler-loop/Cargo.toml
+++ b/crates/lib/scheduler-loop/Cargo.toml
@@ -21,7 +21,6 @@ serde_json = { workspace = true }
 tokio = { workspace = true, features = ["macros"] }
 tokio-util = { workspace = true }
 tracing = { workspace = true }
-uuid = { workspace = true }
 
 [dev-dependencies]
 waymark-backend-memory = { workspace = true }

--- a/crates/lib/scheduler-loop/src/lib.rs
+++ b/crates/lib/scheduler-loop/src/lib.rs
@@ -193,10 +193,9 @@ mod tests {
     use chrono::{Duration as ChronoDuration, Utc};
     use prost::Message;
     use serde_json::Value;
-    use uuid::Uuid;
     use waymark_backend_memory::MemoryBackend;
     use waymark_core_backend::{CoreBackend, LockClaim};
-    use waymark_ids::LockId;
+    use waymark_ids::{LockId, WorkflowVersionId};
     use waymark_scheduler_backend::SchedulerBackend;
     use waymark_scheduler_config::SchedulerConfig;
     use waymark_scheduler_core::{CreateScheduleParams, ScheduleType};
@@ -245,7 +244,7 @@ fn main(input: [number], output: [result]):
             async move {
                 if matches {
                     Ok::<_, std::convert::Infallible>(Some(WorkflowDag {
-                        version_id: Uuid::new_v4(),
+                        version_id: WorkflowVersionId::new_uuid_v4(),
                         dag: resolver_dag,
                     }))
                 } else {

--- a/crates/lib/workflow-registry-backend/Cargo.toml
+++ b/crates/lib/workflow-registry-backend/Cargo.toml
@@ -6,8 +6,7 @@ edition = "2024"
 
 [dependencies]
 waymark-backends-core = { workspace = true }
-
-uuid = { workspace = true }
+waymark-ids = { workspace = true }
 
 [lib]
 test = false

--- a/crates/lib/workflow-registry-backend/src/lib.rs
+++ b/crates/lib/workflow-registry-backend/src/lib.rs
@@ -1,6 +1,5 @@
-use uuid::Uuid;
-
 pub use waymark_backends_core::{BackendError, BackendResult};
+use waymark_ids::WorkflowVersionId;
 
 /// Registration payload for storing workflow DAG metadata.
 #[derive(Clone, Debug)]
@@ -15,7 +14,7 @@ pub struct WorkflowRegistration {
 #[derive(Clone, Debug)]
 /// Stored workflow version metadata and IR payload.
 pub struct WorkflowVersion {
-    pub id: Uuid,
+    pub id: WorkflowVersionId,
     pub workflow_name: String,
     pub workflow_version: String,
     pub ir_hash: String,
@@ -28,10 +27,10 @@ pub trait WorkflowRegistryBackend {
     fn upsert_workflow_version<'a>(
         &'a self,
         registration: &'a WorkflowRegistration,
-    ) -> impl Future<Output = BackendResult<Uuid>> + Send + 'a;
+    ) -> impl Future<Output = BackendResult<WorkflowVersionId>> + Send + 'a;
 
     fn get_workflow_versions<'a>(
         &'a self,
-        ids: &'a [Uuid],
+        ids: &'a [WorkflowVersionId],
     ) -> impl Future<Output = BackendResult<Vec<WorkflowVersion>>> + Send + 'a;
 }


### PR DESCRIPTION
Goes in after #342.

This PR adds a proper id type for where we had `Uuid`s for workflow versions ids. Similar to #296.

Notable, a lot of crates got rid of an explicit dependency in the `uuid` crate.