### PR TITLE
Switch schedule id to a waymark-ids newtype and use it consistently

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4149,7 +4149,6 @@ dependencies = [
  "chrono",
  "nonempty-collections",
  "serde",
- "uuid",
  "waymark-backends-core",
  "waymark-ids",
  "waymark-runner-executor-core",
@@ -4527,7 +4526,6 @@ dependencies = [
  "cron",
  "rand 0.9.3",
  "serde",
- "uuid",
  "waymark-ids",
 ]
 
@@ -4766,7 +4764,6 @@ dependencies = [
 name = "waymark-webapp-backend"
 version = "0.1.0"
 dependencies = [
- "uuid",
  "waymark-backends-core",
  "waymark-ids",
  "waymark-webapp-core",

--- a/crates/bin/bridge/src/bridge_service.rs
+++ b/crates/bin/bridge/src/bridge_service.rs
@@ -22,7 +22,7 @@ use waymark_runloop::{RunLoop, RunLoopConfig};
 use waymark_runner_executor_core::ExecutionException;
 use waymark_runner_state::RunnerState;
 use waymark_scheduler_backend::SchedulerBackend as _;
-use waymark_scheduler_core::{CreateScheduleParams, ScheduleId, ScheduleStatus, ScheduleType};
+use waymark_scheduler_core::{CreateScheduleParams, ScheduleStatus, ScheduleType};
 use waymark_worker_core::ActionCompletion;
 use waymark_workflow_registry_backend::{WorkflowRegistration, WorkflowRegistryBackend as _};
 
@@ -472,7 +472,7 @@ impl proto::workflow_service_server::WorkflowService for BridgeService {
 
         let updated = store
             .backend
-            .update_schedule_status(ScheduleId(schedule.id), status.as_str())
+            .update_schedule_status(schedule.id, status.as_str())
             .await
             .map_err(|err| Status::internal(format!("schedule update failed: {err}")))?;
 
@@ -505,7 +505,7 @@ impl proto::workflow_service_server::WorkflowService for BridgeService {
 
         let deleted = store
             .backend
-            .delete_schedule(ScheduleId(schedule.id))
+            .delete_schedule(schedule.id)
             .await
             .map_err(|err| Status::internal(format!("schedule delete failed: {err}")))?;
 

--- a/crates/lib/backend-memory/src/lib.rs
+++ b/crates/lib/backend-memory/src/lib.rs
@@ -24,8 +24,8 @@ use std::sync::{Arc, Mutex};
 use chrono::{DateTime, Utc};
 
 use waymark_core_backend::{ActionDone, GraphUpdate, InstanceDone, QueuedInstance};
-use waymark_ids::{InstanceId, LockId, WorkflowVersionId};
-use waymark_scheduler_core::{ScheduleId, WorkflowSchedule};
+use waymark_ids::{InstanceId, LockId, ScheduleId, WorkflowVersionId};
+use waymark_scheduler_core::WorkflowSchedule;
 use waymark_worker_status_backend::WorkerStatusUpdate;
 use waymark_workflow_registry_backend::WorkflowRegistration;
 

--- a/crates/lib/backend-memory/src/scheduler_backend.rs
+++ b/crates/lib/backend-memory/src/scheduler_backend.rs
@@ -1,9 +1,9 @@
 use chrono::Utc;
 use waymark_backends_core::{BackendError, BackendResult};
-use waymark_ids::InstanceId;
+use waymark_ids::{InstanceId, ScheduleId};
 use waymark_scheduler_backend::SchedulerBackend;
 use waymark_scheduler_core::{
-    CreateScheduleParams, ScheduleId, ScheduleType, WorkflowSchedule, compute_next_run,
+    CreateScheduleParams, ScheduleType, WorkflowSchedule, compute_next_run,
 };
 
 impl SchedulerBackend for crate::MemoryBackend {
@@ -21,7 +21,7 @@ impl SchedulerBackend for crate::MemoryBackend {
         let schedule_id = existing_schedule
             .as_ref()
             .map(|(id, _)| *id)
-            .unwrap_or_else(ScheduleId::new);
+            .unwrap_or_else(ScheduleId::new_uuid_v4);
         let now = Utc::now();
         let next_run_at = match existing_schedule
             .as_ref()
@@ -40,7 +40,7 @@ impl SchedulerBackend for crate::MemoryBackend {
             ),
         };
         let schedule = WorkflowSchedule {
-            id: schedule_id.0,
+            id: schedule_id,
             workflow_name: params.workflow_name.clone(),
             schedule_name: params.schedule_name.clone(),
             schedule_type: params.schedule_type.as_str().to_string(),

--- a/crates/lib/backend-memory/src/webapp_backend.rs
+++ b/crates/lib/backend-memory/src/webapp_backend.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use chrono::Utc;
 use uuid::Uuid;
 use waymark_backends_core::{BackendError, BackendResult};
-use waymark_ids::InstanceId;
+use waymark_ids::{InstanceId, ScheduleId};
 use waymark_webapp_backend::WebappBackend;
 use waymark_webapp_core::{
     ExecutionGraphView, InstanceDetail, InstanceStatus, InstanceSummary, ScheduleDetail,
@@ -101,7 +101,7 @@ impl WebappBackend for crate::MemoryBackend {
             .skip(start)
             .take(page_limit)
             .map(|schedule| ScheduleSummary {
-                id: schedule.id.to_string(),
+                id: schedule.id,
                 workflow_name: schedule.workflow_name,
                 schedule_name: schedule.schedule_name,
                 schedule_type: schedule.schedule_type,
@@ -115,7 +115,7 @@ impl WebappBackend for crate::MemoryBackend {
             .collect())
     }
 
-    async fn get_schedule(&self, schedule_id: Uuid) -> BackendResult<ScheduleDetail> {
+    async fn get_schedule(&self, schedule_id: ScheduleId) -> BackendResult<ScheduleDetail> {
         let guard = self.schedules.lock().expect("schedules poisoned");
         let schedule = guard
             .values()
@@ -130,7 +130,7 @@ impl WebappBackend for crate::MemoryBackend {
         });
 
         Ok(ScheduleDetail {
-            id: schedule.id.to_string(),
+            id: schedule.id,
             workflow_name: schedule.workflow_name,
             schedule_name: schedule.schedule_name,
             schedule_type: schedule.schedule_type,
@@ -149,20 +149,24 @@ impl WebappBackend for crate::MemoryBackend {
         })
     }
 
-    async fn count_schedule_invocations(&self, _schedule_id: Uuid) -> BackendResult<i64> {
+    async fn count_schedule_invocations(&self, _schedule_id: ScheduleId) -> BackendResult<i64> {
         Ok(0)
     }
 
     async fn list_schedule_invocations(
         &self,
-        _schedule_id: Uuid,
+        _schedule_id: ScheduleId,
         _limit: i64,
         _offset: i64,
     ) -> BackendResult<Vec<ScheduleInvocationSummary>> {
         Ok(Vec::new())
     }
 
-    async fn update_schedule_status(&self, schedule_id: Uuid, status: &str) -> BackendResult<bool> {
+    async fn update_schedule_status(
+        &self,
+        schedule_id: ScheduleId,
+        status: &str,
+    ) -> BackendResult<bool> {
         let mut guard = self.schedules.lock().expect("schedules poisoned");
         let Some(schedule) = guard
             .values_mut()

--- a/crates/lib/backend-postgres/src/scheduler.rs
+++ b/crates/lib/backend-postgres/src/scheduler.rs
@@ -1,13 +1,12 @@
 use chrono::{DateTime, Utc};
 use sqlx::Row;
-use uuid::Uuid;
 use waymark_backends_core::{BackendError, BackendResult};
-use waymark_ids::InstanceId;
+use waymark_ids::{InstanceId, ScheduleId};
 use waymark_scheduler_backend::SchedulerBackend;
 use waymark_timed_future::TimedFutureExt as _;
 
 use waymark_scheduler_core::compute_next_run;
-use waymark_scheduler_core::{CreateScheduleParams, ScheduleId, ScheduleType, WorkflowSchedule};
+use waymark_scheduler_core::{CreateScheduleParams, ScheduleType, WorkflowSchedule};
 
 impl SchedulerBackend for crate::PostgresBackend {
     #[function_name::named]
@@ -56,8 +55,8 @@ impl SchedulerBackend for crate::PostgresBackend {
         .timed(crate::query_timing_histogram!("upsert:workflow_schedules"))
         .await?;
 
-        let id: Uuid = row.get("id");
-        Ok(ScheduleId(id))
+        let id: ScheduleId = row.get("id");
+        Ok(id)
     }
 
     #[function_name::named]
@@ -71,7 +70,7 @@ impl SchedulerBackend for crate::PostgresBackend {
             WHERE id = $1
             "#,
         )
-        .bind(id.0)
+        .bind(id)
         .fetch_optional(&self.pool)
         .timed(crate::query_timing_histogram!("select:workflow_schedules_by_id"))
         .await?
@@ -151,7 +150,7 @@ impl SchedulerBackend for crate::PostgresBackend {
             WHERE id = $1
             "#,
         )
-        .bind(id.0)
+        .bind(id)
         .bind(status)
         .execute(&self.pool)
         .timed(crate::query_timing_histogram!(
@@ -202,7 +201,7 @@ impl SchedulerBackend for crate::PostgresBackend {
             )
             "#,
         )
-        .bind(schedule_id.0)
+        .bind(schedule_id)
         .fetch_one(&self.pool)
         .timed(crate::query_timing_histogram!(
             "select:runner_instances_exists_by_schedule_id"
@@ -240,7 +239,7 @@ impl SchedulerBackend for crate::PostgresBackend {
             WHERE id = $1
             "#,
         )
-        .bind(schedule_id.0)
+        .bind(schedule_id)
         .bind(instance_id)
         .bind(next_run_at)
         .execute(&self.pool)
@@ -273,7 +272,7 @@ impl SchedulerBackend for crate::PostgresBackend {
             WHERE id = $1
             "#,
         )
-        .bind(schedule_id.0)
+        .bind(schedule_id)
         .bind(next_run_at)
         .execute(&self.pool)
         .timed(crate::query_timing_histogram!(
@@ -287,7 +286,7 @@ impl SchedulerBackend for crate::PostgresBackend {
 
 #[derive(sqlx::FromRow)]
 struct ScheduleRow {
-    id: Uuid,
+    id: ScheduleId,
     workflow_name: String,
     schedule_name: String,
     schedule_type: String,
@@ -370,12 +369,12 @@ mod tests {
 
         let id = insert_schedule(&backend, "upsert").await;
         let row = sqlx::query("SELECT id FROM workflow_schedules WHERE id = $1")
-            .bind(id.0)
+            .bind(id)
             .fetch_one(backend.pool())
             .await
             .expect("select schedule");
 
-        assert_eq!(row.get::<Uuid, _>("id"), id.0);
+        assert_eq!(row.get::<ScheduleId, _>("id"), id);
     }
 
     #[serial(postgres)]
@@ -387,14 +386,14 @@ mod tests {
         sqlx::query(
             "UPDATE workflow_schedules SET next_run_at = NOW() + INTERVAL '2 days' WHERE id = $1",
         )
-        .bind(id.0)
+        .bind(id)
         .execute(backend.pool())
         .await
         .expect("force next_run_at");
 
         let before: Option<chrono::DateTime<Utc>> =
             sqlx::query_scalar("SELECT next_run_at FROM workflow_schedules WHERE id = $1")
-                .bind(id.0)
+                .bind(id)
                 .fetch_one(backend.pool())
                 .await
                 .expect("select next_run_at before");
@@ -403,11 +402,11 @@ mod tests {
             SchedulerBackend::upsert_schedule(&backend, &sample_params("preserve-next-run"))
                 .await
                 .expect("upsert existing schedule");
-        assert_eq!(upserted_id.0, id.0);
+        assert_eq!(upserted_id, id);
 
         let after: Option<chrono::DateTime<Utc>> =
             sqlx::query_scalar("SELECT next_run_at FROM workflow_schedules WHERE id = $1")
-                .bind(id.0)
+                .bind(id)
                 .fetch_one(backend.pool())
                 .await
                 .expect("select next_run_at after");
@@ -425,7 +424,7 @@ mod tests {
             .await
             .expect("get schedule");
 
-        assert_eq!(schedule.id, id.0);
+        assert_eq!(schedule.id, id);
         assert_eq!(schedule.schedule_name, "get");
         assert_eq!(schedule.workflow_name, "tests.workflow");
     }
@@ -442,7 +441,7 @@ mod tests {
                 .expect("get schedule by name")
                 .expect("expected schedule");
 
-        assert_eq!(schedule.id, id.0);
+        assert_eq!(schedule.id, id);
         assert_eq!(schedule.schedule_name, "by-name");
     }
 
@@ -490,7 +489,7 @@ mod tests {
 
         let status: String =
             sqlx::query_scalar("SELECT status FROM workflow_schedules WHERE id = $1")
-                .bind(id.0)
+                .bind(id)
                 .fetch_one(backend.pool())
                 .await
                 .expect("select status");
@@ -510,7 +509,7 @@ mod tests {
 
         let status: String =
             sqlx::query_scalar("SELECT status FROM workflow_schedules WHERE id = $1")
-                .bind(id.0)
+                .bind(id)
                 .fetch_one(backend.pool())
                 .await
                 .expect("select status");
@@ -526,7 +525,7 @@ mod tests {
         sqlx::query(
             "UPDATE workflow_schedules SET next_run_at = NOW() - INTERVAL '1 minute' WHERE id = $1",
         )
-        .bind(id.0)
+        .bind(id)
         .execute(backend.pool())
         .await
         .expect("force schedule due");
@@ -535,7 +534,7 @@ mod tests {
             .await
             .expect("find due schedules");
         assert_eq!(due.len(), 1);
-        assert_eq!(due[0].id, id.0);
+        assert_eq!(due[0].id, id);
     }
 
     #[serial(postgres)]
@@ -543,9 +542,10 @@ mod tests {
     async fn scheduler_has_running_instance_happy_path() {
         let backend = setup_backend().await;
 
-        let has_running = SchedulerBackend::has_running_instance(&backend, ScheduleId::new())
-            .await
-            .expect("has running instance");
+        let has_running =
+            SchedulerBackend::has_running_instance(&backend, ScheduleId::new_uuid_v4())
+                .await
+                .expect("has running instance");
         assert!(!has_running);
     }
 
@@ -561,7 +561,7 @@ mod tests {
         )
         .bind(instance_id)
         .bind(Uuid::new_v4())
-        .bind(schedule_id.0)
+        .bind(schedule_id)
         .execute(backend.pool())
         .await
         .expect("insert runner instance");
@@ -592,7 +592,7 @@ mod tests {
         let row = sqlx::query(
             "SELECT last_instance_id, last_run_at, next_run_at FROM workflow_schedules WHERE id = $1",
         )
-        .bind(id.0)
+        .bind(id)
         .fetch_one(backend.pool())
         .await
         .expect("select schedule");
@@ -615,7 +615,7 @@ mod tests {
         sqlx::query(
             "UPDATE workflow_schedules SET next_run_at = NOW() - INTERVAL '1 minute' WHERE id = $1",
         )
-        .bind(id.0)
+        .bind(id)
         .execute(backend.pool())
         .await
         .expect("force schedule due");
@@ -626,7 +626,7 @@ mod tests {
 
         let next_run_at: Option<chrono::DateTime<Utc>> =
             sqlx::query_scalar("SELECT next_run_at FROM workflow_schedules WHERE id = $1")
-                .bind(id.0)
+                .bind(id)
                 .fetch_one(backend.pool())
                 .await
                 .expect("select next_run_at");

--- a/crates/lib/backend-postgres/src/webapp.rs
+++ b/crates/lib/backend-postgres/src/webapp.rs
@@ -11,7 +11,7 @@ use waymark_backends_core::{BackendError, BackendResult};
 use waymark_core_backend::{GraphUpdate, QueuedInstance};
 use waymark_dag::{DAGNode, EdgeType};
 use waymark_dag_builder::convert_to_dag;
-use waymark_ids::{ExecutionId, InstanceId, WorkflowVersionId};
+use waymark_ids::{ExecutionId, InstanceId, ScheduleId, WorkflowVersionId};
 use waymark_ir_conversions::literal_from_json_value;
 use waymark_proto::ast as ir;
 use waymark_runner::replay_action_kwargs;
@@ -877,7 +877,7 @@ impl waymark_webapp_backend::WebappBackend for crate::PostgresBackend {
         let mut schedules = Vec::new();
         for row in rows {
             schedules.push(ScheduleSummary {
-                id: row.get::<Uuid, _>("id").to_string(),
+                id: row.get::<ScheduleId, _>("id"),
                 workflow_name: row.get("workflow_name"),
                 schedule_name: row.get("schedule_name"),
                 schedule_type: row.get("schedule_type"),
@@ -898,7 +898,7 @@ impl waymark_webapp_backend::WebappBackend for crate::PostgresBackend {
     }
 
     #[function_name::named]
-    async fn get_schedule(&self, schedule_id: Uuid) -> BackendResult<ScheduleDetail> {
+    async fn get_schedule(&self, schedule_id: ScheduleId) -> BackendResult<ScheduleDetail> {
         let row = sqlx::query(
             r#"
             SELECT id, workflow_name, schedule_name, schedule_type, cron_expression, interval_seconds,
@@ -923,7 +923,7 @@ impl waymark_webapp_backend::WebappBackend for crate::PostgresBackend {
             });
 
         Ok(ScheduleDetail {
-            id: row.get::<Uuid, _>("id").to_string(),
+            id: row.get::<ScheduleId, _>("id"),
             workflow_name: row.get("workflow_name"),
             schedule_name: row.get("schedule_name"),
             schedule_type: row.get("schedule_type"),
@@ -949,7 +949,7 @@ impl waymark_webapp_backend::WebappBackend for crate::PostgresBackend {
     }
 
     #[function_name::named]
-    async fn count_schedule_invocations(&self, schedule_id: Uuid) -> BackendResult<i64> {
+    async fn count_schedule_invocations(&self, schedule_id: ScheduleId) -> BackendResult<i64> {
         let count = sqlx::query_scalar::<_, i64>(
             r#"
             SELECT COUNT(*)
@@ -969,7 +969,7 @@ impl waymark_webapp_backend::WebappBackend for crate::PostgresBackend {
     #[function_name::named]
     async fn list_schedule_invocations(
         &self,
-        schedule_id: Uuid,
+        schedule_id: ScheduleId,
         limit: i64,
         offset: i64,
     ) -> BackendResult<Vec<ScheduleInvocationSummary>> {
@@ -1008,7 +1008,11 @@ impl waymark_webapp_backend::WebappBackend for crate::PostgresBackend {
     }
 
     #[function_name::named]
-    async fn update_schedule_status(&self, schedule_id: Uuid, status: &str) -> BackendResult<bool> {
+    async fn update_schedule_status(
+        &self,
+        schedule_id: ScheduleId,
+        status: &str,
+    ) -> BackendResult<bool> {
         let result = sqlx::query(
             r#"
             UPDATE workflow_schedules
@@ -2029,7 +2033,7 @@ fn main(input: [items], output: [total]):
         .expect("insert loop workflow version")
     }
 
-    async fn insert_schedule(backend: &PostgresBackend, schedule_name: &str) -> Uuid {
+    async fn insert_schedule(backend: &PostgresBackend, schedule_name: &str) -> ScheduleId {
         SchedulerBackend::upsert_schedule(
             backend,
             &CreateScheduleParams {
@@ -2049,12 +2053,11 @@ fn main(input: [items], output: [total]):
         )
         .await
         .expect("upsert schedule")
-        .0
     }
 
     async fn insert_scheduled_instance(
         backend: &PostgresBackend,
-        schedule_id: Uuid,
+        schedule_id: ScheduleId,
         created_at: DateTime<Utc>,
         with_result: bool,
     ) -> InstanceId {
@@ -2487,7 +2490,7 @@ fn main(input: [items], output: [total]):
             .await
             .expect("list schedules");
         assert_eq!(schedules.len(), 1);
-        assert_eq!(schedules[0].id, schedule_id.to_string());
+        assert_eq!(schedules[0].id, schedule_id);
         assert_eq!(schedules[0].schedule_name, "list");
     }
 
@@ -2500,7 +2503,7 @@ fn main(input: [items], output: [total]):
         let schedule = WebappBackend::get_schedule(&backend, schedule_id)
             .await
             .expect("get schedule");
-        assert_eq!(schedule.id, schedule_id.to_string());
+        assert_eq!(schedule.id, schedule_id);
         assert_eq!(schedule.schedule_name, "detail");
     }
 

--- a/crates/lib/core-backend/Cargo.toml
+++ b/crates/lib/core-backend/Cargo.toml
@@ -13,7 +13,6 @@ waymark-runner-state = { workspace = true }
 chrono = { workspace = true }
 nonempty-collections = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
-uuid = { workspace = true }
 
 [lib]
 test = false

--- a/crates/lib/core-backend/src/data.rs
+++ b/crates/lib/core-backend/src/data.rs
@@ -6,20 +6,19 @@ use std::collections::{HashMap, HashSet};
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use uuid::Uuid;
 use waymark_runner_executor_core::{
     ExecutionException, ExecutionSuccess, UncheckedExecutionResult,
 };
 use waymark_runner_state::{ExecutionEdge, ExecutionNode, NodeStatus, RunnerState};
 
-use waymark_ids::{ExecutionId, InstanceId, LockId, WorkflowVersionId};
+use waymark_ids::{ExecutionId, InstanceId, LockId, ScheduleId, WorkflowVersionId};
 
 /// Queued instance payload for the run loop.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct QueuedInstance {
     pub workflow_version_id: WorkflowVersionId,
     #[serde(default)]
-    pub schedule_id: Option<Uuid>,
+    pub schedule_id: Option<ScheduleId>,
     pub entry_node: ExecutionId,
     pub state: Option<RunnerState>,
     #[serde(

--- a/crates/lib/ids/src/lib.rs
+++ b/crates/lib/ids/src/lib.rs
@@ -136,7 +136,8 @@ uuid_types![
     LockId,
     DispatchToken,
     ExecutionId,
-    WorkflowVersionId
+    WorkflowVersionId,
+    ScheduleId
 ];
 
 #[deprecated = "use InstanceId instead"]

--- a/crates/lib/scheduler-backend/src/lib.rs
+++ b/crates/lib/scheduler-backend/src/lib.rs
@@ -1,6 +1,6 @@
 pub use waymark_backends_core::{BackendError, BackendResult};
-use waymark_ids::InstanceId;
-use waymark_scheduler_core::{CreateScheduleParams, ScheduleId, WorkflowSchedule};
+use waymark_ids::{InstanceId, ScheduleId};
+use waymark_scheduler_core::{CreateScheduleParams, WorkflowSchedule};
 
 /// Backend capability for workflow schedule persistence.
 pub trait SchedulerBackend {

--- a/crates/lib/scheduler-core/Cargo.toml
+++ b/crates/lib/scheduler-core/Cargo.toml
@@ -11,7 +11,6 @@ chrono = { workspace = true, features = ["serde"] }
 cron = { workspace = true }
 rand = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
-uuid = { workspace = true, features = ["serde", "v4"] }
 
 [dev-dependencies]
 chrono = { workspace = true, features = ["clock"] }

--- a/crates/lib/scheduler-core/src/types.rs
+++ b/crates/lib/scheduler-core/src/types.rs
@@ -2,30 +2,7 @@
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use uuid::Uuid;
-use waymark_ids::InstanceId;
-
-/// Unique identifier for a schedule.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub struct ScheduleId(pub Uuid);
-
-impl ScheduleId {
-    pub fn new() -> Self {
-        Self(Uuid::new_v4())
-    }
-}
-
-impl Default for ScheduleId {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl std::fmt::Display for ScheduleId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
+use waymark_ids::{InstanceId, ScheduleId};
 
 /// Type of schedule.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -95,7 +72,7 @@ impl std::fmt::Display for ScheduleStatus {
 /// A workflow schedule (recurring execution).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WorkflowSchedule {
-    pub id: Uuid,
+    pub id: ScheduleId,
     pub workflow_name: String,
     pub schedule_name: String,
     pub schedule_type: String,

--- a/crates/lib/scheduler-loop/src/lib.rs
+++ b/crates/lib/scheduler-loop/src/lib.rs
@@ -13,7 +13,7 @@ use waymark_ids::InstanceId;
 use waymark_ir_conversions::literal_from_json_value;
 use waymark_proto::messages as proto;
 use waymark_scheduler_config::SchedulerConfig;
-use waymark_scheduler_core::{ScheduleId, WorkflowSchedule};
+use waymark_scheduler_core::WorkflowSchedule;
 
 /// Background scheduler task.
 pub struct SchedulerTask<Backend, DagResolver> {
@@ -77,11 +77,7 @@ where
                     "failed to fire schedule"
                 );
                 // Skip to next run time to avoid retrying immediately
-                if let Err(skip_err) = self
-                    .backend
-                    .skip_schedule_run(ScheduleId(schedule.id))
-                    .await
-                {
+                if let Err(skip_err) = self.backend.skip_schedule_run(schedule.id).await {
                     error!(error = ?skip_err, "failed to skip schedule run");
                 }
             }
@@ -96,19 +92,14 @@ where
         schedule: &WorkflowSchedule,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         // Check for duplicates if not allowed
-        if !schedule.allow_duplicate
-            && self
-                .backend
-                .has_running_instance(ScheduleId(schedule.id))
-                .await?
-        {
+        if !schedule.allow_duplicate && self.backend.has_running_instance(schedule.id).await? {
             debug!(
                 schedule_id = %schedule.id,
                 "skipping schedule due to running instance"
             );
             return self
                 .backend
-                .skip_schedule_run(ScheduleId(schedule.id))
+                .skip_schedule_run(schedule.id)
                 .await
                 .map_err(|e| e.into());
         }
@@ -171,7 +162,7 @@ where
 
         // Mark the schedule as executed
         self.backend
-            .mark_schedule_executed(ScheduleId(schedule.id), instance_id)
+            .mark_schedule_executed(schedule.id, instance_id)
             .await?;
 
         info!(

--- a/crates/lib/webapp-backend/Cargo.toml
+++ b/crates/lib/webapp-backend/Cargo.toml
@@ -9,8 +9,6 @@ waymark-backends-core = { workspace = true }
 waymark-ids = { workspace = true }
 waymark-webapp-core = { workspace = true }
 
-uuid = { workspace = true }
-
 [lib]
 test = false
 doctest = false

--- a/crates/lib/webapp-backend/src/lib.rs
+++ b/crates/lib/webapp-backend/src/lib.rs
@@ -1,8 +1,7 @@
 use std::future::Future;
 
-use uuid::Uuid;
 use waymark_backends_core::BackendResult;
-use waymark_ids::InstanceId;
+use waymark_ids::{InstanceId, ScheduleId};
 use waymark_webapp_core::{
     ExecutionGraphView, InstanceDetail, InstanceSummary, ScheduleDetail, ScheduleInvocationSummary,
     ScheduleSummary, TimelineEntry, WorkerActionRow, WorkerAggregateStats, WorkerStatus,
@@ -64,24 +63,24 @@ pub trait WebappBackend {
 
     fn get_schedule(
         &self,
-        schedule_id: Uuid,
+        schedule_id: ScheduleId,
     ) -> impl Future<Output = BackendResult<ScheduleDetail>> + Send + '_;
 
     fn count_schedule_invocations(
         &self,
-        schedule_id: Uuid,
+        schedule_id: ScheduleId,
     ) -> impl Future<Output = BackendResult<i64>> + Send + '_;
 
     fn list_schedule_invocations(
         &self,
-        schedule_id: Uuid,
+        schedule_id: ScheduleId,
         limit: i64,
         offset: i64,
     ) -> impl Future<Output = BackendResult<Vec<ScheduleInvocationSummary>>> + Send + '_;
 
     fn update_schedule_status<'a>(
         &'a self,
-        schedule_id: Uuid,
+        schedule_id: ScheduleId,
         status: &'a str,
     ) -> impl Future<Output = BackendResult<bool>> + Send + 'a;
 

--- a/crates/lib/webapp-core/src/lib.rs
+++ b/crates/lib/webapp-core/src/lib.rs
@@ -3,7 +3,7 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
-use waymark_ids::{ExecutionId, InstanceId};
+use waymark_ids::{ExecutionId, InstanceId, ScheduleId};
 
 /// Instance status.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -206,7 +206,7 @@ pub struct InstanceExportInfo {
 /// Schedule summary for listing.
 #[derive(Debug, Clone, Serialize)]
 pub struct ScheduleSummary {
-    pub id: String,
+    pub id: ScheduleId,
     pub workflow_name: String,
     pub schedule_name: String,
     pub schedule_type: String,
@@ -221,7 +221,7 @@ pub struct ScheduleSummary {
 /// Full schedule details.
 #[derive(Debug, Clone, Serialize)]
 pub struct ScheduleDetail {
-    pub id: String,
+    pub id: ScheduleId,
     pub workflow_name: String,
     pub schedule_name: String,
     pub schedule_type: String,

--- a/crates/lib/webapp-routes/src/lib.rs
+++ b/crates/lib/webapp-routes/src/lib.rs
@@ -14,7 +14,7 @@ use serde::Serialize;
 use tera::{Context as TeraContext, Tera};
 use tracing::error;
 use uuid::Uuid;
-use waymark_ids::InstanceId;
+use waymark_ids::{InstanceId, ScheduleId};
 use waymark_webapp_core::WorkerStatus;
 use waymark_webapp_core::{
     ActionLogsResponse, FilterValuesResponse, HealthResponse, InstanceExportInfo, TimelineEntry,
@@ -546,7 +546,7 @@ where
 
 async fn schedule_detail<WebappBackend>(
     State(state): State<WebappState<WebappBackend>>,
-    Path(schedule_id): Path<Uuid>,
+    Path(schedule_id): Path<ScheduleId>,
     axum::extract::Query(query): axum::extract::Query<ScheduleDetailQuery>,
 ) -> impl IntoResponse
 where
@@ -615,7 +615,7 @@ struct ScheduleDetailQuery {
 
 async fn pause_schedule<WebappBackend>(
     State(state): State<WebappState<WebappBackend>>,
-    Path(schedule_id): Path<Uuid>,
+    Path(schedule_id): Path<ScheduleId>,
 ) -> impl IntoResponse
 where
     WebappBackend: ?Sized,
@@ -636,7 +636,7 @@ where
 
 async fn resume_schedule<WebappBackend>(
     State(state): State<WebappState<WebappBackend>>,
-    Path(schedule_id): Path<Uuid>,
+    Path(schedule_id): Path<ScheduleId>,
 ) -> impl IntoResponse
 where
     WebappBackend: ?Sized,
@@ -657,7 +657,7 @@ where
 
 async fn delete_schedule<WebappBackend>(
     State(state): State<WebappState<WebappBackend>>,
-    Path(schedule_id): Path<Uuid>,
+    Path(schedule_id): Path<ScheduleId>,
 ) -> impl IntoResponse
 where
     WebappBackend: ?Sized,
@@ -1066,7 +1066,7 @@ struct SchedulesPageContext {
 
 #[derive(Serialize)]
 struct ScheduleRow {
-    id: String,
+    id: ScheduleId,
     workflow_name: String,
     schedule_name: String,
     schedule_type: String,
@@ -1092,7 +1092,7 @@ fn render_schedules_page(
                 format!("every {} seconds", s.interval_seconds.unwrap_or(0))
             };
             ScheduleRow {
-                id: s.id.clone(),
+                id: s.id,
                 workflow_name: s.workflow_name.clone(),
                 schedule_name: s.schedule_name.clone(),
                 schedule_type: s.schedule_type.clone(),
@@ -1131,7 +1131,7 @@ struct ScheduleDetailPageContext {
 
 #[derive(Serialize)]
 struct ScheduleDetailView {
-    id: String,
+    id: ScheduleId,
     workflow_name: String,
     schedule_name: String,
     schedule_type: String,
@@ -1183,7 +1183,7 @@ fn render_schedule_detail_page(
         title: format!("Schedule: {}", schedule.schedule_name),
         active_tab: "scheduled".to_string(),
         schedule: ScheduleDetailView {
-            id: schedule.id.clone(),
+            id: schedule.id,
             workflow_name: schedule.workflow_name.clone(),
             schedule_name: schedule.schedule_name.clone(),
             schedule_type: schedule.schedule_type.clone(),


### PR DESCRIPTION
Goes in after #343.

This is the next logical step towards getting rid of raw UUID usage in the codebase. Similar to #343 and #296.

Notably:
- we switch webapp to the new id type too, from a mix of `String`, `ScheduleId` and `Uuid`; any use of `String` / `Uuid` for where the `ScheduleId` should be used is considered a bug after this PR;
- more crates drop direct dependencies on `uuid` crate