### PR TITLE
Switch dag node ids to newtypes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4161,7 +4161,7 @@ version = "0.1.0"
 dependencies = [
  "rustc-hash",
  "serde",
- "uuid",
+ "waymark-ids",
  "waymark-proto",
 ]
 
@@ -4170,9 +4170,9 @@ name = "waymark-dag-builder"
 version = "0.1.0"
 dependencies = [
  "thiserror",
- "uuid",
  "waymark-dag",
  "waymark-dag-validator",
+ "waymark-ids",
  "waymark-ir-parser",
  "waymark-proto",
 ]

--- a/crates/lib/dag-builder/Cargo.toml
+++ b/crates/lib/dag-builder/Cargo.toml
@@ -7,10 +7,10 @@ publish.workspace = true
 [dependencies]
 waymark-dag = { workspace = true }
 waymark-dag-validator = { workspace = true }
+waymark-ids = { workspace = true }
 waymark-proto = { workspace = true, features = ["serde"] }
 
 thiserror = { workspace = true }
-uuid = { workspace = true, features = ["v4"] }
 
 [dev-dependencies]
 waymark-ir-parser = { workspace = true }

--- a/crates/lib/dag-builder/src/expansion.rs
+++ b/crates/lib/dag-builder/src/expansion.rs
@@ -2,7 +2,7 @@
 
 use std::collections::{HashMap, HashSet};
 
-use uuid::Uuid;
+use waymark_ids::NodeUuid;
 
 use crate::DagConversionError;
 
@@ -440,20 +440,20 @@ impl DAGConverter {
 
     fn update_node_uuid(&self, node: &mut DAGNode) {
         match node {
-            DAGNode::Input(node) => node.node_uuid = Uuid::new_v4(),
-            DAGNode::Output(node) => node.node_uuid = Uuid::new_v4(),
-            DAGNode::Assignment(node) => node.node_uuid = Uuid::new_v4(),
-            DAGNode::ActionCall(node) => node.node_uuid = Uuid::new_v4(),
-            DAGNode::FnCall(node) => node.node_uuid = Uuid::new_v4(),
-            DAGNode::Parallel(node) => node.node_uuid = Uuid::new_v4(),
-            DAGNode::Aggregator(node) => node.node_uuid = Uuid::new_v4(),
-            DAGNode::Branch(node) => node.node_uuid = Uuid::new_v4(),
-            DAGNode::Join(node) => node.node_uuid = Uuid::new_v4(),
-            DAGNode::Return(node) => node.node_uuid = Uuid::new_v4(),
-            DAGNode::Break(node) => node.node_uuid = Uuid::new_v4(),
-            DAGNode::Continue(node) => node.node_uuid = Uuid::new_v4(),
-            DAGNode::Sleep(node) => node.node_uuid = Uuid::new_v4(),
-            DAGNode::Expression(node) => node.node_uuid = Uuid::new_v4(),
+            DAGNode::Input(node) => node.node_uuid = NodeUuid::new_uuid_v4(),
+            DAGNode::Output(node) => node.node_uuid = NodeUuid::new_uuid_v4(),
+            DAGNode::Assignment(node) => node.node_uuid = NodeUuid::new_uuid_v4(),
+            DAGNode::ActionCall(node) => node.node_uuid = NodeUuid::new_uuid_v4(),
+            DAGNode::FnCall(node) => node.node_uuid = NodeUuid::new_uuid_v4(),
+            DAGNode::Parallel(node) => node.node_uuid = NodeUuid::new_uuid_v4(),
+            DAGNode::Aggregator(node) => node.node_uuid = NodeUuid::new_uuid_v4(),
+            DAGNode::Branch(node) => node.node_uuid = NodeUuid::new_uuid_v4(),
+            DAGNode::Join(node) => node.node_uuid = NodeUuid::new_uuid_v4(),
+            DAGNode::Return(node) => node.node_uuid = NodeUuid::new_uuid_v4(),
+            DAGNode::Break(node) => node.node_uuid = NodeUuid::new_uuid_v4(),
+            DAGNode::Continue(node) => node.node_uuid = NodeUuid::new_uuid_v4(),
+            DAGNode::Sleep(node) => node.node_uuid = NodeUuid::new_uuid_v4(),
+            DAGNode::Expression(node) => node.node_uuid = NodeUuid::new_uuid_v4(),
         }
     }
 }

--- a/crates/lib/dag/Cargo.toml
+++ b/crates/lib/dag/Cargo.toml
@@ -5,11 +5,11 @@ publish.workspace = true
 edition = "2024"
 
 [dependencies]
+waymark-ids = { workspace = true }
 waymark-proto = { workspace = true }
 
 rustc-hash = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
-uuid = { workspace = true, features = ["serde", "v4"] }
 
 [lib]
 test = false

--- a/crates/lib/dag/src/models.rs
+++ b/crates/lib/dag/src/models.rs
@@ -4,8 +4,8 @@ use std::collections::{HashMap, HashSet};
 
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
-use uuid::Uuid;
 
+use waymark_ids::NodeUuid;
 use waymark_proto::ast as ir;
 
 use super::nodes::{
@@ -178,7 +178,7 @@ pub enum DAGNode {
 trait DagNodeView {
     fn id(&self) -> &str;
     fn function_name(&self) -> Option<&str>;
-    fn node_uuid(&self) -> &Uuid;
+    fn node_uuid(&self) -> &waymark_ids::NodeUuid;
     fn label(&self) -> String;
 }
 
@@ -212,7 +212,7 @@ macro_rules! impl_dag_node_view {
                 self.function_name.as_deref()
             }
 
-            fn node_uuid(&self) -> &Uuid {
+            fn node_uuid(&self) -> &waymark_ids::NodeUuid {
                 &self.node_uuid
             }
 
@@ -265,7 +265,7 @@ impl DAGNode {
         self.view().function_name()
     }
 
-    pub fn node_uuid(&self) -> &Uuid {
+    pub fn node_uuid(&self) -> &NodeUuid {
         self.view().node_uuid()
     }
 

--- a/crates/lib/dag/src/nodes.rs
+++ b/crates/lib/dag/src/nodes.rs
@@ -3,8 +3,8 @@
 use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
-use uuid::Uuid;
 
+use waymark_ids::NodeUuid;
 use waymark_proto::ast as ir;
 
 /// Function entry node that declares input variables.
@@ -13,7 +13,7 @@ use waymark_proto::ast as ir;
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct InputNode {
     pub id: String,
-    pub node_uuid: Uuid,
+    pub node_uuid: NodeUuid,
     pub function_name: Option<String>,
     pub io_vars: Vec<String>,
 }
@@ -22,7 +22,7 @@ impl InputNode {
     pub fn new(id: impl Into<String>, io_vars: Vec<String>, function_name: Option<String>) -> Self {
         Self {
             id: id.into(),
-            node_uuid: Uuid::new_v4(),
+            node_uuid: NodeUuid::new_uuid_v4(),
             function_name,
             io_vars,
         }
@@ -43,7 +43,7 @@ impl InputNode {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct OutputNode {
     pub id: String,
-    pub node_uuid: Uuid,
+    pub node_uuid: NodeUuid,
     pub function_name: Option<String>,
     pub io_vars: Vec<String>,
 }
@@ -52,7 +52,7 @@ impl OutputNode {
     pub fn new(id: impl Into<String>, io_vars: Vec<String>, function_name: Option<String>) -> Self {
         Self {
             id: id.into(),
-            node_uuid: Uuid::new_v4(),
+            node_uuid: NodeUuid::new_uuid_v4(),
             function_name,
             io_vars,
         }
@@ -69,7 +69,7 @@ impl OutputNode {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct AssignmentNode {
     pub id: String,
-    pub node_uuid: Uuid,
+    pub node_uuid: NodeUuid,
     pub function_name: Option<String>,
     pub targets: Vec<String>,
     pub target: Option<String>,
@@ -89,7 +89,7 @@ impl AssignmentNode {
         let fallback = targets.first().cloned();
         Self {
             id: id.into(),
-            node_uuid: Uuid::new_v4(),
+            node_uuid: NodeUuid::new_uuid_v4(),
             function_name,
             targets,
             target: target.or(fallback),
@@ -123,7 +123,7 @@ impl AssignmentNode {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ActionCallNode {
     pub id: String,
-    pub node_uuid: Uuid,
+    pub node_uuid: NodeUuid,
     pub function_name: Option<String>,
     pub action_name: String,
     pub module_name: Option<String>,
@@ -175,7 +175,7 @@ impl ActionCallNode {
         let fallback = targets.as_ref().and_then(|items| items.first().cloned());
         Self {
             id: id.into(),
-            node_uuid: Uuid::new_v4(),
+            node_uuid: NodeUuid::new_uuid_v4(),
             function_name,
             action_name: action_name.into(),
             module_name,
@@ -227,7 +227,7 @@ impl ActionCallNode {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct FnCallNode {
     pub id: String,
-    pub node_uuid: Uuid,
+    pub node_uuid: NodeUuid,
     pub function_name: Option<String>,
     pub called_function: String,
     pub kwargs: HashMap<String, String>,
@@ -270,7 +270,7 @@ impl FnCallNode {
         let fallback = targets.as_ref().and_then(|items| items.first().cloned());
         Self {
             id: id.into(),
-            node_uuid: Uuid::new_v4(),
+            node_uuid: NodeUuid::new_uuid_v4(),
             function_name,
             called_function: called_function.into(),
             kwargs,
@@ -309,7 +309,7 @@ impl FnCallNode {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ParallelNode {
     pub id: String,
-    pub node_uuid: Uuid,
+    pub node_uuid: NodeUuid,
     pub function_name: Option<String>,
 }
 
@@ -317,7 +317,7 @@ impl ParallelNode {
     pub fn new(id: impl Into<String>, function_name: Option<String>) -> Self {
         Self {
             id: id.into(),
-            node_uuid: Uuid::new_v4(),
+            node_uuid: NodeUuid::new_uuid_v4(),
             function_name,
         }
     }
@@ -335,7 +335,7 @@ impl ParallelNode {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct AggregatorNode {
     pub id: String,
-    pub node_uuid: Uuid,
+    pub node_uuid: NodeUuid,
     pub function_name: Option<String>,
     pub aggregates_from: String,
     pub targets: Option<Vec<String>>,
@@ -355,7 +355,7 @@ impl AggregatorNode {
         let fallback = targets.as_ref().and_then(|items| items.first().cloned());
         Self {
             id: id.into(),
-            node_uuid: Uuid::new_v4(),
+            node_uuid: NodeUuid::new_uuid_v4(),
             function_name,
             aggregates_from: aggregates_from.into(),
             targets,
@@ -391,7 +391,7 @@ impl AggregatorNode {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct BranchNode {
     pub id: String,
-    pub node_uuid: Uuid,
+    pub node_uuid: NodeUuid,
     pub function_name: Option<String>,
     pub description: String,
 }
@@ -404,7 +404,7 @@ impl BranchNode {
     ) -> Self {
         Self {
             id: id.into(),
-            node_uuid: Uuid::new_v4(),
+            node_uuid: NodeUuid::new_uuid_v4(),
             function_name,
             description: description.into(),
         }
@@ -421,7 +421,7 @@ impl BranchNode {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct JoinNode {
     pub id: String,
-    pub node_uuid: Uuid,
+    pub node_uuid: NodeUuid,
     pub function_name: Option<String>,
     pub description: String,
     pub targets: Option<Vec<String>>,
@@ -439,7 +439,7 @@ impl JoinNode {
         let fallback = targets.as_ref().and_then(|items| items.first().cloned());
         Self {
             id: id.into(),
-            node_uuid: Uuid::new_v4(),
+            node_uuid: NodeUuid::new_uuid_v4(),
             function_name,
             description: description.into(),
             targets,
@@ -458,7 +458,7 @@ impl JoinNode {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ReturnNode {
     pub id: String,
-    pub node_uuid: Uuid,
+    pub node_uuid: NodeUuid,
     pub function_name: Option<String>,
     pub assign_expr: Option<ir::Expr>,
     pub targets: Option<Vec<String>>,
@@ -476,7 +476,7 @@ impl ReturnNode {
         let fallback = targets.as_ref().and_then(|items| items.first().cloned());
         Self {
             id: id.into(),
-            node_uuid: Uuid::new_v4(),
+            node_uuid: NodeUuid::new_uuid_v4(),
             function_name,
             assign_expr,
             targets,
@@ -493,7 +493,7 @@ impl ReturnNode {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct BreakNode {
     pub id: String,
-    pub node_uuid: Uuid,
+    pub node_uuid: NodeUuid,
     pub function_name: Option<String>,
 }
 
@@ -501,7 +501,7 @@ impl BreakNode {
     pub fn new(id: impl Into<String>, function_name: Option<String>) -> Self {
         Self {
             id: id.into(),
-            node_uuid: Uuid::new_v4(),
+            node_uuid: NodeUuid::new_uuid_v4(),
             function_name,
         }
     }
@@ -515,7 +515,7 @@ impl BreakNode {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ContinueNode {
     pub id: String,
-    pub node_uuid: Uuid,
+    pub node_uuid: NodeUuid,
     pub function_name: Option<String>,
 }
 
@@ -523,7 +523,7 @@ impl ContinueNode {
     pub fn new(id: impl Into<String>, function_name: Option<String>) -> Self {
         Self {
             id: id.into(),
-            node_uuid: Uuid::new_v4(),
+            node_uuid: NodeUuid::new_uuid_v4(),
             function_name,
         }
     }
@@ -537,7 +537,7 @@ impl ContinueNode {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct SleepNode {
     pub id: String,
-    pub node_uuid: Uuid,
+    pub node_uuid: NodeUuid,
     pub function_name: Option<String>,
     pub duration_expr: Option<ir::Expr>,
     pub label_hint: Option<String>,
@@ -552,7 +552,7 @@ impl SleepNode {
     ) -> Self {
         Self {
             id: id.into(),
-            node_uuid: Uuid::new_v4(),
+            node_uuid: NodeUuid::new_uuid_v4(),
             function_name,
             duration_expr,
             label_hint,
@@ -570,7 +570,7 @@ impl SleepNode {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ExpressionNode {
     pub id: String,
-    pub node_uuid: Uuid,
+    pub node_uuid: NodeUuid,
     pub function_name: Option<String>,
 }
 
@@ -578,7 +578,7 @@ impl ExpressionNode {
     pub fn new(id: impl Into<String>, function_name: Option<String>) -> Self {
         Self {
             id: id.into(),
-            node_uuid: Uuid::new_v4(),
+            node_uuid: NodeUuid::new_uuid_v4(),
             function_name,
         }
     }

--- a/crates/lib/ids/src/lib.rs
+++ b/crates/lib/ids/src/lib.rs
@@ -137,7 +137,8 @@ uuid_types![
     DispatchToken,
     ExecutionId,
     WorkflowVersionId,
-    ScheduleId
+    ScheduleId,
+    NodeUuid
 ];
 
 #[deprecated = "use InstanceId instead"]


### PR DESCRIPTION
Goes in after #344.

Surprisingly, the node UUIDs are not used much; also, while looking into the DAG, I noticed that it has a lot of code duplication that should be implemented via composition with generics instead - so a refactor is warranted.

We might want to look places that should be using the node UUIDs but don't; this could be relevant for VCR. Also, we should consider dropping the node UUIDs - they are not persisted, so they are not going to be very useful.