### PR TITLE
Drop unutilized NodeUuid and node uuids in DAG

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4161,7 +4161,6 @@ version = "0.1.0"
 dependencies = [
  "rustc-hash",
  "serde",
- "waymark-ids",
  "waymark-proto",
 ]
 
@@ -4172,7 +4171,6 @@ dependencies = [
  "thiserror",
  "waymark-dag",
  "waymark-dag-validator",
- "waymark-ids",
  "waymark-ir-parser",
  "waymark-proto",
 ]

--- a/crates/lib/dag-builder/Cargo.toml
+++ b/crates/lib/dag-builder/Cargo.toml
@@ -7,7 +7,6 @@ publish.workspace = true
 [dependencies]
 waymark-dag = { workspace = true }
 waymark-dag-validator = { workspace = true }
-waymark-ids = { workspace = true }
 waymark-proto = { workspace = true, features = ["serde"] }
 
 thiserror = { workspace = true }

--- a/crates/lib/dag-builder/src/expansion.rs
+++ b/crates/lib/dag-builder/src/expansion.rs
@@ -2,8 +2,6 @@
 
 use std::collections::{HashMap, HashSet};
 
-use waymark_ids::NodeUuid;
-
 use crate::DagConversionError;
 
 use super::converter::DAGConverter;
@@ -288,7 +286,6 @@ impl DAGConverter {
 
             let mut cloned = node.clone();
             self.update_node_id(&mut cloned, &new_id);
-            self.update_node_uuid(&mut cloned);
             if let Some(prefix) = &id_prefix {
                 if let DAGNode::ActionCall(action_node) = &mut cloned
                     && let Some(aggregates_to) = &action_node.aggregates_to
@@ -435,25 +432,6 @@ impl DAGConverter {
             DAGNode::Continue(node) => node.id = new_id.to_string(),
             DAGNode::Sleep(node) => node.id = new_id.to_string(),
             DAGNode::Expression(node) => node.id = new_id.to_string(),
-        }
-    }
-
-    fn update_node_uuid(&self, node: &mut DAGNode) {
-        match node {
-            DAGNode::Input(node) => node.node_uuid = NodeUuid::new_uuid_v4(),
-            DAGNode::Output(node) => node.node_uuid = NodeUuid::new_uuid_v4(),
-            DAGNode::Assignment(node) => node.node_uuid = NodeUuid::new_uuid_v4(),
-            DAGNode::ActionCall(node) => node.node_uuid = NodeUuid::new_uuid_v4(),
-            DAGNode::FnCall(node) => node.node_uuid = NodeUuid::new_uuid_v4(),
-            DAGNode::Parallel(node) => node.node_uuid = NodeUuid::new_uuid_v4(),
-            DAGNode::Aggregator(node) => node.node_uuid = NodeUuid::new_uuid_v4(),
-            DAGNode::Branch(node) => node.node_uuid = NodeUuid::new_uuid_v4(),
-            DAGNode::Join(node) => node.node_uuid = NodeUuid::new_uuid_v4(),
-            DAGNode::Return(node) => node.node_uuid = NodeUuid::new_uuid_v4(),
-            DAGNode::Break(node) => node.node_uuid = NodeUuid::new_uuid_v4(),
-            DAGNode::Continue(node) => node.node_uuid = NodeUuid::new_uuid_v4(),
-            DAGNode::Sleep(node) => node.node_uuid = NodeUuid::new_uuid_v4(),
-            DAGNode::Expression(node) => node.node_uuid = NodeUuid::new_uuid_v4(),
         }
     }
 }

--- a/crates/lib/dag/Cargo.toml
+++ b/crates/lib/dag/Cargo.toml
@@ -5,7 +5,6 @@ publish.workspace = true
 edition = "2024"
 
 [dependencies]
-waymark-ids = { workspace = true }
 waymark-proto = { workspace = true }
 
 rustc-hash = { workspace = true }

--- a/crates/lib/dag/src/models.rs
+++ b/crates/lib/dag/src/models.rs
@@ -5,7 +5,6 @@ use std::collections::{HashMap, HashSet};
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 
-use waymark_ids::NodeUuid;
 use waymark_proto::ast as ir;
 
 use super::nodes::{
@@ -178,7 +177,6 @@ pub enum DAGNode {
 trait DagNodeView {
     fn id(&self) -> &str;
     fn function_name(&self) -> Option<&str>;
-    fn node_uuid(&self) -> &waymark_ids::NodeUuid;
     fn label(&self) -> String;
 }
 
@@ -210,10 +208,6 @@ macro_rules! impl_dag_node_view {
 
             fn function_name(&self) -> Option<&str> {
                 self.function_name.as_deref()
-            }
-
-            fn node_uuid(&self) -> &waymark_ids::NodeUuid {
-                &self.node_uuid
             }
 
             fn label(&self) -> String {
@@ -263,10 +257,6 @@ impl DAGNode {
 
     pub fn function_name(&self) -> Option<&str> {
         self.view().function_name()
-    }
-
-    pub fn node_uuid(&self) -> &NodeUuid {
-        self.view().node_uuid()
     }
 
     pub fn node_type(&self) -> &'static str {

--- a/crates/lib/dag/src/nodes.rs
+++ b/crates/lib/dag/src/nodes.rs
@@ -4,7 +4,6 @@ use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 
-use waymark_ids::NodeUuid;
 use waymark_proto::ast as ir;
 
 /// Function entry node that declares input variables.
@@ -13,7 +12,6 @@ use waymark_proto::ast as ir;
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct InputNode {
     pub id: String,
-    pub node_uuid: NodeUuid,
     pub function_name: Option<String>,
     pub io_vars: Vec<String>,
 }
@@ -22,7 +20,6 @@ impl InputNode {
     pub fn new(id: impl Into<String>, io_vars: Vec<String>, function_name: Option<String>) -> Self {
         Self {
             id: id.into(),
-            node_uuid: NodeUuid::new_uuid_v4(),
             function_name,
             io_vars,
         }
@@ -43,7 +40,6 @@ impl InputNode {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct OutputNode {
     pub id: String,
-    pub node_uuid: NodeUuid,
     pub function_name: Option<String>,
     pub io_vars: Vec<String>,
 }
@@ -52,7 +48,6 @@ impl OutputNode {
     pub fn new(id: impl Into<String>, io_vars: Vec<String>, function_name: Option<String>) -> Self {
         Self {
             id: id.into(),
-            node_uuid: NodeUuid::new_uuid_v4(),
             function_name,
             io_vars,
         }
@@ -69,7 +64,6 @@ impl OutputNode {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct AssignmentNode {
     pub id: String,
-    pub node_uuid: NodeUuid,
     pub function_name: Option<String>,
     pub targets: Vec<String>,
     pub target: Option<String>,
@@ -89,7 +83,6 @@ impl AssignmentNode {
         let fallback = targets.first().cloned();
         Self {
             id: id.into(),
-            node_uuid: NodeUuid::new_uuid_v4(),
             function_name,
             targets,
             target: target.or(fallback),
@@ -123,7 +116,6 @@ impl AssignmentNode {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ActionCallNode {
     pub id: String,
-    pub node_uuid: NodeUuid,
     pub function_name: Option<String>,
     pub action_name: String,
     pub module_name: Option<String>,
@@ -175,7 +167,6 @@ impl ActionCallNode {
         let fallback = targets.as_ref().and_then(|items| items.first().cloned());
         Self {
             id: id.into(),
-            node_uuid: NodeUuid::new_uuid_v4(),
             function_name,
             action_name: action_name.into(),
             module_name,
@@ -227,7 +218,6 @@ impl ActionCallNode {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct FnCallNode {
     pub id: String,
-    pub node_uuid: NodeUuid,
     pub function_name: Option<String>,
     pub called_function: String,
     pub kwargs: HashMap<String, String>,
@@ -270,7 +260,6 @@ impl FnCallNode {
         let fallback = targets.as_ref().and_then(|items| items.first().cloned());
         Self {
             id: id.into(),
-            node_uuid: NodeUuid::new_uuid_v4(),
             function_name,
             called_function: called_function.into(),
             kwargs,
@@ -309,7 +298,6 @@ impl FnCallNode {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ParallelNode {
     pub id: String,
-    pub node_uuid: NodeUuid,
     pub function_name: Option<String>,
 }
 
@@ -317,7 +305,6 @@ impl ParallelNode {
     pub fn new(id: impl Into<String>, function_name: Option<String>) -> Self {
         Self {
             id: id.into(),
-            node_uuid: NodeUuid::new_uuid_v4(),
             function_name,
         }
     }
@@ -335,7 +322,6 @@ impl ParallelNode {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct AggregatorNode {
     pub id: String,
-    pub node_uuid: NodeUuid,
     pub function_name: Option<String>,
     pub aggregates_from: String,
     pub targets: Option<Vec<String>>,
@@ -355,7 +341,6 @@ impl AggregatorNode {
         let fallback = targets.as_ref().and_then(|items| items.first().cloned());
         Self {
             id: id.into(),
-            node_uuid: NodeUuid::new_uuid_v4(),
             function_name,
             aggregates_from: aggregates_from.into(),
             targets,
@@ -391,7 +376,6 @@ impl AggregatorNode {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct BranchNode {
     pub id: String,
-    pub node_uuid: NodeUuid,
     pub function_name: Option<String>,
     pub description: String,
 }
@@ -404,7 +388,6 @@ impl BranchNode {
     ) -> Self {
         Self {
             id: id.into(),
-            node_uuid: NodeUuid::new_uuid_v4(),
             function_name,
             description: description.into(),
         }
@@ -421,7 +404,6 @@ impl BranchNode {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct JoinNode {
     pub id: String,
-    pub node_uuid: NodeUuid,
     pub function_name: Option<String>,
     pub description: String,
     pub targets: Option<Vec<String>>,
@@ -439,7 +421,6 @@ impl JoinNode {
         let fallback = targets.as_ref().and_then(|items| items.first().cloned());
         Self {
             id: id.into(),
-            node_uuid: NodeUuid::new_uuid_v4(),
             function_name,
             description: description.into(),
             targets,
@@ -458,7 +439,6 @@ impl JoinNode {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ReturnNode {
     pub id: String,
-    pub node_uuid: NodeUuid,
     pub function_name: Option<String>,
     pub assign_expr: Option<ir::Expr>,
     pub targets: Option<Vec<String>>,
@@ -476,7 +456,6 @@ impl ReturnNode {
         let fallback = targets.as_ref().and_then(|items| items.first().cloned());
         Self {
             id: id.into(),
-            node_uuid: NodeUuid::new_uuid_v4(),
             function_name,
             assign_expr,
             targets,
@@ -493,7 +472,6 @@ impl ReturnNode {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct BreakNode {
     pub id: String,
-    pub node_uuid: NodeUuid,
     pub function_name: Option<String>,
 }
 
@@ -501,7 +479,6 @@ impl BreakNode {
     pub fn new(id: impl Into<String>, function_name: Option<String>) -> Self {
         Self {
             id: id.into(),
-            node_uuid: NodeUuid::new_uuid_v4(),
             function_name,
         }
     }
@@ -515,7 +492,6 @@ impl BreakNode {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ContinueNode {
     pub id: String,
-    pub node_uuid: NodeUuid,
     pub function_name: Option<String>,
 }
 
@@ -523,7 +499,6 @@ impl ContinueNode {
     pub fn new(id: impl Into<String>, function_name: Option<String>) -> Self {
         Self {
             id: id.into(),
-            node_uuid: NodeUuid::new_uuid_v4(),
             function_name,
         }
     }
@@ -537,7 +512,6 @@ impl ContinueNode {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct SleepNode {
     pub id: String,
-    pub node_uuid: NodeUuid,
     pub function_name: Option<String>,
     pub duration_expr: Option<ir::Expr>,
     pub label_hint: Option<String>,
@@ -552,7 +526,6 @@ impl SleepNode {
     ) -> Self {
         Self {
             id: id.into(),
-            node_uuid: NodeUuid::new_uuid_v4(),
             function_name,
             duration_expr,
             label_hint,
@@ -570,7 +543,6 @@ impl SleepNode {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ExpressionNode {
     pub id: String,
-    pub node_uuid: NodeUuid,
     pub function_name: Option<String>,
 }
 
@@ -578,7 +550,6 @@ impl ExpressionNode {
     pub fn new(id: impl Into<String>, function_name: Option<String>) -> Self {
         Self {
             id: id.into(),
-            node_uuid: NodeUuid::new_uuid_v4(),
             function_name,
         }
     }

--- a/crates/lib/ids/src/lib.rs
+++ b/crates/lib/ids/src/lib.rs
@@ -137,8 +137,7 @@ uuid_types![
     DispatchToken,
     ExecutionId,
     WorkflowVersionId,
-    ScheduleId,
-    NodeUuid
+    ScheduleId
 ];
 
 #[deprecated = "use InstanceId instead"]


### PR DESCRIPTION
After a quick investigation in relation to what I brought up at #345, it turns out the DAG UUIDs are never used.

This PR removes them to reduce the complexity and clutter.

Goes in after #345.

This caused some unnecessary confusion during the VCR design, so it also clarifies things somewhat as to what options are available to correlate executions (is show - DAG won't be helpful, and we should implement everything at the executor side).