### PR TITLE
Refactor the RunnerState construction API

### DIFF
--- a/crates/bin/benchmark/src/main.rs
+++ b/crates/bin/benchmark/src/main.rs
@@ -148,7 +148,7 @@ fn build_cases(base: i64) -> HashMap<String, BenchmarkCase> {
 }
 
 fn build_instance(case: &BenchmarkCase, workflow_version_id: WorkflowVersionId) -> QueuedInstance {
-    let mut state = RunnerState::new(Some(Arc::clone(&case.dag)), None, None, false);
+    let mut state = RunnerState::from_dag(Arc::clone(&case.dag));
     for (name, value) in &case.inputs {
         let expr = literal_from_json_value(value);
         let label = format!("input {name} = {value}");

--- a/crates/bin/bridge/src/bridge_service.rs
+++ b/crates/bin/bridge/src/bridge_service.rs
@@ -604,7 +604,7 @@ fn build_queued_instance(
     dag: Arc<waymark_dag::DAG>,
     initial_context: Option<proto::WorkflowArguments>,
 ) -> Result<QueuedInstance, String> {
-    let mut state = RunnerState::new(Some(Arc::clone(&dag)), None, None, false);
+    let mut state = RunnerState::from_dag(Arc::clone(&dag));
 
     if let Some(context) = initial_context {
         let inputs = workflow_arguments_to_json_map(&context);

--- a/crates/bin/fuzzer/src/harness.rs
+++ b/crates/bin/fuzzer/src/harness.rs
@@ -123,7 +123,7 @@ fn build_instance(
     dag: Arc<waymark_dag::DAG>,
     base: i64,
 ) -> Result<QueuedInstance> {
-    let mut state = RunnerState::new(Some(Arc::clone(&dag)), None, None, false);
+    let mut state = RunnerState::from_dag(Arc::clone(&dag));
     state
         .record_assignment(
             vec!["base".to_string()],

--- a/crates/bin/integration-test/src/main.rs
+++ b/crates/bin/integration-test/src/main.rs
@@ -612,7 +612,7 @@ fn build_queued_instance(
     dag: Arc<DAG>,
     kwargs: &HashMap<String, Value>,
 ) -> Result<QueuedInstance> {
-    let mut state = RunnerState::new(Some(Arc::clone(&dag)), None, None, false);
+    let mut state = RunnerState::from_dag(Arc::clone(&dag));
 
     for (name, value) in kwargs {
         let expr = literal_from_json_value(value);

--- a/crates/bin/smoke/src/main.rs
+++ b/crates/bin/smoke/src/main.rs
@@ -85,7 +85,7 @@ async fn run_program_smoke(case: &SmokeCase, worker_pool: RemoteWorkerPool) -> R
         output_path.display()
     );
 
-    let mut state = RunnerState::new(Some(Arc::clone(&dag)), None, None, false);
+    let mut state = RunnerState::from_dag(Arc::clone(&dag));
     let queue = Arc::new(Mutex::new(VecDeque::new()));
     let backend = MemoryBackend::with_queue(queue.clone());
     let workflow_version_id = backend

--- a/crates/bin/soak-harness/src/flow.rs
+++ b/crates/bin/soak-harness/src/flow.rs
@@ -351,7 +351,7 @@ fn build_instance(
     workflow: &crate::setup_workflows::RegisteredWorkflow,
     item: WorkItem,
 ) -> Result<QueuedInstance> {
-    let mut state = RunnerState::new(Some(Arc::clone(&workflow.dag)), None, None, false);
+    let mut state = RunnerState::from_dag(Arc::clone(&workflow.dag));
     if item.step_delays_ms.len() != item.step_should_fail.len()
         || item.step_delays_ms.len() != item.step_payload_bytes.len()
         || item.step_delays_ms.len() != item.step_include_payload.len()

--- a/crates/lib/backend-postgres/src/core.rs
+++ b/crates/lib/backend-postgres/src/core.rs
@@ -831,8 +831,7 @@ impl PostgresBackend {
                     action_node_ids_by_instance.insert(instance_id, action_node_ids);
                 }
 
-                instance.state =
-                    RunnerState::new(None, Some(graph.nodes), Some(graph.edges), false);
+                instance.state = RunnerState::from_parts(graph.nodes, graph.edges);
 
                 Ok(instance)
             })

--- a/crates/lib/backend-postgres/src/webapp.rs
+++ b/crates/lib/backend-postgres/src/webapp.rs
@@ -678,12 +678,7 @@ impl waymark_webapp_backend::WebappBackend for crate::PostgresBackend {
         let graph_update: GraphUpdate = rmp_serde::from_slice(&state_bytes)
             .map_err(|e| BackendError::Message(format!("failed to decode state: {}", e)))?;
 
-        let runner_state = RunnerState::new(
-            None,
-            Some(graph_update.nodes.clone()),
-            Some(graph_update.edges),
-            false,
-        );
+        let runner_state = RunnerState::from_parts(graph_update.nodes.clone(), graph_update.edges);
         let action_nodes: HashMap<ExecutionId, ExecutionNode> = graph_update
             .nodes
             .into_iter()
@@ -1446,7 +1441,7 @@ fn build_queued_instance(
     dag: Arc<waymark_dag::DAG>,
     input_payload: &serde_json::Map<String, Value>,
 ) -> BackendResult<QueuedInstance> {
-    let mut state = RunnerState::new(Some(Arc::clone(&dag)), None, None, false);
+    let mut state = RunnerState::from_dag(Arc::clone(&dag));
     // TODO: Centralize initial input seeding and the `input {name} = {value}` label
     // convention. This duplicates the bridge path in
     // `crates/bin/bridge/src/bridge_service.rs::build_queued_instance`, and

--- a/crates/lib/runloop/tests/integration.rs
+++ b/crates/lib/runloop/tests/integration.rs
@@ -48,7 +48,7 @@ fn main(input: [x], output: [y]):
     let ir_hash = format!("{:x}", Sha256::digest(&program_proto));
     let dag = Arc::new(convert_to_dag(&program).expect("convert to dag"));
 
-    let mut state = RunnerState::new(Some(Arc::clone(&dag)), None, None, false);
+    let mut state = RunnerState::from_dag(Arc::clone(&dag));
     let _ = state
         .record_assignment(
             vec!["x".to_string()],
@@ -199,7 +199,7 @@ fn main(input: [x], output: [y]):
     );
 
     for input in [2_i64, 7_i64] {
-        let mut state = RunnerState::new(Some(Arc::clone(&dag)), None, None, false);
+        let mut state = RunnerState::from_dag(Arc::clone(&dag));
         let _ = state
             .record_assignment(
                 vec!["x".to_string()],
@@ -264,7 +264,7 @@ fn main(input: [x], output: [y]):
     let ir_hash = format!("{:x}", Sha256::digest(&program_proto));
     let dag = Arc::new(convert_to_dag(&program).expect("convert to dag"));
 
-    let mut state = RunnerState::new(Some(Arc::clone(&dag)), None, None, false);
+    let mut state = RunnerState::from_dag(Arc::clone(&dag));
     let _ = state
         .record_assignment(
             vec!["x".to_string()],
@@ -368,7 +368,7 @@ fn main(input: [], output: [y]):
     let ir_hash = format!("{:x}", Sha256::digest(&program_proto));
     let dag = Arc::new(convert_to_dag(&program).expect("convert to dag"));
 
-    let mut state = RunnerState::new(Some(Arc::clone(&dag)), None, None, false);
+    let mut state = RunnerState::from_dag(Arc::clone(&dag));
     let entry_node = dag
         .entry_node
         .as_ref()
@@ -492,7 +492,7 @@ fn main(input: [x], output: [y]):
     let dag = Arc::new(convert_to_dag(&program).expect("convert to dag"));
 
     // Intentionally omit input assignment so action kwarg resolution fails at runtime.
-    let mut state = RunnerState::new(Some(Arc::clone(&dag)), None, None, false);
+    let mut state = RunnerState::from_dag(Arc::clone(&dag));
     let entry_node = dag
         .entry_node
         .as_ref()
@@ -587,7 +587,7 @@ fn main(input: [limit], output: [result]):
     let ir_hash = format!("{:x}", Sha256::digest(&program_proto));
     let dag = Arc::new(convert_to_dag(&program).expect("convert to dag"));
 
-    let mut state = RunnerState::new(Some(Arc::clone(&dag)), None, None, false);
+    let mut state = RunnerState::from_dag(Arc::clone(&dag));
     let _ = state
         .record_assignment(
             vec!["limit".to_string()],
@@ -800,7 +800,7 @@ fn main(input: [x], output: [y]):
     let ir_hash = format!("{:x}", Sha256::digest(&program_proto));
     let dag = Arc::new(convert_to_dag(&program).expect("convert to dag"));
 
-    let mut state = RunnerState::new(Some(Arc::clone(&dag)), None, None, false);
+    let mut state = RunnerState::from_dag(Arc::clone(&dag));
     let _ = state
         .record_assignment(
             vec!["x".to_string()],
@@ -922,7 +922,7 @@ fn main(input: [], output: [result]):
     let ir_hash = format!("{:x}", Sha256::digest(&program_proto));
     let dag = Arc::new(convert_to_dag(&program).expect("convert to dag"));
 
-    let mut state = RunnerState::new(Some(Arc::clone(&dag)), None, None, false);
+    let mut state = RunnerState::from_dag(Arc::clone(&dag));
     let entry_node = dag
         .entry_node
         .as_ref()
@@ -1016,7 +1016,7 @@ fn main(input: [], output: [result]):
     let ir_hash = format!("{:x}", Sha256::digest(&program_proto));
     let dag = Arc::new(convert_to_dag(&program).expect("convert to dag"));
 
-    let mut state = RunnerState::new(Some(Arc::clone(&dag)), None, None, false);
+    let mut state = RunnerState::from_dag(Arc::clone(&dag));
     let entry_node = dag
         .entry_node
         .as_ref()
@@ -1090,7 +1090,7 @@ fn main(input: [], output: [result]):
     let ir_hash = format!("{:x}", Sha256::digest(&program_proto));
     let dag = Arc::new(convert_to_dag(&program).expect("convert to dag"));
 
-    let mut state = RunnerState::new(Some(Arc::clone(&dag)), None, None, false);
+    let mut state = RunnerState::from_dag(Arc::clone(&dag));
     let entry_node = dag
         .entry_node
         .as_ref()

--- a/crates/lib/runner-state/src/state.rs
+++ b/crates/lib/runner-state/src/state.rs
@@ -338,10 +338,39 @@ pub struct RunnerState {
 }
 
 impl RunnerState {
+    #[allow(deprecated)]
     pub fn dummy() -> Self {
         Self::new(None, None, None, false)
     }
 
+    #[allow(deprecated)]
+    pub fn from_dag(dag: Arc<DAG>) -> Self {
+        Self::new(Some(dag), None, None, false)
+    }
+
+    #[allow(deprecated)]
+    pub fn from_parts(
+        nodes: HashMap<ExecutionId, ExecutionNode>,
+        edges: HashSet<ExecutionEdge>,
+    ) -> Self {
+        Self::new(None, Some(nodes), Some(edges), false)
+    }
+
+    #[allow(deprecated)]
+    pub fn with_link_queued_nodes() -> Self {
+        Self::new(None, None, None, true)
+    }
+
+    #[allow(deprecated)]
+    pub fn full(
+        dag: Arc<DAG>,
+        nodes: HashMap<ExecutionId, ExecutionNode>,
+        edges: HashSet<ExecutionEdge>,
+    ) -> Self {
+        Self::new(Some(dag), Some(nodes), Some(edges), false)
+    }
+
+    #[deprecated]
     pub fn new(
         dag: Option<Arc<DAG>>,
         nodes: Option<HashMap<ExecutionId, ExecutionNode>>,
@@ -1949,7 +1978,7 @@ mod tests {
 
     #[test]
     fn test_runner_state_unrolls_loop_assignments() {
-        let mut state = RunnerState::new(None, None, None, true);
+        let mut state = RunnerState::with_link_queued_nodes();
 
         state
             .queue_action(
@@ -2046,7 +2075,7 @@ mod tests {
 
     #[test]
     fn test_runner_state_single_target_assignments_stay_symbolic() {
-        let mut state = RunnerState::new(None, None, None, true);
+        let mut state = RunnerState::with_link_queued_nodes();
 
         let initial = ValueExpr::Dict(DictValue {
             entries: vec![DictEntryValue {
@@ -2098,7 +2127,7 @@ mod tests {
 
     #[test]
     fn test_materialize_value_keeps_self_referential_variable_symbolic() {
-        let mut state = RunnerState::new(None, None, None, true);
+        let mut state = RunnerState::with_link_queued_nodes();
         state
             .record_assignment_value(
                 vec!["count".to_string()],
@@ -2137,7 +2166,7 @@ mod tests {
 
     #[test]
     fn test_runner_state_graph_dirty_for_action_updates() {
-        let mut state = RunnerState::new(None, None, None, true);
+        let mut state = RunnerState::with_link_queued_nodes();
         assert!(!state.consume_graph_dirty_for_durable_execution());
 
         let action_result = state
@@ -2160,7 +2189,7 @@ mod tests {
 
     #[test]
     fn test_runner_state_graph_dirty_not_set_for_assignments() {
-        let mut state = RunnerState::new(None, None, None, true);
+        let mut state = RunnerState::with_link_queued_nodes();
         let value_expr = ValueExpr::Literal(LiteralValue {
             value: Value::Number(1.into()),
         });
@@ -2173,7 +2202,7 @@ mod tests {
 
     #[test]
     fn test_runner_state_records_action_start_stop_timestamps() {
-        let mut state = RunnerState::new(None, None, None, true);
+        let mut state = RunnerState::with_link_queued_nodes();
         let action_result = state
             .queue_action(
                 "action",
@@ -2232,7 +2261,7 @@ mod tests {
 
     #[test]
     fn test_runner_state_enforces_node_limit() {
-        let mut state = RunnerState::new(None, None, None, true);
+        let mut state = RunnerState::with_link_queued_nodes();
 
         for index in 0..*MAX_RUNNER_STATE_NODES {
             state

--- a/crates/lib/runner/src/executor.rs
+++ b/crates/lib/runner/src/executor.rs
@@ -1632,7 +1632,7 @@ mod tests {
         edges: HashSet<ExecutionEdge>,
         action_results: HashMap<ExecutionId, UncheckedExecutionResult>,
     ) -> RunnerExecutor<SHOULD_COLLECT_UPDATES> {
-        let state = RunnerState::new(Some(Arc::clone(dag)), Some(nodes), Some(edges), false);
+        let state = RunnerState::full(Arc::clone(dag), nodes, edges);
         RunnerExecutor::new(Arc::clone(dag), state, action_results)
     }
 
@@ -1674,7 +1674,7 @@ mod tests {
     fn build_executor_at_entry<const SHOULD_COLLECT_UPDATES: bool>(
         dag: &Arc<DAG>,
     ) -> (RunnerExecutor<SHOULD_COLLECT_UPDATES>, ExecutionId) {
-        let mut state = RunnerState::new(Some(Arc::clone(dag)), None, None, false);
+        let mut state = RunnerState::from_dag(Arc::clone(dag));
         let entry_template = dag.entry_node.as_ref().expect("dag entry node");
         let entry_exec = state
             .queue_template_node(entry_template, None)
@@ -1696,7 +1696,7 @@ fn main(input: [], output: [result]):
 "#,
         );
 
-        let mut state = RunnerState::new(Some(Arc::clone(&dag)), None, None, false);
+        let mut state = RunnerState::from_dag(Arc::clone(&dag));
         let entry_template = dag.entry_node.as_ref().expect("dag entry node");
         let entry_exec = state
             .queue_template_node(entry_template, None)
@@ -2161,7 +2161,7 @@ fn main(input: [], output: [done]):
         ));
 
         let dag = Arc::new(dag);
-        let mut state = RunnerState::new(Some(dag.clone()), None, None, false);
+        let mut state = RunnerState::from_dag(dag.clone());
         let start_exec = state
             .queue_template_node(&action_start.id, None)
             .expect("queue");
@@ -2210,7 +2210,7 @@ fn main(input: [], output: [done]):
         ));
 
         let dag = Arc::new(dag);
-        let mut state = RunnerState::new(Some(dag.clone()), None, None, false);
+        let mut state = RunnerState::from_dag(dag.clone());
         let exec1 = state.queue_template_node(&action1.id, None).expect("queue");
         let executor =
             RunnerExecutor::without_updates_collection(dag.clone(), state, HashMap::new());
@@ -2250,7 +2250,7 @@ fn main(input: [], output: [done]):
         ));
 
         let dag = Arc::new(dag);
-        let mut state = RunnerState::new(Some(dag.clone()), None, None, false);
+        let mut state = RunnerState::from_dag(dag.clone());
         let exec1 = state.queue_template_node(&action1.id, None).expect("queue");
 
         let mut action_results = HashMap::new();
@@ -2315,7 +2315,7 @@ fn main(input: [], output: [done]):
         ));
 
         let dag = Arc::new(dag);
-        let mut state = RunnerState::new(Some(dag.clone()), None, None, false);
+        let mut state = RunnerState::from_dag(dag.clone());
         let exec1 = state.queue_template_node(&action1.id, None).expect("queue");
         let mut executor =
             RunnerExecutor::without_updates_collection(dag.clone(), state, HashMap::new());
@@ -2408,7 +2408,7 @@ fn main(input: [], output: [done]):
         ));
 
         let dag = Arc::new(dag);
-        let mut state = RunnerState::new(Some(dag.clone()), None, None, false);
+        let mut state = RunnerState::from_dag(dag.clone());
         let exec1 = state.queue_template_node(&action1.id, None).expect("queue");
 
         let mut action_results = HashMap::new();
@@ -2466,7 +2466,7 @@ fn main(input: [], output: [done]):
 
         dag.add_node(waymark_dag::DAGNode::ActionCall(action1.clone()));
         let dag = Arc::new(dag);
-        let mut state = RunnerState::new(Some(dag.clone()), None, None, false);
+        let mut state = RunnerState::from_dag(dag.clone());
         let exec1 = state.queue_template_node(&action1.id, None).expect("queue");
         let executor =
             RunnerExecutor::without_updates_collection(dag.clone(), state, HashMap::new());
@@ -2513,7 +2513,7 @@ fn main(input: [], output: [done]):
         ));
 
         let dag = Arc::new(dag);
-        let mut state = RunnerState::new(Some(dag.clone()), None, None, false);
+        let mut state = RunnerState::from_dag(dag.clone());
         let exec1 = state.queue_template_node(&action1.id, None).expect("queue");
 
         let mut action_results = HashMap::new();
@@ -2560,7 +2560,7 @@ fn main(input: [], output: [done]):
         dag.add_node(waymark_dag::DAGNode::ActionCall(action1.clone()));
 
         let dag = Arc::new(dag);
-        let mut state = RunnerState::new(Some(dag.clone()), None, None, false);
+        let mut state = RunnerState::from_dag(dag.clone());
         let exec1 = state.queue_template_node(&action1.id, None).expect("queue");
         state.mark_running(exec1.node_id).expect("mark running");
 
@@ -2598,7 +2598,7 @@ fn main(input: [], output: [done]):
         dag.add_node(waymark_dag::DAGNode::ActionCall(action.clone()));
 
         let dag = Arc::new(dag);
-        let mut state = RunnerState::new(Some(dag.clone()), None, None, false);
+        let mut state = RunnerState::from_dag(dag.clone());
         let exec = state.queue_template_node(&action.id, None).expect("queue");
 
         let mut executor = RunnerExecutor::<true>::new(dag, state, HashMap::new());
@@ -2653,7 +2653,7 @@ fn main(input: [], output: [done]):
         dag.add_node(waymark_dag::DAGNode::ActionCall(action.clone()));
 
         let dag = Arc::new(dag);
-        let mut state = RunnerState::new(Some(dag.clone()), None, None, false);
+        let mut state = RunnerState::from_dag(dag.clone());
         let exec = state.queue_template_node(&action.id, None).expect("queue");
 
         let mut executor = RunnerExecutor::<true>::new(dag, state, HashMap::new());
@@ -2738,7 +2738,7 @@ fn main(input: [], output: [done]):
         ));
 
         let dag = Arc::new(dag);
-        let mut state = RunnerState::new(Some(dag.clone()), None, None, false);
+        let mut state = RunnerState::from_dag(dag.clone());
         let exec1 = state.queue_template_node(&action1.id, None).expect("queue");
 
         let mut action_results = HashMap::new();
@@ -2820,7 +2820,7 @@ fn main(input: [], output: [done]):
         ));
 
         let dag = Arc::new(dag);
-        let mut state = RunnerState::new(Some(dag.clone()), None, None, false);
+        let mut state = RunnerState::from_dag(dag.clone());
         let initial_exec = state
             .queue_template_node(&initial_action.id, None)
             .expect("queue");
@@ -2897,7 +2897,7 @@ fn main(input: [], output: [done]):
         ));
 
         let dag = Arc::new(dag);
-        let mut state = RunnerState::new(Some(dag.clone()), None, None, false);
+        let mut state = RunnerState::from_dag(dag.clone());
         let initial_exec = state
             .queue_template_node(&initial_action.id, None)
             .expect("queue");
@@ -2972,7 +2972,7 @@ fn main(input: [], output: [done]):
         }
 
         let dag = Arc::new(dag);
-        let mut state = RunnerState::new(Some(dag.clone()), None, None, false);
+        let mut state = RunnerState::from_dag(dag.clone());
         let mut exec_nodes: Vec<ExecutionNode> = Vec::new();
         exec_nodes.push(
             state
@@ -3037,7 +3037,7 @@ fn main(input: [], output: [done]):
         ));
 
         let dag = Arc::new(dag);
-        let mut state = RunnerState::new(Some(dag.clone()), None, None, false);
+        let mut state = RunnerState::from_dag(dag.clone());
         let exec1 = state.queue_template_node(&action1.id, None).expect("queue");
 
         let mut action_results = HashMap::new();

--- a/crates/lib/runner/src/expression_evaluator.rs
+++ b/crates/lib/runner/src/expression_evaluator.rs
@@ -703,7 +703,7 @@ mod tests {
     fn empty_executor<const SHOULD_COLLECT_UPDATES: bool>() -> RunnerExecutor<SHOULD_COLLECT_UPDATES>
     {
         let dag = Arc::new(DAG::default());
-        let state = RunnerState::new(Some(Arc::clone(&dag)), None, None, false);
+        let state = RunnerState::from_dag(Arc::clone(&dag));
         RunnerExecutor::new(dag, state, HashMap::new())
     }
 
@@ -712,7 +712,7 @@ mod tests {
         value: ValueExpr,
     ) -> RunnerExecutor<SHOULD_COLLECT_UPDATES> {
         let dag = Arc::new(DAG::default());
-        let mut state = RunnerState::new(Some(Arc::clone(&dag)), None, None, false);
+        let mut state = RunnerState::from_dag(Arc::clone(&dag));
         state
             .record_assignment_value(
                 vec![name.to_string()],
@@ -770,7 +770,7 @@ mod tests {
     #[test]
     fn test_resolve_action_kwargs_uses_data_flow_for_self_referential_targets() {
         let dag = Arc::new(DAG::default());
-        let mut state = RunnerState::new(Some(Arc::clone(&dag)), None, None, false);
+        let mut state = RunnerState::from_dag(Arc::clone(&dag));
         state
             .record_assignment_value(
                 vec!["current".to_string()],
@@ -850,7 +850,7 @@ mod tests {
     #[test]
     fn test_evaluate_assignment_uses_data_flow_for_self_referential_updates() {
         let dag = Arc::new(DAG::default());
-        let mut state = RunnerState::new(Some(Arc::clone(&dag)), None, None, false);
+        let mut state = RunnerState::from_dag(Arc::clone(&dag));
         state
             .record_assignment_value(
                 vec!["count".to_string()],

--- a/crates/lib/runner/src/replay.rs
+++ b/crates/lib/runner/src/replay.rs
@@ -556,7 +556,7 @@ mod tests {
 
     #[test]
     fn test_replay_variables_resolves_action_results() {
-        let mut state = RunnerState::new(None, None, None, true);
+        let mut state = RunnerState::with_link_queued_nodes();
 
         let action0 = state
             .queue_action(
@@ -632,7 +632,7 @@ mod tests {
 
     #[test]
     fn test_replay_action_kwargs_resolves_variable_inputs() {
-        let mut state = RunnerState::new(None, None, None, true);
+        let mut state = RunnerState::with_link_queued_nodes();
 
         let number_expr = ir::Expr {
             kind: Some(ir::expr::Kind::Literal(ir::Literal {

--- a/crates/lib/runner/tests/stack_overflow.rs
+++ b/crates/lib/runner/tests/stack_overflow.rs
@@ -27,7 +27,7 @@ fn build_completed_state(chain_len: usize) -> RunnerState {
     let program = parse_program(source.trim()).expect("parse program");
     let dag = Arc::new(convert_to_dag(&program).expect("convert to dag"));
 
-    let mut state = RunnerState::new(Some(Arc::clone(&dag)), None, None, false);
+    let mut state = RunnerState::from_dag(Arc::clone(&dag));
     state
         .record_assignment(
             vec!["x".to_string()],

--- a/crates/lib/scheduler-loop/src/lib.rs
+++ b/crates/lib/scheduler-loop/src/lib.rs
@@ -124,8 +124,7 @@ where
             .as_ref()
             .ok_or_else(|| "DAG has no entry node".to_string())?;
 
-        let mut state =
-            waymark_runner_state::RunnerState::new(Some(Arc::clone(&dag)), None, None, false);
+        let mut state = waymark_runner_state::RunnerState::from_dag(Arc::clone(&dag));
         if let Some(input_payload) = schedule.input_payload.as_deref() {
             let input_payload = proto::WorkflowArguments::decode(input_payload)
                 .map_err(|_| "failed to decode schedule input payload".to_string())?;


### PR DESCRIPTION
Slight changes to the runner state construction API: instead of a generic `new` fn, there are now a number of more specific constructors: for when you got a DAG, when you got the nodes and edges, when you have everything and when you will be inserting the nodes manually and expect to have the edges added automatically (i.e. in tests

This is useful to quickly figure out what APIs are used where by using LSP references lookup in the IDE.