### PR TITLE
Add `either` support to more backends

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4147,6 +4147,7 @@ name = "waymark-core-backend"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "either",
  "nonempty-collections",
  "serde",
  "waymark-backends-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4915,6 +4915,7 @@ dependencies = [
 name = "waymark-workflow-registry-backend"
 version = "0.1.0"
 dependencies = [
+ "either",
  "waymark-backends-core",
  "waymark-ids",
 ]

--- a/crates/lib/core-backend/Cargo.toml
+++ b/crates/lib/core-backend/Cargo.toml
@@ -4,6 +4,9 @@ version.workspace = true
 publish.workspace = true
 edition = "2024"
 
+[features]
+default = ["either"]
+
 [dependencies]
 waymark-backends-core = { workspace = true }
 waymark-ids = { workspace = true }
@@ -11,6 +14,7 @@ waymark-runner-executor-core = { workspace = true }
 waymark-runner-state = { workspace = true }
 
 chrono = { workspace = true }
+either = { workspace = true, optional = true }
 nonempty-collections = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 

--- a/crates/lib/core-backend/src/either.rs
+++ b/crates/lib/core-backend/src/either.rs
@@ -1,0 +1,101 @@
+use either::Either;
+
+use crate::CoreBackend;
+
+impl<Left, Right> CoreBackend for Either<Left, Right>
+where
+    Left: CoreBackend,
+    Right: CoreBackend<PollQueuedInstancesError = Left::PollQueuedInstancesError>,
+{
+    fn save_graphs<'a>(
+        &'a self,
+        claim: crate::LockClaim,
+        graphs: &'a [crate::GraphUpdate],
+    ) -> impl Future<Output = waymark_backends_core::BackendResult<Vec<crate::InstanceLockStatus>>>
+    + Send
+    + 'a {
+        match self {
+            Either::Left(inner) => Either::Left(inner.save_graphs(claim, graphs)),
+            Either::Right(inner) => Either::Right(inner.save_graphs(claim, graphs)),
+        }
+    }
+
+    fn save_actions_done<'a>(
+        &'a self,
+        actions: &'a [crate::ActionDone],
+    ) -> impl Future<Output = waymark_backends_core::BackendResult<()>> + Send + 'a {
+        match self {
+            Either::Left(inner) => Either::Left(inner.save_actions_done(actions)),
+            Either::Right(inner) => Either::Right(inner.save_actions_done(actions)),
+        }
+    }
+
+    type PollQueuedInstancesError = Left::PollQueuedInstancesError;
+
+    fn poll_queued_instances(
+        &self,
+        size: std::num::NonZeroUsize,
+        claim: crate::LockClaim,
+    ) -> impl Future<
+        Output = Result<
+            nonempty_collections::NEVec<crate::QueuedInstance>,
+            Self::PollQueuedInstancesError,
+        >,
+    > + Send
+    + '_ {
+        match self {
+            Either::Left(inner) => Either::Left(inner.poll_queued_instances(size, claim)),
+            Either::Right(inner) => Either::Right(inner.poll_queued_instances(size, claim)),
+        }
+    }
+
+    fn refresh_instance_locks<'a>(
+        &'a self,
+        claim: crate::LockClaim,
+        instance_ids: &'a [waymark_ids::InstanceId],
+    ) -> impl Future<Output = waymark_backends_core::BackendResult<Vec<crate::InstanceLockStatus>>>
+    + Send
+    + 'a {
+        match self {
+            Either::Left(inner) => Either::Left(inner.refresh_instance_locks(claim, instance_ids)),
+            Either::Right(inner) => {
+                Either::Right(inner.refresh_instance_locks(claim, instance_ids))
+            }
+        }
+    }
+
+    fn release_instance_locks<'a>(
+        &'a self,
+        lock_uuid: waymark_ids::LockId,
+        instance_ids: &'a [waymark_ids::InstanceId],
+    ) -> impl Future<Output = waymark_backends_core::BackendResult<()>> + Send + 'a {
+        match self {
+            Either::Left(inner) => {
+                Either::Left(inner.release_instance_locks(lock_uuid, instance_ids))
+            }
+            Either::Right(inner) => {
+                Either::Right(inner.release_instance_locks(lock_uuid, instance_ids))
+            }
+        }
+    }
+
+    fn save_instances_done<'a>(
+        &'a self,
+        instances: &'a [crate::InstanceDone],
+    ) -> impl Future<Output = waymark_backends_core::BackendResult<()>> + Send + 'a {
+        match self {
+            Either::Left(inner) => Either::Left(inner.save_instances_done(instances)),
+            Either::Right(inner) => Either::Right(inner.save_instances_done(instances)),
+        }
+    }
+
+    fn queue_instances<'a>(
+        &'a self,
+        instances: &'a [crate::QueuedInstance],
+    ) -> impl Future<Output = waymark_backends_core::BackendResult<()>> + Send + 'a {
+        match self {
+            Either::Left(inner) => Either::Left(inner.queue_instances(instances)),
+            Either::Right(inner) => Either::Right(inner.queue_instances(instances)),
+        }
+    }
+}

--- a/crates/lib/core-backend/src/lib.rs
+++ b/crates/lib/core-backend/src/lib.rs
@@ -1,6 +1,10 @@
 //! Core backend traits for waymark.
 
+#[cfg(feature = "either")]
+mod either;
+
 mod data;
+
 pub mod poll_queued_instances;
 
 use nonempty_collections::NEVec;

--- a/crates/lib/workflow-registry-backend/Cargo.toml
+++ b/crates/lib/workflow-registry-backend/Cargo.toml
@@ -4,9 +4,14 @@ version.workspace = true
 publish.workspace = true
 edition = "2024"
 
+[features]
+default = ["either"]
+
 [dependencies]
 waymark-backends-core = { workspace = true }
 waymark-ids = { workspace = true }
+
+either = { workspace = true, optional = true }
 
 [lib]
 test = false

--- a/crates/lib/workflow-registry-backend/src/either.rs
+++ b/crates/lib/workflow-registry-backend/src/either.rs
@@ -1,0 +1,33 @@
+use either::Either;
+use waymark_ids::WorkflowVersionId;
+
+use crate::WorkflowRegistryBackend;
+
+impl<Left, Right> WorkflowRegistryBackend for Either<Left, Right>
+where
+    Left: WorkflowRegistryBackend,
+    Right: WorkflowRegistryBackend,
+{
+    fn upsert_workflow_version<'a>(
+        &'a self,
+        registration: &'a crate::WorkflowRegistration,
+    ) -> impl Future<Output = waymark_backends_core::BackendResult<WorkflowVersionId>> + Send + 'a
+    {
+        match self {
+            Either::Left(inner) => Either::Left(inner.upsert_workflow_version(registration)),
+            Either::Right(inner) => Either::Right(inner.upsert_workflow_version(registration)),
+        }
+    }
+
+    fn get_workflow_versions<'a>(
+        &'a self,
+        ids: &'a [WorkflowVersionId],
+    ) -> impl Future<Output = waymark_backends_core::BackendResult<Vec<crate::WorkflowVersion>>>
+    + Send
+    + 'a {
+        match self {
+            Either::Left(inner) => Either::Left(inner.get_workflow_versions(ids)),
+            Either::Right(inner) => Either::Right(inner.get_workflow_versions(ids)),
+        }
+    }
+}

--- a/crates/lib/workflow-registry-backend/src/lib.rs
+++ b/crates/lib/workflow-registry-backend/src/lib.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "either")]
+mod either;
+
 pub use waymark_backends_core::{BackendError, BackendResult};
 use waymark_ids::WorkflowVersionId;
 


### PR DESCRIPTION
This PR adds either support to more backends; this is something I'm planning to use in the VCR to allow dynamically switching between different backends without having to use dyn traits.