### PR TITLE
Introduce a new ExecutionGraph type and use it at the RunnerState and GraphUpdate

### DIFF
--- a/crates/lib/backend-postgres/src/core.rs
+++ b/crates/lib/backend-postgres/src/core.rs
@@ -435,8 +435,8 @@ impl PostgresBackend {
                 continue;
             };
             match Self::deserialize::<GraphUpdate>(&state_payload) {
-                Ok(graph) => {
-                    for (execution_id, node) in graph.nodes {
+                Ok(graph_update) => {
+                    for (execution_id, node) in graph_update.graph.nodes {
                         if node.is_action_call() {
                             action_execution_ids.push(execution_id);
                         }
@@ -817,10 +817,11 @@ impl PostgresBackend {
 
                 // If we do - parse the graph and assign state.
 
-                let graph: GraphUpdate = crate::codec::deserialize(&state_payload)
+                let graph_update: GraphUpdate = crate::codec::deserialize(&state_payload)
                     .map_err(PollQueuedInstancesError::GraphUpdateDecode)?;
 
-                let action_node_ids: Vec<ExecutionId> = graph
+                let action_node_ids: Vec<ExecutionId> = graph_update
+                    .graph
                     .nodes
                     .iter()
                     .filter_map(|(node_id, node)| node.is_action_call().then_some(*node_id))
@@ -831,7 +832,7 @@ impl PostgresBackend {
                     action_node_ids_by_instance.insert(instance_id, action_node_ids);
                 }
 
-                instance.state = RunnerState::from_parts(graph.nodes, graph.edges);
+                instance.state = RunnerState::from_graph(graph_update.graph);
 
                 Ok(instance)
             })
@@ -1154,7 +1155,7 @@ mod tests {
     use uuid::Uuid;
     use waymark_core_backend::{ActionAttemptStatus, CoreBackend};
     use waymark_ids::ExecutionId;
-    use waymark_runner_execution_core::{ExecutionNode, NodeStatus};
+    use waymark_runner_execution_core::{ExecutionGraph, ExecutionNode, NodeStatus};
     use waymark_runner_executor_core::UncheckedExecutionResult;
 
     use super::super::test_helpers::setup_backend;
@@ -1408,15 +1409,16 @@ mod tests {
         completed_action_node.status = NodeStatus::Completed;
         completed_action_node.scheduled_at = None;
 
-        let graph = GraphUpdate {
-            instance_id,
+        let graph = ExecutionGraph {
             nodes: HashMap::from([(execution_id, completed_action_node)]),
             edges: std::collections::HashSet::new(),
         };
+
+        let graph_update = GraphUpdate { instance_id, graph };
         CoreBackend::save_graphs(
             &backend,
             initial_claim.clone(),
-            std::slice::from_ref(&graph),
+            std::slice::from_ref(&graph_update),
         )
         .await
         .expect("persist graph");
@@ -1489,14 +1491,16 @@ mod tests {
         nodes.insert(execution_id, sample_execution_node(execution_id));
         let graph = GraphUpdate {
             instance_id,
-            nodes,
-            edges: std::collections::HashSet::from([
-                waymark_runner_execution_core::ExecutionEdge {
-                    source: execution_id,
-                    target: execution_id,
-                    edge_type: EdgeType::StateMachine,
-                },
-            ]),
+            graph: ExecutionGraph {
+                nodes,
+                edges: std::collections::HashSet::from([
+                    waymark_runner_execution_core::ExecutionEdge {
+                        source: execution_id,
+                        target: execution_id,
+                        edge_type: EdgeType::StateMachine,
+                    },
+                ]),
+            },
         };
         let extended_claim = LockClaim {
             lock_uuid: claim.lock_uuid,
@@ -1528,8 +1532,8 @@ mod tests {
                 .expect("runner state payload");
         let decoded: GraphUpdate = rmp_serde::from_slice(&state_payload.expect("state payload"))
             .expect("decode graph update");
-        assert_eq!(decoded.nodes.len(), 1);
-        assert_eq!(decoded.edges.len(), 1);
+        assert_eq!(decoded.graph.nodes.len(), 1);
+        assert_eq!(decoded.graph.edges.len(), 1);
     }
 
     #[serial(postgres)]
@@ -1547,13 +1551,17 @@ mod tests {
         let second_node_id = ExecutionId::new_uuid_v4();
         let first_graph = GraphUpdate {
             instance_id,
-            nodes: HashMap::from([(first_node_id, sample_execution_node(first_node_id))]),
-            edges: HashSet::new(),
+            graph: ExecutionGraph {
+                nodes: HashMap::from([(first_node_id, sample_execution_node(first_node_id))]),
+                edges: HashSet::new(),
+            },
         };
         let second_graph = GraphUpdate {
             instance_id,
-            nodes: HashMap::from([(second_node_id, sample_execution_node(second_node_id))]),
-            edges: HashSet::new(),
+            graph: ExecutionGraph {
+                nodes: HashMap::from([(second_node_id, sample_execution_node(second_node_id))]),
+                edges: HashSet::new(),
+            },
         };
 
         let locks = CoreBackend::save_graphs(
@@ -1989,8 +1997,10 @@ mod tests {
 
         let state = GraphUpdate {
             instance_id,
-            nodes: HashMap::from([(execution_id, sample_execution_node(execution_id))]),
-            edges: HashSet::new(),
+            graph: ExecutionGraph {
+                nodes: HashMap::from([(execution_id, sample_execution_node(execution_id))]),
+                edges: HashSet::new(),
+            },
         };
         let state_payload = PostgresBackend::serialize(&state).expect("serialize state");
         let result_payload =
@@ -2059,8 +2069,10 @@ mod tests {
         let workflow_version_id = Uuid::new_v4();
         let state_payload = PostgresBackend::serialize(&GraphUpdate {
             instance_id,
-            nodes: HashMap::new(),
-            edges: HashSet::new(),
+            graph: ExecutionGraph {
+                nodes: HashMap::new(),
+                edges: HashSet::new(),
+            },
         })
         .expect("serialize state");
         let result_payload =

--- a/crates/lib/backend-postgres/src/webapp.rs
+++ b/crates/lib/backend-postgres/src/webapp.rs
@@ -463,6 +463,7 @@ impl waymark_webapp_backend::WebappBackend for crate::PostgresBackend {
             .map_err(|e| BackendError::Message(format!("failed to decode state: {}", e)))?;
 
         let nodes: Vec<ExecutionNodeView> = graph_update
+            .graph
             .nodes
             .values()
             .map(|node| ExecutionNodeView {
@@ -476,6 +477,7 @@ impl waymark_webapp_backend::WebappBackend for crate::PostgresBackend {
             .collect();
 
         let edges: Vec<ExecutionEdgeView> = graph_update
+            .graph
             .edges
             .iter()
             .map(|edge| ExecutionEdgeView {
@@ -590,7 +592,7 @@ impl waymark_webapp_backend::WebappBackend for crate::PostgresBackend {
             let graph_update: GraphUpdate = rmp_serde::from_slice(&state_bytes)
                 .map_err(|err| BackendError::Message(format!("failed to decode state: {err}")))?;
 
-            for node in graph_update.nodes.values() {
+            for node in graph_update.graph.nodes.values() {
                 let Some(template_id) = node.template_id.as_ref() else {
                     continue;
                 };
@@ -678,8 +680,9 @@ impl waymark_webapp_backend::WebappBackend for crate::PostgresBackend {
         let graph_update: GraphUpdate = rmp_serde::from_slice(&state_bytes)
             .map_err(|e| BackendError::Message(format!("failed to decode state: {}", e)))?;
 
-        let runner_state = RunnerState::from_parts(graph_update.nodes.clone(), graph_update.edges);
+        let runner_state = RunnerState::from_graph(graph_update.graph.clone());
         let action_nodes: HashMap<ExecutionId, ExecutionNode> = graph_update
+            .graph
             .nodes
             .into_iter()
             .filter(|(_, node)| node.is_action_call())
@@ -1370,8 +1373,8 @@ fn extract_input_preview(state_bytes: &Option<Vec<u8>>) -> String {
     };
 
     match rmp_serde::from_slice::<GraphUpdate>(bytes) {
-        Ok(graph) => {
-            let count = graph.nodes.len();
+        Ok(graph_update) => {
+            let count = graph_update.graph.nodes.len();
             format!("{{nodes: {count}}}")
         }
         Err(_) => "{}".to_string(),
@@ -1401,9 +1404,9 @@ fn extract_input_payload_map(
     let Some(bytes) = state_bytes else {
         return Ok(serde_json::Map::new());
     };
-    let graph: GraphUpdate = rmp_serde::from_slice(bytes)
+    let graph_update: GraphUpdate = rmp_serde::from_slice(bytes)
         .map_err(|err| BackendError::Message(format!("failed to decode state: {err}")))?;
-    Ok(extract_input_map(&graph.nodes))
+    Ok(extract_input_map(&graph_update.graph.nodes))
 }
 
 fn extract_input_map(
@@ -1605,7 +1608,7 @@ mod tests {
     use serial_test::serial;
     use uuid::Uuid;
     use waymark_ids::ExecutionId;
-    use waymark_runner_execution_core::ExecutionEdge;
+    use waymark_runner_execution_core::{ExecutionEdge, ExecutionGraph};
     use waymark_scheduler_backend::SchedulerBackend;
     use waymark_webapp_backend::WebappBackend;
     use waymark_worker_status_backend::{WorkerStatusBackend, WorkerStatusUpdate};
@@ -1851,12 +1854,14 @@ mod tests {
 
         GraphUpdate {
             instance_id,
-            nodes,
-            edges: HashSet::from([ExecutionEdge {
-                source: execution_id,
-                target: execution_id,
-                edge_type: EdgeType::StateMachine,
-            }]),
+            graph: ExecutionGraph {
+                nodes,
+                edges: HashSet::from([ExecutionEdge {
+                    source: execution_id,
+                    target: execution_id,
+                    edge_type: EdgeType::StateMachine,
+                }]),
+            },
         }
     }
 
@@ -1890,11 +1895,13 @@ mod tests {
         let input_label = sample_input_node("label", serde_json::json!("latest"));
         GraphUpdate {
             instance_id,
-            nodes: HashMap::from([
-                (input_number.node_id, input_number),
-                (input_label.node_id, input_label),
-            ]),
-            edges: HashSet::new(),
+            graph: ExecutionGraph {
+                nodes: HashMap::from([
+                    (input_number.node_id, input_number),
+                    (input_label.node_id, input_label),
+                ]),
+                edges: HashSet::new(),
+            },
         }
     }
 
@@ -2278,7 +2285,7 @@ fn main(input: [items], output: [total]):
         let queued: QueuedInstance =
             rmp_serde::from_slice(&queued_payload).expect("decode queued payload");
         assert_eq!(queued.workflow_version_id, latest_version_id);
-        let rendered_inputs = format_extracted_inputs(&queued.state.nodes);
+        let rendered_inputs = format_extracted_inputs(&queued.state.graph.nodes);
         let rendered_value: Value =
             serde_json::from_str(&rendered_inputs).expect("decode queued input payload");
         assert_eq!(

--- a/crates/lib/core-backend/src/data.rs
+++ b/crates/lib/core-backend/src/data.rs
@@ -2,11 +2,11 @@
 // have specified in our database/Postgres backend, but not 1:1. It's better for
 // us to internally convert within the given backend
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use waymark_runner_execution_core::{ExecutionEdge, ExecutionNode, NodeStatus};
+use waymark_runner_execution_core::{ExecutionGraph, NodeStatus};
 use waymark_runner_executor_core::{
     ExecutionException, ExecutionSuccess, UncheckedExecutionResult,
 };
@@ -64,22 +64,21 @@ pub struct InstanceDone {
 /// derived caches) so persistence stays lightweight.
 pub struct GraphUpdate {
     pub instance_id: InstanceId,
-    pub nodes: HashMap<ExecutionId, ExecutionNode>,
-    pub edges: HashSet<ExecutionEdge>,
+    #[serde(flatten)]
+    pub graph: ExecutionGraph,
 }
 
 impl GraphUpdate {
     pub fn from_state(instance_id: InstanceId, state: &RunnerState) -> Self {
         Self {
             instance_id,
-            nodes: state.nodes.clone(),
-            edges: state.edges.clone(),
+            graph: state.graph.clone(),
         }
     }
 
     pub fn next_scheduled_at(&self) -> DateTime<Utc> {
         let mut next: Option<DateTime<Utc>> = None;
-        for node in self.nodes.values() {
+        for node in self.graph.nodes.values() {
             if matches!(node.status, NodeStatus::Completed | NodeStatus::Failed) {
                 continue;
             }

--- a/crates/lib/runloop/src/shard/executor.rs
+++ b/crates/lib/runloop/src/shard/executor.rs
@@ -104,7 +104,7 @@ impl Executor {
     ) -> Result<Option<super::Step>, HandleWakeError> {
         let mut finished_nodes = Vec::new();
         for node_id in node_ids {
-            if self.executor.state().nodes.contains_key(&node_id) {
+            if self.executor.state().graph.nodes.contains_key(&node_id) {
                 self.inflight.remove(&node_id);
                 finished_nodes.push(node_id);
             }

--- a/crates/lib/runloop/src/shard/run.rs
+++ b/crates/lib/runloop/src/shard/run.rs
@@ -143,7 +143,7 @@ pub fn run_executor_shard(
                 let mut grouped: HashMap<InstanceId, Vec<ExecutionId>> = HashMap::new();
                 for node_id in node_ids {
                     for (executor_id, owner) in &executors {
-                        if owner.executor.state().nodes.contains_key(&node_id) {
+                        if owner.executor.state().graph.nodes.contains_key(&node_id) {
                             grouped.entry(*executor_id).or_default().push(node_id);
                             break;
                         }

--- a/crates/lib/runloop/tests/integration.rs
+++ b/crates/lib/runloop/tests/integration.rs
@@ -447,7 +447,7 @@ fn main(input: [], output: [y]):
     let mut saw_running_snapshot = false;
     let mut saw_failed_snapshot = false;
     for update in graph_updates {
-        let Some(node) = update.nodes.get(&execution_id) else {
+        let Some(node) = update.graph.nodes.get(&execution_id) else {
             continue;
         };
         if node.status == NodeStatus::Running && node.started_at.is_some() {
@@ -844,6 +844,7 @@ fn main(input: [x], output: [y]):
     assert!(
         bootstrap_executor
             .state()
+            .graph
             .nodes
             .get(&action_exec.node_id)
             .is_some_and(|node| node.is_action_call() && node.status == NodeStatus::Completed),

--- a/crates/lib/runner-execution-core/src/graph.rs
+++ b/crates/lib/runner-execution-core/src/graph.rs
@@ -1,0 +1,12 @@
+use std::collections::{HashMap, HashSet};
+
+use serde::{Deserialize, Serialize};
+use waymark_ids::ExecutionId;
+
+use crate::{ExecutionEdge, ExecutionNode};
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ExecutionGraph {
+    pub nodes: HashMap<ExecutionId, ExecutionNode>,
+    pub edges: HashSet<ExecutionEdge>,
+}

--- a/crates/lib/runner-execution-core/src/lib.rs
+++ b/crates/lib/runner-execution-core/src/lib.rs
@@ -1,11 +1,13 @@
 //! The core runner execution state.
 
 mod edge;
+mod graph;
 mod node;
 mod node_status;
 mod node_type;
 
 pub use crate::edge::*;
+pub use crate::graph::*;
 pub use crate::node::*;
 pub use crate::node_status::*;
 pub use crate::node_type::*;

--- a/crates/lib/runner-state/src/state.rs
+++ b/crates/lib/runner-state/src/state.rs
@@ -6,7 +6,9 @@ use std::sync::Arc;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use waymark_ids::ExecutionId;
-use waymark_runner_execution_core::{ExecutionEdge, ExecutionNode, ExecutionNodeType, NodeStatus};
+use waymark_runner_execution_core::{
+    ExecutionEdge, ExecutionGraph, ExecutionNode, ExecutionNodeType, NodeStatus,
+};
 
 use crate::max_nodes::MAX_RUNNER_STATE_NODES;
 use crate::util::is_truthy;
@@ -87,8 +89,7 @@ pub struct QueueNodeParams {
 pub struct RunnerState {
     #[serde(skip, default)]
     pub dag: Option<Arc<DAG>>,
-    pub nodes: HashMap<ExecutionId, ExecutionNode>,
-    pub edges: HashSet<ExecutionEdge>,
+    pub graph: ExecutionGraph,
     pub ready_queue: Vec<ExecutionId>,
     pub timeline: Vec<ExecutionId>,
     link_queued_nodes: bool,
@@ -99,54 +100,48 @@ pub struct RunnerState {
 impl RunnerState {
     #[allow(deprecated)]
     pub fn dummy() -> Self {
-        Self::new(None, None, None, false)
+        Self::new(None, None, false)
     }
 
     #[allow(deprecated)]
     pub fn from_dag(dag: Arc<DAG>) -> Self {
-        Self::new(Some(dag), None, None, false)
+        Self::new(Some(dag), None, false)
     }
 
     #[allow(deprecated)]
-    pub fn from_parts(
-        nodes: HashMap<ExecutionId, ExecutionNode>,
-        edges: HashSet<ExecutionEdge>,
-    ) -> Self {
-        Self::new(None, Some(nodes), Some(edges), false)
+    pub fn from_graph(graph: ExecutionGraph) -> Self {
+        Self::new(None, Some(graph), false)
     }
 
     #[allow(deprecated)]
     pub fn with_link_queued_nodes() -> Self {
-        Self::new(None, None, None, true)
+        Self::new(None, None, true)
     }
 
     #[allow(deprecated)]
-    pub fn full(
-        dag: Arc<DAG>,
-        nodes: HashMap<ExecutionId, ExecutionNode>,
-        edges: HashSet<ExecutionEdge>,
-    ) -> Self {
-        Self::new(Some(dag), Some(nodes), Some(edges), false)
+    pub fn full(dag: Arc<DAG>, graph: ExecutionGraph) -> Self {
+        Self::new(Some(dag), Some(graph), false)
     }
 
     #[deprecated]
     pub fn new(
         dag: Option<Arc<DAG>>,
-        nodes: Option<HashMap<ExecutionId, ExecutionNode>>,
-        edges: Option<HashSet<ExecutionEdge>>,
+        graph: Option<ExecutionGraph>,
         link_queued_nodes: bool,
     ) -> Self {
         let mut state = Self {
             dag,
-            nodes: nodes.unwrap_or_default(),
-            edges: edges.unwrap_or_default(),
+            graph: graph.unwrap_or_else(|| ExecutionGraph {
+                nodes: Default::default(),
+                edges: Default::default(),
+            }),
             ready_queue: Vec::new(),
             timeline: Vec::new(),
             link_queued_nodes,
             latest_assignments: HashMap::new(),
             graph_dirty: false,
         };
-        if !state.nodes.is_empty() || !state.edges.is_empty() {
+        if !state.graph.nodes.is_empty() || !state.graph.edges.is_empty() {
             state.rehydrate_state();
         }
         state
@@ -300,7 +295,7 @@ impl RunnerState {
             iteration_index,
             true,
         )?;
-        if let Some(node_mut) = self.nodes.get_mut(&node.node_id) {
+        if let Some(node_mut) = self.graph.nodes.get_mut(&node.node_id) {
             node_mut.value_expr = Some(ValueExpr::ActionResult(result.clone()));
         }
         Ok(result)
@@ -332,7 +327,7 @@ impl RunnerState {
             iteration_index,
             true,
         )?;
-        if let Some(node) = self.nodes.get_mut(&node.node_id) {
+        if let Some(node) = self.graph.nodes.get_mut(&node.node_id) {
             node.value_expr = Some(ValueExpr::ActionResult(result.clone()));
         }
         Ok(result)
@@ -445,19 +440,19 @@ impl RunnerState {
     /// - queue node A then node B with link_queued_nodes=True
     ///   This creates a state-machine edge A -> B automatically.
     fn register_node(&mut self, node: ExecutionNode) -> Result<(), RunnerStateError> {
-        if self.nodes.contains_key(&node.node_id) {
+        if self.graph.nodes.contains_key(&node.node_id) {
             return Err(RunnerStateError(format!(
                 "execution node already queued: {}",
                 node.node_id
             )));
         }
-        if self.nodes.len() >= *MAX_RUNNER_STATE_NODES {
+        if self.graph.nodes.len() >= *MAX_RUNNER_STATE_NODES {
             return Err(RunnerStateError::node_limit_exceeded(
                 node.node_id,
-                self.nodes.len(),
+                self.graph.nodes.len(),
             ));
         }
-        self.nodes.insert(node.node_id, node.clone());
+        self.graph.nodes.insert(node.node_id, node.clone());
         self.ready_queue.push(node.node_id);
         if node.is_action_call() {
             self.mark_graph_dirty();
@@ -476,7 +471,7 @@ impl RunnerState {
     }
 
     fn register_edge(&mut self, edge: ExecutionEdge) {
-        self.edges.insert(edge);
+        self.graph.edges.insert(edge);
     }
 
     fn mark_graph_dirty(&mut self) {
@@ -495,7 +490,7 @@ impl RunnerState {
         self.timeline = self.build_timeline();
         self.latest_assignments.clear();
         for node_id in &self.timeline {
-            if let Some(node) = self.nodes.get(node_id) {
+            if let Some(node) = self.graph.nodes.get(node_id) {
                 for target in node.assignments.keys() {
                     self.latest_assignments.insert(target.clone(), *node_id);
                 }
@@ -506,7 +501,8 @@ impl RunnerState {
                 .timeline
                 .iter()
                 .filter(|node_id| {
-                    self.nodes
+                    self.graph
+                        .nodes
                         .get(node_id)
                         .map(|node| node.status == NodeStatus::Queued)
                         .unwrap_or(false)
@@ -517,17 +513,22 @@ impl RunnerState {
     }
 
     fn build_timeline(&self) -> Vec<ExecutionId> {
-        if self.edges.is_empty() {
-            return self.nodes.keys().cloned().collect();
+        if self.graph.edges.is_empty() {
+            return self.graph.nodes.keys().cloned().collect();
         }
         let mut adjacency: HashMap<ExecutionId, Vec<ExecutionId>> = self
+            .graph
             .nodes
             .keys()
             .map(|node_id| (*node_id, Vec::new()))
             .collect();
-        let mut in_degree: HashMap<ExecutionId, usize> =
-            self.nodes.keys().map(|node_id| (*node_id, 0)).collect();
-        let mut edges: Vec<&ExecutionEdge> = self.edges.iter().collect();
+        let mut in_degree: HashMap<ExecutionId, usize> = self
+            .graph
+            .nodes
+            .keys()
+            .map(|node_id| (*node_id, 0))
+            .collect();
+        let mut edges: Vec<&ExecutionEdge> = self.graph.edges.iter().collect();
         edges.sort_by_key(|edge| (edge.source, edge.target));
         for edge in edges {
             if edge.edge_type != EdgeType::StateMachine {
@@ -563,6 +564,7 @@ impl RunnerState {
             }
         }
         let mut remaining: Vec<ExecutionId> = self
+            .graph
             .nodes
             .keys()
             .filter(|node_id| !order.contains(node_id))
@@ -577,7 +579,8 @@ impl RunnerState {
         &mut self,
         node_id: ExecutionId,
     ) -> Result<&mut ExecutionNode, RunnerStateError> {
-        self.nodes
+        self.graph
+            .nodes
             .get_mut(&node_id)
             .ok_or_else(|| RunnerStateError(format!("execution node not found: {node_id}")))
     }
@@ -667,13 +670,13 @@ impl RunnerState {
                 ..
             }) => {
                 let value_expr = self.expr_to_value(expr, None)?;
-                if let Some(node_mut) = self.nodes.get_mut(&exec_node.node_id) {
+                if let Some(node_mut) = self.graph.nodes.get_mut(&exec_node.node_id) {
                     node_mut.value_expr = Some(value_expr.clone());
                 }
                 self.record_data_flow_from_value(exec_node.node_id, &value_expr);
                 let assignments =
                     self.build_assignments(&self.node_targets(template), &value_expr)?;
-                if let Some(node) = self.nodes.get_mut(&exec_node.node_id) {
+                if let Some(node) = self.graph.nodes.get_mut(&exec_node.node_id) {
                     node.assignments.extend(assignments.clone());
                 }
                 self.mark_latest_assignments(exec_node.node_id, &assignments);
@@ -686,6 +689,7 @@ impl RunnerState {
                 ..
             }) => {
                 let kwarg_values = self
+                    .graph
                     .nodes
                     .get(&exec_node.node_id)
                     .and_then(|node| node.action.as_ref())
@@ -704,7 +708,7 @@ impl RunnerState {
                     iteration_index,
                     true,
                 )?;
-                if let Some(node_mut) = self.nodes.get_mut(&exec_node.node_id) {
+                if let Some(node_mut) = self.graph.nodes.get_mut(&exec_node.node_id) {
                     node_mut.value_expr = Some(ValueExpr::ActionResult(result));
                 }
                 return Ok(());
@@ -714,7 +718,7 @@ impl RunnerState {
                 ..
             }) => {
                 let value_expr = self.expr_to_value(expr, None)?;
-                if let Some(node_mut) = self.nodes.get_mut(&exec_node.node_id) {
+                if let Some(node_mut) = self.graph.nodes.get_mut(&exec_node.node_id) {
                     node_mut.value_expr = Some(value_expr.clone());
                 }
                 self.record_data_flow_from_value(exec_node.node_id, &value_expr);
@@ -725,13 +729,13 @@ impl RunnerState {
                 ..
             }) => {
                 let value_expr = self.expr_to_value(expr, None)?;
-                if let Some(node_mut) = self.nodes.get_mut(&exec_node.node_id) {
+                if let Some(node_mut) = self.graph.nodes.get_mut(&exec_node.node_id) {
                     node_mut.value_expr = Some(value_expr.clone());
                 }
                 self.record_data_flow_from_value(exec_node.node_id, &value_expr);
                 let assignments =
                     self.build_assignments(&self.node_targets(template), &value_expr)?;
-                if let Some(node) = self.nodes.get_mut(&exec_node.node_id) {
+                if let Some(node) = self.graph.nodes.get_mut(&exec_node.node_id) {
                     node.assignments.extend(assignments.clone());
                 }
                 self.mark_latest_assignments(exec_node.node_id, &assignments);
@@ -743,13 +747,13 @@ impl RunnerState {
                 ..
             }) => {
                 let value_expr = self.expr_to_value(expr, None)?;
-                if let Some(node_mut) = self.nodes.get_mut(&exec_node.node_id) {
+                if let Some(node_mut) = self.graph.nodes.get_mut(&exec_node.node_id) {
                     node_mut.value_expr = Some(value_expr.clone());
                 }
                 self.record_data_flow_from_value(exec_node.node_id, &value_expr);
                 let target = target.clone().unwrap_or_else(|| "result".to_string());
                 let assignments = self.build_assignments(&[target], &value_expr)?;
-                if let Some(node) = self.nodes.get_mut(&exec_node.node_id) {
+                if let Some(node) = self.graph.nodes.get_mut(&exec_node.node_id) {
                     node.assignments.extend(assignments.clone());
                 }
                 self.mark_latest_assignments(exec_node.node_id, &assignments);
@@ -799,7 +803,7 @@ impl RunnerState {
         let assignments =
             self.build_assignments(targets, &ValueExpr::ActionResult(result_ref.clone()))?;
         if !assignments.is_empty() {
-            if let Some(node) = self.nodes.get_mut(&node.node_id) {
+            if let Some(node) = self.graph.nodes.get_mut(&node.node_id) {
                 node.assignments.extend(assignments.clone());
             }
             if update_latest {
@@ -949,7 +953,7 @@ impl RunnerState {
                 });
             }
         };
-        let node = match self.nodes.get(&node_id) {
+        let node = match self.graph.nodes.get(&node_id) {
             Some(node) => node,
             None => {
                 return ValueExpr::Variable(VariableValue {
@@ -1394,7 +1398,7 @@ impl RunnerState {
             iteration_index,
             true,
         )?;
-        if let Some(node) = self.nodes.get_mut(&node.node_id) {
+        if let Some(node) = self.graph.nodes.get_mut(&node.node_id) {
             node.value_expr = Some(ValueExpr::ActionResult(result.clone()));
         }
         Ok(result)
@@ -1446,7 +1450,7 @@ impl RunnerState {
         )?;
         self.record_data_flow_from_value(exec_node_id, &value_expr);
         let assignments = self.build_assignments(&targets, &value_expr)?;
-        if let Some(node_mut) = self.nodes.get_mut(&node.node_id) {
+        if let Some(node_mut) = self.graph.nodes.get_mut(&node.node_id) {
             node_mut.assignments.extend(assignments.clone());
         }
         self.mark_latest_assignments(node.node_id, &assignments);
@@ -1655,7 +1659,7 @@ mod tests {
 
         let mut results: Option<ValueExpr> = None;
         for node_id in state.timeline.iter().rev() {
-            let node = state.nodes.get(node_id).unwrap();
+            let node = state.graph.nodes.get(node_id).unwrap();
             if let Some(value) = node.assignments.get("results") {
                 results = Some(value.clone());
                 break;
@@ -1729,7 +1733,7 @@ mod tests {
 
         let mut latest: Option<ValueExpr> = None;
         for node_id in state.timeline.iter().rev() {
-            let node = state.nodes.get(node_id).expect("node");
+            let node = state.graph.nodes.get(node_id).expect("node");
             if let Some(value) = node.assignments.get("result") {
                 latest = Some(value.clone());
                 break;
@@ -1842,6 +1846,7 @@ mod tests {
             .mark_running(action_result.node_id)
             .expect("mark running");
         let started_at = state
+            .graph
             .nodes
             .get(&action_result.node_id)
             .and_then(|node| node.started_at);
@@ -1851,6 +1856,7 @@ mod tests {
         );
         assert!(
             state
+                .graph
                 .nodes
                 .get(&action_result.node_id)
                 .and_then(|node| node.completed_at)
@@ -1867,6 +1873,7 @@ mod tests {
             .mark_completed(action_result.node_id)
             .expect("mark completed");
         let completed_at = state
+            .graph
             .nodes
             .get(&action_result.node_id)
             .and_then(|node| node.completed_at);

--- a/crates/lib/runner/src/executor.rs
+++ b/crates/lib/runner/src/executor.rs
@@ -272,7 +272,7 @@ impl<const SHOULD_COLLECT_UPDATES: bool> RunnerExecutor<SHOULD_COLLECT_UPDATES> 
     /// and retryable nodes are re-queued for execution.
     pub fn resume(&mut self) -> Result<ExecutorStep, RunnerExecutorError> {
         let mut finished_nodes = Vec::new();
-        for (node_id, node) in &self.state.nodes {
+        for (node_id, node) in &self.state.graph.nodes {
             if node.is_action_call() && node.status == NodeStatus::Running {
                 finished_nodes.push(*node_id);
                 self.action_results.insert(
@@ -966,7 +966,7 @@ impl<const SHOULD_COLLECT_UPDATES: bool> RunnerExecutor<SHOULD_COLLECT_UPDATES> 
                 false,
             )
             .map_err(|err| RunnerExecutorError(err.0))?;
-        if let Some(node_mut) = self.state.nodes.get_mut(&node.node_id) {
+        if let Some(node_mut) = self.state.graph.nodes.get_mut(&node.node_id) {
             node_mut.value_expr = Some(ValueExpr::ActionResult(result));
         }
         Ok(node)
@@ -1002,6 +1002,7 @@ impl<const SHOULD_COLLECT_UPDATES: bool> RunnerExecutor<SHOULD_COLLECT_UPDATES> 
         let now = Utc::now();
         let scheduled_at = self
             .state
+            .graph
             .nodes
             .get(&node.node_id)
             .and_then(|node| node.scheduled_at);
@@ -1017,6 +1018,7 @@ impl<const SHOULD_COLLECT_UPDATES: bool> RunnerExecutor<SHOULD_COLLECT_UPDATES> 
 
         let value_expr = self
             .state
+            .graph
             .nodes
             .get(&node.node_id)
             .and_then(|node| node.value_expr.clone())
@@ -1088,7 +1090,7 @@ impl<const SHOULD_COLLECT_UPDATES: bool> RunnerExecutor<SHOULD_COLLECT_UPDATES> 
                 }
             }
             for edge in incoming {
-                if let Some(source) = self.state.nodes.get(&edge.source) {
+                if let Some(source) = self.state.graph.nodes.get(&edge.source) {
                     if !matches!(source.status, NodeStatus::Completed | NodeStatus::Failed) {
                         return false;
                     }
@@ -1100,7 +1102,7 @@ impl<const SHOULD_COLLECT_UPDATES: bool> RunnerExecutor<SHOULD_COLLECT_UPDATES> 
         }
 
         for edge in incoming {
-            if let Some(source) = self.state.nodes.get(&edge.source) {
+            if let Some(source) = self.state.graph.nodes.get(&edge.source) {
                 if !matches!(source.status, NodeStatus::Completed | NodeStatus::Failed) {
                     return false;
                 }
@@ -1138,7 +1140,7 @@ impl<const SHOULD_COLLECT_UPDATES: bool> RunnerExecutor<SHOULD_COLLECT_UPDATES> 
             .unwrap_or_default()
             .into_iter()
             .filter(|edge| edge.edge_type == EdgeType::StateMachine)
-            .filter_map(|edge| self.state.nodes.get(&edge.source).cloned())
+            .filter_map(|edge| self.state.graph.nodes.get(&edge.source).cloned())
             .collect();
 
         let mut values = Vec::new();
@@ -1152,7 +1154,7 @@ impl<const SHOULD_COLLECT_UPDATES: bool> RunnerExecutor<SHOULD_COLLECT_UPDATES> 
         let ordered = self.order_aggregated_values(&incoming_nodes, &values)?;
         let list_value = ValueExpr::List(ListValue { elements: ordered });
         let assignment = HashMap::from([(targets[0].clone(), list_value.clone())]);
-        if let Some(node_mut) = self.state.nodes.get_mut(&node.node_id) {
+        if let Some(node_mut) = self.state.graph.nodes.get_mut(&node.node_id) {
             node_mut.assignments.extend(assignment.clone());
         }
         self.state
@@ -1266,7 +1268,7 @@ impl<const SHOULD_COLLECT_UPDATES: bool> RunnerExecutor<SHOULD_COLLECT_UPDATES> 
         state: &RunnerState,
     ) -> FxHashMap<ExecutionId, Vec<ExecutionEdge>> {
         let mut incoming: FxHashMap<ExecutionId, Vec<ExecutionEdge>> = FxHashMap::default();
-        for edge in &state.edges {
+        for edge in &state.graph.edges {
             if edge.edge_type != EdgeType::StateMachine {
                 continue;
             }
@@ -1277,7 +1279,7 @@ impl<const SHOULD_COLLECT_UPDATES: bool> RunnerExecutor<SHOULD_COLLECT_UPDATES> 
 
     fn build_template_to_exec_nodes(state: &RunnerState) -> FxHashMap<String, Vec<ExecutionId>> {
         let mut index: FxHashMap<String, Vec<ExecutionId>> = FxHashMap::default();
-        for (node_id, node) in &state.nodes {
+        for (node_id, node) in &state.graph.nodes {
             if let Some(template_id) = &node.template_id {
                 index.entry(template_id.clone()).or_default().push(*node_id);
             }
@@ -1299,10 +1301,10 @@ impl<const SHOULD_COLLECT_UPDATES: bool> RunnerExecutor<SHOULD_COLLECT_UPDATES> 
             target,
             edge_type: EdgeType::StateMachine,
         };
-        if self.state.edges.contains(&edge) {
+        if self.state.graph.edges.contains(&edge) {
             return;
         }
-        self.state.edges.insert(edge.clone());
+        self.state.graph.edges.insert(edge.clone());
         self.incoming_exec_edges
             .entry(target)
             .or_default()
@@ -1317,7 +1319,7 @@ impl<const SHOULD_COLLECT_UPDATES: bool> RunnerExecutor<SHOULD_COLLECT_UPDATES> 
             .cloned()
             .unwrap_or_default()
         {
-            if let Some(source) = self.state.nodes.get(&edge.source)
+            if let Some(source) = self.state.graph.nodes.get(&edge.source)
                 && let Some(template_id) = &source.template_id
             {
                 connected.insert(template_id.clone());
@@ -1331,11 +1333,11 @@ impl<const SHOULD_COLLECT_UPDATES: bool> RunnerExecutor<SHOULD_COLLECT_UPDATES> 
         source_id: ExecutionId,
         template_id: &str,
     ) -> Option<ExecutionNode> {
-        for edge in &self.state.edges {
+        for edge in &self.state.graph.edges {
             if edge.edge_type != EdgeType::StateMachine || edge.source != source_id {
                 continue;
             }
-            let target = self.state.nodes.get(&edge.target)?;
+            let target = self.state.graph.nodes.get(&edge.target)?;
             if target.template_id.as_deref() == Some(template_id) {
                 return Some(target.clone());
             }
@@ -1349,6 +1351,7 @@ impl<const SHOULD_COLLECT_UPDATES: bool> RunnerExecutor<SHOULD_COLLECT_UPDATES> 
     ) -> Result<ExecutionNode, RunnerExecutorError> {
         let mut candidates: Vec<ExecutionNode> = self
             .state
+            .graph
             .nodes
             .values()
             .filter(|node| {
@@ -1386,7 +1389,7 @@ impl<const SHOULD_COLLECT_UPDATES: bool> RunnerExecutor<SHOULD_COLLECT_UPDATES> 
             let mut best_timeline_pos: Option<usize> = None;
 
             for &node_id in node_ids {
-                if let Some(node) = self.state.nodes.get(&node_id)
+                if let Some(node) = self.state.graph.nodes.get(&node_id)
                     && !matches!(node.status, NodeStatus::Completed | NodeStatus::Failed)
                 {
                     let timeline_pos = self.state.timeline.iter().position(|&id| id == node_id);
@@ -1404,6 +1407,7 @@ impl<const SHOULD_COLLECT_UPDATES: bool> RunnerExecutor<SHOULD_COLLECT_UPDATES> 
             if let Some(node_id) = best_node_id {
                 return self
                     .state
+                    .graph
                     .nodes
                     .get(&node_id)
                     .cloned()
@@ -1422,6 +1426,7 @@ impl<const SHOULD_COLLECT_UPDATES: bool> RunnerExecutor<SHOULD_COLLECT_UPDATES> 
 
     fn execution_node(&self, node_id: ExecutionId) -> Result<&ExecutionNode, RunnerExecutorError> {
         self.state
+            .graph
             .nodes
             .get(&node_id)
             .ok_or_else(|| RunnerExecutorError(format!("execution node not found: {node_id}")))
@@ -1432,6 +1437,7 @@ impl<const SHOULD_COLLECT_UPDATES: bool> RunnerExecutor<SHOULD_COLLECT_UPDATES> 
         node_id: ExecutionId,
     ) -> Result<&mut ExecutionNode, RunnerExecutorError> {
         self.state
+            .graph
             .nodes
             .get_mut(&node_id)
             .ok_or_else(|| RunnerExecutorError(format!("execution node not found: {node_id}")))
@@ -1510,7 +1516,7 @@ mod tests {
     use waymark_dag_builder::convert_to_dag;
     use waymark_ir_parser::parse_program;
     use waymark_proto::ast as ir;
-    use waymark_runner_execution_core::{ExecutionEdge, ExecutionNode, NodeStatus};
+    use waymark_runner_execution_core::{ExecutionGraph, ExecutionNode, NodeStatus};
     use waymark_runner_state::RunnerState;
 
     fn variable(name: &str) -> ir::Expr {
@@ -1616,24 +1622,18 @@ mod tests {
         state: &RunnerState,
         action_results: &ExecutionResultMap,
     ) -> (
-        HashMap<ExecutionId, ExecutionNode>,
-        HashSet<ExecutionEdge>,
+        ExecutionGraph,
         HashMap<ExecutionId, UncheckedExecutionResult>,
     ) {
-        (
-            state.nodes.clone(),
-            state.edges.clone(),
-            action_results.clone(),
-        )
+        (state.graph.clone(), action_results.clone())
     }
 
     fn create_rehydrated_executor<const SHOULD_COLLECT_UPDATES: bool>(
         dag: &Arc<DAG>,
-        nodes: HashMap<ExecutionId, ExecutionNode>,
-        edges: HashSet<ExecutionEdge>,
+        graph: ExecutionGraph,
         action_results: HashMap<ExecutionId, UncheckedExecutionResult>,
     ) -> RunnerExecutor<SHOULD_COLLECT_UPDATES> {
-        let state = RunnerState::full(Arc::clone(dag), nodes, edges);
+        let state = RunnerState::full(Arc::clone(dag), graph);
         RunnerExecutor::new(Arc::clone(dag), state, action_results)
     }
 
@@ -1644,19 +1644,19 @@ mod tests {
         let orig_state = original.state();
         let rehy_state = rehydrated.state();
         assert_eq!(
-            orig_state.nodes.keys().collect::<HashSet<_>>(),
-            rehy_state.nodes.keys().collect::<HashSet<_>>(),
+            orig_state.graph.nodes.keys().collect::<HashSet<_>>(),
+            rehy_state.graph.nodes.keys().collect::<HashSet<_>>(),
         );
-        for node_id in orig_state.nodes.keys() {
-            let orig_node = orig_state.nodes.get(node_id).unwrap();
-            let rehy_node = rehy_state.nodes.get(node_id).unwrap();
+        for node_id in orig_state.graph.nodes.keys() {
+            let orig_node = orig_state.graph.nodes.get(node_id).unwrap();
+            let rehy_node = rehy_state.graph.nodes.get(node_id).unwrap();
             assert_eq!(orig_node.node_type, rehy_node.node_type);
             assert_eq!(orig_node.status, rehy_node.status);
             assert_eq!(orig_node.template_id, rehy_node.template_id);
             assert_eq!(orig_node.targets, rehy_node.targets);
             assert_eq!(orig_node.action_attempt, rehy_node.action_attempt);
         }
-        assert_eq!(orig_state.edges, rehy_state.edges);
+        assert_eq!(orig_state.graph.edges, rehy_state.graph.edges);
     }
 
     fn completion_action_result(action: &ExecutionNode) -> UncheckedExecutionResult {
@@ -1786,12 +1786,11 @@ fn main(input: [], output: [result]):
         }
 
         fn fork_from_canonical(&mut self) {
-            let (nodes_snap, edges_snap, results_snap) =
+            let (graph_snap, results_snap) =
                 snapshot_state(self.canonical.state(), self.canonical.action_results());
             self.branches.push(create_rehydrated_executor(
                 &self.dag,
-                nodes_snap,
-                edges_snap,
+                graph_snap,
                 results_snap,
             ));
         }
@@ -1823,6 +1822,7 @@ fn main(input: [], output: [result]):
         ) -> Result<bool, RunnerExecutorError> {
             let active_actions: Vec<ExecutionNode> = executor
                 .state()
+                .graph
                 .nodes
                 .values()
                 .filter(|node| {
@@ -1842,6 +1842,7 @@ fn main(input: [], output: [result]):
             finished_nodes.extend(
                 executor
                     .state()
+                    .graph
                     .nodes
                     .values()
                     .filter(|node| {
@@ -1900,7 +1901,7 @@ fn main(input: [], output: [result]):
         fn node_shape_counts(
             executor: &RunnerExecutor<SHOULD_COLLECT_UPDATES>,
         ) -> HashMap<String, usize> {
-            Self::count_keyed(executor.state().nodes.values().map(|node| {
+            Self::count_keyed(executor.state().graph.nodes.values().map(|node| {
                 let mut targets = node.targets.clone();
                 targets.sort();
                 let mut assignment_keys: Vec<String> = node.assignments.keys().cloned().collect();
@@ -1929,9 +1930,10 @@ fn main(input: [], output: [result]):
         fn edge_shape_counts(
             executor: &RunnerExecutor<SHOULD_COLLECT_UPDATES>,
         ) -> HashMap<String, usize> {
-            Self::count_keyed(executor.state().edges.iter().map(|edge| {
+            Self::count_keyed(executor.state().graph.edges.iter().map(|edge| {
                 let source = executor
                     .state()
+                    .graph
                     .nodes
                     .get(&edge.source)
                     .expect("source node")
@@ -1940,6 +1942,7 @@ fn main(input: [], output: [result]):
                     .unwrap_or_else(|| "__unknown_source".to_string());
                 let target = executor
                     .state()
+                    .graph
                     .nodes
                     .get(&edge.target)
                     .expect("target node")
@@ -1956,6 +1959,7 @@ fn main(input: [], output: [result]):
             Self::count_keyed(executor.action_results().iter().map(|(node_id, value)| {
                 let template_id = executor
                     .state()
+                    .graph
                     .nodes
                     .get(node_id)
                     .and_then(|node| node.template_id.clone())
@@ -1999,7 +2003,7 @@ fn main(input: [], output: [result]):
                     .expect("replay rehydrated");
 
             let mut assignment_counts: HashMap<String, usize> = HashMap::new();
-            for node in canonical.state().nodes.values() {
+            for node in canonical.state().graph.nodes.values() {
                 for target in node.assignments.keys() {
                     *assignment_counts.entry(target.clone()).or_insert(0) += 1;
                 }
@@ -2216,12 +2220,17 @@ fn main(input: [], output: [done]):
         let executor =
             RunnerExecutor::without_updates_collection(dag.clone(), state, HashMap::new());
 
-        let (nodes_snap, edges_snap, results_snap) =
+        let (graph_snap, results_snap) =
             snapshot_state(executor.state(), executor.action_results());
-        let rehydrated = create_rehydrated_executor(&dag, nodes_snap, edges_snap, results_snap);
+        let rehydrated = create_rehydrated_executor(&dag, graph_snap, results_snap);
 
         compare_executor_states(&executor, &rehydrated);
-        let node = rehydrated.state().nodes.get(&exec1.node_id).expect("node");
+        let node = rehydrated
+            .state()
+            .graph
+            .nodes
+            .get(&exec1.node_id)
+            .expect("node");
         assert_eq!(node.status, NodeStatus::Queued);
     }
 
@@ -2267,14 +2276,14 @@ fn main(input: [], output: [done]):
         let exec2 = &step.actions[0];
         assert_eq!(exec2.template_id.as_deref(), Some(action2.id.as_str()));
 
-        let (nodes_snap, edges_snap, results_snap) =
+        let (graph_snap, results_snap) =
             snapshot_state(executor.state(), executor.action_results());
-        let rehydrated = create_rehydrated_executor(&dag, nodes_snap, edges_snap, results_snap);
+        let rehydrated = create_rehydrated_executor(&dag, graph_snap, results_snap);
         compare_executor_states(&executor, &rehydrated);
 
-        let node1 = rehydrated.state().nodes.get(&exec1.node_id).unwrap();
+        let node1 = rehydrated.state().graph.nodes.get(&exec1.node_id).unwrap();
         assert_eq!(node1.status, NodeStatus::Completed);
-        let node2 = rehydrated.state().nodes.get(&exec2.node_id).unwrap();
+        let node2 = rehydrated.state().graph.nodes.get(&exec2.node_id).unwrap();
         assert_eq!(node2.status, NodeStatus::Running);
     }
 
@@ -2321,9 +2330,9 @@ fn main(input: [], output: [done]):
         let mut executor =
             RunnerExecutor::without_updates_collection(dag.clone(), state, HashMap::new());
 
-        let (nodes_snap, edges_snap, results_snap) =
+        let (graph_snap, results_snap) =
             snapshot_state(executor.state(), executor.action_results());
-        let rehydrated = create_rehydrated_executor(&dag, nodes_snap, edges_snap, results_snap);
+        let rehydrated = create_rehydrated_executor(&dag, graph_snap, results_snap);
         compare_executor_states(&executor, &rehydrated);
 
         executor.set_action_result(
@@ -2333,9 +2342,9 @@ fn main(input: [], output: [done]):
         let step1 = executor.increment(&[exec1.node_id]).expect("increment");
         let exec2 = step1.actions[0].clone();
 
-        let (nodes_snap, edges_snap, results_snap) =
+        let (graph_snap, results_snap) =
             snapshot_state(executor.state(), executor.action_results());
-        let rehydrated = create_rehydrated_executor(&dag, nodes_snap, edges_snap, results_snap);
+        let rehydrated = create_rehydrated_executor(&dag, graph_snap, results_snap);
         compare_executor_states(&executor, &rehydrated);
 
         executor.set_action_result(
@@ -2345,9 +2354,9 @@ fn main(input: [], output: [done]):
         let step2 = executor.increment(&[exec2.node_id]).expect("increment");
         let exec3 = step2.actions[0].clone();
 
-        let (nodes_snap, edges_snap, results_snap) =
+        let (graph_snap, results_snap) =
             snapshot_state(executor.state(), executor.action_results());
-        let rehydrated = create_rehydrated_executor(&dag, nodes_snap, edges_snap, results_snap);
+        let rehydrated = create_rehydrated_executor(&dag, graph_snap, results_snap);
         compare_executor_states(&executor, &rehydrated);
 
         executor.set_action_result(
@@ -2357,12 +2366,12 @@ fn main(input: [], output: [done]):
         let step3 = executor.increment(&[exec3.node_id]).expect("increment");
         assert!(step3.actions.is_empty());
 
-        let (nodes_snap, edges_snap, results_snap) =
+        let (graph_snap, results_snap) =
             snapshot_state(executor.state(), executor.action_results());
-        let rehydrated = create_rehydrated_executor(&dag, nodes_snap, edges_snap, results_snap);
+        let rehydrated = create_rehydrated_executor(&dag, graph_snap, results_snap);
         compare_executor_states(&executor, &rehydrated);
 
-        for node in rehydrated.state().nodes.values() {
+        for node in rehydrated.state().graph.nodes.values() {
             if node.is_action_call() {
                 assert_eq!(node.status, NodeStatus::Completed);
             }
@@ -2427,13 +2436,14 @@ fn main(input: [], output: [done]):
             Some(action2.id.as_str())
         );
 
-        let (nodes_snap, edges_snap, results_snap) =
+        let (graph_snap, results_snap) =
             snapshot_state(executor.state(), executor.action_results());
-        let rehydrated = create_rehydrated_executor(&dag, nodes_snap, edges_snap, results_snap);
+        let rehydrated = create_rehydrated_executor(&dag, graph_snap, results_snap);
         compare_executor_states(&executor, &rehydrated);
 
         let assign_nodes: Vec<_> = rehydrated
             .state()
+            .graph
             .nodes
             .values()
             .filter(|node| node.template_id.as_deref() == Some(&assign.id))
@@ -2472,13 +2482,12 @@ fn main(input: [], output: [done]):
         let executor =
             RunnerExecutor::without_updates_collection(dag.clone(), state, HashMap::new());
 
-        let (nodes_snap, edges_snap, results_snap) =
+        let (graph_snap, results_snap) =
             snapshot_state(executor.state(), executor.action_results());
-        let rehydrated =
-            create_rehydrated_executor::<false>(&dag, nodes_snap, edges_snap, results_snap);
+        let rehydrated = create_rehydrated_executor::<false>(&dag, graph_snap, results_snap);
 
-        let orig_node = executor.state().nodes.get(&exec1.node_id).unwrap();
-        let rehy_node = rehydrated.state().nodes.get(&exec1.node_id).unwrap();
+        let orig_node = executor.state().graph.nodes.get(&exec1.node_id).unwrap();
+        let rehy_node = rehydrated.state().graph.nodes.get(&exec1.node_id).unwrap();
         assert!(orig_node.action.is_some());
         assert!(rehy_node.action.is_some());
         let orig_action = orig_node.action.as_ref().unwrap();
@@ -2525,10 +2534,9 @@ fn main(input: [], output: [done]):
         let mut executor =
             RunnerExecutor::without_updates_collection(dag.clone(), state, action_results);
 
-        let (nodes_snap, edges_snap, results_snap) =
+        let (graph_snap, results_snap) =
             snapshot_state(executor.state(), executor.action_results());
-        let mut rehydrated =
-            create_rehydrated_executor::<false>(&dag, nodes_snap, edges_snap, results_snap);
+        let mut rehydrated = create_rehydrated_executor::<false>(&dag, graph_snap, results_snap);
 
         let orig_step = executor.increment(&[exec1.node_id]).expect("increment");
         let rehy_step = rehydrated.increment(&[exec1.node_id]).expect("increment");
@@ -2567,20 +2575,25 @@ fn main(input: [], output: [done]):
 
         let executor =
             RunnerExecutor::without_updates_collection(dag.clone(), state, HashMap::new());
-        let (nodes_snap, edges_snap, results_snap) =
+        let (graph_snap, results_snap) =
             snapshot_state(executor.state(), executor.action_results());
-        let mut rehydrated =
-            create_rehydrated_executor::<false>(&dag, nodes_snap, edges_snap, results_snap);
+        let mut rehydrated = create_rehydrated_executor::<false>(&dag, graph_snap, results_snap);
 
         assert_eq!(
-            rehydrated.state().nodes.get(&exec1.node_id).unwrap().status,
+            rehydrated
+                .state()
+                .graph
+                .nodes
+                .get(&exec1.node_id)
+                .unwrap()
+                .status,
             NodeStatus::Running
         );
 
         let step = rehydrated.resume().expect("resume");
         assert_eq!(step.actions.len(), 1);
         assert_eq!(step.actions[0].node_id, exec1.node_id);
-        let node = rehydrated.state().nodes.get(&exec1.node_id).unwrap();
+        let node = rehydrated.state().graph.nodes.get(&exec1.node_id).unwrap();
         assert_eq!(node.status, NodeStatus::Running);
         assert_eq!(node.action_attempt, 2);
         assert!(node.started_at.is_some());
@@ -2623,7 +2636,12 @@ fn main(input: [], output: [done]):
             Some("ValueError")
         );
         assert_eq!(
-            executor.state().nodes.get(&exec.node_id).map(|n| n.status),
+            executor
+                .state()
+                .graph
+                .nodes
+                .get(&exec.node_id)
+                .map(|n| n.status),
             Some(NodeStatus::Failed)
         );
     }
@@ -2671,12 +2689,18 @@ fn main(input: [], output: [done]):
         assert_eq!(first_updates.actions_done.len(), 1);
         assert_eq!(first_updates.actions_done[0].attempt, 1);
         assert_eq!(
-            executor.state().nodes.get(&exec.node_id).map(|n| n.status),
+            executor
+                .state()
+                .graph
+                .nodes
+                .get(&exec.node_id)
+                .map(|n| n.status),
             Some(NodeStatus::Running)
         );
         assert_eq!(
             executor
                 .state()
+                .graph
                 .nodes
                 .get(&exec.node_id)
                 .map(|n| n.action_attempt),
@@ -2694,7 +2718,12 @@ fn main(input: [], output: [done]):
         assert_eq!(second_updates.actions_done.len(), 1);
         assert_eq!(second_updates.actions_done[0].attempt, 2);
         assert_eq!(
-            executor.state().nodes.get(&exec.node_id).map(|n| n.status),
+            executor
+                .state()
+                .graph
+                .nodes
+                .get(&exec.node_id)
+                .map(|n| n.status),
             Some(NodeStatus::Completed)
         );
     }
@@ -2742,10 +2771,9 @@ fn main(input: [], output: [done]):
         let orig_replay =
             crate::replay_variables(executor.state(), executor.action_results()).expect("replay");
 
-        let (nodes_snap, edges_snap, results_snap) =
+        let (graph_snap, results_snap) =
             snapshot_state(executor.state(), executor.action_results());
-        let rehydrated =
-            create_rehydrated_executor::<false>(&dag, nodes_snap, edges_snap, results_snap);
+        let rehydrated = create_rehydrated_executor::<false>(&dag, graph_snap, results_snap);
 
         let rehy_replay = crate::replay_variables(rehydrated.state(), rehydrated.action_results())
             .expect("replay");
@@ -2827,13 +2855,14 @@ fn main(input: [], output: [done]):
             .expect("increment");
         assert_eq!(step1.actions.len(), 3);
 
-        let (nodes_snap, edges_snap, results_snap) =
+        let (graph_snap, results_snap) =
             snapshot_state(executor.state(), executor.action_results());
-        let rehydrated = create_rehydrated_executor(&dag, nodes_snap, edges_snap, results_snap);
+        let rehydrated = create_rehydrated_executor(&dag, graph_snap, results_snap);
 
         compare_executor_states(&executor, &rehydrated);
         let action_nodes: Vec<_> = executor
             .state()
+            .graph
             .nodes
             .values()
             .filter(|node| {
@@ -2842,7 +2871,12 @@ fn main(input: [], output: [done]):
             .collect();
         assert_eq!(action_nodes.len(), 3);
         for action_node in action_nodes {
-            let rehy_node = rehydrated.state().nodes.get(&action_node.node_id).unwrap();
+            let rehy_node = rehydrated
+                .state()
+                .graph
+                .nodes
+                .get(&action_node.node_id)
+                .unwrap();
             assert_eq!(rehy_node.node_type, action_node.node_type);
             assert_eq!(rehy_node.status, action_node.status);
         }
@@ -2905,9 +2939,9 @@ fn main(input: [], output: [done]):
         let spread_nodes = step1.actions;
         assert_eq!(spread_nodes.len(), 2);
 
-        let (nodes_snap, edges_snap, results_snap) =
+        let (graph_snap, results_snap) =
             snapshot_state(executor.state(), executor.action_results());
-        let rehydrated = create_rehydrated_executor(&dag, nodes_snap, edges_snap, results_snap);
+        let rehydrated = create_rehydrated_executor(&dag, graph_snap, results_snap);
         compare_executor_states(&executor, &rehydrated);
 
         for (idx, node) in spread_nodes.iter().enumerate() {
@@ -2921,13 +2955,14 @@ fn main(input: [], output: [done]):
             .increment(&spread_nodes.iter().map(|n| n.node_id).collect::<Vec<_>>())
             .expect("increment");
 
-        let (nodes_snap, edges_snap, results_snap) =
+        let (graph_snap, results_snap) =
             snapshot_state(executor.state(), executor.action_results());
-        let rehydrated = create_rehydrated_executor(&dag, nodes_snap, edges_snap, results_snap);
+        let rehydrated = create_rehydrated_executor(&dag, graph_snap, results_snap);
         compare_executor_states(&executor, &rehydrated);
 
         let agg_nodes: Vec<_> = rehydrated
             .state()
+            .graph
             .nodes
             .values()
             .filter(|node| node.template_id.as_deref() == Some(&aggregator.id))
@@ -2986,10 +3021,9 @@ fn main(input: [], output: [done]):
             }
         }
 
-        let (nodes_snap, edges_snap, results_snap) =
+        let (graph_snap, results_snap) =
             snapshot_state(executor.state(), executor.action_results());
-        let rehydrated =
-            create_rehydrated_executor::<false>(&dag, nodes_snap, edges_snap, results_snap);
+        let rehydrated = create_rehydrated_executor::<false>(&dag, graph_snap, results_snap);
 
         let orig_timeline = executor.state().timeline.clone();
         let rehy_timeline = rehydrated.state().timeline.clone();
@@ -3039,13 +3073,13 @@ fn main(input: [], output: [done]):
         let step = executor.increment(&[exec1.node_id]).expect("increment");
         let exec2 = step.actions[0].clone();
 
-        let (nodes_snap, edges_snap, results_snap) =
+        let (graph_snap, results_snap) =
             snapshot_state(executor.state(), executor.action_results());
-        let rehydrated =
-            create_rehydrated_executor::<false>(&dag, nodes_snap, edges_snap, results_snap);
+        let rehydrated = create_rehydrated_executor::<false>(&dag, graph_snap, results_snap);
 
         let queued_nodes: Vec<_> = rehydrated
             .state()
+            .graph
             .nodes
             .values()
             .filter(|node| node.status == NodeStatus::Queued)
@@ -3053,6 +3087,7 @@ fn main(input: [], output: [done]):
         assert!(queued_nodes.is_empty());
         let running_nodes: Vec<_> = rehydrated
             .state()
+            .graph
             .nodes
             .values()
             .filter(|node| node.status == NodeStatus::Running)

--- a/crates/lib/runner/src/expression_evaluator.rs
+++ b/crates/lib/runner/src/expression_evaluator.rs
@@ -229,12 +229,14 @@ impl<const SHOULD_COLLECT_UPDATES: bool> RunnerExecutor<SHOULD_COLLECT_UPDATES> 
             .collect();
 
         self.state()
+            .graph
             .edges
             .iter()
             .filter(|edge| edge.edge_type == EdgeType::DataFlow && edge.target == current_node_id)
             .map(|edge| edge.source)
             .filter(|source| {
                 self.state()
+                    .graph
                     .nodes
                     .get(source)
                     .map(|node| node.assignments.contains_key(name))
@@ -274,6 +276,7 @@ impl<const SHOULD_COLLECT_UPDATES: bool> RunnerExecutor<SHOULD_COLLECT_UPDATES> 
 
         let node = self
             .state()
+            .graph
             .nodes
             .get(&node_id)
             .ok_or_else(|| RunnerExecutorError(format!("missing assignment for {target}")))?;
@@ -794,6 +797,7 @@ mod tests {
             )
             .expect("queue increment");
         let action_node = state
+            .graph
             .nodes
             .get(&action_result.node_id)
             .expect("action node")

--- a/crates/lib/runner/src/replay.rs
+++ b/crates/lib/runner/src/replay.rs
@@ -51,7 +51,7 @@ impl<'a> ReplayEngine<'a> {
         action_results: &'a HashMap<ExecutionId, UncheckedExecutionResult>,
     ) -> Self {
         let timeline = if state.timeline.is_empty() {
-            state.nodes.keys().cloned().collect()
+            state.graph.nodes.keys().cloned().collect()
         } else {
             state.timeline.clone()
         };
@@ -84,7 +84,7 @@ impl<'a> ReplayEngine<'a> {
     pub fn replay_variables(&self) -> Result<ReplayResult, ReplayError> {
         let mut variables: HashMap<String, Value> = HashMap::new();
         for node_id in self.timeline.iter().rev() {
-            let node = match self.state.nodes.get(node_id) {
+            let node = match self.state.graph.nodes.get(node_id) {
                 Some(node) => node,
                 None => continue,
             };
@@ -116,6 +116,7 @@ impl<'a> ReplayEngine<'a> {
     ) -> Result<HashMap<String, Value>, ReplayError> {
         let node = self
             .state
+            .graph
             .nodes
             .get(&node_id)
             .ok_or_else(|| ReplayError(format!("action node not found: {node_id}")))?;
@@ -157,7 +158,7 @@ impl<'a> ReplayEngine<'a> {
         }
 
         let node =
-            self.state.nodes.get(&node_id).ok_or_else(|| {
+            self.state.graph.nodes.get(&node_id).ok_or_else(|| {
                 ReplayError(format!("missing assignment for {target} in {node_id}"))
             })?;
         let expr = node
@@ -280,7 +281,7 @@ impl<'a> ReplayEngine<'a> {
             if self.index.get(source_id).copied().unwrap_or(0) > current_idx {
                 continue;
             }
-            if let Some(node) = self.state.nodes.get(source_id)
+            if let Some(node) = self.state.graph.nodes.get(source_id)
                 && node.assignments.contains_key(name)
             {
                 return Some(*source_id);
@@ -487,7 +488,7 @@ fn build_incoming_data_map(
     index: &HashMap<ExecutionId, usize>,
 ) -> HashMap<ExecutionId, Vec<ExecutionId>> {
     let mut incoming: HashMap<ExecutionId, Vec<ExecutionId>> = HashMap::new();
-    for edge in &state.edges {
+    for edge in &state.graph.edges {
         if edge.edge_type != EdgeType::DataFlow {
             continue;
         }


### PR DESCRIPTION
There is no reason to duplicate the definitions of nodes and edges everywhere.

This PR replaces those individual declarations by a single struct that represents the whole graph.