### PR TITLE
Drop serde from runner state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4562,7 +4562,6 @@ name = "waymark-runner-state"
 version = "0.1.0"
 dependencies = [
  "chrono",
- "serde",
  "serde_json",
  "thiserror",
  "waymark-dag",

--- a/crates/lib/runner-state/Cargo.toml
+++ b/crates/lib/runner-state/Cargo.toml
@@ -13,7 +13,6 @@ waymark-runner-execution-core = { workspace = true }
 waymark-runner-expr = { workspace = true }
 
 chrono = { workspace = true, features = ["serde", "clock"] }
-serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 

--- a/crates/lib/runner-state/src/state.rs
+++ b/crates/lib/runner-state/src/state.rs
@@ -4,7 +4,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
-use serde::{Deserialize, Serialize};
+
 use waymark_ids::ExecutionId;
 use waymark_runner_execution_core::{
     ExecutionEdge, ExecutionGraph, ExecutionNode, ExecutionNodeType, NodeStatus,
@@ -85,9 +85,8 @@ pub struct QueueNodeParams {
 /// action and the results update. Subsequent iterations repeat the same
 /// sequence, producing a chain of assignments where replay can reconstruct the
 /// incremental `results` value by following data-flow edges.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug)]
 pub struct RunnerState {
-    #[serde(skip, default)]
     pub dag: Option<Arc<DAG>>,
     pub graph: ExecutionGraph,
     pub ready_queue: Vec<ExecutionId>,


### PR DESCRIPTION
Now that runner state is not used in the `QueuedInstance` anymore it doesn't need to know how to serialize/deserialize. Removing this functionality to prevent accidental misuse (we don't *intend* for it to actually be serialized/deserialized now) and simplify the possibilities in the domain space to account for.

Goes is after #361.