### PR TITLE
Add worker reservation crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2960,6 +2960,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
+name = "slotmap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "slug"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4946,6 +4955,15 @@ dependencies = [
  "waymark-worker-core",
  "waymark-worker-metrics",
  "waymark-worker-status-core",
+]
+
+[[package]]
+name = "waymark-worker-reservation"
+version = "0.1.0"
+dependencies = [
+ "slotmap",
+ "thiserror",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,6 +109,7 @@ serde_json = "1"
 serial_test = "2"
 sha1_smol = "1"
 sha2 = "0.10"
+slotmap = "1"
 sqlx = { version = "0.8", default-features = false }
 strum = "0.28"
 syn = "2"

--- a/crates/lib/worker-reservation/Cargo.toml
+++ b/crates/lib/worker-reservation/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "waymark-worker-reservation"
+edition = "2024"
+version.workspace = true
+publish.workspace = true
+
+[dependencies]
+slotmap = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["sync"] }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt"] }

--- a/crates/lib/worker-reservation/src/id.rs
+++ b/crates/lib/worker-reservation/src/id.rs
@@ -1,0 +1,75 @@
+slotmap::new_key_type! {
+    /// Opaque identifier for a pending worker reservation.
+    ///
+    /// This is typically created by [`crate::Registry::reserve`]. Converting an
+    /// arbitrary integer into an `Id` is supported for deserialization and tests,
+    /// but not every raw integer corresponds to a previously issued reservation.
+    pub struct Id;
+}
+
+impl core::fmt::Display for Id {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{}", self.0.as_ffi())
+    }
+}
+
+impl core::str::FromStr for Id {
+    type Err = std::num::ParseIntError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let ffi: u64 = s.parse()?;
+        Ok(Self::from(ffi))
+    }
+}
+
+impl From<u64> for Id {
+    fn from(value: u64) -> Self {
+        let key_data = slotmap::KeyData::from_ffi(value);
+        Self::from(key_data)
+    }
+}
+
+impl From<Id> for u64 {
+    fn from(value: Id) -> Self {
+        value.0.as_ffi()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Id;
+
+    #[test]
+    fn id_roundtrips_through_u64() {
+        let sample: Id = Id::default();
+
+        let encoded: u64 = sample.into();
+        let decoded: Id = encoded.into();
+
+        assert_eq!(sample, decoded);
+    }
+
+    #[test]
+    fn id_roundtrips_through_string() {
+        let sample: Id = Id::default();
+
+        let encoded = sample.to_string();
+        let decoded: Id = encoded.parse().unwrap();
+
+        assert_eq!(sample, decoded);
+    }
+
+    #[test]
+    fn invalid_id_string_fails_to_parse() {
+        assert!("not-a-number".parse::<Id>().is_err());
+    }
+
+    #[test]
+    fn note_that_constructing_id_manually_does_not_hold_usual_structural_invariant() {
+        // 42 is a value we just came up with, it's not a valid ID.
+        let id = Id::from(42);
+
+        // The actual representation of the `id` is not 42.
+        assert_ne!(u64::from(id), 42);
+    }
+}

--- a/crates/lib/worker-reservation/src/lib.rs
+++ b/crates/lib/worker-reservation/src/lib.rs
@@ -1,0 +1,11 @@
+//! Tooling for tracking the state of connecting worker reservations.
+
+#![warn(missing_docs)]
+
+mod id;
+mod registry;
+mod reservation;
+
+pub use self::id::*;
+pub use self::registry::*;
+pub use self::reservation::*;

--- a/crates/lib/worker-reservation/src/registry.rs
+++ b/crates/lib/worker-reservation/src/registry.rs
@@ -1,0 +1,150 @@
+use std::sync::Arc;
+
+use slotmap::SlotMap;
+
+use crate::Reservation;
+
+pub(crate) type ActiveReservations<Payload> =
+    SlotMap<crate::Id, tokio::sync::oneshot::Sender<Payload>>;
+
+/// Tracks outstanding worker reservations until their payloads arrive.
+pub struct Registry<Payload> {
+    active_reservations: std::sync::Mutex<ActiveReservations<Payload>>,
+}
+
+impl<Payload> Default for Registry<Payload> {
+    fn default() -> Self {
+        Self {
+            active_reservations: Default::default(),
+        }
+    }
+}
+
+/// Errors that can occur while completing a reservation.
+#[derive(Debug, thiserror::Error)]
+pub enum RegisterError<Payload> {
+    /// The reservation no longer exists, usually because it was already
+    /// dropped or completed.
+    #[error("reservation {reservation_id} not found")]
+    ReservationNotFound {
+        /// The requested reservation ID.
+        reservation_id: crate::Id,
+
+        /// The payload that could not be delivered.
+        payload: Payload,
+    },
+
+    /// The reservation existed, but the waiting side was already gone when sending.
+    #[error("unable to send payload for reservation {reservation_id}")]
+    PayloadSend {
+        /// The requested reservation ID.
+        reservation_id: crate::Id,
+
+        /// The payload that could not be delivered.
+        payload: Payload,
+    },
+}
+
+impl<Payload> Registry<Payload> {
+    /// Creates a new reservation that can later be completed
+    /// with [`Self::register`].
+    pub fn reserve(self: &Arc<Self>) -> Reservation<Payload> {
+        let mut active_reservations = self.active_reservations.lock().unwrap();
+
+        let (tx, rx) = tokio::sync::oneshot::channel();
+
+        let reservation_id = active_reservations.insert(tx);
+
+        let registry = Arc::clone(self);
+
+        Reservation::issue_from_registry(registry, reservation_id, rx)
+    }
+
+    /// Completes a reservation by delivering its payload to the waiting handle.
+    ///
+    /// Returns [`RegisterError::ReservationNotFound`] if the reservation no longer
+    /// exists, or [`RegisterError::PayloadSend`] if the receiver was already gone.
+    pub fn register(
+        &self,
+        reservation_id: crate::Id,
+        payload: Payload,
+    ) -> Result<(), RegisterError<Payload>> {
+        let mut active_reservations = self.active_reservations.lock().unwrap();
+
+        let Some(tx) = active_reservations.remove(reservation_id) else {
+            return Err(RegisterError::ReservationNotFound {
+                reservation_id,
+                payload,
+            });
+        };
+
+        tx.send(payload)
+            .map_err(|payload| RegisterError::PayloadSend {
+                reservation_id,
+                payload,
+            })
+    }
+
+    pub(crate) fn reservation_drop_cleanup(&self, reservation_id: crate::Id) {
+        let mut active_reservations = self.active_reservations.lock().unwrap();
+        let _ = active_reservations.remove(reservation_id);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn register_then_wait_delivers_payload() {
+        let registry = Arc::new(Registry::default());
+
+        let reservation = registry.reserve();
+        let reservation_id = reservation.id();
+
+        registry.register(reservation_id, "hello").unwrap();
+
+        let payload = reservation.wait().await.unwrap();
+        assert_eq!(payload, "hello");
+    }
+
+    #[tokio::test]
+    async fn dropping_reservation_cleans_up_registry_entry() {
+        let registry = Arc::new(Registry::default());
+
+        let reservation = registry.reserve();
+        let reservation_id = reservation.id();
+        drop(reservation);
+
+        let result = registry.register(reservation_id, "payload");
+
+        match result {
+            Err(RegisterError::ReservationNotFound {
+                reservation_id: id,
+                payload,
+            }) => {
+                assert_eq!(id, reservation_id);
+                assert_eq!(payload, "payload");
+            }
+            other => panic!("expected ReservationNotFound, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn multiple_reservations_are_isolated() {
+        let registry = Arc::new(Registry::default());
+
+        let first = registry.reserve();
+        let first_id = first.id();
+        let second = registry.reserve();
+        let second_id = second.id();
+
+        registry.register(second_id, "second").unwrap();
+        registry.register(first_id, "first").unwrap();
+
+        assert_eq!(first.wait().await.unwrap(), "first");
+        assert_eq!(second.wait().await.unwrap(), "second");
+    }
+}

--- a/crates/lib/worker-reservation/src/reservation.rs
+++ b/crates/lib/worker-reservation/src/reservation.rs
@@ -1,0 +1,62 @@
+use std::sync::Arc;
+
+use crate::Registry;
+
+/// A reservation handle that allows to wait for payload.
+pub struct Reservation<Payload> {
+    registry: Arc<Registry<Payload>>,
+    id: crate::Id,
+    rx: Option<tokio::sync::oneshot::Receiver<Payload>>,
+}
+
+/// Error returned when a reservation is cancelled before receiving a payload.
+#[derive(Debug, thiserror::Error)]
+#[error("reservation {reservation_id} was cancelled")]
+pub struct ReservationCancelledError {
+    /// The reservation that was dropped or otherwise cancelled before
+    /// a payload arrived.
+    pub reservation_id: crate::Id,
+}
+
+impl<Payload> Reservation<Payload> {
+    pub(crate) fn issue_from_registry(
+        registry: Arc<Registry<Payload>>,
+        id: crate::Id,
+        rx: tokio::sync::oneshot::Receiver<Payload>,
+    ) -> Self {
+        Self {
+            registry,
+            id,
+            rx: Some(rx),
+        }
+    }
+
+    /// Returns the identifier that the registry uses to complete
+    /// this reservation.
+    pub fn id(&self) -> crate::Id {
+        self.id
+    }
+
+    /// Waits for the payload to be sent for this reservation.
+    ///
+    /// Returns [`ReservationCancelledError`] if the reservation is dropped
+    /// or the sender disappears before delivering a payload.
+    pub async fn wait(mut self) -> Result<Payload, ReservationCancelledError> {
+        let channel_rx = self.rx.take().unwrap(); // only ever consumed here
+        match channel_rx.await {
+            Ok(val) => Ok(val),
+            Err(_) => Err(ReservationCancelledError {
+                reservation_id: self.id,
+            }),
+        }
+    }
+}
+
+impl<Payload> Drop for Reservation<Payload> {
+    fn drop(&mut self) {
+        if let Some(rx) = &mut self.rx {
+            rx.close()
+        }
+        self.registry.reservation_drop_cleanup(self.id);
+    }
+}


### PR DESCRIPTION
This PR introduces a new `waymark-worker-reservation` crate, which provides tooling for tracking and managing worker reservations in an asynchronous context.

This crate is a structural and encapsulated replacement for the similar functionality that already exists in waymark but is present in the monolithic `waymark-worker-remote` crate.

This is a part of the #278 series of patches, check that side out for more context.