### PR TITLE
Add worker process crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4946,6 +4946,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "waymark-worker-process"
+version = "0.1.0"
+dependencies = [
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "waymark-managed-process",
+ "waymark-worker-message-protocol",
+ "waymark-worker-reservation",
+]
+
+[[package]]
 name = "waymark-worker-remote"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ waymark-ids = { path = "crates/lib/ids" }
 waymark-ir-conversions = { path = "crates/lib/ir-conversions" }
 waymark-ir-format = { path = "crates/lib/ir-format" }
 waymark-ir-parser = { path = "crates/lib/ir-parser" }
+waymark-managed-process = { path = "crates/lib/managed-process" }
 waymark-message-conversions = { path = "crates/lib/message-conversions" }
 waymark-metrics-util = { path = "crates/lib/metrics-util" }
 waymark-nonzero-duration = { path = "crates/lib/nonzero-duration" }
@@ -68,8 +69,10 @@ waymark-webapp-core = { path = "crates/lib/webapp-core" }
 waymark-webapp-routes = { path = "crates/lib/webapp-routes" }
 waymark-worker-core = { path = "crates/lib/worker-core" }
 waymark-worker-inline = { path = "crates/lib/worker-inline" }
+waymark-worker-message-protocol = { path = "crates/lib/worker-message-protocol" }
 waymark-worker-metrics = { path = "crates/lib/worker-metrics" }
 waymark-worker-remote = { path = "crates/lib/worker-remote" }
+waymark-worker-reservation = { path = "crates/lib/worker-reservation" }
 waymark-worker-status-backend = { path = "crates/lib/worker-status-backend" }
 waymark-worker-status-core = { path = "crates/lib/worker-status-core" }
 waymark-worker-status-reporter = { path = "crates/lib/worker-status-reporter" }

--- a/crates/lib/worker-process/Cargo.toml
+++ b/crates/lib/worker-process/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "waymark-worker-process"
+edition = "2024"
+version.workspace = true
+publish.workspace = true
+
+[dependencies]
+waymark-managed-process = { workspace = true }
+waymark-worker-message-protocol = { workspace = true }
+waymark-worker-reservation = { workspace = true }
+
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["rt"] }
+tokio-util = { workspace = true }
+tracing = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time", "sync"] }

--- a/crates/lib/worker-process/src/lib.rs
+++ b/crates/lib/worker-process/src/lib.rs
@@ -1,0 +1,264 @@
+//! Worker process lifecycle utilities.
+//!
+//! This crate coordinates three parts of a worker's lifecycle:
+//! - process spawning,
+//! - message protocol channel attachment via a reservation,
+//! - and graceful shutdown for both async tasks and the child process.
+
+#![warn(missing_docs)]
+
+use std::time::Duration;
+
+/// Worker channel reservation for the message protocol.
+pub type Reservation =
+    waymark_worker_reservation::Reservation<waymark_worker_message_protocol::Channels>;
+
+/// Parameters used to spawn and initialize a worker process.
+pub struct SpawnParams {
+    /// Process command used to spawn the worker binary.
+    pub command: tokio::process::Command,
+
+    /// Maximum time to wait for the worker to attach to the reservation.
+    pub wait_for_playload_timeout: Duration,
+
+    /// Shutdown behavior used when startup or later teardown occurs.
+    pub shutdown_params: ShutdownParams,
+}
+
+/// Errors returned by [`spawn`].
+#[derive(Debug, thiserror::Error)]
+pub enum SpawnError {
+    /// Failed to spawn the worker child process.
+    #[error("spawn: {0}")]
+    Spawn(std::io::Error),
+
+    /// Timed out while waiting for the worker to attach.
+    #[error("timed out after waiting for worker to attach")]
+    ReservationWaitTimeout {
+        /// Configured wait duration that elapsed.
+        timeout: Duration,
+    },
+
+    /// Reservation wait was cancelled or otherwise failed.
+    #[error("reservation wait: {0}")]
+    ReservationWaitError(waymark_worker_reservation::ReservationCancelledError),
+}
+
+/// Spawn a worker process and wait for it to attach to the reservation.
+///
+/// This function:
+/// - starts the configured child process,
+/// - waits for message channels from `reservation` up to
+///   [`SpawnParams::wait_for_playload_timeout`],
+/// - starts the worker message protocol loop as an associated task,
+/// - and returns a [`Handle`] plus a [`waymark_worker_message_protocol::Sender`].
+///
+/// If reservation attachment fails or times out, the child process is shut
+/// down before returning a [`SpawnError`].
+pub async fn spawn(
+    reservation: Reservation,
+    params: SpawnParams,
+) -> Result<(Handle, waymark_worker_message_protocol::Sender), SpawnError> {
+    let SpawnParams {
+        wait_for_playload_timeout,
+        command,
+        shutdown_params,
+    } = params;
+
+    // Spawn the process.
+    let child = waymark_managed_process::spawn(command).map_err(SpawnError::Spawn)?;
+
+    // Wait for the worker to connect (with timeout).
+    let result = tokio::time::timeout(wait_for_playload_timeout, reservation.wait()).await;
+    let result = match result {
+        Ok(Ok(channels)) => Ok(channels),
+        Ok(Err(err)) => Err(SpawnError::ReservationWaitError(err)),
+        Err(tokio::time::error::Elapsed { .. }) => Err(SpawnError::ReservationWaitTimeout {
+            timeout: wait_for_playload_timeout,
+        }),
+    };
+
+    // Pass the payload or terminate the process gracefully.
+    let channels = match result {
+        Ok(channels) => channels,
+        Err(error) => {
+            let shutdown_result = shutdown_params.shutdown_child_process(child).await;
+            tracing::debug!(
+                ?error,
+                ?shutdown_result,
+                "worker process shut down after failed payload wait"
+            );
+            return Err(error);
+        }
+    };
+
+    tracing::info!("worker process connected");
+
+    // Prepare the join set for all worker-associated tasks and a cancellation
+    // token for graceful task termination.
+    let mut tasks = tokio::task::JoinSet::new();
+    let task_shutdown_token = tokio_util::sync::CancellationToken::new();
+
+    // Set up the message protocol.
+    let (sender, fut) = waymark_worker_message_protocol::setup(channels);
+    let fut = {
+        let task_shutdown_token = task_shutdown_token.clone();
+        async move {
+            let output = task_shutdown_token
+                .clone()
+                .run_until_cancelled_owned(fut)
+                .await;
+            if output.is_none() {
+                tracing::debug!(
+                    message =
+                        "worker message protocol loop has just shut down via future cancellation"
+                );
+            }
+        }
+    };
+
+    // Spawn the message protocol loop into the worker-associated tasks set.
+    tasks.spawn(fut);
+
+    let task_shutdown_guard = task_shutdown_token.clone().drop_guard();
+    let handle = Handle {
+        child: Some(child),
+        tasks,
+        task_shutdown_token,
+        task_shutdown_guard,
+        shutdown_params,
+    };
+
+    Ok((handle, sender))
+}
+
+/// Parameters controlling graceful worker shutdown.
+pub struct ShutdownParams {
+    /// Maximum time to wait for spawned worker tasks to finish gracefully.
+    pub tasks_graceful_shutdown_timeout: Duration,
+
+    /// Grace period to allow the process to exit after termination is requested.
+    pub process_graceful_shutdown_timeout: Duration,
+
+    /// Maximum time to wait after sending a force-kill signal.
+    pub process_kill_timeout: Duration,
+}
+
+/// Handle to a spawned worker process and its associated tasks.
+pub struct Handle {
+    /// The managed child process.
+    child: Option<waymark_managed_process::Child>,
+
+    /// All of the async tasks managed by this process.
+    tasks: tokio::task::JoinSet<()>,
+
+    /// The task graceful shutdown token.
+    task_shutdown_token: tokio_util::sync::CancellationToken,
+
+    /// The task shutdown drop guard.
+    task_shutdown_guard: tokio_util::sync::DropGuard,
+
+    /// The params used for shutdown.
+    shutdown_params: ShutdownParams,
+}
+
+impl Handle {
+    /// Gracefully shut down the worker process.
+    ///
+    /// Shutdown ordering:
+    /// - cancel associated tasks via the shared cancellation token,
+    /// - wait for those tasks to finish (or force-abort on timeout),
+    /// - then shut down the child process.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the underlying managed process fails to terminate
+    /// within configured limits.
+    pub async fn shutdown(mut self) -> Result<(), waymark_managed_process::ShutdownError> {
+        tracing::info!("shutting down worker");
+
+        // Start graceful termination of the tasks.
+        drop(self.task_shutdown_guard);
+
+        // Wait for graceful shutdown of the tasks.
+        self.shutdown_params.shutdown_tasks(&mut self.tasks).await;
+
+        // Shutdown the managed process gracefully.
+        if let Some(child) = self.child.take() {
+            let exit_status = self.shutdown_params.shutdown_child_process(child).await?;
+            tracing::debug!(?exit_status, "worker child process exited");
+        }
+
+        tracing::info!("worker shutdown complete");
+        Ok(())
+    }
+
+    /// Get a cancellation future that resolves when worker shutdown begins.
+    ///
+    /// This is useful for tasks that need to cooperatively stop when
+    /// [`Handle::shutdown`] is called.
+    pub fn task_shutdown_signal(&self) -> tokio_util::sync::WaitForCancellationFutureOwned {
+        self.task_shutdown_token.clone().cancelled_owned()
+    }
+
+    /// Spawn an async task that is owned by this worker handle.
+    ///
+    /// The task is tracked in the handle's internal join set, so it
+    /// participates in the same shutdown lifecycle as other worker-associated
+    /// tasks.
+    ///
+    /// Returns a task abort handle that can be used for early cancellation.
+    pub fn spawn_associated_task<F>(&mut self, f: F) -> tokio::task::AbortHandle
+    where
+        F: Future<Output = ()>,
+        F: Send + 'static,
+    {
+        self.tasks.spawn(f)
+    }
+}
+
+impl ShutdownParams {
+    async fn shutdown_child_process(
+        &self,
+        child: waymark_managed_process::Child,
+    ) -> Result<std::process::ExitStatus, waymark_managed_process::ShutdownError> {
+        child
+            .shutdown(
+                self.process_graceful_shutdown_timeout,
+                self.process_kill_timeout,
+            )
+            .await
+    }
+
+    async fn shutdown_tasks(&self, mut tasks: &mut tokio::task::JoinSet<()>) {
+        // Prepare a future to wait for all the tasks to join.
+        let gracefully_terminate_tasks_fut = {
+            let tasks = &mut tasks;
+            async move {
+                while let Some(join_result) = tasks.join_next().await {
+                    match join_result {
+                        Ok(()) => {}
+                        Err(error) if error.is_cancelled() => {}
+                        Err(error) => std::panic::resume_unwind(error.into_panic()),
+                    }
+                }
+            }
+        };
+
+        // Attempt to wait for graceful task shutdown first.
+        let task_shutdown_result = tokio::time::timeout(
+            self.tasks_graceful_shutdown_timeout,
+            gracefully_terminate_tasks_fut,
+        )
+        .await;
+
+        // Abort the tasks forcefully if they didn't finish in time.
+        if task_shutdown_result.is_err() {
+            tracing::debug!(
+                tasks_graceful_shutdown_timeout = ?self.tasks_graceful_shutdown_timeout,
+                "worker tasks didn't shut down gracefully in time"
+            );
+            tasks.shutdown().await;
+        }
+    }
+}

--- a/crates/lib/worker-process/tests/integration.rs
+++ b/crates/lib/worker-process/tests/integration.rs
@@ -1,0 +1,205 @@
+use std::{sync::Arc, time::Duration};
+
+use waymark_worker_message_protocol::Channels;
+use waymark_worker_process::{Handle, ShutdownParams, SpawnError, SpawnParams, spawn};
+use waymark_worker_reservation::Registry;
+
+fn sleeping_command() -> tokio::process::Command {
+    let mut command = tokio::process::Command::new("sh");
+    command.arg("-c").arg("sleep 60");
+    command
+}
+
+async fn spawn_test_worker(
+    command: tokio::process::Command,
+    tasks_graceful_shutdown_timeout: Duration,
+) -> Handle {
+    let registry = Arc::new(Registry::<Channels>::default());
+    let reservation = registry.reserve();
+    let reservation_id = reservation.id();
+
+    let spawn_task = tokio::spawn(spawn(
+        reservation,
+        SpawnParams {
+            command,
+            wait_for_playload_timeout: Duration::from_secs(1),
+            shutdown_params: ShutdownParams {
+                tasks_graceful_shutdown_timeout,
+                process_graceful_shutdown_timeout: Duration::from_millis(50),
+                process_kill_timeout: Duration::from_secs(1),
+            },
+        },
+    ));
+
+    let (to_worker, _to_worker_rx) = tokio::sync::mpsc::channel(1);
+    let (_from_worker_tx, from_worker) = tokio::sync::mpsc::channel(1);
+
+    let registration_result = registry.register(
+        reservation_id,
+        Channels {
+            to_worker,
+            from_worker,
+        },
+    );
+    assert!(
+        registration_result.is_ok(),
+        "reservation registration should succeed"
+    );
+
+    let (handle, _sender) = spawn_task
+        .await
+        .expect("spawn task should not panic")
+        .expect("worker spawn should succeed");
+
+    handle
+}
+
+#[tokio::test]
+async fn spawn_returns_spawn_error_for_missing_command() {
+    let registry = Arc::new(Registry::<Channels>::default());
+    let reservation = registry.reserve();
+
+    let command = tokio::process::Command::new("/definitely/missing/waymark-worker-process-test");
+
+    let result = spawn(
+        reservation,
+        SpawnParams {
+            command,
+            wait_for_playload_timeout: Duration::from_millis(25),
+            shutdown_params: ShutdownParams {
+                tasks_graceful_shutdown_timeout: Duration::from_millis(25),
+                process_graceful_shutdown_timeout: Duration::from_millis(25),
+                process_kill_timeout: Duration::from_millis(25),
+            },
+        },
+    )
+    .await;
+
+    assert!(
+        matches!(result, Err(SpawnError::Spawn(_))),
+        "missing executable should return SpawnError::Spawn"
+    );
+}
+
+#[tokio::test]
+async fn spawn_returns_timeout_when_worker_never_registers() {
+    let registry = Arc::new(Registry::<Channels>::default());
+    let reservation = registry.reserve();
+
+    let result = tokio::time::timeout(
+        Duration::from_millis(200),
+        spawn(
+            reservation,
+            SpawnParams {
+                command: sleeping_command(),
+                wait_for_playload_timeout: Duration::from_millis(25),
+                shutdown_params: ShutdownParams {
+                    tasks_graceful_shutdown_timeout: Duration::from_millis(25),
+                    process_graceful_shutdown_timeout: Duration::from_millis(25),
+                    process_kill_timeout: Duration::from_secs(1),
+                },
+            },
+        ),
+    )
+    .await
+    .expect("spawn should time out instead of hanging");
+
+    assert!(
+        matches!(
+            result,
+            Err(SpawnError::ReservationWaitTimeout { timeout })
+                if timeout == Duration::from_millis(25)
+        ),
+        "missing worker registration should return SpawnError::ReservationWaitTimeout"
+    );
+}
+
+#[tokio::test]
+async fn shutdown_notifies_associated_tasks_via_cancellation_signal() {
+    let mut handle = spawn_test_worker(sleeping_command(), Duration::from_millis(50)).await;
+    let signal = handle.task_shutdown_signal();
+    let (tx, rx) = tokio::sync::oneshot::channel();
+
+    handle.spawn_associated_task(async move {
+        signal.await;
+        tx.send(()).expect("test receiver should still be alive");
+    });
+
+    handle.shutdown().await.expect("shutdown should succeed");
+
+    tokio::time::timeout(Duration::from_millis(100), rx)
+        .await
+        .expect("associated task should observe shutdown")
+        .expect("associated task should send completion signal");
+}
+
+#[tokio::test]
+async fn shutdown_waits_for_cooperative_associated_task_cleanup() {
+    let mut handle = spawn_test_worker(sleeping_command(), Duration::from_millis(50)).await;
+    let signal = handle.task_shutdown_signal();
+    let (tx, rx) = tokio::sync::oneshot::channel();
+
+    handle.spawn_associated_task(async move {
+        signal.await;
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        tx.send(()).expect("test receiver should still be alive");
+    });
+
+    handle.shutdown().await.expect("shutdown should succeed");
+
+    rx.await
+        .expect("shutdown should wait for cooperative task cleanup");
+}
+
+#[tokio::test]
+async fn shutdown_aborts_non_cooperative_tasks_after_timeout() {
+    let mut handle = spawn_test_worker(sleeping_command(), Duration::from_millis(20)).await;
+
+    handle.spawn_associated_task(async move {
+        loop {
+            tokio::time::sleep(Duration::from_secs(60)).await;
+        }
+    });
+
+    tokio::time::timeout(Duration::from_millis(200), handle.shutdown())
+        .await
+        .expect("shutdown should complete after aborting stuck tasks")
+        .expect("shutdown should succeed");
+}
+
+#[tokio::test]
+async fn shutdown_falls_back_to_kill_when_child_ignores_sigterm() {
+    let mut command = tokio::process::Command::new("sh");
+    command.arg("-c").arg("trap '' TERM; sleep 60");
+
+    let handle = spawn_test_worker(command, Duration::from_millis(25)).await;
+
+    tokio::time::timeout(Duration::from_secs(2), handle.shutdown())
+        .await
+        .expect("shutdown should finish after kill fallback")
+        .expect("shutdown should succeed after kill fallback");
+}
+
+#[tokio::test]
+async fn shutdown_propagates_panic_from_associated_task() {
+    let mut handle = spawn_test_worker(sleeping_command(), Duration::from_millis(50)).await;
+
+    handle.spawn_associated_task(async move {
+        panic!("associated task panicked");
+    });
+    tokio::task::yield_now().await;
+
+    let join_error = tokio::spawn(handle.shutdown())
+        .await
+        .expect_err("shutdown should propagate the task panic");
+
+    assert!(join_error.is_panic(), "expected a panic JoinError");
+
+    let panic_message = join_error
+        .into_panic()
+        .downcast_ref::<&str>()
+        .copied()
+        .expect("panic payload should be a &str");
+
+    assert_eq!(panic_message, "associated task panicked");
+}


### PR DESCRIPTION
Goes in after #369.

This PR introduces an encapsulated worker process crate. This is, again, an extract of the functionality from the `waymark-worker-remote` crate - but this time it's not a one-to-one replacement but rather a reimplementation based on the new building blocks from the previous PRs.

Differences from the original functionality:
- a concise, purpose-built, opinionated API
- and stronger guarantees for worker processes termination in case of errors
- full support for graceful termination
- general support for spawning async tasks with the lifecycle attached to the worker process (automatic cancellation and graceful termination)
- a separation between the worker handle and the sender (allowing for more flexible management of the senders without having to move the handles into the shared state)

Ultimately this is a new powerful building block that greatly simplifies building further parts of the system; see #278 for how it's used later on.

---

We might want to further subdivide the tasks handling from this process crate once we have proper facilities for the task management - but for now this is the way to do it; later on I imagine we'd take in a task spawning handle in the input rather than creating our own task joinset.