### PR TITLE
Add worker remote bridge service crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3685,6 +3685,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-futures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
+dependencies = [
+ "futures",
+ "futures-task",
+ "pin-project",
+ "tracing",
+]
+
+[[package]]
 name = "tracing-log"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4981,6 +4993,24 @@ dependencies = [
  "waymark-worker-core",
  "waymark-worker-metrics",
  "waymark-worker-status-core",
+]
+
+[[package]]
+name = "waymark-worker-remote-bridge-service"
+version = "0.1.0"
+dependencies = [
+ "async-stream",
+ "futures-core",
+ "prost 0.12.6",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tonic 0.11.0",
+ "tracing",
+ "tracing-futures",
+ "waymark-proto",
+ "waymark-worker-message-protocol",
+ "waymark-worker-reservation",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,7 @@ waymark-worker-status-reporter = { path = "crates/lib/worker-status-reporter" }
 waymark-workflow-registry-backend = { path = "crates/lib/workflow-registry-backend" }
 
 anyhow = "1"
+async-stream = "0.3"
 axum = "0.8"
 chrono = { version = "0.4", default-features = false }
 clap = "4.5"
@@ -128,6 +129,7 @@ tonic-health = "0.11"
 tower = "0.5"
 tracing = "0.1"
 tracing-chrome = "0.7"
+tracing-futures = "0.2"
 tracing-subscriber = "0.3"
 uuid = "1.23"
 zeroize = "1"

--- a/crates/lib/worker-remote-bridge-service/Cargo.toml
+++ b/crates/lib/worker-remote-bridge-service/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "waymark-worker-remote-bridge-service"
+edition = "2024"
+version.workspace = true
+publish.workspace = true
+
+[dependencies]
+waymark-proto = { workspace = true }
+waymark-worker-message-protocol = { workspace = true }
+waymark-worker-reservation = { workspace = true }
+
+async-stream = { workspace = true }
+futures-core = { workspace = true }
+prost = { workspace = true }
+tokio = { workspace = true, features = ["sync", "macros"] }
+tonic = { workspace = true }
+tracing = { workspace = true }
+tracing-futures = { workspace = true, features = ["futures-03"] }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "net", "rt-multi-thread", "sync", "time"] }
+tokio-stream = { workspace = true, features = ["net"] }
+tokio-util = { workspace = true }

--- a/crates/lib/worker-remote-bridge-service/src/lib.rs
+++ b/crates/lib/worker-remote-bridge-service/src/lib.rs
@@ -1,0 +1,134 @@
+use std::{pin::Pin, sync::Arc};
+
+use async_stream::try_stream;
+use futures_core::Stream;
+use prost::Message;
+use tokio::sync::mpsc;
+use tonic::{Request, Response, Status, Streaming, async_trait};
+use tracing_futures::Instrument;
+
+use waymark_proto::messages as proto;
+
+type Registry = waymark_worker_reservation::Registry<waymark_worker_message_protocol::Channels>;
+
+/// Buffer size of 64 provides reasonable backpressure while allowing
+/// some pipelining of requests.
+const MESSAGE_PROTOCOL_CHANNEL_SIZE: usize = 64;
+
+/// gRPC service implementation for the WorkerBridge.
+#[derive(Clone)]
+pub struct WorkerBridgeService {
+    pub workers_registry: Arc<Registry>,
+}
+
+type BridgeAttachStream =
+    Pin<Box<dyn Stream<Item = Result<proto::Envelope, Status>> + Send + 'static>>;
+
+#[async_trait]
+impl proto::worker_bridge_server::WorkerBridge for WorkerBridgeService {
+    type AttachStream = BridgeAttachStream;
+
+    async fn attach(
+        &self,
+        request: Request<Streaming<proto::Envelope>>,
+    ) -> Result<Response<Self::AttachStream>, Status> {
+        let mut stream = request.into_inner();
+
+        // Read and validate the handshake message
+        let handshake = stream
+            .message()
+            .await
+            .map_err(|err| Status::internal(format!("failed to read handshake: {err}")))?
+            .ok_or_else(|| Status::invalid_argument("missing worker handshake"))?;
+
+        let kind = proto::MessageKind::try_from(handshake.kind)
+            .map_err(|_| Status::invalid_argument("invalid message kind"))?;
+
+        if kind != proto::MessageKind::WorkerHello {
+            return Err(Status::failed_precondition(
+                "expected WorkerHello as first message",
+            ));
+        }
+
+        let hello = proto::WorkerHello::decode(&*handshake.payload).map_err(|err| {
+            Status::invalid_argument(format!("invalid WorkerHello payload: {err}"))
+        })?;
+
+        let worker_id = hello.worker_id;
+        tracing::info!(worker_id, "worker connected and sent hello");
+
+        // Create channels for bidirectional communication.
+        let (to_worker_tx, to_worker_rx) = mpsc::channel(MESSAGE_PROTOCOL_CHANNEL_SIZE);
+        let (from_worker_tx, from_worker_rx) = mpsc::channel(MESSAGE_PROTOCOL_CHANNEL_SIZE);
+
+        let reservation_id = waymark_worker_reservation::Id::from(worker_id);
+        let channels = waymark_worker_message_protocol::Channels {
+            to_worker: to_worker_tx,
+            from_worker: from_worker_rx,
+        };
+
+        // Complete the registration - this unblocks the spawn code
+        self.workers_registry
+            .register(reservation_id, channels)
+            .map_err(|err| tonic::Status::not_found(err.to_string()))?;
+
+        let worker_span = tracing::info_span!("worker_bridge_attach", worker_id);
+
+        let inbound = pipe_inbound_messages(stream, from_worker_tx);
+        let outbound = stream_outbound_messages(inbound, to_worker_rx).instrument(worker_span);
+
+        let outbound = Box::pin(outbound) as Self::AttachStream;
+        Ok(Response::new(outbound))
+    }
+}
+
+async fn pipe_inbound_messages(
+    mut stream: Streaming<proto::Envelope>,
+    from_worker_tx: mpsc::Sender<proto::Envelope>,
+) {
+    loop {
+        let result = stream.message().await;
+        let maybe_envelope = match result {
+            Ok(val) => val,
+            Err(error) => {
+                tracing::warn!(?error, "worker stream receive error");
+                break;
+            }
+        };
+
+        let Some(envelope) = maybe_envelope else {
+            tracing::info!("worker stream closed");
+            break;
+        };
+
+        if from_worker_tx.send(envelope).await.is_err() {
+            tracing::debug!("from worker channel closed");
+            break;
+        }
+    }
+}
+
+fn stream_outbound_messages(
+    inbound_pipe_fut: impl Future<Output = ()>,
+    mut to_worker_rx: mpsc::Receiver<proto::Envelope>,
+) -> impl Stream<Item = Result<proto::Envelope, Status>> {
+    try_stream! {
+        let mut pipe_inbound = true;
+        let mut inbound_pipe_fut = std::pin::pin!(inbound_pipe_fut);
+
+        loop {
+            tokio::select! {
+                () = &mut inbound_pipe_fut, if pipe_inbound => {
+                    pipe_inbound = false;
+                }
+                Some(envelope) = to_worker_rx.recv() => {
+                    yield envelope;
+                }
+                else => {
+                    tracing::debug!("to worker channel closed");
+                    break;
+                }
+            }
+        }
+    }
+}

--- a/crates/lib/worker-remote-bridge-service/tests/bridge_service.rs
+++ b/crates/lib/worker-remote-bridge-service/tests/bridge_service.rs
@@ -1,0 +1,211 @@
+use std::{net::SocketAddr, sync::Arc, time::Duration};
+
+use prost::Message;
+use tokio::{net::TcpListener, sync::mpsc, time::timeout};
+use tokio_stream::wrappers::{ReceiverStream, TcpListenerStream};
+use tokio_util::sync::{CancellationToken, DropGuard};
+use tonic::{Code, Request, transport::Server};
+use waymark_proto::messages as proto;
+use waymark_worker_remote_bridge_service::WorkerBridgeService;
+
+type Registry = waymark_worker_reservation::Registry<waymark_worker_message_protocol::Channels>;
+
+struct TestServer {
+    addr: SocketAddr,
+    shutdown_guard: Option<DropGuard>,
+    server_handle: Option<tokio::task::JoinHandle<()>>,
+}
+
+impl Drop for TestServer {
+    fn drop(&mut self) {
+        let Some(shutdown_guard) = self.shutdown_guard.take() else {
+            return;
+        };
+
+        let Some(server_handle) = self.server_handle.take() else {
+            drop(shutdown_guard);
+            return;
+        };
+
+        if let Ok(runtime_handle) = tokio::runtime::Handle::try_current() {
+            runtime_handle.spawn(async move {
+                drop(shutdown_guard);
+                let _ = server_handle.await;
+            });
+        } else {
+            drop(shutdown_guard);
+            server_handle.abort();
+        }
+    }
+}
+
+fn worker_hello_envelope(worker_id: u64) -> proto::Envelope {
+    proto::Envelope {
+        delivery_id: 0,
+        partition_id: 0,
+        kind: proto::MessageKind::WorkerHello as i32,
+        payload: proto::WorkerHello { worker_id }.encode_to_vec(),
+    }
+}
+
+fn heartbeat_envelope(delivery_id: u64) -> proto::Envelope {
+    proto::Envelope {
+        delivery_id,
+        partition_id: 0,
+        kind: proto::MessageKind::Heartbeat as i32,
+        payload: Vec::new(),
+    }
+}
+
+async fn start_test_server(workers_registry: Arc<Registry>) -> TestServer {
+    let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))
+        .await
+        .expect("bind test worker bridge listener");
+    let addr = listener.local_addr().expect("resolve test bridge addr");
+    let shutdown_token = CancellationToken::new();
+    let shutdown_guard = shutdown_token.clone().drop_guard();
+
+    let service = WorkerBridgeService { workers_registry };
+    let server_shutdown = shutdown_token.clone();
+    let server_handle = tokio::spawn(async move {
+        Server::builder()
+            .add_service(proto::worker_bridge_server::WorkerBridgeServer::new(
+                service,
+            ))
+            .serve_with_incoming_shutdown(
+                TcpListenerStream::new(listener),
+                server_shutdown.cancelled_owned(),
+            )
+            .await
+            .expect("test worker bridge server should shut down cleanly");
+    });
+
+    TestServer {
+        addr,
+        shutdown_guard: Some(shutdown_guard),
+        server_handle: Some(server_handle),
+    }
+}
+
+async fn connect_client(
+    addr: SocketAddr,
+) -> proto::worker_bridge_client::WorkerBridgeClient<tonic::transport::Channel> {
+    proto::worker_bridge_client::WorkerBridgeClient::connect(format!("http://{addr}"))
+        .await
+        .expect("connect test worker bridge client")
+}
+
+#[tokio::test]
+async fn attach_registers_reserved_worker_and_bridges_messages() {
+    let registry = Arc::new(Registry::default());
+    let server = start_test_server(Arc::clone(&registry)).await;
+
+    let reservation = registry.reserve();
+    let worker_id = u64::from(reservation.id());
+
+    let mut client = connect_client(server.addr).await;
+    let (request_tx, request_rx) = mpsc::channel(4);
+    request_tx
+        .send(worker_hello_envelope(worker_id))
+        .await
+        .expect("queue handshake envelope");
+
+    let response = client
+        .attach(Request::new(ReceiverStream::new(request_rx)))
+        .await
+        .expect("attach should succeed for a reserved worker");
+    let mut outbound = response.into_inner();
+
+    let mut channels = timeout(Duration::from_secs(1), reservation.wait())
+        .await
+        .expect("reservation registration timed out")
+        .expect("reservation should receive bridge channels");
+
+    let outbound_envelope = heartbeat_envelope(11);
+    channels
+        .to_worker
+        .send(outbound_envelope.clone())
+        .await
+        .expect("send envelope to bridged worker");
+
+    let received_by_client = timeout(Duration::from_secs(1), outbound.message())
+        .await
+        .expect("client receive timed out")
+        .expect("outbound stream should stay healthy")
+        .expect("client should receive outbound envelope");
+    assert_eq!(received_by_client, outbound_envelope);
+
+    let inbound_envelope = heartbeat_envelope(22);
+    request_tx
+        .send(inbound_envelope.clone())
+        .await
+        .expect("send inbound envelope from worker");
+
+    let received_by_registry = timeout(Duration::from_secs(1), channels.from_worker.recv())
+        .await
+        .expect("registry receive timed out")
+        .expect("registry should receive forwarded envelope");
+    assert_eq!(received_by_registry, inbound_envelope);
+}
+
+#[tokio::test]
+async fn attach_rejects_missing_handshake() {
+    let registry = Arc::new(Registry::default());
+    let server = start_test_server(registry).await;
+
+    let mut client = connect_client(server.addr).await;
+    let (request_tx, request_rx) = mpsc::channel(1);
+    drop(request_tx);
+
+    let err = client
+        .attach(Request::new(ReceiverStream::new(request_rx)))
+        .await
+        .expect_err("empty stream must be rejected");
+
+    assert_eq!(err.code(), Code::InvalidArgument);
+    assert_eq!(err.message(), "missing worker handshake");
+}
+
+#[tokio::test]
+async fn attach_rejects_non_hello_first_message() {
+    let registry = Arc::new(Registry::default());
+    let server = start_test_server(registry).await;
+
+    let mut client = connect_client(server.addr).await;
+    let (request_tx, request_rx) = mpsc::channel(1);
+    request_tx
+        .send(heartbeat_envelope(1))
+        .await
+        .expect("queue non-hello handshake envelope");
+    drop(request_tx);
+
+    let err = client
+        .attach(Request::new(ReceiverStream::new(request_rx)))
+        .await
+        .expect_err("non-hello handshake must be rejected");
+
+    assert_eq!(err.code(), Code::FailedPrecondition);
+    assert_eq!(err.message(), "expected WorkerHello as first message");
+}
+
+#[tokio::test]
+async fn attach_rejects_unreserved_worker_id() {
+    let registry = Arc::new(Registry::default());
+    let server = start_test_server(registry).await;
+
+    let mut client = connect_client(server.addr).await;
+    let (request_tx, request_rx) = mpsc::channel(1);
+    request_tx
+        .send(worker_hello_envelope(42))
+        .await
+        .expect("queue handshake for unreserved worker");
+    drop(request_tx);
+
+    let err = client
+        .attach(Request::new(ReceiverStream::new(request_rx)))
+        .await
+        .expect_err("unreserved worker must be rejected");
+
+    assert_eq!(err.code(), Code::NotFound);
+    assert!(err.message().contains("not found"));
+}


### PR DESCRIPTION
Goes in after #370.

This PR adds the worker-bridge-service crate to fulfill the worker reservations and establish two-way communication to the connecting worker processes.

It operates similarly to how it is done at the `worker-remote` crate now, but is encapsulated and provides more explicit control flow management by the virtue of being implemented via `async-stream` vs doing `tokio::spawn`.