### PR TITLE
Bump rust to 1.95.0

### DIFF
--- a/crates/lib/dag-builder/src/expansion.rs
+++ b/crates/lib/dag-builder/src/expansion.rs
@@ -243,10 +243,8 @@ impl DAGConverter {
 
                     let fn_call_targets = if let Some(targets) = &fn_node.targets {
                         Some(targets.clone())
-                    } else if let Some(target) = &fn_node.target {
-                        Some(vec![target.clone()])
                     } else {
-                        None
+                        fn_node.target.clone().map(|target| vec![target])
                     };
 
                     if let Some(targets) = fn_call_targets {

--- a/crates/lib/runner-state/src/state.rs
+++ b/crates/lib/runner-state/src/state.rs
@@ -844,7 +844,7 @@ impl RunnerState {
                     return Err(RunnerStateError("tuple unpacking mismatch".to_string()));
                 }
                 let mut map = HashMap::new();
-                for (target, item) in targets.iter().zip(elements.into_iter()) {
+                for (target, item) in targets.iter().zip(elements) {
                     map.insert(target.clone(), item);
                 }
                 Ok(map)

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.93.1"
+channel = "1.95.0"
 components = ["rustfmt", "clippy"]
 profile = "minimal"


### PR DESCRIPTION
This PR bumps rust to new version: 1.95.0.

I want the new `cfg_select!` macro in one of my PRs.

https://blog.rust-lang.org/2026/04/16/Rust-1.95.0/