### PR TITLE
Add worker python crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5043,6 +5043,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "waymark-worker-python"
+version = "0.1.0"
+dependencies = [
+ "tokio",
+ "tracing",
+ "waymark-worker-process",
+ "waymark-worker-process-spec",
+ "waymark-worker-reservation",
+]
+
+[[package]]
 name = "waymark-worker-remote"
 version = "0.1.0"
 dependencies = [

--- a/crates/lib/worker-python/Cargo.toml
+++ b/crates/lib/worker-python/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "waymark-worker-python"
+edition = "2024"
+version.workspace = true
+publish.workspace = true
+
+[dependencies]
+waymark-worker-process = { workspace = true }
+waymark-worker-process-spec = { workspace = true }
+waymark-worker-reservation = { workspace = true }
+
+tokio = { workspace = true, features = ["process"] }
+tracing = { workspace = true }

--- a/crates/lib/worker-python/src/config.rs
+++ b/crates/lib/worker-python/src/config.rs
@@ -1,0 +1,133 @@
+use std::path::{Path, PathBuf};
+
+/// Configuration for spawning Python workers.
+#[derive(Clone, Debug)]
+pub struct Config {
+    /// Path to the script/executable to run (e.g., "uv" or "waymark-worker")
+    pub script_path: PathBuf,
+
+    /// Arguments to pass before the worker-specific args
+    pub script_args: Vec<String>,
+
+    /// Python module(s) to preload (contains @action definitions)
+    pub user_modules: Vec<String>,
+
+    /// Additional paths to add to PYTHONPATH
+    pub extra_python_paths: Vec<PathBuf>,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        let (script_path, script_args) = default_runner();
+        Self {
+            script_path,
+            script_args,
+            user_modules: vec![],
+            extra_python_paths: vec![],
+        }
+    }
+}
+
+impl Config {
+    /// Create a new config with default runner detection.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set the user module to preload.
+    pub fn with_user_module(mut self, module: &str) -> Self {
+        self.user_modules = vec![module.to_string()];
+        self
+    }
+
+    /// Set multiple user modules to preload.
+    pub fn with_user_modules(mut self, modules: Vec<String>) -> Self {
+        self.user_modules = modules;
+        self
+    }
+
+    /// Add extra paths to PYTHONPATH.
+    pub fn with_python_paths(mut self, paths: Vec<PathBuf>) -> Self {
+        self.extra_python_paths = paths;
+        self
+    }
+}
+
+/// Find the default Python runner.
+/// Prefers `waymark-worker` if in PATH, otherwise uses `uv run`.
+fn default_runner() -> (PathBuf, Vec<String>) {
+    if let Some(path) = find_executable("waymark-worker") {
+        return (path, Vec::new());
+    }
+    (
+        PathBuf::from("uv"),
+        vec![
+            "run".to_string(),
+            "python".to_string(),
+            "-m".to_string(),
+            "waymark.worker".to_string(),
+        ],
+    )
+}
+
+/// Search PATH for an executable.
+fn find_executable(bin: impl AsRef<Path>) -> Option<PathBuf> {
+    let path_var = std::env::var_os("PATH")?;
+    for dir in std::env::split_paths(&path_var) {
+        let candidate = dir.join(bin.as_ref());
+        // BUG: this is blocking disk io, we shouldn't block the runtime
+        // executor on this.
+        // BUG: this code doesn't allow symlinks/junctions.
+        // TODO: rewrite this to do it correctly
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+        #[cfg(windows)]
+        {
+            let exe_candidate = dir.join(bin.as_ref().with_added_extension("exe"));
+            if exe_candidate.is_file() {
+                return Some(exe_candidate);
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_config_builder() {
+        let config = Config::new()
+            .with_user_module("my_module")
+            .with_python_paths(vec![PathBuf::from("/extra/path")]);
+
+        assert_eq!(config.user_modules, vec!["my_module".to_string()]);
+        assert_eq!(
+            config.extra_python_paths,
+            vec![PathBuf::from("/extra/path")]
+        );
+    }
+
+    #[test]
+    fn test_config_with_multiple_modules() {
+        let config =
+            Config::new().with_user_modules(vec!["module1".to_string(), "module2".to_string()]);
+
+        assert_eq!(config.user_modules, vec!["module1", "module2"]);
+    }
+
+    #[test]
+    fn test_default_runner_detection() {
+        // Should return uv as fallback if waymark-worker not in PATH
+        let (path, args) = default_runner();
+        // Either waymark-worker was found, or we get uv with args
+        if args.is_empty() {
+            assert!(path.to_string_lossy().contains("waymark-worker"));
+        } else {
+            assert_eq!(path, PathBuf::from("uv"));
+            assert_eq!(args, vec!["run", "python", "-m", "waymark.worker"]);
+        }
+    }
+}

--- a/crates/lib/worker-python/src/lib.rs
+++ b/crates/lib/worker-python/src/lib.rs
@@ -1,0 +1,102 @@
+//! The Python worker process spec.
+
+#![warn(missing_docs)]
+
+use std::{path::PathBuf, time::Duration};
+
+mod config;
+
+pub use config::Config;
+
+/// Python worker process spec.
+// TODO: rewrite to fully cache effective values, like workdir, as constructor.
+pub struct Spec {
+    /// The address of the bridge server to connect the worker to.
+    pub bridge_server_addr: std::net::SocketAddr,
+
+    /// The worker config.
+    pub config: Config,
+}
+
+impl waymark_worker_process_spec::Spec for Spec {
+    fn prepare_spawn_params(
+        &self,
+        reservation_id: waymark_worker_reservation::Id,
+    ) -> waymark_worker_process::SpawnParams {
+        // Determine working directory and module paths
+        let package_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("python");
+        let working_dir = if package_root.is_dir() {
+            Some(package_root.clone())
+        } else {
+            None
+        };
+
+        // Build PYTHONPATH with all necessary directories
+        let mut module_paths = Vec::new();
+        if let Some(root) = working_dir.as_ref() {
+            module_paths.push(root.clone());
+            let src_dir = root.join("src");
+            if src_dir.exists() {
+                module_paths.push(src_dir);
+            }
+            let proto_dir = root.join("proto");
+            if proto_dir.exists() {
+                module_paths.push(proto_dir);
+            }
+        }
+        module_paths.extend(self.config.extra_python_paths.clone());
+
+        let joined_python_path = module_paths
+            .iter()
+            .map(|path| path.display().to_string())
+            .collect::<Vec<_>>()
+            .join(":");
+
+        let python_path = match std::env::var("PYTHONPATH") {
+            Ok(existing) if !existing.is_empty() => format!("{existing}:{joined_python_path}"),
+            _ => joined_python_path,
+        };
+
+        tracing::info!(python_path = %python_path, ?reservation_id, "configured python path for worker");
+
+        // Build the command
+        let mut command = tokio::process::Command::new(&self.config.script_path);
+        command.args(&self.config.script_args);
+        command
+            .arg("--bridge")
+            .arg(self.bridge_server_addr.to_string())
+            .arg("--worker-id")
+            .arg(reservation_id.to_string());
+
+        // Add user modules
+        for module in &self.config.user_modules {
+            command.arg("--user-module").arg(module);
+        }
+
+        command.env("PYTHONPATH", python_path);
+
+        if let Some(dir) = working_dir {
+            tracing::info!(?dir, "using package root for worker process");
+            command.current_dir(dir);
+        } else {
+            // TODO: move this fallible initialization outside of this impl.
+            let cwd = std::env::current_dir().expect("failed to resolve current directory");
+            tracing::info!(
+                ?cwd,
+                "package root missing, using current directory for worker process"
+            );
+            command.current_dir(cwd);
+        }
+
+        waymark_worker_process::SpawnParams {
+            command,
+            // TODO: move to config
+            wait_for_playload_timeout: Duration::from_secs(15),
+            shutdown_params: waymark_worker_process::ShutdownParams {
+                tasks_graceful_shutdown_timeout: Duration::from_secs(5),
+                process_graceful_shutdown_timeout: Duration::from_secs(5),
+                process_kill_timeout: Duration::from_secs(10),
+            },
+        }
+    }
+}


### PR DESCRIPTION
This is a small PR adding a python worker process spec; it builds on top of #374 and encapsulates the specifics of booting up the worker process implemented in python.

This code contents of this crate is left mostly as-is from the baseline implementation at the `waymark-worker-remote` on purpose; it will be refactored in the future, but the scope is confined and small enough for us to not bother with this now.