### PR TITLE
Add worker-remote-pool crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5097,6 +5097,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "waymark-worker-remote-pool"
+version = "0.1.0"
+dependencies = [
+ "metrics",
+ "nonempty-collections",
+ "prost 0.12.6",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "waymark-managed-process",
+ "waymark-message-conversions",
+ "waymark-proto",
+ "waymark-runner-executor-core",
+ "waymark-worker-core",
+ "waymark-worker-message-protocol",
+ "waymark-worker-metrics",
+ "waymark-worker-process-pool",
+ "waymark-worker-process-spec",
+ "waymark-worker-status-core",
+]
+
+[[package]]
 name = "waymark-worker-reservation"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,7 @@ waymark-worker-inline = { path = "crates/lib/worker-inline" }
 waymark-worker-message-protocol = { path = "crates/lib/worker-message-protocol" }
 waymark-worker-metrics = { path = "crates/lib/worker-metrics" }
 waymark-worker-process = { path = "crates/lib/worker-process" }
+waymark-worker-process-pool = { path = "crates/lib/worker-process-pool" }
 waymark-worker-process-spec = { path = "crates/lib/worker-process-spec" }
 waymark-worker-remote = { path = "crates/lib/worker-remote" }
 waymark-worker-reservation = { path = "crates/lib/worker-reservation" }

--- a/crates/lib/worker-remote-pool/Cargo.toml
+++ b/crates/lib/worker-remote-pool/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "waymark-worker-remote-pool"
+edition = "2024"
+version.workspace = true
+publish.workspace = true
+
+[dependencies]
+waymark-managed-process = { workspace = true }
+waymark-message-conversions = { workspace = true }
+waymark-proto = { workspace = true }
+waymark-runner-executor-core = { workspace = true }
+waymark-worker-core = { workspace = true }
+waymark-worker-message-protocol = { workspace = true }
+waymark-worker-metrics = { workspace = true }
+waymark-worker-process-pool = { workspace = true }
+waymark-worker-process-spec = { workspace = true }
+waymark-worker-status-core = { workspace = true }
+
+metrics = { workspace = true }
+nonempty-collections = { workspace = true }
+prost = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true, features = ["process"] }
+tracing = { workspace = true }

--- a/crates/lib/worker-remote-pool/src/lib.rs
+++ b/crates/lib/worker-remote-pool/src/lib.rs
@@ -1,0 +1,223 @@
+mod request;
+mod response;
+
+use std::{
+    sync::{
+        Arc, Mutex as StdMutex,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::Duration,
+};
+
+use nonempty_collections::NEVec;
+
+use tokio::sync::{Mutex, mpsc};
+
+use waymark_runner_executor_core::UncheckedExecutionResult;
+use waymark_worker_core::{ActionCompletion, ActionRequest, WorkerPoolError, error_to_value};
+
+async fn execute_remote_request<Spec>(
+    pool: &Arc<waymark_worker_process_pool::Pool<Spec>>,
+    request: ActionRequest,
+) -> ActionCompletion
+where
+    Spec: waymark_worker_process_spec::Spec,
+    Spec: Send + Sync + 'static,
+{
+    let executor_id = request.executor_id;
+    let execution_id = request.execution_id;
+    let attempt_number = request.attempt_number;
+    let dispatch_token = request.dispatch_token;
+
+    let dispatch = match request::to_dispatch_payload(request) {
+        Ok(dispatch) => dispatch,
+        Err(short_circuit) => return short_circuit,
+    };
+
+    let before = std::time::Instant::now();
+    let worker_idx = loop {
+        if let Some(idx) = pool.try_acquire_slot() {
+            break idx;
+        }
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    };
+    metrics::histogram!("waymark_worker_remote_execute_remote_request_worker_wait_seconds")
+        .record(before.elapsed());
+
+    let sender = pool.get_worker_sender(worker_idx).await;
+
+    let before = std::time::Instant::now();
+    let result = sender.send_action(dispatch).await;
+    metrics::histogram!("waymark_worker_remote_send_action_seconds").record(before.elapsed());
+
+    match result {
+        Ok(metrics) => {
+            pool.record_latency(metrics.ack_latency, metrics.worker_duration);
+            pool.record_completion(worker_idx, Arc::clone(pool));
+            ActionCompletion {
+                executor_id,
+                execution_id,
+                attempt_number,
+                dispatch_token,
+                result: UncheckedExecutionResult(response::decode_action_result(&metrics)),
+            }
+        }
+        Err(err) => {
+            pool.release_slot(worker_idx);
+            ActionCompletion {
+                executor_id,
+                execution_id,
+                attempt_number,
+                dispatch_token,
+                result: UncheckedExecutionResult(error_to_value(&WorkerPoolError::new(
+                    "RemoteWorkerPoolError",
+                    err.to_string(),
+                ))),
+            }
+        }
+    }
+}
+
+// This type's only purpose is to provide transport layer to the underlying
+// pool, however that poll should be itself capable of providing the said
+// transport.
+// TODO: move this into to `waymark-worker-message-protocol`; not done yet
+// since it requires substantial changes to the code layout of the integration
+// surfaces, and we want to keep things in place for review purposes.
+// Another downside is the process pool wrapping requires an `Arc`, which may
+// prevent proper shutdown - but without a real need for it (we only need
+// to give out a tiny communication handle under an `Arc` - but that's also for
+// later).
+pub struct RemoteWorkerPool<Spec> {
+    pool: Arc<waymark_worker_process_pool::Pool<Spec>>,
+    request_tx: mpsc::Sender<ActionRequest>,
+    request_rx: StdMutex<Option<mpsc::Receiver<ActionRequest>>>,
+    completion_tx: mpsc::Sender<ActionCompletion>,
+    completion_rx: Mutex<mpsc::Receiver<ActionCompletion>>,
+    launched: AtomicBool,
+}
+
+impl<Spec> RemoteWorkerPool<Spec> {
+    const DEFAULT_QUEUE_CAPACITY: usize = 1024;
+
+    pub fn new(pool: impl Into<Arc<waymark_worker_process_pool::Pool<Spec>>>) -> Self {
+        Self::with_capacity(
+            pool,
+            Self::DEFAULT_QUEUE_CAPACITY,
+            Self::DEFAULT_QUEUE_CAPACITY,
+        )
+    }
+
+    pub fn with_capacity(
+        pool: impl Into<Arc<waymark_worker_process_pool::Pool<Spec>>>,
+        request_capacity: usize,
+        completion_capacity: usize,
+    ) -> Self {
+        let (request_tx, request_rx) = mpsc::channel(request_capacity.max(1));
+        let (completion_tx, completion_rx) = mpsc::channel(completion_capacity.max(1));
+        Self {
+            pool: pool.into(),
+            request_tx,
+            request_rx: StdMutex::new(Some(request_rx)),
+            completion_tx,
+            completion_rx: Mutex::new(completion_rx),
+            launched: AtomicBool::new(false),
+        }
+    }
+
+    pub async fn shutdown_arc(
+        self: Arc<Self>,
+    ) -> Result<(), waymark_managed_process::ShutdownError> {
+        let Some(inner) = Arc::into_inner(self) else {
+            tracing::warn!(
+                "remote worker pool still referenced during shutdown; skipping shutdown"
+            );
+            return Ok(());
+        };
+        inner.shutdown().await
+    }
+
+    pub async fn shutdown(self) -> Result<(), waymark_managed_process::ShutdownError> {
+        self.pool.shutdown_arc().await
+    }
+}
+
+impl<Spec> waymark_worker_core::BaseWorkerPool for RemoteWorkerPool<Spec>
+where
+    Spec: waymark_worker_process_spec::Spec,
+    Spec: Send + Sync + 'static,
+{
+    async fn launch(&self) -> std::result::Result<(), waymark_worker_core::WorkerPoolError> {
+        if self.launched.swap(true, Ordering::SeqCst) {
+            return Ok(());
+        }
+
+        let request_rx = {
+            let mut guard = self.request_rx.lock().map_err(|_| {
+                WorkerPoolError::new("RemoteWorkerPoolError", "failed to lock request receiver")
+            })?;
+            guard.take()
+        };
+
+        let Some(mut request_rx) = request_rx else {
+            return Ok(());
+        };
+
+        let pool = Arc::clone(&self.pool);
+        let completion_tx = self.completion_tx.clone();
+
+        // Start a background loop to handle the `ActionRequest`s coming
+        // through the `request_rx`: serve each of them independently
+        // (each in their own background task) via `execute_remote_request`
+        // and, finally, send the completion over to the pool for polling.
+        tokio::spawn(async move {
+            while let Some(request) = request_rx.recv().await {
+                tokio::spawn({
+                    let completion_tx = completion_tx.clone();
+                    let pool = Arc::clone(&pool);
+                    async move {
+                        let before = std::time::Instant::now();
+
+                        let completion = execute_remote_request(&pool, request).await;
+
+                        metrics::histogram!("waymark_worker_remote_execute_remote_request_seconds")
+                            .record(before.elapsed());
+
+                        let _ = completion_tx.send(completion).await;
+                    }
+                });
+            }
+        });
+
+        Ok(())
+    }
+
+    fn queue(&self, request: ActionRequest) -> Result<(), WorkerPoolError> {
+        self.request_tx.try_send(request).map_err(|err| {
+            WorkerPoolError::new(
+                "RemoteWorkerPoolError",
+                format!("failed to enqueue action request: {err}"),
+            )
+        })
+    }
+
+    async fn poll_complete(&self) -> Option<NEVec<ActionCompletion>> {
+        let mut receiver = self.completion_rx.lock().await;
+
+        let first = receiver.recv().await?;
+
+        let mut completions = NEVec::new(first);
+
+        while let Ok(item) = receiver.try_recv() {
+            completions.push(item);
+        }
+
+        Some(completions)
+    }
+}
+
+impl<Spec> waymark_worker_status_core::WorkerPoolStats for RemoteWorkerPool<Spec> {
+    fn stats_snapshot(&self) -> waymark_worker_status_core::WorkerPoolStatsSnapshot {
+        self.pool.stats_snapshot()
+    }
+}

--- a/crates/lib/worker-remote-pool/src/request.rs
+++ b/crates/lib/worker-remote-pool/src/request.rs
@@ -1,0 +1,63 @@
+use std::collections::HashMap;
+
+use waymark_proto::messages as proto;
+use waymark_runner_executor_core::UncheckedExecutionResult;
+use waymark_worker_core::{ActionCompletion, ActionRequest, WorkerPoolError, error_to_value};
+use waymark_worker_message_protocol::ActionDispatchPayload;
+
+fn kwargs_to_workflow_arguments(
+    kwargs: &HashMap<String, serde_json::Value>,
+) -> proto::WorkflowArguments {
+    let mut arguments = Vec::with_capacity(kwargs.len());
+    for (key, value) in kwargs {
+        let arg_value = waymark_message_conversions::json_to_workflow_argument_value(value);
+        arguments.push(proto::WorkflowArgument {
+            key: key.clone(),
+            value: Some(arg_value),
+        });
+    }
+    proto::WorkflowArguments { arguments }
+}
+
+pub fn to_dispatch_payload(
+    request: ActionRequest,
+) -> Result<ActionDispatchPayload, ActionCompletion> {
+    let ActionRequest {
+        executor_id,
+        execution_id,
+        action_name,
+        module_name,
+        kwargs,
+        timeout_seconds,
+        attempt_number,
+        dispatch_token,
+    } = request;
+
+    let Some(module_name) = module_name else {
+        return Err(ActionCompletion {
+            executor_id,
+            execution_id,
+            attempt_number,
+            dispatch_token,
+            result: UncheckedExecutionResult(error_to_value(&WorkerPoolError::new(
+                "RemoteWorkerPoolError",
+                "missing module name for action request",
+            ))),
+        });
+    };
+
+    let dispatch = ActionDispatchPayload {
+        action_id: execution_id.to_string(),
+        instance_id: executor_id.to_string(),
+        sequence: 0,
+        action_name,
+        module_name,
+        kwargs: kwargs_to_workflow_arguments(&kwargs),
+        timeout_seconds,
+        max_retries: 0,
+        attempt_number,
+        dispatch_token,
+    };
+
+    Ok(dispatch)
+}

--- a/crates/lib/worker-remote-pool/src/response.rs
+++ b/crates/lib/worker-remote-pool/src/response.rs
@@ -1,0 +1,70 @@
+use prost::Message as _;
+use waymark_proto::messages as proto;
+use waymark_worker_core::{WorkerPoolError, error_to_value};
+
+fn ensure_error_fields(mut map: serde_json::Map<String, serde_json::Value>) -> serde_json::Value {
+    let error_type = map
+        .get("type")
+        .and_then(|value| value.as_str())
+        .unwrap_or("RemoteWorkerError")
+        .to_string();
+    let error_message = map
+        .get("message")
+        .and_then(|value| value.as_str())
+        .unwrap_or("remote worker error")
+        .to_string();
+    if !map.contains_key("type") {
+        map.insert("type".to_string(), serde_json::Value::String(error_type));
+    }
+    if !map.contains_key("message") {
+        map.insert(
+            "message".to_string(),
+            serde_json::Value::String(error_message),
+        );
+    }
+    serde_json::Value::Object(map)
+}
+
+fn normalize_error_value(error: serde_json::Value) -> serde_json::Value {
+    let serde_json::Value::Object(mut map) = error else {
+        return error;
+    };
+
+    if let Some(serde_json::Value::Object(exception)) = map.remove("__exception__") {
+        return ensure_error_fields(exception);
+    }
+
+    ensure_error_fields(map)
+}
+
+pub fn decode_action_result(
+    metrics: &waymark_worker_metrics::RoundTripMetrics,
+) -> serde_json::Value {
+    let payload = proto::WorkflowArguments::decode(metrics.response_payload.as_slice())
+        .map(waymark_message_conversions::workflow_arguments_to_json)
+        .unwrap_or(serde_json::Value::Null);
+
+    if metrics.success {
+        if let serde_json::Value::Object(mut map) = payload {
+            if let Some(result) = map.remove("result") {
+                return result;
+            }
+            return serde_json::Value::Object(map);
+        }
+        return payload;
+    }
+
+    if let serde_json::Value::Object(mut map) = payload {
+        if let Some(error) = map.remove("error") {
+            return normalize_error_value(error);
+        }
+        return serde_json::Value::Object(map);
+    }
+
+    let error_type = metrics.error_type.as_deref().unwrap_or("RemoteWorkerError");
+    let error_message = metrics
+        .error_message
+        .as_deref()
+        .unwrap_or("remote worker error");
+    error_to_value(&WorkerPoolError::new(error_type, error_message))
+}


### PR DESCRIPTION
Redo after #376 misclick (again).

Goes in after #375.

This PR adds the `worker-remote-pool` crate that wraps the `worker-process-pool` crate; this doesn't make much sense as it is tbh, and this implementation can, at the very least, just be inlined into the `worker-process-pool` - or reworked in even better and more modular way - but we're sticking with this approach for now to reduce the moving parts.

The general strategy at this point is to finalize the switch of the internals to the `waymark-worker-process` - and keep, for now, the logic in parts on top of it as-is.

Ultimately though, we should probably ave the following composable parts instead of this odd `worker-process-pool` / `worker-remote-pool` pair:
- `worker-pool-core` - a new abstract trait to capture the interface required for maintaining a pool of workers; the current `BaseWorkerPool` trait is something else, and should probably be renamed to something like `ActionExecutor` - where a possible implementation of it could be for a worker pool.
- `worker-process-pool` - a concrete implementation of the process pool that can maintain the workers and replace the missing ones, but with no extra fuss like roundtrip metrics or even sender maintenance
- `worker-pool-manager` - a generalized driver over any worker pool implementation that tracks and issues the worker recycling on `max_action_lifecycle`, allocates slots and keeps track of worker usage, and provides an implementation of that new `ActionExecutor` trait on top of any managed worker pool
- `measured-worker-pool` - a simple pool implementation that wraps another implementation and tracks and exposes the metrics for the worker pool - with granularity at the per-worker level
- `measured-action-executor` - a simple `ActionExecutor` implementation that wraps another implementation and tracks and exposes the metrics for the action executor (more high-level ones than the `measured-worker-pool` would be able to capture, but more portable, like would work in the VCR replay where we don't really have a pool of workers)