### PR TITLE
Add waymark_runner_register_node_graph_nodes_len metric

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4636,11 +4636,13 @@ name = "waymark-runner-state"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "metrics",
  "serde_json",
  "thiserror",
  "waymark-dag",
  "waymark-ids",
  "waymark-ir-conversions",
+ "waymark-metrics-util",
  "waymark-proto",
  "waymark-runner-execution-core",
  "waymark-runner-expr",

--- a/crates/lib/runner-state/Cargo.toml
+++ b/crates/lib/runner-state/Cargo.toml
@@ -8,11 +8,13 @@ edition = "2024"
 waymark-dag = { workspace = true }
 waymark-ids = { workspace = true }
 waymark-ir-conversions = { workspace = true }
+waymark-metrics-util = { workspace = true }
 waymark-proto = { workspace = true }
 waymark-runner-execution-core = { workspace = true }
 waymark-runner-expr = { workspace = true }
 
 chrono = { workspace = true, features = ["serde", "clock"] }
+metrics = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 

--- a/crates/lib/runner-state/src/state.rs
+++ b/crates/lib/runner-state/src/state.rs
@@ -451,6 +451,9 @@ impl RunnerState {
                 self.graph.nodes.len(),
             ));
         }
+        metrics::histogram!("waymark_runner_register_node_graph_nodes_len")
+            .record(waymark_metrics_util::Val(self.graph.nodes.len()));
+
         self.graph.nodes.insert(node.node_id, node.clone());
         self.ready_queue.push(node.node_id);
         if node.is_action_call() {


### PR DESCRIPTION
This is a new metric to make it easier to evaluate the `WAYMARK_UNSTABLE_MAX_RUNNER_STATE_NODES` to tune it so it effectively stops offending workloads without touching the well-behaved ones.