### PR TITLE
Increase grpc message limit

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -8,6 +8,7 @@ extend-exclude = [
   # Generated files
   "python/src/waymark/proto/**",
   "target/**",
+  "**/node_modules/**",
   # Proto generated Rust code
   "crates/lib/proto/src/*.rs",
 ]

--- a/crates/bin/bridge/src/main.rs
+++ b/crates/bin/bridge/src/main.rs
@@ -64,11 +64,13 @@ async fn main() -> Result<()> {
 
     info!(%grpc_addr, in_memory, "waymark bridge starting");
 
+    let workflow_service = proto::workflow_service_server::WorkflowServiceServer::new(service)
+        .max_decoding_message_size(waymark_proto::GRPC_MAX_MESSAGE_SIZE_BYTES)
+        .max_encoding_message_size(waymark_proto::GRPC_MAX_MESSAGE_SIZE_BYTES);
+
     tonic::transport::Server::builder()
         .add_service(health_service)
-        .add_service(proto::workflow_service_server::WorkflowServiceServer::new(
-            service,
-        ))
+        .add_service(workflow_service)
         .serve(grpc_addr)
         .await
         .context("bridge server exited")?;

--- a/crates/lib/proto/src/lib.rs
+++ b/crates/lib/proto/src/lib.rs
@@ -1,5 +1,8 @@
 //! Protocol buffer message types.
 
+/// Maximum gRPC message payload size for Waymark services.
+pub const GRPC_MAX_MESSAGE_SIZE_BYTES: usize = 25 * 1024 * 1024;
+
 /// Re-export [`prost_types`] for easier consumption.
 pub use prost_types;
 

--- a/crates/lib/worker-remote-bridge-bringup/src/lib.rs
+++ b/crates/lib/worker-remote-bridge-bringup/src/lib.rs
@@ -35,10 +35,12 @@ pub async fn start(
     let task = tokio::spawn(async move {
         let incoming = tokio_stream::wrappers::TcpListenerStream::new(listener);
 
+        let worker_bridge_service = proto::worker_bridge_server::WorkerBridgeServer::new(service)
+            .max_decoding_message_size(waymark_proto::GRPC_MAX_MESSAGE_SIZE_BYTES)
+            .max_encoding_message_size(waymark_proto::GRPC_MAX_MESSAGE_SIZE_BYTES);
+
         let result = Server::builder()
-            .add_service(proto::worker_bridge_server::WorkerBridgeServer::new(
-                service,
-            ))
+            .add_service(worker_bridge_service)
             .serve_with_incoming_shutdown(incoming, shutdown_token.cancelled())
             .await;
         if let Err(err) = result {

--- a/python/src/waymark/bridge.py
+++ b/python/src/waymark/bridge.py
@@ -19,6 +19,7 @@ from waymark.proto import messages_pb2 as pb2
 from waymark.proto import messages_pb2_grpc as pb2_grpc
 
 from .actions import serialize_error_payload, serialize_result_payload
+from .grpc_config import GRPC_CHANNEL_OPTIONS
 from .workflow_runtime import execute_action
 
 DEFAULT_HOST = "127.0.0.1"
@@ -250,7 +251,7 @@ async def _workflow_stub() -> pb2_grpc.WorkflowServiceStub:
             and not loop.is_closed()
         ):
             return _GRPC_STUB
-        channel = aio.insecure_channel(target)
+        channel = aio.insecure_channel(target, options=GRPC_CHANNEL_OPTIONS)
         stub = pb2_grpc.WorkflowServiceStub(channel)
         _GRPC_CHANNEL = channel
         _GRPC_STUB = stub

--- a/python/src/waymark/grpc_config.py
+++ b/python/src/waymark/grpc_config.py
@@ -1,0 +1,6 @@
+GRPC_MAX_MESSAGE_SIZE_BYTES = 25 * 1024 * 1024
+
+GRPC_CHANNEL_OPTIONS = (
+    ("grpc.max_send_message_length", GRPC_MAX_MESSAGE_SIZE_BYTES),
+    ("grpc.max_receive_message_length", GRPC_MAX_MESSAGE_SIZE_BYTES),
+)

--- a/python/src/waymark/worker.py
+++ b/python/src/waymark/worker.py
@@ -16,6 +16,7 @@ from waymark.proto import messages_pb2 as pb2
 from waymark.proto import messages_pb2_grpc as pb2_grpc
 
 from . import workflow_runtime
+from .grpc_config import GRPC_CHANNEL_OPTIONS
 from .logger import configure as configure_logger
 
 LOGGER = configure_logger("waymark.worker")
@@ -198,7 +199,7 @@ async def _run_worker(args: argparse.Namespace) -> None:
         LOGGER.info("Preloading user module %s", module_name)
         importlib.import_module(module_name)
 
-    async with aio.insecure_channel(args.bridge) as channel:
+    async with aio.insecure_channel(args.bridge, options=GRPC_CHANNEL_OPTIONS) as channel:
         stub = pb2_grpc.WorkerBridgeStub(channel)
         LOGGER.info("Worker %s connected to %s", args.worker_id, args.bridge)
         try:

--- a/python/tests/test_bridge.py
+++ b/python/tests/test_bridge.py
@@ -16,6 +16,7 @@ from waymark.bridge import (
     run_instances_batch,
     wait_for_instance,
 )
+from waymark.grpc_config import GRPC_CHANNEL_OPTIONS
 from waymark.proto import messages_pb2 as pb2
 
 
@@ -34,7 +35,8 @@ class TestWorkflowStub:
             async def channel_ready(self) -> None:
                 return None
 
-        def fake_insecure_channel(_target: str) -> FakeChannel:
+        def fake_insecure_channel(_target: str, *, options: object) -> FakeChannel:
+            assert options == GRPC_CHANNEL_OPTIONS
             channel = FakeChannel()
             created_channels.append(channel)
             return channel

--- a/python/tests/test_worker.py
+++ b/python/tests/test_worker.py
@@ -1,6 +1,8 @@
+import argparse
 import asyncio
 
 from waymark import worker
+from waymark.grpc_config import GRPC_CHANNEL_OPTIONS
 from waymark.proto import messages_pb2 as pb2
 
 
@@ -36,3 +38,38 @@ def test_send_ack_helper() -> None:
         assert ack.acked_delivery_id == 7
 
     asyncio.run(scenario())
+
+
+def test_run_worker_configures_grpc_message_limit(monkeypatch) -> None:
+    created_channels: list[tuple[str, object]] = []
+
+    class FakeChannel:
+        async def __aenter__(self) -> "FakeChannel":
+            return self
+
+        async def __aexit__(self, *_args: object) -> None:
+            return None
+
+    def fake_insecure_channel(target: str, *, options: object) -> FakeChannel:
+        created_channels.append((target, options))
+        return FakeChannel()
+
+    class FakeStub:
+        def __init__(self, channel: FakeChannel) -> None:
+            self.channel = channel
+
+    async def fake_handle_incoming_stream(
+        _stub: FakeStub,
+        _worker_id: int,
+        _outgoing: "asyncio.Queue[pb2.Envelope]",
+    ) -> None:
+        return None
+
+    monkeypatch.setattr(worker.aio, "insecure_channel", fake_insecure_channel)
+    monkeypatch.setattr(worker.pb2_grpc, "WorkerBridgeStub", FakeStub)
+    monkeypatch.setattr(worker, "_handle_incoming_stream", fake_handle_incoming_stream)
+
+    args = argparse.Namespace(bridge="127.0.0.1:24118", worker_id=7, user_module=[])
+    asyncio.run(worker._run_worker(args))
+
+    assert created_channels == [("127.0.0.1:24118", GRPC_CHANNEL_OPTIONS)]


### PR DESCRIPTION
By default grpc has a 4MB limit, this PR expands that to 25MB to have a bit more headroom to handle large JSON payloads. 4MB is on the smaller side of legitimate action payloads for complex workflows. This PR is still a draft as we decide whether postgres can even handle TOAST sizes this large or if we're better off just requiring users to keep their payload more compact.

We could also consider gzip/brotli encoding if we want to minimize the payload size that's stored.