### PR TITLE
Add vm-ast-old and ast-old parsing from proto

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4909,6 +4909,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "waymark-vm-ast-old"
+version = "0.1.0"
+
+[[package]]
+name = "waymark-vm-ast-old-proto"
+version = "0.1.0"
+dependencies = [
+ "thiserror",
+ "waymark-proto",
+ "waymark-vm-ast-old",
+]
+
+[[package]]
 name = "waymark-webapp-backend"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ waymark-timed-future = { path = "crates/lib/timed-future" }
 waymark-tokio-metrics-bringup = { path = "crates/lib/tokio-metrics-bringup" }
 waymark-utils-futures = { path = "crates/lib/utils-futures" }
 waymark-utils-tokio-channel = { path = "crates/lib/utils-tokio-channel" }
+waymark-vm-ast-old = { path = "crates/lib/vm-ast-old" }
 waymark-webapp-backend = { path = "crates/lib/webapp-backend" }
 waymark-webapp-bringup = { path = "crates/lib/webapp-bringup" }
 waymark-webapp-config = { path = "crates/lib/webapp-config" }

--- a/crates/lib/vm-ast-old-proto/Cargo.toml
+++ b/crates/lib/vm-ast-old-proto/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "waymark-vm-ast-old-proto"
+edition = "2024"
+version.workspace = true
+publish.workspace = true
+
+[dependencies]
+waymark-proto = { workspace = true }
+waymark-vm-ast-old = { workspace = true }
+
+thiserror = { workspace = true }

--- a/crates/lib/vm-ast-old-proto/src/lib.rs
+++ b/crates/lib/vm-ast-old-proto/src/lib.rs
@@ -1,0 +1,531 @@
+//! The conversions between the native old AST types and protobuf codegen.
+
+mod machinery;
+
+#[cfg(test)]
+mod tests;
+
+use waymark_proto::ast;
+use waymark_vm_ast_old::{self as vm_ast, Spanned};
+
+use machinery::*;
+
+pub use machinery::{ConvertError, convert};
+
+impl Convert<ast::Program> for Converter {
+    type To = vm_ast::Program;
+
+    fn convert(from: ast::Program) -> Result<Self::To> {
+        let functions = from
+            .functions
+            .into_iter()
+            .map(convert)
+            .collect::<Result<Vec<_>>>()?;
+        Ok(vm_ast::Program { functions })
+    }
+}
+
+impl Convert<ast::FunctionDef> for Converter {
+    type To = Spanned<vm_ast::FunctionDef>;
+
+    fn convert(from: ast::FunctionDef) -> Result<Self::To> {
+        let value = vm_ast::FunctionDef {
+            name: from.name,
+            io: convert_required(from.io, "FunctionDef.io")?,
+            body: convert_required(from.body, "FunctionDef.body")?,
+        };
+        spanned(value, from.span)
+    }
+}
+
+impl Convert<ast::IoDecl> for Converter {
+    type To = Spanned<vm_ast::IoDecl>;
+
+    fn convert(from: ast::IoDecl) -> Result<Self::To> {
+        let value = vm_ast::IoDecl {
+            inputs: from.inputs,
+            outputs: from.outputs,
+        };
+        spanned(value, from.span)
+    }
+}
+
+impl Convert<ast::Block> for Converter {
+    type To = Spanned<vm_ast::Block>;
+
+    fn convert(from: ast::Block) -> Result<Self::To> {
+        let statements = from
+            .statements
+            .into_iter()
+            .map(convert)
+            .collect::<Result<Vec<_>>>()?;
+        let value = vm_ast::Block { statements };
+        spanned(value, from.span)
+    }
+}
+
+impl Convert<ast::Statement> for Converter {
+    type To = Spanned<vm_ast::Statement>;
+
+    fn convert(from: ast::Statement) -> Result<Self::To> {
+        let value = match required(from.kind, "Statement.kind")? {
+            ast::statement::Kind::Assignment(assign) => vm_ast::Statement::Assignment {
+                targets: assign.targets,
+                value: convert_required(assign.value, "Assignment.value")?,
+            },
+            ast::statement::Kind::ActionCall(call) => vm_ast::Statement::ActionCall {
+                call: convert(call)?,
+            },
+            ast::statement::Kind::SpreadAction(spread) => {
+                let spread: ast::SpreadAction = spread.into_owned();
+                vm_ast::Statement::SpreadAction {
+                    collection: convert_required(spread.collection, "SpreadAction.collection")?,
+                    loop_var: spread.loop_var,
+                    action: convert_required(spread.action, "SpreadAction.action")?,
+                }
+            }
+            ast::statement::Kind::ParallelBlock(parallel) => {
+                let parallel: ast::ParallelBlock = parallel.into_owned();
+                let calls = parallel
+                    .calls
+                    .into_iter()
+                    .map(convert)
+                    .collect::<Result<Vec<_>>>()?;
+                vm_ast::Statement::ParallelBlock { calls }
+            }
+            ast::statement::Kind::ForLoop(loop_stmt) => {
+                let loop_stmt: ast::ForLoop = loop_stmt.into_owned();
+                vm_ast::Statement::ForLoop {
+                    loop_vars: loop_stmt.loop_vars,
+                    iterable: convert_required(loop_stmt.iterable, "ForLoop.iterable")?,
+                    body: convert_required(loop_stmt.block_body, "ForLoop.block_body")?,
+                }
+            }
+            ast::statement::Kind::Conditional(conditional) => {
+                let conditional: ast::Conditional = conditional.into_owned();
+                let elif_branches = conditional
+                    .elif_branches
+                    .into_iter()
+                    .map(convert)
+                    .collect::<Result<Vec<_>>>()?;
+                vm_ast::Statement::Conditional {
+                    if_branch: convert_required(conditional.if_branch, "Conditional.if_branch")?,
+                    elif_branches,
+                    else_branch: convert_optional_owned::<ast::ElseBranch, _>(
+                        conditional.else_branch,
+                    )?,
+                }
+            }
+            ast::statement::Kind::TryExcept(try_except) => {
+                let try_except: ast::TryExcept = try_except.into_owned();
+                let handlers = try_except
+                    .handlers
+                    .into_iter()
+                    .map(convert)
+                    .collect::<Result<Vec<_>>>()?;
+                vm_ast::Statement::TryExcept {
+                    handlers,
+                    try_block: convert_required(try_except.try_block, "TryExcept.try_block")?,
+                }
+            }
+            ast::statement::Kind::ReturnStmt(ret) => vm_ast::Statement::Return {
+                value: convert_optional_owned(ret.value)?,
+            },
+            ast::statement::Kind::ExprStmt(expr_stmt) => vm_ast::Statement::ExprStmt {
+                expr: convert_required(expr_stmt.expr, "ExprStmt.expr")?,
+            },
+            ast::statement::Kind::BreakStmt(_) => vm_ast::Statement::Break,
+            ast::statement::Kind::ContinueStmt(_) => vm_ast::Statement::Continue,
+            ast::statement::Kind::WhileLoop(loop_stmt) => {
+                let loop_stmt: ast::WhileLoop = loop_stmt.into_owned();
+                vm_ast::Statement::WhileLoop {
+                    condition: convert_required(loop_stmt.condition, "WhileLoop.condition")?,
+                    body: convert_required(loop_stmt.block_body, "WhileLoop.block_body")?,
+                }
+            }
+            ast::statement::Kind::SleepStmt(sleep_stmt) => vm_ast::Statement::Sleep {
+                duration: convert_optional_owned(sleep_stmt.duration)?,
+            },
+        };
+
+        spanned(value, from.span)
+    }
+}
+
+impl Convert<ast::Expr> for Converter {
+    type To = Spanned<vm_ast::Expr>;
+
+    fn convert(from: ast::Expr) -> Result<Self::To> {
+        let value = match required(from.kind, "Expr.kind")? {
+            ast::expr::Kind::Literal(literal) => vm_ast::Expr::Literal {
+                value: convert(literal)?,
+            },
+            ast::expr::Kind::Variable(variable) => vm_ast::Expr::Variable {
+                name: variable.name,
+            },
+            ast::expr::Kind::BinaryOp(binary) => {
+                let binary: ast::BinaryOp = binary.into_owned();
+                vm_ast::Expr::BinaryOp {
+                    left: Box::new(convert_required_owned::<ast::Expr, _>(
+                        binary.left,
+                        "BinaryOp.left",
+                    )?),
+                    op: convert_binary_operator(binary.op)?,
+                    right: Box::new(convert_required_owned::<ast::Expr, _>(
+                        binary.right,
+                        "BinaryOp.right",
+                    )?),
+                }
+            }
+            ast::expr::Kind::UnaryOp(unary) => {
+                let unary: ast::UnaryOp = unary.into_owned();
+                vm_ast::Expr::UnaryOp {
+                    op: convert_unary_operator(unary.op)?,
+                    operand: Box::new(convert_required_owned::<ast::Expr, _>(
+                        unary.operand,
+                        "UnaryOp.operand",
+                    )?),
+                }
+            }
+            ast::expr::Kind::List(list) => vm_ast::Expr::List {
+                elements: list
+                    .elements
+                    .into_iter()
+                    .map(convert)
+                    .collect::<Result<Vec<_>>>()?,
+            },
+            ast::expr::Kind::Dict(dict) => vm_ast::Expr::Dict {
+                entries: dict
+                    .entries
+                    .into_iter()
+                    .map(convert)
+                    .collect::<Result<Vec<_>>>()?,
+            },
+            ast::expr::Kind::Index(index) => {
+                let index: ast::IndexAccess = index.into_owned();
+                vm_ast::Expr::Index {
+                    object: Box::new(convert_required_owned::<ast::Expr, _>(
+                        index.object,
+                        "IndexAccess.object",
+                    )?),
+                    index: Box::new(convert_required_owned::<ast::Expr, _>(
+                        index.index,
+                        "IndexAccess.index",
+                    )?),
+                }
+            }
+            ast::expr::Kind::Dot(dot) => {
+                let dot: ast::DotAccess = dot.into_owned();
+                vm_ast::Expr::Dot {
+                    object: Box::new(convert_required_owned::<ast::Expr, _>(
+                        dot.object,
+                        "DotAccess.object",
+                    )?),
+                    attribute: dot.attribute,
+                }
+            }
+            ast::expr::Kind::FunctionCall(call) => vm_ast::Expr::FunctionCall {
+                call: convert(call)?,
+            },
+            ast::expr::Kind::ActionCall(call) => vm_ast::Expr::ActionCall {
+                call: convert(call)?,
+            },
+            ast::expr::Kind::ParallelExpr(parallel) => {
+                let parallel: ast::ParallelExpr = parallel.into_owned();
+                vm_ast::Expr::ParallelExpr {
+                    calls: parallel
+                        .calls
+                        .into_iter()
+                        .map(convert)
+                        .collect::<Result<Vec<_>>>()?,
+                }
+            }
+            ast::expr::Kind::SpreadExpr(spread) => {
+                let spread: ast::SpreadExpr = spread.into_owned();
+                vm_ast::Expr::SpreadExpr {
+                    collection: Box::new(convert_required_owned::<ast::Expr, _>(
+                        spread.collection,
+                        "SpreadExpr.collection",
+                    )?),
+                    loop_var: spread.loop_var,
+                    action: convert_required(spread.action, "SpreadExpr.action")?,
+                }
+            }
+        };
+
+        spanned(value, from.span)
+    }
+}
+
+impl Convert<ast::Literal> for Converter {
+    type To = vm_ast::Literal;
+
+    fn convert(from: ast::Literal) -> Result<Self::To> {
+        let literal = match required(from.value, "Literal.value")? {
+            ast::literal::Value::IntValue(value) => vm_ast::Literal::Int(value),
+            ast::literal::Value::FloatValue(value) => vm_ast::Literal::Float(value),
+            ast::literal::Value::StringValue(value) => vm_ast::Literal::String(value),
+            ast::literal::Value::BoolValue(value) => vm_ast::Literal::Bool(value),
+            ast::literal::Value::IsNone(_) => vm_ast::Literal::None,
+        };
+        Ok(literal)
+    }
+}
+
+impl Convert<ast::DictEntry> for Converter {
+    type To = vm_ast::DictEntry;
+
+    fn convert(from: ast::DictEntry) -> Result<Self::To> {
+        Ok(vm_ast::DictEntry {
+            key: convert_required(from.key, "DictEntry.key")?,
+            value: convert_required(from.value, "DictEntry.value")?,
+        })
+    }
+}
+
+impl Convert<ast::ActionCall> for Converter {
+    type To = vm_ast::ActionCall;
+
+    fn convert(from: ast::ActionCall) -> Result<Self::To> {
+        let kwargs = from
+            .kwargs
+            .into_iter()
+            .map(convert)
+            .collect::<Result<Vec<_>>>()?;
+        let policies = from
+            .policies
+            .into_iter()
+            .map(convert)
+            .collect::<Result<Vec<_>>>()?;
+
+        Ok(vm_ast::ActionCall {
+            action_name: from.action_name,
+            kwargs,
+            policies,
+            module_name: from.module_name,
+        })
+    }
+}
+
+impl Convert<ast::Call> for Converter {
+    type To = vm_ast::Call;
+
+    fn convert(from: ast::Call) -> Result<Self::To> {
+        let call = match required(from.kind, "Call.kind")? {
+            ast::call::Kind::Action(action) => vm_ast::Call::Action(convert(action)?),
+            ast::call::Kind::Function(function) => vm_ast::Call::Function(convert(function)?),
+        };
+        Ok(call)
+    }
+}
+
+impl Convert<ast::FunctionCall> for Converter {
+    type To = vm_ast::FunctionCall;
+
+    fn convert(from: ast::FunctionCall) -> Result<Self::To> {
+        let args = from
+            .args
+            .into_iter()
+            .map(convert)
+            .collect::<Result<Vec<_>>>()?;
+        let kwargs = from
+            .kwargs
+            .into_iter()
+            .map(convert)
+            .collect::<Result<Vec<_>>>()?;
+
+        Ok(vm_ast::FunctionCall {
+            name: from.name,
+            args,
+            kwargs,
+            global_function: convert_global_function(from.global_function)?,
+        })
+    }
+}
+
+impl Convert<ast::Kwarg> for Converter {
+    type To = vm_ast::Kwarg;
+
+    fn convert(from: ast::Kwarg) -> Result<Self::To> {
+        Ok(vm_ast::Kwarg {
+            name: from.name,
+            value: convert_required(from.value, "Kwarg.value")?,
+        })
+    }
+}
+
+impl Convert<ast::IfBranch> for Converter {
+    type To = Spanned<vm_ast::IfBranch>;
+
+    fn convert(from: ast::IfBranch) -> Result<Self::To> {
+        let value = vm_ast::IfBranch {
+            condition: convert_required(from.condition, "IfBranch.condition")?,
+            body: convert_required(from.block_body, "IfBranch.block_body")?,
+        };
+        spanned(value, from.span)
+    }
+}
+
+impl Convert<ast::ElifBranch> for Converter {
+    type To = Spanned<vm_ast::ElifBranch>;
+
+    fn convert(from: ast::ElifBranch) -> Result<Self::To> {
+        let value = vm_ast::ElifBranch {
+            condition: convert_required(from.condition, "ElifBranch.condition")?,
+            body: convert_required(from.block_body, "ElifBranch.block_body")?,
+        };
+        spanned(value, from.span)
+    }
+}
+
+impl Convert<ast::ElseBranch> for Converter {
+    type To = Spanned<vm_ast::ElseBranch>;
+
+    fn convert(from: ast::ElseBranch) -> Result<Self::To> {
+        let value = vm_ast::ElseBranch {
+            body: convert_required(from.block_body, "ElseBranch.block_body")?,
+        };
+        spanned(value, from.span)
+    }
+}
+
+impl Convert<ast::ExceptHandler> for Converter {
+    type To = Spanned<vm_ast::ExceptHandler>;
+
+    fn convert(from: ast::ExceptHandler) -> Result<Self::To> {
+        let value = vm_ast::ExceptHandler {
+            exception_types: from.exception_types,
+            exception_var: from.exception_var,
+            body: convert_required(from.block_body, "ExceptHandler.block_body")?,
+        };
+        spanned(value, from.span)
+    }
+}
+
+impl Convert<ast::PolicyBracket> for Converter {
+    type To = vm_ast::PolicyBracket;
+
+    fn convert(from: ast::PolicyBracket) -> Result<Self::To> {
+        let policy = match required(from.kind, "PolicyBracket.kind")? {
+            ast::policy_bracket::Kind::Retry(retry) => {
+                vm_ast::PolicyBracket::Retry(convert(retry)?)
+            }
+            ast::policy_bracket::Kind::Timeout(timeout) => {
+                vm_ast::PolicyBracket::Timeout(convert(timeout)?)
+            }
+        };
+        Ok(policy)
+    }
+}
+
+impl Convert<ast::RetryPolicy> for Converter {
+    type To = vm_ast::RetryPolicy;
+
+    fn convert(from: ast::RetryPolicy) -> Result<Self::To> {
+        Ok(vm_ast::RetryPolicy {
+            exception_types: from.exception_types,
+            max_retries: from.max_retries,
+            backoff: from.backoff.map(convert).transpose()?,
+        })
+    }
+}
+
+impl Convert<ast::TimeoutPolicy> for Converter {
+    type To = vm_ast::TimeoutPolicy;
+
+    fn convert(from: ast::TimeoutPolicy) -> Result<Self::To> {
+        Ok(vm_ast::TimeoutPolicy {
+            timeout: convert_required(from.timeout, "TimeoutPolicy.timeout")?,
+        })
+    }
+}
+
+impl Convert<ast::Duration> for Converter {
+    type To = vm_ast::DurationLiteral;
+
+    fn convert(from: ast::Duration) -> Result<Self::To> {
+        Ok(vm_ast::DurationLiteral {
+            seconds: from.seconds,
+        })
+    }
+}
+
+impl Convert<ast::Span> for Converter {
+    type To = vm_ast::Span;
+
+    fn convert(from: ast::Span) -> Result<Self::To> {
+        Ok(vm_ast::Span {
+            start_line: from.start_line,
+            start_col: from.start_col,
+            end_line: from.end_line,
+            end_col: from.end_col,
+        })
+    }
+}
+
+impl Convert<ast::BinaryOperator> for Converter {
+    type To = vm_ast::BinaryOperator;
+
+    fn convert(from: ast::BinaryOperator) -> Result<Self::To> {
+        let operator = match from {
+            ast::BinaryOperator::BinaryOpUnspecified => {
+                return Err(ConvertError::UnspecifiedEnumValue {
+                    enum_name: "BinaryOperator",
+                });
+            }
+            ast::BinaryOperator::BinaryOpAdd => vm_ast::BinaryOperator::Add,
+            ast::BinaryOperator::BinaryOpSub => vm_ast::BinaryOperator::Sub,
+            ast::BinaryOperator::BinaryOpMul => vm_ast::BinaryOperator::Mul,
+            ast::BinaryOperator::BinaryOpDiv => vm_ast::BinaryOperator::Div,
+            ast::BinaryOperator::BinaryOpFloorDiv => vm_ast::BinaryOperator::FloorDiv,
+            ast::BinaryOperator::BinaryOpMod => vm_ast::BinaryOperator::Mod,
+            ast::BinaryOperator::BinaryOpEq => vm_ast::BinaryOperator::Eq,
+            ast::BinaryOperator::BinaryOpNe => vm_ast::BinaryOperator::Ne,
+            ast::BinaryOperator::BinaryOpLt => vm_ast::BinaryOperator::Lt,
+            ast::BinaryOperator::BinaryOpLe => vm_ast::BinaryOperator::Le,
+            ast::BinaryOperator::BinaryOpGt => vm_ast::BinaryOperator::Gt,
+            ast::BinaryOperator::BinaryOpGe => vm_ast::BinaryOperator::Ge,
+            ast::BinaryOperator::BinaryOpIn => vm_ast::BinaryOperator::In,
+            ast::BinaryOperator::BinaryOpNotIn => vm_ast::BinaryOperator::NotIn,
+            ast::BinaryOperator::BinaryOpAnd => vm_ast::BinaryOperator::And,
+            ast::BinaryOperator::BinaryOpOr => vm_ast::BinaryOperator::Or,
+        };
+        Ok(operator)
+    }
+}
+
+impl Convert<ast::UnaryOperator> for Converter {
+    type To = vm_ast::UnaryOperator;
+
+    fn convert(from: ast::UnaryOperator) -> Result<Self::To> {
+        let operator = match from {
+            ast::UnaryOperator::UnaryOpUnspecified => {
+                return Err(ConvertError::UnspecifiedEnumValue {
+                    enum_name: "UnaryOperator",
+                });
+            }
+            ast::UnaryOperator::UnaryOpNeg => vm_ast::UnaryOperator::Neg,
+            ast::UnaryOperator::UnaryOpNot => vm_ast::UnaryOperator::Not,
+        };
+        Ok(operator)
+    }
+}
+
+impl Convert<ast::GlobalFunction> for Converter {
+    type To = vm_ast::GlobalFunction;
+
+    fn convert(from: ast::GlobalFunction) -> Result<Self::To> {
+        let function = match from {
+            ast::GlobalFunction::Unspecified => {
+                return Err(ConvertError::UnspecifiedEnumValue {
+                    enum_name: "GlobalFunction",
+                });
+            }
+            ast::GlobalFunction::Range => vm_ast::GlobalFunction::Range,
+            ast::GlobalFunction::Len => vm_ast::GlobalFunction::Len,
+            ast::GlobalFunction::Enumerate => vm_ast::GlobalFunction::Enumerate,
+            ast::GlobalFunction::Isexception => vm_ast::GlobalFunction::IsException,
+        };
+        Ok(function)
+    }
+}

--- a/crates/lib/vm-ast-old-proto/src/machinery.rs
+++ b/crates/lib/vm-ast-old-proto/src/machinery.rs
@@ -1,0 +1,126 @@
+use waymark_proto::ast;
+use waymark_vm_ast_old::{self as vm_ast, Spanned};
+
+pub type Result<T> = std::result::Result<T, ConvertError>;
+
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum ConvertError {
+    #[error("waymark_proto::ast missing required field `{field}`")]
+    MissingField { field: &'static str },
+    #[error("waymark_proto::ast contains invalid value `{value}` for enum `{enum_name}`")]
+    InvalidEnumValue { enum_name: &'static str, value: i32 },
+    #[error("waymark_proto::ast contains unspecified value for required enum `{enum_name}`")]
+    UnspecifiedEnumValue { enum_name: &'static str },
+}
+
+pub trait Convert<From> {
+    type To;
+
+    fn convert(from: From) -> Result<Self::To>;
+}
+
+pub enum Converter {}
+
+pub trait IntoOwned<T> {
+    fn into_owned(self) -> T;
+}
+
+impl<T> IntoOwned<T> for T {
+    fn into_owned(self) -> T {
+        self
+    }
+}
+
+impl<T> IntoOwned<T> for Box<T> {
+    fn into_owned(self) -> T {
+        *self
+    }
+}
+
+pub fn convert<T>(from: T) -> Result<<Converter as Convert<T>>::To>
+where
+    Converter: Convert<T>,
+{
+    <Converter as Convert<T>>::convert(from)
+}
+
+pub fn required<T>(value: Option<T>, context: &'static str) -> Result<T> {
+    value.ok_or(ConvertError::MissingField { field: context })
+}
+
+pub fn required_owned<T, U>(value: Option<U>, context: &'static str) -> Result<T>
+where
+    U: IntoOwned<T>,
+{
+    Ok(required(value, context)?.into_owned())
+}
+
+pub fn convert_required<T>(
+    value: Option<T>,
+    context: &'static str,
+) -> Result<<Converter as Convert<T>>::To>
+where
+    Converter: Convert<T>,
+{
+    convert(required(value, context)?)
+}
+
+pub fn convert_required_owned<T, U>(
+    value: Option<U>,
+    context: &'static str,
+) -> Result<<Converter as Convert<T>>::To>
+where
+    U: IntoOwned<T>,
+    Converter: Convert<T>,
+{
+    convert(required_owned(value, context)?)
+}
+
+pub fn convert_optional_owned<T, U>(
+    value: Option<U>,
+) -> Result<Option<<Converter as Convert<T>>::To>>
+where
+    U: IntoOwned<T>,
+    Converter: Convert<T>,
+{
+    value.map(|value| convert(value.into_owned())).transpose()
+}
+
+pub fn default_span() -> vm_ast::Span {
+    vm_ast::Span {
+        start_line: 0,
+        start_col: 0,
+        end_line: 0,
+        end_col: 0,
+    }
+}
+
+pub fn spanned<T>(value: T, span: Option<ast::Span>) -> Result<Spanned<T>> {
+    let span = span.map(convert).transpose()?.unwrap_or_else(default_span);
+    Ok(Spanned { value, span })
+}
+
+pub fn parse_enum<E>(value: i32, context: &'static str) -> Result<E>
+where
+    E: TryFrom<i32>,
+{
+    E::try_from(value).map_err(|_| ConvertError::InvalidEnumValue {
+        enum_name: context,
+        value,
+    })
+}
+
+pub fn convert_binary_operator(value: i32) -> Result<vm_ast::BinaryOperator> {
+    convert(parse_enum::<ast::BinaryOperator>(value, "BinaryOperator")?)
+}
+
+pub fn convert_unary_operator(value: i32) -> Result<vm_ast::UnaryOperator> {
+    convert(parse_enum::<ast::UnaryOperator>(value, "UnaryOperator")?)
+}
+
+pub fn convert_global_function(value: i32) -> Result<Option<vm_ast::GlobalFunction>> {
+    match parse_enum::<ast::GlobalFunction>(value, "GlobalFunction")? {
+        ast::GlobalFunction::Unspecified => Ok(None),
+        global_function => Ok(Some(convert(global_function)?)),
+    }
+}

--- a/crates/lib/vm-ast-old-proto/src/tests.rs
+++ b/crates/lib/vm-ast-old-proto/src/tests.rs
@@ -1,0 +1,158 @@
+use super::*;
+
+fn span(line: u32) -> Option<ast::Span> {
+    Some(ast::Span {
+        start_line: line,
+        start_col: 1,
+        end_line: line,
+        end_col: 10,
+    })
+}
+
+fn int_expr(value: i64, line: u32) -> ast::Expr {
+    ast::Expr {
+        kind: Some(ast::expr::Kind::Literal(ast::Literal {
+            value: Some(ast::literal::Value::IntValue(value)),
+        })),
+        span: span(line),
+    }
+}
+
+#[test]
+fn converts_program_happy_path() {
+    let program = ast::Program {
+        functions: vec![ast::FunctionDef {
+            name: "main".to_string(),
+            io: Some(ast::IoDecl {
+                inputs: vec!["input".to_string()],
+                outputs: vec!["output".to_string()],
+                span: span(2),
+            }),
+            body: Some(ast::Block {
+                statements: vec![ast::Statement {
+                    kind: Some(ast::statement::Kind::ReturnStmt(ast::ReturnStmt {
+                        value: Some(int_expr(7, 4)),
+                    })),
+                    span: span(3),
+                }],
+                span: span(2),
+            }),
+            span: span(1),
+        }],
+    };
+
+    let converted = convert(program).expect("program conversion should succeed");
+    let function = &converted.functions[0];
+
+    assert_eq!(function.span.start_line, 1);
+    assert_eq!(function.value.name, "main");
+    assert_eq!(function.value.io.span.start_line, 2);
+    assert_eq!(function.value.body.span.start_line, 2);
+
+    let statement = &function.value.body.value.statements[0];
+    assert_eq!(statement.span.start_line, 3);
+
+    match &statement.value {
+        vm_ast::Statement::Return { value: Some(expr) } => {
+            assert_eq!(expr.span.start_line, 4);
+            match &expr.value {
+                vm_ast::Expr::Literal {
+                    value: vm_ast::Literal::Int(value),
+                } => assert_eq!(*value, 7),
+                other => panic!("unexpected expression: {other:?}"),
+            }
+        }
+        other => panic!("unexpected statement: {other:?}"),
+    }
+}
+
+#[test]
+fn defaults_missing_span_and_unspecified_global_function() {
+    let expr = ast::Expr {
+        kind: Some(ast::expr::Kind::FunctionCall(ast::FunctionCall {
+            name: "range".to_string(),
+            args: Vec::new(),
+            kwargs: Vec::new(),
+            global_function: ast::GlobalFunction::Unspecified as i32,
+        })),
+        span: None,
+    };
+
+    let converted = convert(expr).expect("function call conversion should succeed");
+
+    assert_eq!(converted.span, default_span());
+
+    match converted.value {
+        vm_ast::Expr::FunctionCall { call } => {
+            assert_eq!(call.name, "range");
+            assert!(call.global_function.is_none());
+        }
+        other => panic!("unexpected expression: {other:?}"),
+    }
+}
+
+#[test]
+fn returns_missing_field_error() {
+    let function = ast::FunctionDef {
+        name: "main".to_string(),
+        io: None,
+        body: Some(ast::Block {
+            statements: Vec::new(),
+            span: None,
+        }),
+        span: None,
+    };
+
+    let error = convert(function).expect_err("missing io should fail conversion");
+
+    assert_eq!(
+        error,
+        ConvertError::MissingField {
+            field: "FunctionDef.io"
+        }
+    );
+}
+
+#[test]
+fn returns_invalid_enum_error() {
+    let expr = ast::Expr {
+        kind: Some(ast::expr::Kind::FunctionCall(ast::FunctionCall {
+            name: "bad".to_string(),
+            args: Vec::new(),
+            kwargs: Vec::new(),
+            global_function: 99,
+        })),
+        span: None,
+    };
+
+    let error = convert(expr).expect_err("invalid global function should fail conversion");
+
+    assert_eq!(
+        error,
+        ConvertError::InvalidEnumValue {
+            enum_name: "GlobalFunction",
+            value: 99,
+        }
+    );
+}
+
+#[test]
+fn returns_unspecified_required_enum_error() {
+    let expr = ast::Expr {
+        kind: Some(ast::expr::Kind::BinaryOp(Box::new(ast::BinaryOp {
+            left: Some(Box::new(int_expr(1, 1))),
+            op: ast::BinaryOperator::BinaryOpUnspecified as i32,
+            right: Some(Box::new(int_expr(2, 1))),
+        }))),
+        span: span(1),
+    };
+
+    let error = convert(expr).expect_err("unspecified binary operator should fail conversion");
+
+    assert_eq!(
+        error,
+        ConvertError::UnspecifiedEnumValue {
+            enum_name: "BinaryOperator",
+        }
+    );
+}

--- a/crates/lib/vm-ast-old/Cargo.toml
+++ b/crates/lib/vm-ast-old/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "waymark-vm-ast-old"
+edition = "2024"
+version.workspace = true
+publish.workspace = true
+
+[dependencies]

--- a/crates/lib/vm-ast-old/src/lib.rs
+++ b/crates/lib/vm-ast-old/src/lib.rs
@@ -1,0 +1,257 @@
+//! The old ast from the DAG-based runner.
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Program {
+    pub functions: Vec<Spanned<FunctionDef>>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct FunctionDef {
+    pub name: String,
+    pub io: Spanned<IoDecl>,
+    pub body: Spanned<Block>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct IoDecl {
+    pub inputs: Vec<String>,
+    pub outputs: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Block {
+    pub statements: Vec<Spanned<Statement>>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Statement {
+    Assignment {
+        targets: Vec<String>,
+        value: Spanned<Expr>,
+    },
+    ActionCall {
+        call: ActionCall,
+    },
+    SpreadAction {
+        collection: Spanned<Expr>,
+        loop_var: String,
+        action: ActionCall,
+    },
+    ParallelBlock {
+        calls: Vec<Call>,
+    },
+    ForLoop {
+        loop_vars: Vec<String>,
+        iterable: Spanned<Expr>,
+        body: Spanned<Block>,
+    },
+    WhileLoop {
+        condition: Spanned<Expr>,
+        body: Spanned<Block>,
+    },
+    Conditional {
+        if_branch: Spanned<IfBranch>,
+        elif_branches: Vec<Spanned<ElifBranch>>,
+        else_branch: Option<Spanned<ElseBranch>>,
+    },
+    TryExcept {
+        handlers: Vec<Spanned<ExceptHandler>>,
+        try_block: Spanned<Block>,
+    },
+    Return {
+        value: Option<Spanned<Expr>>,
+    },
+    ExprStmt {
+        expr: Spanned<Expr>,
+    },
+    Break,
+    Continue,
+    Sleep {
+        duration: Option<Spanned<Expr>>,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Expr {
+    Literal {
+        value: Literal,
+    },
+    Variable {
+        name: String,
+    },
+    BinaryOp {
+        left: Box<Spanned<Expr>>,
+        op: BinaryOperator,
+        right: Box<Spanned<Expr>>,
+    },
+    UnaryOp {
+        op: UnaryOperator,
+        operand: Box<Spanned<Expr>>,
+    },
+    List {
+        elements: Vec<Spanned<Expr>>,
+    },
+    Dict {
+        entries: Vec<DictEntry>,
+    },
+    Index {
+        object: Box<Spanned<Expr>>,
+        index: Box<Spanned<Expr>>,
+    },
+    Dot {
+        object: Box<Spanned<Expr>>,
+        attribute: String,
+    },
+    FunctionCall {
+        call: FunctionCall,
+    },
+    ActionCall {
+        call: ActionCall,
+    },
+    ParallelExpr {
+        calls: Vec<Call>,
+    },
+    SpreadExpr {
+        collection: Box<Spanned<Expr>>,
+        loop_var: String,
+        action: ActionCall,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Literal {
+    Int(i64),
+    Float(f64),
+    String(String),
+    Bool(bool),
+    None,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct DictEntry {
+    pub key: Spanned<Expr>,
+    pub value: Spanned<Expr>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ActionCall {
+    pub action_name: String,
+    pub kwargs: Vec<Kwarg>,
+    pub policies: Vec<PolicyBracket>,
+    pub module_name: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Call {
+    Action(ActionCall),
+    Function(FunctionCall),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct FunctionCall {
+    pub name: String,
+    pub args: Vec<Spanned<Expr>>,
+    pub kwargs: Vec<Kwarg>,
+    pub global_function: Option<GlobalFunction>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Kwarg {
+    pub name: String,
+    pub value: Spanned<Expr>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct IfBranch {
+    pub condition: Spanned<Expr>,
+    pub body: Spanned<Block>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ElifBranch {
+    pub condition: Spanned<Expr>,
+    pub body: Spanned<Block>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ElseBranch {
+    pub body: Spanned<Block>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ExceptHandler {
+    pub exception_types: Vec<String>,
+    pub exception_var: Option<String>,
+    pub body: Spanned<Block>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum BinaryOperator {
+    Add,
+    Sub,
+    Mul,
+    Div,
+    FloorDiv,
+    Mod,
+    Eq,
+    Ne,
+    Lt,
+    Le,
+    Gt,
+    Ge,
+    In,
+    NotIn,
+    And,
+    Or,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum UnaryOperator {
+    Neg,
+    Not,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum GlobalFunction {
+    Range,
+    Len,
+    Enumerate,
+    IsException,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum PolicyBracket {
+    Retry(RetryPolicy),
+    Timeout(TimeoutPolicy),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct RetryPolicy {
+    pub exception_types: Vec<String>,
+    pub max_retries: u32,
+    pub backoff: Option<DurationLiteral>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct TimeoutPolicy {
+    pub timeout: DurationLiteral,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct DurationLiteral {
+    pub seconds: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Span {
+    pub start_line: u32,
+    pub start_col: u32,
+    pub end_line: u32,
+    pub end_col: u32,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Spanned<T> {
+    pub value: T,
+    pub span: Span,
+}


### PR DESCRIPTION
This PR is part of the implementation of the new VM/compiler infrastructure. The core idea is to move away from using transport-level protobuf types in the application code and to move to a more native form.

This PR was prepared with AI help, and it'd mostly be tedious and trivial work.

The native AST is different from the protobuf representation in the following ways:
- protobuf-originating `Option`s are eliminated; when parsing a value with a missing option a conversion error is returned; there might be some misses in the semantics here, but those can be corrected later when we get to actually testing in the AST
- spans are removed from the inside of the types; they are, instead, applied from the outside via a generic `Spanned` type; this will allow us to do some elegant error reporting if needed

---

Overall, it would make more sense to transfer the AST in either the textual form, or some more fitting binary binary form that doesn't introduce unnecessary semantics, like protobuf's value preservation for fields missing in the schema (tonic/prost and rust ecosystem in general is completely broken in this regard with respect to real protobuf specs - better don't use them where you actually need real protobuf either; use google's implementation instead), or inflexibility of representing optional scalars or required objects (this is a severe expressiveness loss, that make sense as a trade-off for cross-service communication but not necessarily for representing big and complex trees if that's all you want to do). We can still use protobuf for the bridge and worker communications.