### PR TITLE
Initial version of the new VM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -697,6 +697,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "dashmap"
 version = "5.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1552,6 +1586,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1593,6 +1633,28 @@ name = "indenter"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
+
+[[package]]
+name = "index_type"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb2d25dd34f71fcc6797f066181e0bdac9f8955e3ec817806b144c1f408b91d3"
+dependencies = [
+ "index_type_macros",
+]
+
+[[package]]
+name = "index_type_macros"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ff612acf0b3a9e096bd56635dbb0d2b7aa04c99ef8aa4afad42dce8e76b078a"
+dependencies = [
+ "darling",
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "indexmap"
@@ -2434,9 +2496,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -4929,6 +4991,164 @@ dependencies = [
  "thiserror",
  "waymark-proto",
  "waymark-vm-ast-old",
+]
+
+[[package]]
+name = "waymark-vm-bytecode"
+version = "0.1.0"
+dependencies = [
+ "index_type",
+ "waymark-vm-bytecode-core",
+ "waymark-vm-executable",
+]
+
+[[package]]
+name = "waymark-vm-bytecode-core"
+version = "0.1.0"
+dependencies = [
+ "index_type",
+]
+
+[[package]]
+name = "waymark-vm-cli"
+version = "0.1.0"
+dependencies = [
+ "index_type",
+ "tokio",
+ "tracing",
+ "waymark-fn-main-common",
+ "waymark-vm-bytecode",
+ "waymark-vm-bytecode-core",
+ "waymark-vm-driver",
+ "waymark-vm-instructions-coreset",
+ "waymark-vm-instructions-fullset",
+ "waymark-vm-instructions-pureset",
+ "waymark-vm-interpreter-coreset",
+ "waymark-vm-interpreter-fullset",
+ "waymark-vm-interpreter-pureset",
+ "waymark-vm-runtime",
+ "waymark-vm-runtime-core",
+]
+
+[[package]]
+name = "waymark-vm-driver"
+version = "0.1.0"
+dependencies = [
+ "tokio",
+ "tracing",
+ "waymark-vm-executable",
+ "waymark-vm-interpreter",
+ "waymark-vm-runtime",
+ "waymark-vm-runtime-core",
+ "waymark-vm-runtime-test",
+]
+
+[[package]]
+name = "waymark-vm-executable"
+version = "0.1.0"
+
+[[package]]
+name = "waymark-vm-instructions-coreset"
+version = "0.1.0"
+dependencies = [
+ "derive-where",
+]
+
+[[package]]
+name = "waymark-vm-instructions-fullset"
+version = "0.1.0"
+dependencies = [
+ "derive-where",
+ "waymark-vm-instructions-coreset",
+ "waymark-vm-instructions-pureset",
+]
+
+[[package]]
+name = "waymark-vm-instructions-pureset"
+version = "0.1.0"
+dependencies = [
+ "derive-where",
+]
+
+[[package]]
+name = "waymark-vm-interpreter"
+version = "0.1.0"
+
+[[package]]
+name = "waymark-vm-interpreter-coreset"
+version = "0.1.0"
+dependencies = [
+ "derive-where",
+ "thiserror",
+ "waymark-vm-executable",
+ "waymark-vm-instructions-coreset",
+ "waymark-vm-interpreter",
+ "waymark-vm-runtime",
+ "waymark-vm-runtime-core",
+ "waymark-vm-runtime-test",
+]
+
+[[package]]
+name = "waymark-vm-interpreter-fullset"
+version = "0.1.0"
+dependencies = [
+ "derive-where",
+ "thiserror",
+ "waymark-vm-executable",
+ "waymark-vm-instructions-coreset",
+ "waymark-vm-instructions-fullset",
+ "waymark-vm-instructions-pureset",
+ "waymark-vm-interpreter",
+ "waymark-vm-interpreter-coreset",
+ "waymark-vm-interpreter-pureset",
+ "waymark-vm-runtime",
+ "waymark-vm-runtime-core",
+ "waymark-vm-runtime-test",
+]
+
+[[package]]
+name = "waymark-vm-interpreter-pureset"
+version = "0.1.0"
+dependencies = [
+ "derive-where",
+ "thiserror",
+ "waymark-vm-instructions-pureset",
+ "waymark-vm-interpreter",
+ "waymark-vm-runtime",
+ "waymark-vm-runtime-core",
+ "waymark-vm-runtime-test",
+]
+
+[[package]]
+name = "waymark-vm-runtime"
+version = "0.1.0"
+dependencies = [
+ "thiserror",
+ "tracing",
+ "waymark-vm-executable",
+ "waymark-vm-interpreter",
+ "waymark-vm-runtime-core",
+ "waymark-vm-runtime-test",
+]
+
+[[package]]
+name = "waymark-vm-runtime-core"
+version = "0.1.0"
+dependencies = [
+ "index_type",
+ "thiserror",
+]
+
+[[package]]
+name = "waymark-vm-runtime-test"
+version = "0.1.0"
+dependencies = [
+ "thiserror",
+ "waymark-vm-bytecode",
+ "waymark-vm-bytecode-core",
+ "waymark-vm-interpreter",
+ "waymark-vm-runtime",
+ "waymark-vm-runtime-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,20 @@ waymark-tokio-metrics-bringup = { path = "crates/lib/tokio-metrics-bringup" }
 waymark-utils-futures = { path = "crates/lib/utils-futures" }
 waymark-utils-tokio-channel = { path = "crates/lib/utils-tokio-channel" }
 waymark-vm-ast-old = { path = "crates/lib/vm-ast-old" }
+waymark-vm-bytecode = { path = "crates/lib/vm-bytecode" }
+waymark-vm-bytecode-core = { path = "crates/lib/vm-bytecode-core" }
+waymark-vm-driver = { path = "crates/lib/vm-driver" }
+waymark-vm-executable = { path = "crates/lib/vm-executable" }
+waymark-vm-instructions-coreset = { path = "crates/lib/vm-instructions-coreset" }
+waymark-vm-instructions-fullset = { path = "crates/lib/vm-instructions-fullset" }
+waymark-vm-instructions-pureset = { path = "crates/lib/vm-instructions-pureset" }
+waymark-vm-interpreter = { path = "crates/lib/vm-interpreter" }
+waymark-vm-interpreter-coreset = { path = "crates/lib/vm-interpreter-coreset" }
+waymark-vm-interpreter-fullset = { path = "crates/lib/vm-interpreter-fullset" }
+waymark-vm-interpreter-pureset = { path = "crates/lib/vm-interpreter-pureset" }
+waymark-vm-runtime = { path = "crates/lib/vm-runtime" }
+waymark-vm-runtime-core = { path = "crates/lib/vm-runtime-core" }
+waymark-vm-runtime-test = { path = "crates/lib/vm-runtime-test" }
 waymark-webapp-backend = { path = "crates/lib/webapp-backend" }
 waymark-webapp-bringup = { path = "crates/lib/webapp-bringup" }
 waymark-webapp-config = { path = "crates/lib/webapp-config" }
@@ -103,6 +117,7 @@ function_name = "0.3"
 futures-core = "0.3"
 futures-util = "0.3"
 http-body-util = "0.1"
+index_type = "0.4"
 metrics = "0.24"
 metrics-exporter-prometheus = "0.18"
 metrics-util = "0.20"

--- a/Makefile
+++ b/Makefile
@@ -68,10 +68,10 @@ rust-lint-verify: rust-lint-base-verify
 	cargo deny check
 
 rust-lint-extended:
-	cargo hack clippy --feature-powerset --no-dev-deps --lib --workspace --exclude waymark-benchmark --exclude waymark-boot-singleton --exclude waymark-bridge --exclude waymark-integration-test --exclude waymark-smoke --exclude waymark-soak-harness --exclude waymark-start-workers -- -D warnings
+	cargo hack clippy --feature-powerset --no-dev-deps --lib --workspace --exclude waymark-benchmark --exclude waymark-boot-singleton --exclude waymark-bridge --exclude waymark-integration-test --exclude waymark-smoke --exclude waymark-soak-harness --exclude waymark-start-workers --exclude waymark-vm-cli -- -D warnings
 
 rust-lint-extended-verify:
-	cargo hack clippy --feature-powerset --no-dev-deps --lib --workspace --exclude waymark-benchmark --exclude waymark-boot-singleton --exclude waymark-bridge --exclude waymark-integration-test --exclude waymark-smoke --exclude waymark-soak-harness --exclude waymark-start-workers -- -D warnings
+	cargo hack clippy --feature-powerset --no-dev-deps --lib --workspace --exclude waymark-benchmark --exclude waymark-boot-singleton --exclude waymark-bridge --exclude waymark-integration-test --exclude waymark-smoke --exclude waymark-soak-harness --exclude waymark-start-workers --exclude waymark-vm-cli -- -D warnings
 
 # Coverage targets
 coverage: python-coverage rust-coverage

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,6 +1,7 @@
 [default.extend-words]
 # Project-specific terms that are not typos
 typle = "typle"
+fullset = "fullset"
 
 
 [files]

--- a/crates/bin/vm-cli/Cargo.toml
+++ b/crates/bin/vm-cli/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "waymark-vm-cli"
+edition = "2024"
+version.workspace = true
+publish.workspace = true
+
+[dependencies]
+waymark-fn-main-common = { workspace = true }
+waymark-vm-bytecode = { workspace = true }
+waymark-vm-bytecode-core = { workspace = true }
+waymark-vm-driver = { workspace = true }
+waymark-vm-instructions-coreset = { workspace = true }
+waymark-vm-instructions-fullset = { workspace = true }
+waymark-vm-instructions-pureset = { workspace = true }
+waymark-vm-interpreter-coreset = { workspace = true }
+waymark-vm-interpreter-fullset = { workspace = true }
+waymark-vm-interpreter-pureset = { workspace = true }
+waymark-vm-runtime = { workspace = true }
+waymark-vm-runtime-core = { workspace = true }
+
+index_type = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "signal", "time"] }
+tracing = { workspace = true }

--- a/crates/bin/vm-cli/src/integration.rs
+++ b/crates/bin/vm-cli/src/integration.rs
@@ -1,0 +1,58 @@
+pub type InstructionSet = waymark_vm_instructions_fullset::FullSet<SampleSpec>;
+
+pub type Executable = waymark_vm_bytecode::Executable<InstructionSet>;
+
+#[derive(Debug)]
+pub struct SampleSpec;
+
+impl waymark_vm_instructions_coreset::Spec for SampleSpec {
+    type RegisterId = waymark_vm_runtime_core::RegisterId;
+    type FunctionId = waymark_vm_bytecode_core::FunctionId;
+    type ExtCallId = SampleExtCallId;
+    type StateId = waymark_vm_bytecode_core::StateId;
+}
+
+impl waymark_vm_instructions_pureset::Spec for SampleSpec {
+    type RegisterId = waymark_vm_runtime_core::RegisterId;
+    type ConstValue = SampleConstValue;
+}
+
+#[derive(Debug, Clone)]
+pub enum SampleConstValue {
+    Usize(usize),
+}
+
+#[derive(Debug, Clone)]
+pub enum SampleValue {
+    Usize(usize),
+}
+
+#[derive(Debug, Clone)]
+pub struct SampleExtCallId(#[allow(dead_code)] pub usize);
+
+impl waymark_vm_interpreter_coreset::value::ShouldJump for SampleValue {
+    fn should_jump(
+        &self,
+    ) -> Result<bool, waymark_vm_interpreter_coreset::value::NotAConditionalError> {
+        let SampleValue::Usize(val) = self;
+        Ok(*val > 0)
+    }
+}
+
+impl waymark_vm_interpreter_pureset::value::Add for SampleValue {
+    fn add(a: &Self, b: &Self) -> Result<Self, waymark_vm_interpreter_pureset::value::AddError> {
+        let SampleValue::Usize(a) = a;
+        let SampleValue::Usize(b) = b;
+
+        let val = a + b;
+
+        Ok(SampleValue::Usize(val))
+    }
+}
+
+impl From<SampleConstValue> for SampleValue {
+    fn from(value: SampleConstValue) -> Self {
+        let SampleConstValue::Usize(value) = value;
+        SampleValue::Usize(value)
+    }
+}

--- a/crates/bin/vm-cli/src/main.rs
+++ b/crates/bin/vm-cli/src/main.rs
@@ -1,0 +1,204 @@
+mod integration;
+
+#[tokio::main]
+async fn main() -> Result<(), waymark_fn_main_common::Error> {
+    waymark_fn_main_common::init()?;
+
+    let executable = sample_executable();
+
+    let interpreter = waymark_vm_interpreter_fullset::FullSetInterpreter::default();
+
+    let runtime =
+        waymark_vm_runtime::Runtime::with_conventional_entrypoint(interpreter, executable)?;
+
+    let (effects_tx, mut effects_rx) = tokio::sync::mpsc::channel(1);
+    let (promise_resolutions_tx, promise_resolutions_rx) = tokio::sync::mpsc::channel(1);
+
+    let mut tasks = tokio::task::JoinSet::new();
+
+    tasks.spawn({
+        let params = waymark_vm_driver::Params {
+            runtime,
+            effects_tx,
+            promise_resolutions_rx,
+        };
+        async move {
+            let Err(error) = waymark_vm_driver::run(params).await;
+            tracing::info!(?error, "vm driver terminated");
+        }
+    });
+
+    let (completion_tx, completion_rx) = tokio::sync::oneshot::channel();
+
+    tasks.spawn({
+        async move {
+            loop {
+                let Some(effect) = effects_rx.recv().await else {
+                    break;
+                };
+
+                match effect {
+                    waymark_vm_interpreter_fullset::Effect::CoreSet(effect) => match effect {
+                        waymark_vm_interpreter_coreset::Effect::Complete(value) => {
+                            completion_tx.send(value).unwrap();
+                            break;
+                        }
+                        waymark_vm_interpreter_coreset::Effect::ExtCall {
+                            promise_state_id,
+                            extcall_id,
+                            args,
+                        } => {
+                            tracing::info!(
+                                ?extcall_id,
+                                ?promise_state_id,
+                                ?args,
+                                "extcall received"
+                            );
+
+                            tokio::spawn({
+                                let promise_resolutions_tx = promise_resolutions_tx.clone();
+                                async move {
+                                    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+
+                                    let value = integration::SampleValue::Usize(42);
+                                    tracing::info!(
+                                        ?extcall_id,
+                                        ?promise_state_id,
+                                        ?args,
+                                        ?value,
+                                        "resolving extcall"
+                                    );
+                                    promise_resolutions_tx
+                                        .send((promise_state_id, value))
+                                        .await
+                                        .unwrap();
+                                }
+                            });
+                        }
+                    },
+                }
+            }
+        }
+    });
+
+    let value = completion_rx.await?;
+
+    let expected = (42 + 5) * 2;
+
+    tracing::info!(?value, ?expected, "program complete");
+    Ok(())
+}
+
+fn sample_executable() -> integration::Executable {
+    use self::integration::*;
+    use index_type::{IndexType, typed_vec};
+    use waymark_vm_bytecode::*;
+    use waymark_vm_bytecode_core::*;
+    use waymark_vm_instructions_coreset::CoreSet;
+    use waymark_vm_instructions_pureset::PureSet;
+    use waymark_vm_runtime_core::RegisterId;
+
+    // function 1: f() = await ExtCall(SampleExtCallId(42)) + 5
+    let f1 = Function {
+        num_regs: 3,
+        states: typed_vec![
+            State {
+                instructions: typed_vec![
+                    CoreSet::ExtCall {
+                        dst: RegisterId::from_scalar(0),
+                        extcall_id: SampleExtCallId(42),
+                        args: vec![],
+                        resume: StateId::from_scalar(1),
+                    }
+                    .into(),
+                ]
+            },
+            State {
+                instructions: typed_vec![
+                    CoreSet::Await {
+                        dst: RegisterId::from_scalar(1),
+                        src: RegisterId::from_scalar(0),
+                        resume: StateId::from_scalar(2),
+                    }
+                    .into(),
+                ],
+            },
+            State {
+                instructions: typed_vec![
+                    PureSet::LoadConst {
+                        dst: RegisterId::from_scalar(2),
+                        value: SampleConstValue::Usize(5),
+                    }
+                    .into(),
+                    PureSet::Add {
+                        dst: RegisterId::from_scalar(2),
+                        a: RegisterId::from_scalar(1),
+                        b: RegisterId::from_scalar(2),
+                    }
+                    .into(),
+                    CoreSet::Return {
+                        src: RegisterId::from_scalar(2),
+                    }
+                    .into()
+                ],
+            },
+        ],
+    };
+
+    // main: run f twice concurrently and sum
+    let main_fn = Function {
+        num_regs: 5,
+        states: typed_vec![
+            State {
+                instructions: typed_vec![
+                    CoreSet::Call {
+                        dst: RegisterId::from_scalar(0),
+                        function_id: FunctionId::from_scalar(1),
+                        args: vec![]
+                    }
+                    .into(),
+                    CoreSet::Call {
+                        dst: RegisterId::from_scalar(1),
+                        function_id: FunctionId::from_scalar(1),
+                        args: vec![]
+                    }
+                    .into(),
+                    CoreSet::Await {
+                        dst: RegisterId::from_scalar(2),
+                        src: RegisterId::from_scalar(0),
+                        resume: StateId::from_scalar(1),
+                    }
+                    .into(),
+                ],
+            },
+            State {
+                instructions: typed_vec![
+                    CoreSet::Await {
+                        dst: RegisterId::from_scalar(3),
+                        src: RegisterId::from_scalar(1),
+                        resume: StateId::from_scalar(2),
+                    }
+                    .into()
+                ],
+            },
+            State {
+                instructions: typed_vec![
+                    PureSet::Add {
+                        dst: RegisterId::from_scalar(4),
+                        a: RegisterId::from_scalar(2),
+                        b: RegisterId::from_scalar(3)
+                    }
+                    .into(),
+                    CoreSet::Return {
+                        src: RegisterId::from_scalar(4)
+                    }
+                    .into()
+                ],
+            },
+        ],
+    };
+
+    waymark_vm_bytecode::Executable {
+        functions: typed_vec![main_fn, f1],
+    }
+}

--- a/crates/lib/vm-bytecode-core/Cargo.toml
+++ b/crates/lib/vm-bytecode-core/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "waymark-vm-bytecode-core"
+edition = "2024"
+version.workspace = true
+publish.workspace = true
+
+[dependencies]
+index_type = { workspace = true }

--- a/crates/lib/vm-bytecode-core/src/lib.rs
+++ b/crates/lib/vm-bytecode-core/src/lib.rs
@@ -1,0 +1,35 @@
+//! Core VM bytecode primitives.
+
+#![warn(missing_docs)]
+
+use index_type::{IndexTooBigError, IndexType};
+
+/// Identifies a function within a VM executable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, IndexType, Default)]
+#[index_type(error = FunctionIdTooBigError)]
+pub struct FunctionId(pub usize);
+
+/// Identifies a state-machine state within a function.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, IndexType, Default)]
+#[index_type(error = StateIdTooBigError)]
+pub struct StateId(pub usize);
+
+/// Identifies an instruction within a state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, IndexType, Default)]
+#[index_type(error = InstructionIdTooBigError)]
+pub struct InstructionId(pub usize);
+
+/// Error returned when a raw index cannot be represented as a [`FunctionId`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, IndexTooBigError)]
+#[index_too_big_error(msg = "function id")]
+pub struct FunctionIdTooBigError;
+
+/// Error returned when a raw index cannot be represented as a [`StateId`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, IndexTooBigError)]
+#[index_too_big_error(msg = "state id")]
+pub struct StateIdTooBigError;
+
+/// Error returned when a raw index cannot be represented as an [`InstructionId`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, IndexTooBigError)]
+#[index_too_big_error(msg = "instruction id")]
+pub struct InstructionIdTooBigError;

--- a/crates/lib/vm-bytecode/Cargo.toml
+++ b/crates/lib/vm-bytecode/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "waymark-vm-bytecode"
+edition = "2024"
+version.workspace = true
+publish.workspace = true
+
+[dependencies]
+waymark-vm-bytecode-core = { workspace = true }
+waymark-vm-executable = { workspace = true }
+
+index_type = { workspace = true }

--- a/crates/lib/vm-bytecode/src/lib.rs
+++ b/crates/lib/vm-bytecode/src/lib.rs
@@ -1,0 +1,58 @@
+//! Generic VM bytecode shape definition.
+
+#![warn(missing_docs)]
+
+use index_type::typed_vec::TypedVec;
+use waymark_vm_bytecode_core::{FunctionId, InstructionId, StateId};
+
+/// An executable with the given `Instruction`s.
+///
+/// A collection of functions.
+pub struct Executable<Instruction> {
+    /// Functions this executable contains.
+    pub functions: TypedVec<FunctionId, Function<Instruction>>,
+}
+
+/// A function with the given `Instruction`s.
+pub struct Function<Instruction> {
+    /// States (as in state-machine states) this function consists of.
+    pub states: TypedVec<StateId, State<Instruction>>,
+
+    /// The number of registers this function uses;
+    pub num_regs: usize,
+}
+
+/// A state (as in state-machine states) with the given `Instruction`s.
+pub struct State<Instruction> {
+    /// The sequence of `Instruction`s.
+    pub instructions: TypedVec<InstructionId, Instruction>,
+}
+
+impl<Instruction> waymark_vm_executable::Functions for Executable<Instruction> {
+    type FunctionId = FunctionId;
+}
+
+impl<Instruction> waymark_vm_executable::FunctionStates for Executable<Instruction> {
+    type StateId = StateId;
+}
+
+impl<Instruction> waymark_vm_executable::FunctionInfo for Executable<Instruction> {
+    fn function_num_regs(&self, function_id: Self::FunctionId) -> Option<usize> {
+        let function = self.functions.get(function_id)?;
+        Some(function.num_regs)
+    }
+}
+
+impl<Instruction> waymark_vm_executable::InstructionsProvider for Executable<Instruction> {
+    type Instruction = Instruction;
+
+    fn function_state_instructions(
+        &self,
+        function_id: Self::FunctionId,
+        state_id: Self::StateId,
+    ) -> Option<impl IntoIterator<Item = &Self::Instruction> + '_> {
+        let function = self.functions.get(function_id)?;
+        let state = function.states.get(state_id)?;
+        Some(state.instructions.iter())
+    }
+}

--- a/crates/lib/vm-driver/Cargo.toml
+++ b/crates/lib/vm-driver/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "waymark-vm-driver"
+edition = "2024"
+version.workspace = true
+publish.workspace = true
+
+[dependencies]
+waymark-vm-executable = { workspace = true }
+waymark-vm-interpreter = { workspace = true }
+waymark-vm-runtime = { workspace = true }
+waymark-vm-runtime-core = { workspace = true }
+
+tokio = { workspace = true, features = ["sync"] }
+tracing = { workspace = true }
+
+[dev-dependencies]
+waymark-vm-runtime-test = { workspace = true }
+
+tokio = { workspace = true, features = ["macros", "rt", "sync"] }

--- a/crates/lib/vm-driver/src/lib.rs
+++ b/crates/lib/vm-driver/src/lib.rs
@@ -1,0 +1,103 @@
+//! Driver loop for a VM runtime.
+//!
+//! This crate ties [`Runtime`] to external async channels by forwarding emitted
+//! effects to a caller-provided sender and resolving pending promises from a
+//! caller-provided promise-resolution receiver.
+
+#![warn(missing_docs)]
+
+use waymark_vm_runtime::{FrameFor, Runtime};
+use waymark_vm_runtime_core::PromiseStateId;
+
+/// Errors returned by the driver loop.
+#[derive(Debug)]
+pub enum Error<ExecutionError, Value> {
+    /// A VM step failed while executing an instruction.
+    Step(waymark_vm_runtime::step::Error<ExecutionError>),
+
+    /// The effect receiver side was dropped.
+    EffectSenderClosed,
+
+    /// The promise-resolution sender side was dropped.
+    PromiseResolutionReceiverClosed,
+
+    /// Resolving a promise failed.
+    ResolvingPromise(waymark_vm_runtime_core::ResolvePromiseError<Value>),
+}
+
+/// Inputs required to run the driver loop.
+pub struct Params<Executable, Interpreter, Value>
+where
+    Executable: waymark_vm_executable::FunctionStates,
+    Interpreter: waymark_vm_interpreter::Interpreter<Frame = FrameFor<Executable, Value>>,
+{
+    /// Runtime instance to drive.
+    pub runtime: Runtime<Executable, Interpreter, Value>,
+
+    /// Channel used to publish effects emitted by the runtime.
+    pub effects_tx: tokio::sync::mpsc::Sender<Interpreter::Effect>,
+
+    /// Channel used to receive promise resolutions for pending promises.
+    pub promise_resolutions_rx: tokio::sync::mpsc::Receiver<(PromiseStateId, Value)>,
+}
+
+/// Drive the runtime until the loop terminates with an error.
+///
+/// The driver repeatedly executes the runtime, forwards emitted effects to
+/// [`Params::effects_tx`], and resolves pending promises with values received
+/// from [`Params::promise_resolutions_rx`]. The function only returns when one
+/// of those operations fails.
+pub async fn run<Executable, Interpreter, Value>(
+    params: Params<Executable, Interpreter, Value>,
+) -> Result<core::convert::Infallible, Error<Interpreter::Error, Value>>
+where
+    Executable: waymark_vm_executable::InstructionsProvider,
+    Executable::FunctionId: Copy,
+    Executable::StateId: Copy + PartialEq,
+    Executable: 'static,
+    Interpreter: waymark_vm_interpreter::Interpreter<
+            Frame = FrameFor<Executable, Value>,
+            Instruction = Executable::Instruction,
+        >,
+    Interpreter: for<'r> waymark_vm_runtime_core::CaptureRuntimeView<
+            Executable,
+            Executable::FunctionId,
+            Executable::StateId,
+            Value,
+            RuntimeView<'r> = <Interpreter as waymark_vm_interpreter::Interpreter>::RuntimeView<'r>,
+        >,
+    Value: 'static,
+    Value: Clone,
+    // Debug
+    Interpreter::Instruction: core::fmt::Debug,
+    Interpreter::Effect: core::fmt::Debug,
+    Value: core::fmt::Debug,
+{
+    let Params {
+        mut runtime,
+        effects_tx,
+        mut promise_resolutions_rx,
+    } = params;
+
+    loop {
+        match runtime.run() {
+            Ok(effect) => {
+                tracing::info!(?effect, "effect");
+                if effects_tx.send(effect).await.is_err() {
+                    return Err(Error::EffectSenderClosed);
+                }
+            }
+            Err(waymark_vm_runtime::RunError::NoReadyFrame) => {
+                let (promise_state_id, value) = promise_resolutions_rx
+                    .recv()
+                    .await
+                    .ok_or(Error::PromiseResolutionReceiverClosed)?;
+                tracing::info!(?promise_state_id, ?value, "promise resolution");
+                runtime
+                    .resolve_promise(promise_state_id, value)
+                    .map_err(Error::ResolvingPromise)?;
+            }
+            Err(waymark_vm_runtime::RunError::Step(error)) => return Err(Error::Step(error)),
+        };
+    }
+}

--- a/crates/lib/vm-driver/tests/integration.rs
+++ b/crates/lib/vm-driver/tests/integration.rs
@@ -1,0 +1,201 @@
+use waymark_vm_driver::{Error, Params, run};
+use waymark_vm_runtime_core::{PromiseStateId, RegisterId, ResolvePromiseError};
+use waymark_vm_runtime_test::{
+    StateId, TestEffect, TestExecutionError, TestInstruction, executable, function, runtime,
+};
+
+#[tokio::test]
+async fn forwards_emitted_effects_to_the_effect_channel() {
+    let (effects_tx, mut effects_rx) = tokio::sync::mpsc::channel(1);
+    let (promise_resolutions_tx, promise_resolutions_rx) = tokio::sync::mpsc::channel(1);
+
+    let task = tokio::spawn(run(Params {
+        runtime: runtime(executable(vec![function(
+            0,
+            vec![vec![TestInstruction::Emit("tick")]],
+        )])),
+        effects_tx,
+        promise_resolutions_rx,
+    }));
+
+    assert_eq!(effects_rx.recv().await, Some(TestEffect::Message("tick")));
+    drop(promise_resolutions_tx);
+
+    assert!(matches!(
+        task.await.expect("driver task should join"),
+        Err(Error::PromiseResolutionReceiverClosed)
+    ));
+}
+
+#[tokio::test]
+async fn resumes_waiting_promises_and_forwards_the_resolved_effect() {
+    let (effects_tx, mut effects_rx) = tokio::sync::mpsc::channel(1);
+    let (promise_resolutions_tx, promise_resolutions_rx) = tokio::sync::mpsc::channel(1);
+
+    let task = tokio::spawn(run(Params {
+        runtime: runtime(executable(vec![function(
+            1,
+            vec![
+                vec![TestInstruction::Suspend {
+                    dst: RegisterId(0),
+                    resume: StateId(1),
+                }],
+                vec![TestInstruction::EmitRegister(RegisterId(0))],
+            ],
+        )])),
+        effects_tx,
+        promise_resolutions_rx,
+    }));
+
+    promise_resolutions_tx
+        .send((PromiseStateId(0), 41))
+        .await
+        .expect("driver should accept the promise resolution");
+
+    assert_eq!(effects_rx.recv().await, Some(TestEffect::Value(41)));
+    drop(promise_resolutions_tx);
+
+    assert!(matches!(
+        task.await.expect("driver task should join"),
+        Err(Error::PromiseResolutionReceiverClosed)
+    ));
+}
+
+#[tokio::test]
+async fn returns_effect_sender_closed_when_the_effect_receiver_is_dropped() {
+    let (effects_tx, effects_rx) = tokio::sync::mpsc::channel(1);
+    let (_promise_resolutions_tx, promise_resolutions_rx) = tokio::sync::mpsc::channel(1);
+    drop(effects_rx);
+
+    let result = run(Params {
+        runtime: runtime(executable(vec![function(
+            0,
+            vec![vec![TestInstruction::Emit("tick")]],
+        )])),
+        effects_tx,
+        promise_resolutions_rx,
+    })
+    .await;
+
+    assert!(matches!(result, Err(Error::EffectSenderClosed)));
+}
+
+#[tokio::test]
+async fn returns_promise_resolution_receiver_closed_when_waiting_runtime_cannot_resume() {
+    let (effects_tx, _effects_rx) = tokio::sync::mpsc::channel(1);
+    let (promise_resolutions_tx, promise_resolutions_rx) = tokio::sync::mpsc::channel(1);
+    drop(promise_resolutions_tx);
+
+    let result = run(Params {
+        runtime: runtime(executable(vec![function(
+            1,
+            vec![vec![TestInstruction::Suspend {
+                dst: RegisterId(0),
+                resume: StateId(1),
+            }]],
+        )])),
+        effects_tx,
+        promise_resolutions_rx,
+    })
+    .await;
+
+    assert!(matches!(
+        result,
+        Err(Error::PromiseResolutionReceiverClosed)
+    ));
+}
+
+#[tokio::test]
+async fn returns_step_errors_from_the_runtime() {
+    let (effects_tx, _effects_rx) = tokio::sync::mpsc::channel(1);
+    let (_promise_resolutions_tx, promise_resolutions_rx) = tokio::sync::mpsc::channel(1);
+
+    let result = run(Params {
+        runtime: runtime(executable(vec![function(
+            0,
+            vec![vec![TestInstruction::Fail("boom")]],
+        )])),
+        effects_tx,
+        promise_resolutions_rx,
+    })
+    .await;
+
+    assert!(matches!(
+        result,
+        Err(Error::Step(waymark_vm_runtime::step::Error::Execution(
+            TestExecutionError("boom")
+        )))
+    ));
+}
+
+#[tokio::test]
+async fn returns_resolving_promise_errors_for_duplicate_resolutions() {
+    let (effects_tx, _effects_rx) = tokio::sync::mpsc::channel(1);
+    let (promise_resolutions_tx, promise_resolutions_rx) = tokio::sync::mpsc::channel(2);
+
+    promise_resolutions_tx
+        .send((PromiseStateId(0), 10))
+        .await
+        .expect("first resolution should enqueue");
+    promise_resolutions_tx
+        .send((PromiseStateId(0), 11))
+        .await
+        .expect("second resolution should enqueue");
+
+    let result = run(Params {
+        runtime: runtime(executable(vec![function(
+            1,
+            vec![
+                vec![TestInstruction::Suspend {
+                    dst: RegisterId(0),
+                    resume: StateId(1),
+                }],
+                vec![TestInstruction::Exit],
+            ],
+        )])),
+        effects_tx,
+        promise_resolutions_rx,
+    })
+    .await;
+
+    let Err(Error::ResolvingPromise(err)) = result else {
+        panic!("duplicate promise resolution should surface as a driver error");
+    };
+
+    let ResolvePromiseError::AlreadyResolved(err) = err else {
+        panic!("duplicate promise resolution should report already-resolved errors");
+    };
+
+    assert_eq!(err.new_value, 11);
+}
+
+#[tokio::test]
+async fn returns_not_found_errors_for_unknown_promise_ids() {
+    let (effects_tx, _effects_rx) = tokio::sync::mpsc::channel(1);
+    let (promise_resolutions_tx, promise_resolutions_rx) = tokio::sync::mpsc::channel(1);
+
+    promise_resolutions_tx
+        .send((PromiseStateId(9), 41))
+        .await
+        .expect("invalid resolution should still enqueue");
+
+    let result = run(Params {
+        runtime: runtime(executable(vec![function(
+            1,
+            vec![vec![TestInstruction::Suspend {
+                dst: RegisterId(0),
+                resume: StateId(1),
+            }]],
+        )])),
+        effects_tx,
+        promise_resolutions_rx,
+    })
+    .await;
+
+    let Err(Error::ResolvingPromise(ResolvePromiseError::PromiseStateNotFound(err))) = result
+    else {
+        panic!("unknown promise IDs should surface a not-found error");
+    };
+
+    assert_eq!(err.promise_state_id, PromiseStateId(9));
+}

--- a/crates/lib/vm-executable/Cargo.toml
+++ b/crates/lib/vm-executable/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "waymark-vm-executable"
+edition = "2024"
+version.workspace = true
+publish.workspace = true
+
+[dependencies]

--- a/crates/lib/vm-executable/src/lib.rs
+++ b/crates/lib/vm-executable/src/lib.rs
@@ -1,0 +1,61 @@
+//! Interfaces for abstract executables supported by the VM.
+
+#![warn(missing_docs)]
+
+/// A trait of an abstract executable having functions.
+pub trait Functions {
+    /// The function ID.
+    ///
+    /// A type that allows referring to a function in the executable.
+    ///
+    /// Typically an index in the functions table.
+    type FunctionId;
+}
+
+/// A trait of an abstract executable having function states.
+pub trait FunctionStates: Functions {
+    /// The state ID.
+    ///
+    /// A type that allows referring to a state with in a function in
+    /// the executable.
+    ///
+    /// Typically an index in the states table (inside the functions table).
+    type StateId;
+}
+
+/// A way for an abstract executable to provide information about a function.
+pub trait FunctionInfo: Functions {
+    /// How many registers a compiled function is expecting to have available
+    /// while executing.
+    ///
+    /// Typically determined by a compiler at compile time and stored in
+    /// the bytecode.
+    ///
+    /// Used for allocating a frame for running the function.
+    ///
+    /// Returns `None` if no function with such `function_id` exists in
+    /// the executable.
+    fn function_num_regs(&self, function_id: Self::FunctionId) -> Option<usize>;
+}
+
+/// A way for an abstract executable to provide instructions sequence for
+/// a given function's sub-state.
+pub trait InstructionsProvider: FunctionStates {
+    /// The instruction type.
+    ///
+    /// Typically an enum representing an instruction set.
+    type Instruction;
+
+    /// Instructions for a given function's sub-state.
+    ///
+    /// Typically used to fetch the instructions for execution.
+    ///
+    /// Returns `None` if a function with such `function_id` or,
+    /// in the corresponding function, a state with such `state_id`
+    /// don't exist in the executable.
+    fn function_state_instructions(
+        &self,
+        function_id: Self::FunctionId,
+        state_id: Self::StateId,
+    ) -> Option<impl IntoIterator<Item = &Self::Instruction> + '_>;
+}

--- a/crates/lib/vm-instructions-coreset/Cargo.toml
+++ b/crates/lib/vm-instructions-coreset/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "waymark-vm-instructions-coreset"
+edition = "2024"
+version.workspace = true
+publish.workspace = true
+
+[dependencies]
+derive-where = { workspace = true }

--- a/crates/lib/vm-instructions-coreset/src/lib.rs
+++ b/crates/lib/vm-instructions-coreset/src/lib.rs
@@ -1,0 +1,98 @@
+//! The "core" instruction set for the VM.
+//!
+//! Responsible for representing function calls, returns, awaits, control flow
+//! and extcalls.
+//!
+//! Minimal core functionality of the VM.
+
+#![warn(missing_docs)]
+
+use derive_where::derive_where;
+
+/// The spec for required data types for the [`CoreSet`].
+pub trait Spec: 'static {
+    /// The type used to refer to the registers.
+    type RegisterId: core::fmt::Debug;
+
+    /// The type used to refer to the executable functions.
+    type FunctionId: core::fmt::Debug;
+
+    /// The type used to refer to the executable function sub-states.
+    type StateId: core::fmt::Debug;
+
+    /// The type used to refer to the extcalls.
+    type ExtCallId: core::fmt::Debug;
+}
+
+/// The core instructions set.
+#[derive_where(Debug)]
+pub enum CoreSet<Spec: self::Spec> {
+    /// Call a function.
+    ///
+    /// Creates a new frame and populates its registers with the arguments.
+    Call {
+        /// The resiter in the current frame to assign the promise for this
+        /// new call completion.
+        dst: Spec::RegisterId,
+
+        /// The function to call.
+        function_id: Spec::FunctionId,
+
+        /// The registers in the current frame to take the arguments to pass to
+        /// the function from.
+        args: Vec<Spec::RegisterId>,
+    },
+
+    /// Start an extcall execution.
+    ///
+    /// External calls are always asynchronous by nature.
+    ExtCall {
+        /// The resiter in the current frame to assign the promise for this
+        /// new call completion.
+        dst: Spec::RegisterId,
+
+        /// The ID of the extcall to invoke.
+        extcall_id: Spec::ExtCallId,
+
+        /// The registers in the current frame to take the arguments to pass to
+        /// the extcall from.
+        args: Vec<Spec::RegisterId>,
+
+        /// The state to resume the execution from after invoking the extcall.
+        resume: Spec::StateId,
+    },
+
+    /// Suspend the execution until a promise is resolved.
+    Await {
+        /// The register containing the promise to suspend on.
+        dst: Spec::RegisterId,
+
+        /// The register to store the resolved promise value at.
+        src: Spec::RegisterId,
+
+        /// Resume from the this state when the promise resolves.
+        resume: Spec::StateId,
+    },
+
+    /// Jump to the specified state.
+    Jump {
+        /// The state to jump to.
+        target_state: Spec::StateId,
+    },
+
+    /// Jump to the specified state if the cond is true.
+    JumpIf {
+        /// The state to jump to.
+        target_state: Spec::StateId,
+
+        /// The register containing the value that will be evaluated as the
+        /// condition for the jump.
+        cond: Spec::RegisterId,
+    },
+
+    /// Return the value at the given registry.
+    Return {
+        /// The register in the current from to take the return value from.
+        src: Spec::RegisterId,
+    },
+}

--- a/crates/lib/vm-instructions-fullset/Cargo.toml
+++ b/crates/lib/vm-instructions-fullset/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "waymark-vm-instructions-fullset"
+edition = "2024"
+version.workspace = true
+publish.workspace = true
+
+[dependencies]
+waymark-vm-instructions-coreset = { workspace = true }
+waymark-vm-instructions-pureset = { workspace = true }
+
+derive-where = { workspace = true }

--- a/crates/lib/vm-instructions-fullset/src/lib.rs
+++ b/crates/lib/vm-instructions-fullset/src/lib.rs
@@ -1,0 +1,46 @@
+//! The "full" instruction set for the VM.
+//!
+//! Merges together all the instruction sets, so far "core" and "pure".
+
+#![warn(missing_docs)]
+
+use derive_where::derive_where;
+
+/// The spec for required data types for the [`FullSet`].
+pub trait Spec:
+    waymark_vm_instructions_coreset::Spec
+    + waymark_vm_instructions_pureset::Spec<
+        RegisterId = <Self as waymark_vm_instructions_coreset::Spec>::RegisterId,
+    >
+{
+}
+
+impl<T> Spec for T where
+    T: waymark_vm_instructions_coreset::Spec
+        + waymark_vm_instructions_pureset::Spec<
+            RegisterId = <Self as waymark_vm_instructions_coreset::Spec>::RegisterId,
+        >
+{
+}
+
+/// The full instructions set.
+#[derive_where(Debug)]
+pub enum FullSet<Spec: self::Spec> {
+    /// Core instructions set.
+    CoreSet(waymark_vm_instructions_coreset::CoreSet<Spec>),
+
+    /// Pure instructions set.
+    PureSet(waymark_vm_instructions_pureset::PureSet<Spec>),
+}
+
+impl<Spec: self::Spec> From<waymark_vm_instructions_coreset::CoreSet<Spec>> for FullSet<Spec> {
+    fn from(value: waymark_vm_instructions_coreset::CoreSet<Spec>) -> Self {
+        Self::CoreSet(value)
+    }
+}
+
+impl<Spec: self::Spec> From<waymark_vm_instructions_pureset::PureSet<Spec>> for FullSet<Spec> {
+    fn from(value: waymark_vm_instructions_pureset::PureSet<Spec>) -> Self {
+        Self::PureSet(value)
+    }
+}

--- a/crates/lib/vm-instructions-pureset/Cargo.toml
+++ b/crates/lib/vm-instructions-pureset/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "waymark-vm-instructions-pureset"
+edition = "2024"
+version.workspace = true
+publish.workspace = true
+
+[dependencies]
+derive-where = { workspace = true }

--- a/crates/lib/vm-instructions-pureset/src/lib.rs
+++ b/crates/lib/vm-instructions-pureset/src/lib.rs
@@ -1,0 +1,47 @@
+//! The "pure" instruction set for the VM.
+//!
+//! Responsible for representing all the pure operations and values support.
+//! Things like addition, index access.
+//!
+//! "Pure" here means operation outputs are fully deterministic based on inputs,
+//! and can never produce any side-effects.
+
+#![warn(missing_docs)]
+
+use derive_where::derive_where;
+
+/// The spec for required data types for the [`PureSet`].
+pub trait Spec: 'static {
+    /// The type used to refer to the registers.
+    type RegisterId: core::fmt::Debug;
+
+    /// The constant value type supported by this instruction set.
+    type ConstValue: core::fmt::Debug;
+}
+
+/// Pure instructions set.
+#[derive_where(Debug)]
+pub enum PureSet<Spec: self::Spec> {
+    /// Load a constant value into the register.
+    LoadConst {
+        /// The resiter in the current frame to store the value at.
+        dst: Spec::RegisterId,
+
+        /// The value to store.
+        value: Spec::ConstValue,
+    },
+
+    /// Add two values together.
+    Add {
+        /// The register to store the addition result at.
+        dst: Spec::RegisterId,
+
+        /// The register that contains the first value for
+        /// the addition operation.
+        a: Spec::RegisterId,
+
+        /// The register that contains the second value for
+        /// the addition operation.
+        b: Spec::RegisterId,
+    },
+}

--- a/crates/lib/vm-interpreter-coreset/Cargo.toml
+++ b/crates/lib/vm-interpreter-coreset/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "waymark-vm-interpreter-coreset"
+edition = "2024"
+version.workspace = true
+publish.workspace = true
+
+[dependencies]
+waymark-vm-executable = { workspace = true }
+waymark-vm-instructions-coreset = { workspace = true }
+waymark-vm-interpreter = { workspace = true }
+waymark-vm-runtime-core = { workspace = true }
+
+derive-where = { workspace = true }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+waymark-vm-runtime = { workspace = true }
+waymark-vm-runtime-test = { workspace = true }

--- a/crates/lib/vm-interpreter-coreset/src/error.rs
+++ b/crates/lib/vm-interpreter-coreset/src/error.rs
@@ -1,0 +1,95 @@
+use waymark_vm_runtime_core::{PromiseStateNotFoundError, UnresolvedPromiseError};
+
+/// The error for the [`crate::CoreSetInterpreter`].
+#[derive(Debug, thiserror::Error)]
+pub enum Error<Spec: waymark_vm_instructions_coreset::Spec> {
+    /// Invoking an extcall failed.
+    #[error("extcall: {0}")]
+    ExtCall(#[source] ExtCallError),
+
+    /// Awaiting a promise failed.
+    #[error("await: {0}")]
+    Await(#[source] AwaitError),
+
+    /// Returning from a function failed.
+    #[error("return: {0}")]
+    Return(#[source] ReturnError),
+
+    /// JumpIf failed.
+    #[error("jump if: {0}")]
+    JumpIf(#[source] JumpIfError),
+
+    /// A function call failed.
+    #[error("function call: {0}")]
+    Call(#[source] CallError<Spec::FunctionId>),
+}
+
+/// Errors produced while handing a function call invocation.
+#[derive(Debug, thiserror::Error)]
+pub enum CallError<FunctionId> {
+    /// The executable did not contain the requested function.
+    #[error("function {function_id:?} not found in the executable")]
+    FunctionNotFound {
+        /// The function ID that was looked up in the executable.
+        function_id: FunctionId,
+    },
+}
+
+/// Errors produced while evaluating an `Await` instruction.
+#[derive(Debug, thiserror::Error)]
+pub enum AwaitError {
+    /// The pending promise no longer existed in the runtime state.
+    #[error("source promise state: {0}")]
+    SourcePromiseStateNotFound(#[source] PromiseStateNotFoundError),
+}
+
+/// Errors produced while evaluating a `JumpIf` instruction.
+#[derive(Debug, thiserror::Error)]
+pub enum JumpIfError {
+    /// The condition register still held an unresolved promise.
+    #[error("unresolved conditional value: {0}")]
+    UnresolvedConditionPromise(#[source] UnresolvedPromiseError),
+
+    /// The resolved condition value could not be interpreted as conditional.
+    #[error("condition check: {0}")]
+    ConditionCheck(#[source] crate::value::NotAConditionalError),
+}
+
+/// Errors produced while preparing an extcall invocation.
+#[derive(Debug, thiserror::Error)]
+pub enum ExtCallError {
+    /// An extcall argument still held an unresolved promise.
+    #[error("unresolved promise argument at position {arg_pos}: {source}")]
+    UnresolvedPromiseArgument {
+        /// The zero-based argument position that failed to resolve.
+        arg_pos: usize,
+
+        /// The underlying unresolved promise error for the argument.
+        #[source]
+        source: UnresolvedPromiseError,
+    },
+}
+
+/// Errors produced while returning from a frame.
+#[derive(Debug, thiserror::Error)]
+pub enum ReturnError {
+    /// Returning from a function-call frame failed.
+    #[error("from fn call: {0}")]
+    FnCall(#[source] ReturnFnCallError),
+
+    /// Returning from the top-level frame encountered an unresolved promise.
+    #[error("toplevel: {0}")]
+    TopLevel(#[source] UnresolvedPromiseError),
+}
+
+/// Errors produced while completing a function-call return.
+#[derive(Debug, thiserror::Error)]
+pub enum ReturnFnCallError {
+    /// The destination promise for the function call no longer exists.
+    #[error("function call result promise was not found")]
+    ReturnPromiseNotFound,
+
+    /// The destination promise for the function call had already been resolved.
+    #[error("function call result promise has already been resolved")]
+    ReturnPromiseAlreadyResolved,
+}

--- a/crates/lib/vm-interpreter-coreset/src/lib.rs
+++ b/crates/lib/vm-interpreter-coreset/src/lib.rs
@@ -1,0 +1,254 @@
+//! The interpreter for the "core" instructions set.
+
+#![warn(missing_docs)]
+
+mod error;
+pub mod value;
+
+use derive_where::derive_where;
+use waymark_vm_interpreter::ExecutionOutcome;
+use waymark_vm_runtime_core::{
+    Continuation, Frame, FrameKind, Promise, PromiseState, PromiseStateId, Registers, RuntimeState,
+};
+
+pub use self::error::*;
+pub use self::value::Value;
+
+/// An interpreter for the "core" instructions set.
+#[derive_where(Default)]
+pub struct CoreSetInterpreter<Spec, Executable, Value> {
+    phantom_data: core::marker::PhantomData<(Spec, Executable, Value)>,
+}
+
+/// The runtime view for the [`CoreSetInterpreter`].
+pub struct RuntimeView<'r, Executable, FunctionId, StateId, Value> {
+    /// The executable access.
+    pub executable: &'r Executable,
+
+    /// The runtime state access.
+    pub state: &'r mut RuntimeState<FunctionId, StateId, Value>,
+}
+
+/// The effect for the [`CoreSetInterpreter`].
+#[derive(Debug)]
+pub enum Effect<Value, ExtCallId> {
+    /// Program execution is complete.
+    Complete(Value),
+
+    /// Extcall invocation is requested.
+    ExtCall {
+        /// The ID of the promise to resolve with the resulting value when
+        /// the extcall completes.
+        promise_state_id: PromiseStateId,
+
+        /// The ID of the extcall to invoke from the extcall table.
+        extcall_id: ExtCallId,
+
+        /// Args to pass to the extcall.
+        args: Vec<Value>,
+    },
+}
+
+impl<Spec, Executable, Value> waymark_vm_interpreter::Interpreter
+    for CoreSetInterpreter<Spec, Executable, Value>
+where
+    Executable: 'static,
+    Executable: waymark_vm_executable::FunctionInfo<FunctionId = Spec::FunctionId>,
+    Spec: waymark_vm_instructions_coreset::Spec<RegisterId = waymark_vm_runtime_core::RegisterId>,
+    Spec::FunctionId: Copy,
+    Spec::StateId: Copy + Default,
+    Spec::ExtCallId: Clone,
+    Value: self::Value,
+    Value: Clone,
+    Value: 'static,
+{
+    type RuntimeView<'r> = RuntimeView<'r, Executable, Spec::FunctionId, Spec::StateId, Value>;
+    type Frame = Frame<Spec::FunctionId, Spec::StateId, Promise<Value>>;
+    type Instruction = waymark_vm_instructions_coreset::CoreSet<Spec>;
+    type Error = Error<Spec>;
+    type Effect = Effect<Value, Spec::ExtCallId>;
+
+    fn execute<'r>(
+        &self,
+        runtime_view: Self::RuntimeView<'r>,
+        mut frame: Frame<Spec::FunctionId, Spec::StateId, Promise<Value>>,
+        instruction: &Self::Instruction,
+    ) -> Result<
+        ExecutionOutcome<Frame<Spec::FunctionId, Spec::StateId, Promise<Value>>, Self::Effect>,
+        Self::Error,
+    > {
+        let Self::RuntimeView { executable, state } = runtime_view;
+
+        match instruction {
+            waymark_vm_instructions_coreset::CoreSet::Call {
+                dst,
+                function_id,
+                args,
+            } => {
+                let num_regs = executable
+                    .function_num_regs(*function_id)
+                    .ok_or(CallError::FunctionNotFound {
+                        function_id: *function_id,
+                    })
+                    .map_err(Error::Call)?;
+
+                let args = args
+                    .iter()
+                    .map(|arg| frame.regs[*arg].clone())
+                    .collect::<Vec<_>>();
+
+                let promise_id = state.promise_states.prepare();
+                frame.regs.set(*dst, Promise::Pending(promise_id));
+
+                let regs = Registers::new_for_fn_call(num_regs, args);
+
+                let new_frame = Frame {
+                    func: *function_id,
+                    state: Spec::StateId::default(),
+                    regs,
+                    kind: FrameKind::FnCall { ret: promise_id },
+                };
+
+                state.ready.push_back(new_frame);
+            }
+            waymark_vm_instructions_coreset::CoreSet::ExtCall {
+                dst,
+                extcall_id,
+                args,
+                resume,
+            } => {
+                let args = args
+                    .iter()
+                    .enumerate()
+                    .map(|(arg_pos, register)| {
+                        let value = frame.regs[*register].clone();
+
+                        value.require_resolved().map_err(|err| {
+                            ExtCallError::UnresolvedPromiseArgument {
+                                arg_pos,
+                                source: err,
+                            }
+                        })
+                    })
+                    .collect::<Result<_, _>>()
+                    .map_err(Error::ExtCall)?;
+
+                let promise_state_id = state.promise_states.prepare();
+                frame.regs.set(*dst, Promise::Pending(promise_state_id));
+
+                frame.state = *resume;
+
+                state.ready.push_front(frame);
+
+                return Ok(ExecutionOutcome::ExitFrameWithEffect(Effect::ExtCall {
+                    promise_state_id,
+                    extcall_id: extcall_id.clone(),
+                    args,
+                }));
+            }
+            waymark_vm_instructions_coreset::CoreSet::Await { dst, src, resume } => {
+                match &frame.regs[*src] {
+                    Promise::Pending(promise_state_id) => {
+                        let promise_state = state
+                            .promise_states
+                            .get_mut(*promise_state_id)
+                            .map_err(AwaitError::SourcePromiseStateNotFound)
+                            .map_err(Error::Await)?;
+                        return Ok(match promise_state {
+                            PromiseState::Ready(value) => {
+                                Continuation::immediate_resume(
+                                    &mut frame,
+                                    *resume,
+                                    *dst,
+                                    value.clone(),
+                                );
+                                state.ready.push_back(frame);
+                                ExecutionOutcome::ExitFrame
+                            }
+                            PromiseState::Waiting(continuations) => {
+                                continuations.push(Continuation::capture(frame, *resume, *dst));
+                                ExecutionOutcome::ExitFrame
+                            }
+                        });
+                    }
+                    Promise::Resolved(value) => {
+                        frame.regs.set(*dst, Promise::Resolved(value.clone()));
+                    }
+                }
+            }
+            waymark_vm_instructions_coreset::CoreSet::Jump { target_state } => {
+                frame.state = *target_state;
+            }
+            waymark_vm_instructions_coreset::CoreSet::JumpIf { target_state, cond } => {
+                let value = &frame.regs[*cond];
+                let value = value
+                    .require_resolved_ref()
+                    .map_err(JumpIfError::UnresolvedConditionPromise)
+                    .map_err(Error::JumpIf)?;
+
+                let should_jump = value
+                    .should_jump()
+                    .map_err(JumpIfError::ConditionCheck)
+                    .map_err(Error::JumpIf)?;
+
+                if should_jump {
+                    frame.state = *target_state;
+                }
+            }
+            waymark_vm_instructions_coreset::CoreSet::Return { src } => {
+                let val = frame.regs[*src].clone();
+
+                return Ok(match frame.kind {
+                    FrameKind::FnCall { ret } => {
+                        state
+                            .resolve_promise(ret, val)
+                            .map_err(|error| {
+                                match error {
+                                waymark_vm_runtime_core::ResolvePromiseError::PromiseStateNotFound(
+                                    _,
+                                ) => ReturnFnCallError::ReturnPromiseNotFound,
+                                waymark_vm_runtime_core::ResolvePromiseError::AlreadyResolved(
+                                    _,
+                                ) => ReturnFnCallError::ReturnPromiseAlreadyResolved,
+                            }
+                            })
+                            .map_err(ReturnError::FnCall)
+                            .map_err(Error::Return)?;
+                        ExecutionOutcome::ExitFrame
+                    }
+                    FrameKind::TopLevel => {
+                        let val = val
+                            .require_resolved()
+                            .map_err(ReturnError::TopLevel)
+                            .map_err(Error::Return)?;
+                        ExecutionOutcome::ExitFrameWithEffect(Effect::Complete(val))
+                    }
+                });
+            }
+        }
+
+        Ok(ExecutionOutcome::Continue(frame))
+    }
+}
+
+impl<Spec, Executable: 'static, Value: 'static>
+    waymark_vm_runtime_core::CaptureRuntimeView<Executable, Spec::FunctionId, Spec::StateId, Value>
+    for CoreSetInterpreter<Spec, Executable, Value>
+where
+    Spec: waymark_vm_instructions_coreset::Spec,
+{
+    type RuntimeView<'v> = RuntimeView<'v, Executable, Spec::FunctionId, Spec::StateId, Value>;
+
+    fn capture_runtime_view<'r>(
+        view: waymark_vm_runtime_core::FullRuntimeView<
+            'r,
+            Executable,
+            Spec::FunctionId,
+            Spec::StateId,
+            Value,
+        >,
+    ) -> Self::RuntimeView<'r> {
+        let waymark_vm_runtime_core::FullRuntimeView { executable, state } = view;
+        RuntimeView { executable, state }
+    }
+}

--- a/crates/lib/vm-interpreter-coreset/src/value.rs
+++ b/crates/lib/vm-interpreter-coreset/src/value.rs
@@ -1,0 +1,20 @@
+//! Value requirements.
+
+/// An error from the [`ShouldJump`].
+#[derive(Debug, thiserror::Error)]
+#[error("the value is not a conditional")]
+pub struct NotAConditionalError;
+
+/// Evaluate a value and determine whether we should jump or not.
+pub trait ShouldJump {
+    /// Evaluate the value.
+    ///
+    /// Return `true` to jump, return `false` to not jump.
+    /// Return an error if the value is not a conditional.
+    fn should_jump(&self) -> Result<bool, NotAConditionalError>;
+}
+
+/// A unifying trait for all value requirements.
+pub trait Value: ShouldJump {}
+
+impl<T> Value for T where T: ShouldJump {}

--- a/crates/lib/vm-interpreter-coreset/tests/integration.rs
+++ b/crates/lib/vm-interpreter-coreset/tests/integration.rs
@@ -1,0 +1,169 @@
+use waymark_vm_instructions_coreset::CoreSet;
+use waymark_vm_interpreter_coreset::{CoreSetInterpreter, Effect};
+use waymark_vm_runtime::{CallSpec, Runtime};
+use waymark_vm_runtime_core::RegisterId;
+use waymark_vm_runtime_test::{FunctionId, StateId, executable, function};
+
+#[derive(Debug)]
+struct TestSpec;
+
+impl waymark_vm_instructions_coreset::Spec for TestSpec {
+    type RegisterId = RegisterId;
+    type FunctionId = FunctionId;
+    type ExtCallId = TestExtCallId;
+    type StateId = StateId;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct TestExtCallId(usize);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum TestValue {
+    Int(i64),
+}
+
+impl waymark_vm_interpreter_coreset::value::ShouldJump for TestValue {
+    fn should_jump(
+        &self,
+    ) -> Result<bool, waymark_vm_interpreter_coreset::value::NotAConditionalError> {
+        let Self::Int(value) = self;
+        Ok(*value != 0)
+    }
+}
+
+#[test]
+fn runtime_executes_call_await_and_return_to_completion() {
+    let executable = executable(vec![
+        function(
+            2,
+            vec![
+                vec![
+                    CoreSet::Call {
+                        dst: RegisterId(1),
+                        function_id: FunctionId(1),
+                        args: vec![RegisterId(0)],
+                    },
+                    CoreSet::Await {
+                        dst: RegisterId(0),
+                        src: RegisterId(1),
+                        resume: StateId(1),
+                    },
+                ],
+                vec![CoreSet::Return { src: RegisterId(0) }],
+            ],
+        ),
+        function(1, vec![vec![CoreSet::Return { src: RegisterId(0) }]]),
+    ]);
+
+    let mut runtime = Runtime::with_custom_entrypoint(
+        CoreSetInterpreter::<TestSpec, _, TestValue>::default(),
+        executable,
+        CallSpec {
+            func: FunctionId(0),
+            args: vec![TestValue::Int(7)],
+        },
+    )
+    .expect("function 0 should exist");
+
+    let effect = runtime
+        .run()
+        .expect("runtime should complete after the nested call resolves");
+
+    match effect {
+        Effect::Complete(value) => assert_eq!(value, TestValue::Int(7)),
+        Effect::ExtCall { .. } => panic!("program should not emit an extcall"),
+    }
+}
+
+#[test]
+fn runtime_emits_extcall_and_completes_after_resolution() {
+    let executable = executable(vec![function(
+        3,
+        vec![
+            vec![CoreSet::ExtCall {
+                dst: RegisterId(1),
+                extcall_id: TestExtCallId(5),
+                args: vec![RegisterId(0)],
+                resume: StateId(1),
+            }],
+            vec![CoreSet::Await {
+                dst: RegisterId(2),
+                src: RegisterId(1),
+                resume: StateId(2),
+            }],
+            vec![CoreSet::Return { src: RegisterId(2) }],
+        ],
+    )]);
+
+    let mut runtime = Runtime::with_custom_entrypoint(
+        CoreSetInterpreter::<TestSpec, _, TestValue>::default(),
+        executable,
+        CallSpec {
+            func: FunctionId(0),
+            args: vec![TestValue::Int(13)],
+        },
+    )
+    .expect("function 0 should exist");
+
+    let promise_state_id = match runtime.run().expect("first run should emit the extcall") {
+        Effect::ExtCall {
+            promise_state_id,
+            extcall_id,
+            args,
+        } => {
+            assert_eq!(extcall_id, TestExtCallId(5));
+            assert_eq!(args, vec![TestValue::Int(13)]);
+            promise_state_id
+        }
+        Effect::Complete(_) => panic!("runtime should suspend on the extcall first"),
+    };
+
+    runtime
+        .resolve_promise(promise_state_id, TestValue::Int(41))
+        .expect("extcall promise should resolve cleanly");
+
+    let effect = runtime
+        .run()
+        .expect("runtime should complete after the promise resolves");
+
+    match effect {
+        Effect::Complete(value) => assert_eq!(value, TestValue::Int(41)),
+        Effect::ExtCall { .. } => panic!("resolved extcall should not emit another extcall"),
+    }
+}
+
+#[test]
+fn runtime_follows_jump_and_jump_if_before_returning() {
+    let executable = executable(vec![function(
+        2,
+        vec![
+            vec![CoreSet::JumpIf {
+                target_state: StateId(1),
+                cond: RegisterId(0),
+            }],
+            vec![CoreSet::Jump {
+                target_state: StateId(2),
+            }],
+            vec![CoreSet::Return { src: RegisterId(1) }],
+        ],
+    )]);
+
+    let mut runtime = Runtime::with_custom_entrypoint(
+        CoreSetInterpreter::<TestSpec, _, TestValue>::default(),
+        executable,
+        CallSpec {
+            func: FunctionId(0),
+            args: vec![TestValue::Int(1), TestValue::Int(9)],
+        },
+    )
+    .expect("function 0 should exist");
+
+    let effect = runtime
+        .run()
+        .expect("runtime should follow the branch states to completion");
+
+    match effect {
+        Effect::Complete(value) => assert_eq!(value, TestValue::Int(9)),
+        Effect::ExtCall { .. } => panic!("branching program should not emit an extcall"),
+    }
+}

--- a/crates/lib/vm-interpreter-fullset/Cargo.toml
+++ b/crates/lib/vm-interpreter-fullset/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "waymark-vm-interpreter-fullset"
+edition = "2024"
+version.workspace = true
+publish.workspace = true
+
+[dependencies]
+waymark-vm-executable = { workspace = true }
+waymark-vm-instructions-coreset = { workspace = true }
+waymark-vm-instructions-fullset = { workspace = true }
+waymark-vm-instructions-pureset = { workspace = true }
+waymark-vm-interpreter = { workspace = true }
+waymark-vm-interpreter-coreset = { workspace = true }
+waymark-vm-interpreter-pureset = { workspace = true }
+waymark-vm-runtime-core = { workspace = true }
+
+derive-where = { workspace = true }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+waymark-vm-runtime = { workspace = true }
+waymark-vm-runtime-test = { workspace = true }

--- a/crates/lib/vm-interpreter-fullset/src/error.rs
+++ b/crates/lib/vm-interpreter-fullset/src/error.rs
@@ -1,0 +1,11 @@
+/// The error for the [`crate::FullSetInterpreter`].
+#[derive(Debug, thiserror::Error)]
+pub enum Error<Spec: waymark_vm_instructions_fullset::Spec> {
+    /// Executing a coreset instruction failed.
+    #[error(transparent)]
+    CoreSet(#[from] waymark_vm_interpreter_coreset::Error<Spec>),
+
+    /// Executing a pureset instruction failed.
+    #[error(transparent)]
+    PureSet(#[from] waymark_vm_interpreter_pureset::Error),
+}

--- a/crates/lib/vm-interpreter-fullset/src/lib.rs
+++ b/crates/lib/vm-interpreter-fullset/src/lib.rs
@@ -1,0 +1,119 @@
+//! The interpreter for the "full" instructions set.
+
+#![warn(missing_docs)]
+
+mod error;
+pub mod value;
+
+use derive_where::derive_where;
+use waymark_vm_interpreter::ExecutionOutcome;
+use waymark_vm_runtime_core::{CaptureRuntimeView as _, Frame, Promise};
+
+pub use self::error::*;
+pub use self::value::Value;
+
+/// An interpreter for the "full" instructions set.
+#[derive_where(Default)]
+pub struct FullSetInterpreter<Spec: waymark_vm_instructions_fullset::Spec, Executable, Value> {
+    /// The coreset interpreter used for core instructions.
+    pub core_set: waymark_vm_interpreter_coreset::CoreSetInterpreter<Spec, Executable, Value>,
+
+    /// The pureset interpreter used for pure instructions.
+    pub pure_set: waymark_vm_interpreter_pureset::PureSetInterpreter<
+        Spec,
+        Spec::FunctionId,
+        Spec::StateId,
+        Value,
+    >,
+}
+
+/// The runtime view for the [`FullSetInterpreter`].
+pub use waymark_vm_runtime_core::FullRuntimeView as RuntimeView;
+
+/// The effect for the [`FullSetInterpreter`].
+#[derive(Debug)]
+pub enum Effect<Value, ExtCallId> {
+    /// An effect produced while executing a coreset instruction.
+    CoreSet(waymark_vm_interpreter_coreset::Effect<Value, ExtCallId>),
+
+    /// An impossible effect produced while executing a pureset instruction.
+    PureSet(core::convert::Infallible),
+}
+
+impl<Spec, Executable, Value> waymark_vm_interpreter::Interpreter
+    for FullSetInterpreter<Spec, Executable, Value>
+where
+    Spec: waymark_vm_instructions_fullset::Spec,
+    Executable: 'static,
+    Executable: waymark_vm_executable::FunctionInfo<FunctionId = Spec::FunctionId>,
+    Spec: waymark_vm_instructions_coreset::Spec<RegisterId = waymark_vm_runtime_core::RegisterId>,
+    Spec: waymark_vm_instructions_pureset::Spec<RegisterId = waymark_vm_runtime_core::RegisterId>,
+    Spec: 'static,
+    Spec::FunctionId: Copy,
+    Spec::StateId: Copy + Default,
+    Spec::ExtCallId: Clone,
+    Value: Clone + 'static,
+    Value: waymark_vm_interpreter_coreset::Value,
+    Value: waymark_vm_interpreter_pureset::Value,
+    Spec::ConstValue: Clone + Into<Value>,
+{
+    type RuntimeView<'r> = RuntimeView<'r, Executable, Spec::FunctionId, Spec::StateId, Value>;
+    type Frame = Frame<Spec::FunctionId, Spec::StateId, Promise<Value>>;
+    type Instruction = waymark_vm_instructions_fullset::FullSet<Spec>;
+    type Error = Error<Spec>;
+    type Effect = Effect<Value, Spec::ExtCallId>;
+
+    fn execute<'r>(
+        &self,
+        runtime_view: Self::RuntimeView<'r>,
+        frame: Frame<Spec::FunctionId, Spec::StateId, Promise<Value>>,
+        instruction: &Self::Instruction,
+    ) -> Result<
+        ExecutionOutcome<Frame<Spec::FunctionId, Spec::StateId, Promise<Value>>, Self::Effect>,
+        Self::Error,
+    > {
+        Ok(match instruction {
+            waymark_vm_instructions_fullset::FullSet::CoreSet(instruction) => {
+                let runtime_view = waymark_vm_interpreter_coreset::CoreSetInterpreter::<
+                    Spec,
+                    Executable,
+                    Value,
+                >::capture_runtime_view(runtime_view);
+                self.core_set
+                    .execute(runtime_view, frame, instruction)?
+                    .map_effect(Effect::CoreSet)
+            }
+            waymark_vm_instructions_fullset::FullSet::PureSet(instruction) => {
+                #[allow(clippy::let_unit_value)]
+                let runtime_view = waymark_vm_interpreter_pureset::PureSetInterpreter::<
+                    Spec,
+                    Spec::FunctionId,
+                    Spec::StateId,
+                    Value,
+                >::capture_runtime_view(runtime_view);
+                self.pure_set
+                    .execute(runtime_view, frame, instruction)?
+                    .map_effect(Effect::PureSet)
+            }
+        })
+    }
+}
+
+impl<Spec: waymark_vm_instructions_fullset::Spec, Executable: 'static, Value: 'static>
+    waymark_vm_runtime_core::CaptureRuntimeView<Executable, Spec::FunctionId, Spec::StateId, Value>
+    for FullSetInterpreter<Spec, Executable, Value>
+{
+    type RuntimeView<'v> = RuntimeView<'v, Executable, Spec::FunctionId, Spec::StateId, Value>;
+
+    fn capture_runtime_view<'r>(
+        view: waymark_vm_runtime_core::FullRuntimeView<
+            'r,
+            Executable,
+            Spec::FunctionId,
+            Spec::StateId,
+            Value,
+        >,
+    ) -> Self::RuntimeView<'r> {
+        view
+    }
+}

--- a/crates/lib/vm-interpreter-fullset/src/value.rs
+++ b/crates/lib/vm-interpreter-fullset/src/value.rs
@@ -1,0 +1,12 @@
+//! Value requirements.
+
+/// A unifying trait for all value requirements.
+pub trait Value:
+    waymark_vm_interpreter_coreset::Value + waymark_vm_interpreter_pureset::Value
+{
+}
+
+impl<T> Value for T where
+    T: waymark_vm_interpreter_coreset::Value + waymark_vm_interpreter_pureset::Value
+{
+}

--- a/crates/lib/vm-interpreter-fullset/tests/integration.rs
+++ b/crates/lib/vm-interpreter-fullset/tests/integration.rs
@@ -1,0 +1,193 @@
+use waymark_vm_instructions_coreset::CoreSet;
+use waymark_vm_instructions_fullset::FullSet;
+use waymark_vm_instructions_pureset::PureSet;
+use waymark_vm_interpreter_fullset::{Effect, FullSetInterpreter};
+use waymark_vm_runtime::{CallSpec, Runtime};
+use waymark_vm_runtime_core::RegisterId;
+use waymark_vm_runtime_test::{FunctionId, StateId, executable, function};
+
+type Instruction = FullSet<TestSpec>;
+
+#[derive(Debug)]
+struct TestSpec;
+
+impl waymark_vm_instructions_coreset::Spec for TestSpec {
+    type RegisterId = RegisterId;
+    type FunctionId = FunctionId;
+    type ExtCallId = TestExtCallId;
+    type StateId = StateId;
+}
+
+impl waymark_vm_instructions_pureset::Spec for TestSpec {
+    type RegisterId = RegisterId;
+    type ConstValue = TestConstValue;
+}
+
+#[derive(Debug, Clone)]
+enum TestConstValue {
+    Int(i64),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct TestExtCallId(usize);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum TestValue {
+    Int(i64),
+}
+
+impl waymark_vm_interpreter_coreset::value::ShouldJump for TestValue {
+    fn should_jump(
+        &self,
+    ) -> Result<bool, waymark_vm_interpreter_coreset::value::NotAConditionalError> {
+        let Self::Int(value) = self;
+        Ok(*value != 0)
+    }
+}
+
+impl waymark_vm_interpreter_pureset::value::Add for TestValue {
+    fn add(a: &Self, b: &Self) -> Result<Self, waymark_vm_interpreter_pureset::value::AddError> {
+        let (Self::Int(a), Self::Int(b)) = (a, b);
+        Ok(Self::Int(a + b))
+    }
+}
+
+impl From<TestConstValue> for TestValue {
+    fn from(value: TestConstValue) -> Self {
+        match value {
+            TestConstValue::Int(value) => Self::Int(value),
+        }
+    }
+}
+
+#[test]
+fn runtime_executes_pure_and_core_instructions_to_completion() {
+    let executable = executable(vec![function::<Instruction>(
+        3,
+        vec![vec![
+            PureSet::LoadConst {
+                dst: RegisterId(0),
+                value: TestConstValue::Int(2),
+            }
+            .into(),
+            PureSet::LoadConst {
+                dst: RegisterId(1),
+                value: TestConstValue::Int(3),
+            }
+            .into(),
+            PureSet::Add {
+                dst: RegisterId(2),
+                a: RegisterId(0),
+                b: RegisterId(1),
+            }
+            .into(),
+            CoreSet::Return { src: RegisterId(2) }.into(),
+        ]],
+    )]);
+
+    let mut runtime = Runtime::with_conventional_entrypoint(
+        FullSetInterpreter::<TestSpec, _, TestValue>::default(),
+        executable,
+    )
+    .expect("function 0 should exist");
+
+    let effect = runtime
+        .run()
+        .expect("mixed fullset program should complete successfully");
+
+    match effect {
+        Effect::CoreSet(waymark_vm_interpreter_coreset::Effect::Complete(value)) => {
+            assert_eq!(value, TestValue::Int(5));
+        }
+        Effect::CoreSet(waymark_vm_interpreter_coreset::Effect::ExtCall { .. }) => {
+            panic!("program should not emit an extcall")
+        }
+        Effect::PureSet(effect) => match effect {},
+    }
+}
+
+#[test]
+fn runtime_resumes_extcalls_and_finishes_with_pure_work() {
+    let executable = executable(vec![function::<Instruction>(
+        4,
+        vec![
+            vec![
+                CoreSet::ExtCall {
+                    dst: RegisterId(1),
+                    extcall_id: TestExtCallId(7),
+                    args: vec![RegisterId(0)],
+                    resume: StateId(1),
+                }
+                .into(),
+            ],
+            vec![
+                CoreSet::Await {
+                    dst: RegisterId(2),
+                    src: RegisterId(1),
+                    resume: StateId(2),
+                }
+                .into(),
+            ],
+            vec![
+                PureSet::LoadConst {
+                    dst: RegisterId(3),
+                    value: TestConstValue::Int(1),
+                }
+                .into(),
+                PureSet::Add {
+                    dst: RegisterId(3),
+                    a: RegisterId(2),
+                    b: RegisterId(3),
+                }
+                .into(),
+                CoreSet::Return { src: RegisterId(3) }.into(),
+            ],
+        ],
+    )]);
+
+    let mut runtime = Runtime::with_custom_entrypoint(
+        FullSetInterpreter::<TestSpec, _, TestValue>::default(),
+        executable,
+        CallSpec {
+            func: FunctionId(0),
+            args: vec![TestValue::Int(41)],
+        },
+    )
+    .expect("function 0 should exist");
+
+    let effect = runtime.run().expect("first run should emit the extcall");
+
+    let promise_state_id = match effect {
+        Effect::CoreSet(waymark_vm_interpreter_coreset::Effect::ExtCall {
+            promise_state_id,
+            extcall_id,
+            args,
+        }) => {
+            assert_eq!(extcall_id, TestExtCallId(7));
+            assert_eq!(args, vec![TestValue::Int(41)]);
+            promise_state_id
+        }
+        Effect::CoreSet(waymark_vm_interpreter_coreset::Effect::Complete(_)) => {
+            panic!("program should suspend on the extcall before completion")
+        }
+        Effect::PureSet(effect) => match effect {},
+    };
+
+    runtime
+        .resolve_promise(promise_state_id, TestValue::Int(41))
+        .expect("extcall promise should resolve cleanly");
+
+    let effect = runtime
+        .run()
+        .expect("second run should finish after resuming the extcall");
+
+    match effect {
+        Effect::CoreSet(waymark_vm_interpreter_coreset::Effect::Complete(value)) => {
+            assert_eq!(value, TestValue::Int(42));
+        }
+        Effect::CoreSet(waymark_vm_interpreter_coreset::Effect::ExtCall { .. }) => {
+            panic!("resolved extcall should not emit another extcall")
+        }
+        Effect::PureSet(effect) => match effect {},
+    }
+}

--- a/crates/lib/vm-interpreter-pureset/Cargo.toml
+++ b/crates/lib/vm-interpreter-pureset/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "waymark-vm-interpreter-pureset"
+edition = "2024"
+version.workspace = true
+publish.workspace = true
+
+[dependencies]
+waymark-vm-instructions-pureset = { workspace = true }
+waymark-vm-interpreter = { workspace = true }
+waymark-vm-runtime-core = { workspace = true }
+
+derive-where = { workspace = true }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+waymark-vm-runtime = { workspace = true }
+waymark-vm-runtime-test = { workspace = true }

--- a/crates/lib/vm-interpreter-pureset/src/error.rs
+++ b/crates/lib/vm-interpreter-pureset/src/error.rs
@@ -1,0 +1,51 @@
+use waymark_vm_runtime_core::{RegisterId, UnresolvedPromiseError};
+
+/// A specified of the operand position in a binary operation.
+///
+/// Used in the errors.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum BinaryOperandPosition {
+    /// First operand.
+    First,
+
+    /// Second operand.
+    Second,
+}
+
+impl core::fmt::Display for BinaryOperandPosition {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            BinaryOperandPosition::First => write!(f, "first"),
+            BinaryOperandPosition::Second => write!(f, "second"),
+        }
+    }
+}
+
+/// The error for the [`crate::PureSetInterpreter`].
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// An `Add` instruction referenced an unset register.
+    #[error(" {operand_pos} add operand in register {register:?} is not initialized")]
+    MissingAddOperand {
+        /// The operand position.
+        operand_pos: BinaryOperandPosition,
+
+        /// The register that was read.
+        register: RegisterId,
+    },
+
+    /// An `Add` instruction referenced an unresolved promise.
+    #[error("{operand_pos} add operand is unresolved: {source}")]
+    UnresolvedAddOperand {
+        /// The operand position.
+        operand_pos: BinaryOperandPosition,
+
+        /// The underlying unresolved promise error.
+        #[source]
+        source: UnresolvedPromiseError,
+    },
+
+    /// Evaluating an `Add` instruction failed.
+    #[error("add: {0}")]
+    Add(#[source] crate::value::AddError),
+}

--- a/crates/lib/vm-interpreter-pureset/src/lib.rs
+++ b/crates/lib/vm-interpreter-pureset/src/lib.rs
@@ -1,0 +1,99 @@
+//! The interpreter for the "pure" instructions set.
+
+#![warn(missing_docs)]
+
+mod error;
+pub mod value;
+
+use derive_where::derive_where;
+use waymark_vm_interpreter::ExecutionOutcome;
+use waymark_vm_runtime_core::{Frame, Promise};
+
+pub use self::error::*;
+pub use self::value::Value;
+
+/// An interpreter for the "pure" instructions set.
+#[derive_where(Default)]
+pub struct PureSetInterpreter<Spec, FunctionId, StateId, Value> {
+    phantom_data: core::marker::PhantomData<(Spec, FunctionId, StateId, Value)>,
+}
+
+impl<Spec, FunctionId, StateId, Value> waymark_vm_interpreter::Interpreter
+    for PureSetInterpreter<Spec, FunctionId, StateId, Value>
+where
+    Spec: waymark_vm_instructions_pureset::Spec<RegisterId = waymark_vm_runtime_core::RegisterId>
+        + 'static,
+    Spec::ConstValue: Clone + Into<Value>,
+    Value: 'static,
+    Value: value::Value,
+{
+    type RuntimeView<'r> = ();
+    type Frame = Frame<FunctionId, StateId, Promise<Value>>;
+    type Instruction = waymark_vm_instructions_pureset::PureSet<Spec>;
+    type Error = Error;
+    type Effect = core::convert::Infallible;
+
+    fn execute<'r>(
+        &self,
+        _runtime_view: Self::RuntimeView<'r>,
+        mut frame: Frame<FunctionId, StateId, Promise<Value>>,
+        instruction: &Self::Instruction,
+    ) -> Result<
+        ExecutionOutcome<Frame<FunctionId, StateId, Promise<Value>>, Self::Effect>,
+        Self::Error,
+    > {
+        match instruction {
+            waymark_vm_instructions_pureset::PureSet::LoadConst { dst, value } => {
+                frame
+                    .regs
+                    .set(*dst, Promise::Resolved(value.clone().into()));
+            }
+            waymark_vm_instructions_pureset::PureSet::Add { dst, a, b } => {
+                let x = frame.regs.get(*a).ok_or(Error::MissingAddOperand {
+                    operand_pos: BinaryOperandPosition::First,
+                    register: *a,
+                })?;
+                let x = x
+                    .require_resolved_ref()
+                    .map_err(|source| Error::UnresolvedAddOperand {
+                        operand_pos: BinaryOperandPosition::First,
+                        source,
+                    })?;
+
+                let y = frame.regs.get(*b).ok_or(Error::MissingAddOperand {
+                    operand_pos: BinaryOperandPosition::Second,
+                    register: *b,
+                })?;
+                let y = y
+                    .require_resolved_ref()
+                    .map_err(|source| Error::UnresolvedAddOperand {
+                        operand_pos: BinaryOperandPosition::Second,
+                        source,
+                    })?;
+
+                let value = Value::add(x, y).map_err(Error::Add)?;
+                frame.regs.set(*dst, Promise::Resolved(value));
+            }
+        }
+
+        Ok(ExecutionOutcome::Continue(frame))
+    }
+}
+
+impl<Spec, Executable, FunctionId, StateId, Value>
+    waymark_vm_runtime_core::CaptureRuntimeView<Executable, FunctionId, StateId, Value>
+    for PureSetInterpreter<Spec, FunctionId, StateId, Value>
+{
+    type RuntimeView<'v>
+        = ()
+    where
+        Executable: 'v,
+        FunctionId: 'v,
+        StateId: 'v,
+        Value: 'v;
+
+    fn capture_runtime_view<'r>(
+        _view: waymark_vm_runtime_core::FullRuntimeView<'r, Executable, FunctionId, StateId, Value>,
+    ) -> Self::RuntimeView<'r> {
+    }
+}

--- a/crates/lib/vm-interpreter-pureset/src/value.rs
+++ b/crates/lib/vm-interpreter-pureset/src/value.rs
@@ -1,0 +1,24 @@
+//! Value requirements.
+
+/// An error from [`Value::add`].
+#[derive(Debug, thiserror::Error)]
+pub enum AddError {
+    /// At least one operand did not support addition.
+    #[error("adding non-addable values")]
+    NotAddable,
+
+    /// The addition result could not be represented by the value type.
+    #[error("addition result is out of bounds")]
+    ResultOutOfBounds,
+}
+
+/// Add two values together and obtain a sum of them.
+pub trait Add: Sized {
+    /// Add two resolved values and return the resulting value.
+    fn add(a: &Self, b: &Self) -> Result<Self, AddError>;
+}
+
+/// A unifying trait for all value requirements.
+pub trait Value: Add {}
+
+impl<T> Value for T where T: Add {}

--- a/crates/lib/vm-interpreter-pureset/tests/integration.rs
+++ b/crates/lib/vm-interpreter-pureset/tests/integration.rs
@@ -1,0 +1,260 @@
+use waymark_vm_instructions_pureset::PureSet;
+use waymark_vm_interpreter::ExecutionOutcome;
+use waymark_vm_interpreter_pureset::{BinaryOperandPosition, Error, PureSetInterpreter};
+use waymark_vm_runtime::{RunError, Runtime};
+use waymark_vm_runtime_core::{CaptureRuntimeView, Frame, Promise, PromiseStateId, RegisterId};
+use waymark_vm_runtime_test::{FunctionId, StateId, executable, function};
+
+#[derive(Debug)]
+struct TestSpec;
+
+impl waymark_vm_instructions_pureset::Spec for TestSpec {
+    type RegisterId = RegisterId;
+    type ConstValue = TestConstValue;
+}
+
+#[derive(Debug, Clone)]
+enum TestConstValue {
+    Int(i64),
+    Text(&'static str),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum TestValue {
+    Int(i64),
+    Text(&'static str),
+}
+
+impl From<TestConstValue> for TestValue {
+    fn from(value: TestConstValue) -> Self {
+        match value {
+            TestConstValue::Int(value) => Self::Int(value),
+            TestConstValue::Text(value) => Self::Text(value),
+        }
+    }
+}
+
+impl waymark_vm_interpreter_pureset::value::Add for TestValue {
+    fn add(a: &Self, b: &Self) -> Result<Self, waymark_vm_interpreter_pureset::value::AddError> {
+        match (a, b) {
+            (Self::Int(a), Self::Int(b)) => Ok(Self::Int(a + b)),
+            _ => Err(waymark_vm_interpreter_pureset::value::AddError::NotAddable),
+        }
+    }
+}
+
+#[derive(Debug)]
+enum RuntimeInstruction {
+    Pure(PureSet<TestSpec>),
+    SetPending {
+        dst: RegisterId,
+        promise_state_id: PromiseStateId,
+    },
+    EmitRegister(RegisterId),
+}
+
+impl From<PureSet<TestSpec>> for RuntimeInstruction {
+    fn from(value: PureSet<TestSpec>) -> Self {
+        Self::Pure(value)
+    }
+}
+
+#[derive(Default)]
+struct RuntimeInterpreter {
+    pure: PureSetInterpreter<TestSpec, FunctionId, StateId, TestValue>,
+}
+
+impl<Executable> CaptureRuntimeView<Executable, FunctionId, StateId, TestValue>
+    for RuntimeInterpreter
+{
+    type RuntimeView<'v>
+        = ()
+    where
+        Executable: 'v,
+        FunctionId: 'v,
+        StateId: 'v,
+        TestValue: 'v;
+
+    fn capture_runtime_view<'r>(
+        _view: waymark_vm_runtime_core::FullRuntimeView<
+            'r,
+            Executable,
+            FunctionId,
+            StateId,
+            TestValue,
+        >,
+    ) -> Self::RuntimeView<'r> {
+    }
+}
+
+impl waymark_vm_interpreter::Interpreter for RuntimeInterpreter {
+    type RuntimeView<'r> = ();
+    type Frame = Frame<FunctionId, StateId, Promise<TestValue>>;
+    type Instruction = RuntimeInstruction;
+    type Error = Error;
+    type Effect = TestValue;
+
+    fn execute<'r>(
+        &self,
+        _runtime_view: Self::RuntimeView<'r>,
+        mut frame: Self::Frame,
+        instruction: &Self::Instruction,
+    ) -> Result<ExecutionOutcome<Self::Frame, Self::Effect>, Self::Error> {
+        match instruction {
+            RuntimeInstruction::Pure(instruction) => self
+                .pure
+                .execute((), frame, instruction)
+                .map(|outcome| outcome.map_effect(|effect| match effect {})),
+            RuntimeInstruction::SetPending {
+                dst,
+                promise_state_id,
+            } => {
+                frame.regs.set(*dst, Promise::Pending(*promise_state_id));
+                Ok(ExecutionOutcome::Continue(frame))
+            }
+            RuntimeInstruction::EmitRegister(register) => {
+                let value = frame.regs[*register].clone().require_resolved().unwrap();
+                Ok(ExecutionOutcome::ExitFrameWithEffect(value))
+            }
+        }
+    }
+}
+
+#[test]
+fn runtime_executes_load_const_and_add_to_a_terminal_effect() {
+    let executable = executable(vec![function::<RuntimeInstruction>(
+        3,
+        vec![vec![
+            PureSet::LoadConst {
+                dst: RegisterId(0),
+                value: TestConstValue::Int(2),
+            }
+            .into(),
+            PureSet::LoadConst {
+                dst: RegisterId(1),
+                value: TestConstValue::Int(3),
+            }
+            .into(),
+            PureSet::Add {
+                dst: RegisterId(2),
+                a: RegisterId(0),
+                b: RegisterId(1),
+            }
+            .into(),
+            RuntimeInstruction::EmitRegister(RegisterId(2)),
+        ]],
+    )]);
+
+    let mut runtime =
+        Runtime::with_conventional_entrypoint(RuntimeInterpreter::default(), executable)
+            .expect("function 0 should exist");
+
+    assert_eq!(
+        runtime
+            .run()
+            .expect("runtime should emit the computed pure result"),
+        TestValue::Int(5)
+    );
+}
+
+#[test]
+fn runtime_surfaces_add_errors_from_the_pureset_interpreter() {
+    let executable = executable(vec![function::<RuntimeInstruction>(
+        2,
+        vec![vec![
+            PureSet::LoadConst {
+                dst: RegisterId(0),
+                value: TestConstValue::Text("left"),
+            }
+            .into(),
+            PureSet::LoadConst {
+                dst: RegisterId(1),
+                value: TestConstValue::Int(3),
+            }
+            .into(),
+            PureSet::Add {
+                dst: RegisterId(0),
+                a: RegisterId(0),
+                b: RegisterId(1),
+            }
+            .into(),
+            RuntimeInstruction::EmitRegister(RegisterId(0)),
+        ]],
+    )]);
+
+    let mut runtime =
+        Runtime::with_conventional_entrypoint(RuntimeInterpreter::default(), executable)
+            .expect("function 0 should exist");
+
+    assert!(matches!(
+        runtime.run(),
+        Err(RunError::Step(waymark_vm_runtime::step::Error::Execution(
+            Error::Add(waymark_vm_interpreter_pureset::value::AddError::NotAddable)
+        )))
+    ));
+}
+
+#[test]
+fn runtime_surfaces_unresolved_add_operand_errors_from_the_pureset_interpreter() {
+    let executable = executable(vec![function::<RuntimeInstruction>(
+        2,
+        vec![vec![
+            RuntimeInstruction::SetPending {
+                dst: RegisterId(0),
+                promise_state_id: PromiseStateId(7),
+            },
+            PureSet::LoadConst {
+                dst: RegisterId(1),
+                value: TestConstValue::Int(3),
+            }
+            .into(),
+            PureSet::Add {
+                dst: RegisterId(0),
+                a: RegisterId(0),
+                b: RegisterId(1),
+            }
+            .into(),
+            RuntimeInstruction::EmitRegister(RegisterId(0)),
+        ]],
+    )]);
+
+    let mut runtime =
+        Runtime::with_conventional_entrypoint(RuntimeInterpreter::default(), executable)
+            .expect("function 0 should exist");
+
+    assert!(matches!(
+        runtime.run(),
+        Err(RunError::Step(waymark_vm_runtime::step::Error::Execution(
+            Error::UnresolvedAddOperand {
+                operand_pos: BinaryOperandPosition::First,
+                source: waymark_vm_runtime_core::UnresolvedPromiseError { promise_state_id },
+            }
+        ))) if promise_state_id == PromiseStateId(7)
+    ));
+}
+
+#[test]
+fn runtime_converts_non_numeric_constants_through_the_spec_type() {
+    let executable = executable(vec![function::<RuntimeInstruction>(
+        1,
+        vec![vec![
+            PureSet::LoadConst {
+                dst: RegisterId(0),
+                value: TestConstValue::Text("hello"),
+            }
+            .into(),
+            RuntimeInstruction::EmitRegister(RegisterId(0)),
+        ]],
+    )]);
+
+    let mut runtime =
+        Runtime::with_conventional_entrypoint(RuntimeInterpreter::default(), executable)
+            .expect("function 0 should exist");
+
+    assert_eq!(
+        runtime
+            .run()
+            .expect("runtime should emit the converted constant"),
+        TestValue::Text("hello")
+    );
+}

--- a/crates/lib/vm-interpreter/Cargo.toml
+++ b/crates/lib/vm-interpreter/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "waymark-vm-interpreter"
+edition = "2024"
+version.workspace = true
+publish.workspace = true
+
+[dependencies]

--- a/crates/lib/vm-interpreter/src/lib.rs
+++ b/crates/lib/vm-interpreter/src/lib.rs
@@ -1,0 +1,70 @@
+//! [`Interpreter`] trait definition.
+
+#![warn(missing_docs)]
+
+/// The interpreter for a given instruction set.
+///
+/// Semantically, this is the building block that enables us to execute
+/// a particular set of instructions.
+///
+/// Runtime is configured with an interpreter that specifies,
+/// and it defines which particular instruction set will be supported.
+///
+/// Should hold the static state (i.e. extcall tables) required
+/// for interpreting a particular instruction set.
+pub trait Interpreter {
+    /// The view into the runtime that this interpreter needs access to
+    /// in order to execute the instructions.
+    type RuntimeView<'r>: 'r;
+
+    /// The frame type to execute the instructions on.
+    type Frame;
+
+    /// The instruction type that this interpreter understands to how execute.
+    ///
+    /// Typically this would be an enum representing an instruction set.
+    type Instruction;
+
+    /// The error that can occur while executing an instruction.
+    type Error;
+
+    /// The side-effect that an execution of an in instruction with this
+    /// interpreter can trigger.
+    type Effect;
+
+    /// Execute the instruction on a given frame.
+    fn execute<'r>(
+        &self,
+        runtime: Self::RuntimeView<'r>,
+        frame: Self::Frame,
+        instruction: &Self::Instruction,
+    ) -> Result<ExecutionOutcome<Self::Frame, Self::Effect>, Self::Error>;
+}
+
+/// The outcome of an execution of a single instruction.
+pub enum ExecutionOutcome<Frame, Effect> {
+    /// Continue executing this frame.
+    Continue(Frame),
+
+    /// Exit the frame, and continue with the next one.
+    ExitFrame,
+
+    /// Exit the frame and emit a side-effect.
+    ExitFrameWithEffect(Effect),
+}
+
+impl<Frame, Effect> ExecutionOutcome<Frame, Effect> {
+    /// The map one effect to the other leaving the variants as-is.
+    pub fn map_effect<OtherEffect>(
+        self,
+        f: impl FnOnce(Effect) -> OtherEffect,
+    ) -> ExecutionOutcome<Frame, OtherEffect> {
+        match self {
+            ExecutionOutcome::Continue(frame) => ExecutionOutcome::Continue(frame),
+            ExecutionOutcome::ExitFrame => ExecutionOutcome::ExitFrame,
+            ExecutionOutcome::ExitFrameWithEffect(effect) => {
+                ExecutionOutcome::ExitFrameWithEffect(f(effect))
+            }
+        }
+    }
+}

--- a/crates/lib/vm-runtime-core/Cargo.toml
+++ b/crates/lib/vm-runtime-core/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "waymark-vm-runtime-core"
+edition = "2024"
+version.workspace = true
+publish.workspace = true
+
+[dependencies]
+index_type = { workspace = true }
+thiserror = { workspace = true }

--- a/crates/lib/vm-runtime-core/src/capture_runtime_view.rs
+++ b/crates/lib/vm-runtime-core/src/capture_runtime_view.rs
@@ -1,0 +1,33 @@
+use crate::RuntimeState;
+
+/// An ability to capture a view to a runtime.
+///
+/// To be used by the instruction set interpreters when they need a view to
+/// a runtime.
+///
+/// This indirection is provided to reduce the coupling between the runtime
+/// and the interpreters, and make the dependency of the interpreter on
+/// the runtime state more explicit.
+pub trait CaptureRuntimeView<Executable, FunctionId, StateId, Value> {
+    /// The view into the runtime to capture.
+    type RuntimeView<'v>
+    where
+        Executable: 'v,
+        FunctionId: 'v,
+        StateId: 'v,
+        Value: 'v;
+
+    /// Capture the recuded runtime view from the full runtime view.
+    fn capture_runtime_view<'r>(
+        view: FullRuntimeView<'r, Executable, FunctionId, StateId, Value>,
+    ) -> Self::RuntimeView<'r>;
+}
+
+/// The full view into the runtime.
+pub struct FullRuntimeView<'r, Executable, FunctionId, StateId, Value> {
+    /// A ref access to the executable we're executing.
+    pub executable: &'r Executable,
+
+    /// A mut access to the runtime state.
+    pub state: &'r mut RuntimeState<FunctionId, StateId, Value>,
+}

--- a/crates/lib/vm-runtime-core/src/continuation.rs
+++ b/crates/lib/vm-runtime-core/src/continuation.rs
@@ -1,0 +1,111 @@
+use crate::{Frame, RegisterId};
+
+/// Captures the ability to resume the execution from the given state when
+/// after a certain async value is resolved.
+///
+/// `Resumer` determines how we resume the execution for this continuation.
+pub struct Continuation<FunctionId, StateId, Value, Resumer> {
+    /// The frame to resume the execution from.
+    prepared_resume_frame: Frame<FunctionId, StateId, Value>,
+
+    /// Holds the state associated with the logic of how we resume from this
+    /// continuation.
+    resumer: Resumer,
+}
+
+/// Specified that a [`Continuation`] is to resume with an value assigned to
+/// a frame register.
+///
+/// Typical use is for continuations that suspend on an asynchronously obtained
+/// value.
+pub struct ResumeWithValue {
+    /// The register to assign the resulting value of this continuation to.
+    pub dst: RegisterId,
+}
+
+impl<FunctionId, StateId, Value> Continuation<FunctionId, StateId, Value, ResumeWithValue> {
+    /// Capture the given `frame` as a continuation, with a `dst` register
+    /// to be populated by a resolved value upon coninuing, and the given
+    /// `state` to resume the execution from.
+    pub fn capture(
+        frame: Frame<FunctionId, StateId, Value>,
+        resume: StateId,
+        dst: RegisterId,
+    ) -> Self {
+        let mut prepared_resume_frame = frame;
+
+        // Prepare the frame to start executing from the `resume` state.
+        prepared_resume_frame.state = resume;
+
+        Self {
+            resumer: ResumeWithValue { dst },
+            prepared_resume_frame,
+        }
+    }
+
+    /// Resume the continuation with the provided value.
+    pub fn resume(self, value: Value) -> Frame<FunctionId, StateId, Value> {
+        let Self {
+            mut prepared_resume_frame,
+            resumer: ResumeWithValue { dst },
+        } = self;
+
+        // Assign the value to the register where it belongs.
+        prepared_resume_frame.regs.set(dst, value);
+
+        prepared_resume_frame
+    }
+
+    /// Resume the continuation with the provided value immediately.
+    ///
+    /// This call doesn't have a chance to yield control, so it's a given that
+    /// this resume happens without suspending.
+    pub fn immediate_resume(
+        frame: &mut Frame<FunctionId, StateId, Value>,
+        resume: StateId,
+        dst: RegisterId,
+        value: Value,
+    ) {
+        // Prepare the frame to resume execution at the `resume` state.
+        frame.state = resume;
+
+        // Assign the value to the register where it belongs.
+        frame.regs.set(dst, value);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Continuation;
+    use crate::{Frame, FrameKind, RegisterId, Registers};
+
+    fn frame(state: usize) -> Frame<&'static str, usize, i32> {
+        Frame {
+            func: "example",
+            state,
+            regs: Registers::new(2),
+            kind: FrameKind::TopLevel,
+        }
+    }
+
+    #[test]
+    fn capture_and_resume_update_state_and_destination_register() {
+        let continuation = Continuation::capture(frame(1), 7, RegisterId(1));
+
+        let resumed = continuation.resume(42);
+
+        assert_eq!(resumed.state, 7);
+        assert_eq!(resumed.regs.get(RegisterId(0)), None);
+        assert_eq!(resumed.regs.get(RegisterId(1)), Some(&42));
+    }
+
+    #[test]
+    fn immediate_resume_updates_frame_in_place() {
+        let mut frame = frame(1);
+
+        Continuation::immediate_resume(&mut frame, 9, RegisterId(0), 11);
+
+        assert_eq!(frame.state, 9);
+        assert_eq!(frame.regs.get(RegisterId(0)), Some(&11));
+    }
+}

--- a/crates/lib/vm-runtime-core/src/frame.rs
+++ b/crates/lib/vm-runtime-core/src/frame.rs
@@ -1,0 +1,36 @@
+use crate::{PromiseStateId, Registers};
+
+/// A frame shape used in runtime.
+pub struct Frame<FunctionId, StateId, Value> {
+    /// A function this frame is executing.
+    pub func: FunctionId,
+
+    /// A function sub-state this frame is executing.
+    pub state: StateId,
+
+    /// Registers that hold values for this frame.
+    pub regs: Registers<Value>,
+
+    /// The kind of the frame.
+    pub kind: FrameKind,
+}
+
+/// The kind of a frame.
+#[derive(Debug)]
+pub enum FrameKind {
+    /// Top level frame.
+    ///
+    /// Represents a function that the execution of the runtime
+    /// began with.
+    /// A return from the top-level frame completes the whole runtime execution.
+    TopLevel,
+
+    /// A function call frame.
+    ///
+    /// Represents an function that was invoked from somewhere and that has
+    /// as associated promise to fulful upon the function return.
+    FnCall {
+        /// The promise to resolve when this frame returns.
+        ret: PromiseStateId,
+    },
+}

--- a/crates/lib/vm-runtime-core/src/lib.rs
+++ b/crates/lib/vm-runtime-core/src/lib.rs
@@ -1,0 +1,21 @@
+//! The core building blocks of the VM runtime.
+
+#![warn(missing_docs)]
+
+mod capture_runtime_view;
+mod continuation;
+mod frame;
+mod promise_state;
+mod promise_states;
+mod promise_value;
+mod registers;
+mod runtime_state;
+
+pub use self::capture_runtime_view::*;
+pub use self::continuation::*;
+pub use self::frame::*;
+pub use self::promise_state::*;
+pub use self::promise_states::*;
+pub use self::promise_value::*;
+pub use self::registers::*;
+pub use self::runtime_state::*;

--- a/crates/lib/vm-runtime-core/src/promise_state.rs
+++ b/crates/lib/vm-runtime-core/src/promise_state.rs
@@ -1,0 +1,120 @@
+use crate::{Continuation, ResumeWithValue};
+
+/// An errors that occurs when an attempt to resolve an already resolved
+/// promise is made.
+///
+/// Resolving a promise is idempotent, so you could ignore this error if there
+/// is no strong need for the promise to be resolved with *this* particular
+/// operation. The consequence of this error is that the value that was
+/// provided for resolving the promise has not been able to be stored in
+/// the promise.
+#[derive(Debug, thiserror::Error)]
+#[error("resolving an already resolved promise")]
+pub struct ResolvingAlreadyResolvedPromiseError<Value> {
+    /// The new value that has not been able to be stored in
+    /// the already-resolved promise.
+    pub new_value: Value,
+}
+
+/// A runtime internal state associated with a promise.
+pub enum PromiseState<FunctionId, StateId, Value> {
+    /// A list of continuations to resume when a promise resolves.
+    ///
+    /// Awaiting on it will add the frame to the list of continuations.
+    Waiting(Vec<Continuation<FunctionId, StateId, Value, ResumeWithValue>>),
+
+    /// A promise that is ready.
+    ///
+    /// Awaiting on it will resume immediately.
+    Ready(Value),
+}
+
+impl<FunctionId, StateId, Value> PromiseState<FunctionId, StateId, Value> {
+    /// Idempotently resolve a promise.
+    ///
+    /// Returns a list of continuations to resume, or an error is this promise
+    /// has already been resolved.
+    #[allow(clippy::type_complexity)]
+    pub fn resolve(
+        &mut self,
+        value: Value,
+    ) -> Result<
+        Vec<crate::Continuation<FunctionId, StateId, Value, crate::ResumeWithValue>>,
+        ResolvingAlreadyResolvedPromiseError<Value>,
+    > {
+        let ready = Self::Ready(value);
+        let replaced = std::mem::replace(self, ready);
+        let continuations = match replaced {
+            PromiseState::Waiting(continuations) => continuations,
+            PromiseState::Ready(old_value) => {
+                // This shouldn't happen often.
+                std::hint::cold_path();
+
+                // Replace the value back as we want first-wins semantics.
+                let new_value = std::mem::replace(self, Self::Ready(old_value));
+
+                // Match on the value we've just provided, guaranteed to be
+                // `Ready`.
+                let Self::Ready(new_value) = new_value else {
+                    unreachable!();
+                };
+
+                return Err(ResolvingAlreadyResolvedPromiseError { new_value });
+            }
+        };
+        Ok(continuations)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::PromiseState;
+    use crate::{Continuation, Frame, FrameKind, RegisterId, Registers};
+
+    fn continuation(
+        dst: RegisterId,
+        resume_state: usize,
+    ) -> Continuation<&'static str, usize, i32, crate::ResumeWithValue> {
+        Continuation::capture(
+            Frame {
+                func: "example",
+                state: 0,
+                regs: Registers::new(2),
+                kind: FrameKind::TopLevel,
+            },
+            resume_state,
+            dst,
+        )
+    }
+
+    #[test]
+    fn resolve_waiting_promise_returns_continuations_and_marks_ready() {
+        let mut state = PromiseState::Waiting(vec![continuation(RegisterId(1), 3)]);
+
+        let continuations = state.resolve(17).expect("waiting promise should resolve");
+
+        assert_eq!(continuations.len(), 1);
+        assert!(matches!(&state, PromiseState::Ready(value) if *value == 17));
+
+        let resumed = continuations
+            .into_iter()
+            .next()
+            .expect("continuation is returned")
+            .resume(17);
+        assert_eq!(resumed.state, 3);
+        assert_eq!(resumed.regs.get(RegisterId(1)), Some(&17));
+    }
+
+    #[test]
+    fn resolve_ready_promise_returns_error_and_preserves_original_value() {
+        let mut state = PromiseState::<&'static str, usize, i32>::Ready(5);
+
+        let err = match state.resolve(9) {
+            Ok(_) => panic!("resolved promise should reject a second value"),
+            Err(err) => err,
+        };
+
+        assert_eq!(err.new_value, 9);
+        assert!(matches!(&state, PromiseState::Ready(value) if *value == 5));
+    }
+}

--- a/crates/lib/vm-runtime-core/src/promise_states.rs
+++ b/crates/lib/vm-runtime-core/src/promise_states.rs
@@ -1,0 +1,176 @@
+use index_type::{IndexTooBigError, IndexType, typed_vec::TypedVec};
+
+use crate::{Continuation, PromiseState, ResolvingAlreadyResolvedPromiseError};
+
+/// Error returned when a raw index cannot be represented as a [`PromiseStateId`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, IndexTooBigError)]
+#[index_too_big_error(msg = "promise state id")]
+pub struct PromiseStateIdTooBigError;
+
+/// Index of a [`PromiseState`] in the [`PromiseStates`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, IndexType)]
+#[index_type(error = PromiseStateIdTooBigError)]
+pub struct PromiseStateId(pub usize);
+
+/// A list of promise states.
+pub struct PromiseStates<FunctionId, StateId, Value>(
+    TypedVec<PromiseStateId, PromiseState<FunctionId, StateId, Value>>,
+);
+
+impl<FunctionId, StateId, Value> Default for PromiseStates<FunctionId, StateId, Value> {
+    fn default() -> Self {
+        Self(Default::default())
+    }
+}
+
+impl<FunctionId, StateId, Value> PromiseStates<FunctionId, StateId, Value> {
+    /// Create a new list of promised states.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Allocate a new waiting promise state and return its id.
+    pub fn prepare(&mut self) -> PromiseStateId {
+        self.0.push(PromiseState::Waiting(Vec::new()))
+    }
+}
+
+/// Error returned when a promise state lookup refers to an unknown ID.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[error("promise state {promise_state_id:?} not found")]
+pub struct PromiseStateNotFoundError {
+    /// The promise state ID that could not be found.
+    pub promise_state_id: PromiseStateId,
+}
+
+impl<FunctionId, StateId, Value> PromiseStates<FunctionId, StateId, Value> {
+    /// Borrow a promise state by `promise_state_id`.
+    pub fn get(
+        &self,
+        promise_state_id: PromiseStateId,
+    ) -> Result<&PromiseState<FunctionId, StateId, Value>, PromiseStateNotFoundError> {
+        self.0
+            .get(promise_state_id)
+            .ok_or(PromiseStateNotFoundError { promise_state_id })
+    }
+
+    /// Mutably borrow a promise state by `promise_state_id`.
+    pub fn get_mut(
+        &mut self,
+        promise_state_id: PromiseStateId,
+    ) -> Result<&mut PromiseState<FunctionId, StateId, Value>, PromiseStateNotFoundError> {
+        self.0
+            .get_mut(promise_state_id)
+            .ok_or(PromiseStateNotFoundError { promise_state_id })
+    }
+}
+
+/// Errors returned when resolving a promise state.
+#[derive(Debug, thiserror::Error)]
+pub enum ResolvePromiseError<Value> {
+    /// The requested promise state ID does not exist.
+    #[error(transparent)]
+    PromiseStateNotFound(#[from] PromiseStateNotFoundError),
+
+    /// The promise state has already been resolved.
+    #[error(transparent)]
+    AlreadyResolved(#[from] ResolvingAlreadyResolvedPromiseError<Value>),
+}
+
+impl<FunctionId, StateId, Value> PromiseStates<FunctionId, StateId, Value> {
+    /// Idempotently resolve a promise at a given `promise_state_id` with
+    /// the provided `value`.
+    ///
+    /// Returns a list of continuations to resume, or an error is this promise
+    /// has already been resolved.
+    #[allow(clippy::type_complexity)]
+    pub fn resolve(
+        &mut self,
+        promise_state_id: PromiseStateId,
+        value: Value,
+    ) -> Result<
+        Vec<Continuation<FunctionId, StateId, Value, crate::ResumeWithValue>>,
+        ResolvePromiseError<Value>,
+    > {
+        let promise_state = self.get_mut(promise_state_id)?;
+
+        promise_state
+            .resolve(value)
+            .map_err(ResolvePromiseError::AlreadyResolved)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{PromiseStateId, PromiseStateNotFoundError, PromiseStates, ResolvePromiseError};
+    use crate::{Continuation, Frame, FrameKind, PromiseState, RegisterId, Registers};
+
+    fn continuation(
+        dst: RegisterId,
+        resume_state: usize,
+    ) -> Continuation<&'static str, usize, i32, crate::ResumeWithValue> {
+        Continuation::capture(
+            Frame {
+                func: "example",
+                state: 0,
+                regs: Registers::new(2),
+                kind: FrameKind::TopLevel,
+            },
+            resume_state,
+            dst,
+        )
+    }
+
+    #[test]
+    fn prepare_allocates_waiting_states_in_order() {
+        let mut states = PromiseStates::<&'static str, usize, i32>::new();
+
+        let first = states.prepare();
+        let second = states.prepare();
+
+        assert_eq!(first, PromiseStateId(0));
+        assert_eq!(second, PromiseStateId(1));
+        assert!(matches!(
+            states.get(first).expect("promise state exists"),
+            PromiseState::Waiting(continuations) if continuations.is_empty()
+        ));
+        assert!(matches!(
+            states.get(second).expect("promise state exists"),
+            PromiseState::Waiting(continuations) if continuations.is_empty()
+        ));
+    }
+
+    #[test]
+    fn resolve_updates_state_and_returns_continuations() {
+        let mut states = PromiseStates::<&'static str, usize, i32>::new();
+        let promise_state_id = states.prepare();
+        let state = states
+            .get_mut(promise_state_id)
+            .expect("promise state exists");
+        *state = PromiseState::Waiting(vec![continuation(RegisterId(0), 4)]);
+
+        let continuations = states
+            .resolve(promise_state_id, 23)
+            .expect("prepared promise should resolve");
+
+        assert_eq!(continuations.len(), 1);
+        assert!(matches!(
+            states.get(promise_state_id).expect("promise state exists"),
+            PromiseState::Ready(value) if *value == 23
+        ));
+    }
+
+    #[test]
+    fn resolve_rejects_unknown_promise_state_ids() {
+        let mut states = PromiseStates::<&'static str, usize, i32>::new();
+
+        let Err(ResolvePromiseError::PromiseStateNotFound(PromiseStateNotFoundError {
+            promise_state_id,
+        })) = states.resolve(PromiseStateId(4), 23)
+        else {
+            panic!("unknown promise state IDs should be rejected");
+        };
+
+        assert_eq!(promise_state_id, PromiseStateId(4));
+    }
+}

--- a/crates/lib/vm-runtime-core/src/promise_value.rs
+++ b/crates/lib/vm-runtime-core/src/promise_value.rs
@@ -1,0 +1,104 @@
+use crate::PromiseStateId;
+
+/// A promise value.
+///
+/// Wraps a non-promise value type with the possibilities of either it being
+/// immediately available (`Resolved`) or being in a placeholder
+/// state (`Pending`) waiting for a wrapped value to be resolved with.
+#[derive(Clone, Debug)]
+pub enum Promise<Value> {
+    /// Placeholder for a value and the ID of the associated state that holds
+    /// continuations to resume when the promise resolves.
+    Pending(PromiseStateId),
+
+    /// Actual value.
+    Resolved(Value),
+}
+
+/// A resolved promise was required but the actual value was pending.
+#[derive(Debug, thiserror::Error)]
+#[error("an unresolved async value is used where a resolved value is expected")]
+pub struct UnresolvedPromiseError {
+    /// The ID of the promise state.
+    ///
+    /// For reconstructing the promise back if needed.
+    pub promise_state_id: PromiseStateId,
+}
+
+impl<Value> Promise<Value> {
+    /// Require a promise to be resolved and unwrap it into the raw value.
+    pub fn require_resolved(self) -> Result<Value, UnresolvedPromiseError> {
+        match self {
+            Promise::Pending(promise_state_id) => Err(UnresolvedPromiseError { promise_state_id }),
+            Promise::Resolved(value) => Ok(value),
+        }
+    }
+
+    /// Require a promise to be resolved and unwrap it into the raw value ref.
+    pub fn require_resolved_ref(&self) -> Result<&Value, UnresolvedPromiseError> {
+        match self {
+            Promise::Pending(promise_state_id) => Err(UnresolvedPromiseError {
+                promise_state_id: *promise_state_id,
+            }),
+            Promise::Resolved(value) => Ok(value),
+        }
+    }
+
+    /// Require a promise to be resolved and unwrap it into the raw value mut ref.
+    pub fn require_resolved_mut(&mut self) -> Result<&mut Value, UnresolvedPromiseError> {
+        match self {
+            Promise::Pending(promise_state_id) => Err(UnresolvedPromiseError {
+                promise_state_id: *promise_state_id,
+            }),
+            Promise::Resolved(value) => Ok(value),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Promise;
+    use crate::PromiseStateId;
+
+    #[test]
+    fn require_resolved_returns_owned_value_for_ready_promises() {
+        let promise = Promise::Resolved(String::from("ready"));
+
+        assert_eq!(
+            promise.require_resolved().expect("promise is resolved"),
+            "ready"
+        );
+    }
+
+    #[test]
+    fn require_resolved_ref_and_mut_report_pending_promise_ids() {
+        let promise = Promise::<String>::Pending(PromiseStateId(3));
+        let err = promise
+            .require_resolved_ref()
+            .expect_err("pending promise should fail by reference");
+        assert_eq!(err.promise_state_id, PromiseStateId(3));
+
+        let mut promise = Promise::<String>::Pending(PromiseStateId(5));
+        let err = promise
+            .require_resolved_mut()
+            .expect_err("pending promise should fail by mutable reference");
+        assert_eq!(err.promise_state_id, PromiseStateId(5));
+    }
+
+    #[test]
+    fn require_resolved_mut_returns_mutable_reference_for_ready_promises() {
+        let mut promise = Promise::Resolved(String::from("ready"));
+
+        promise
+            .require_resolved_mut()
+            .expect("promise is resolved")
+            .push_str(" now");
+
+        assert_eq!(
+            promise
+                .require_resolved_ref()
+                .expect("promise remains resolved"),
+            "ready now"
+        );
+    }
+}

--- a/crates/lib/vm-runtime-core/src/registers.rs
+++ b/crates/lib/vm-runtime-core/src/registers.rs
@@ -1,0 +1,110 @@
+use index_type::{IndexTooBigError, IndexType, typed_vec::TypedVec};
+
+/// Error returned when a raw index cannot be represented as a [`RegisterId`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, IndexTooBigError)]
+#[index_too_big_error(msg = "register id")]
+pub struct RegisterIdTooBigError;
+
+/// Index of a register in the [`Registers`] type.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, IndexType)]
+#[index_type(error = RegisterIdTooBigError)]
+pub struct RegisterId(pub usize);
+
+/// A list of registers.
+///
+/// Used to store values per frame.
+#[derive(Debug)]
+pub struct Registers<Value>(TypedVec<RegisterId, Option<Value>>);
+
+impl<Value> std::ops::Index<RegisterId> for Registers<Value> {
+    type Output = Value;
+
+    fn index(&self, index: RegisterId) -> &Self::Output {
+        self.0[index].as_ref().unwrap()
+    }
+}
+
+impl<Value> Registers<Value> {
+    /// New [`Registers`] for an function call.
+    ///
+    /// Takes the `size` as the amount of the registers to allocate, and
+    /// the `args` to fill in the values into the corresponding registers.
+    pub fn new_for_fn_call(size: usize, args: impl IntoIterator<Item = Value>) -> Self {
+        let mut regs = TypedVec::<RegisterId, _>::with_capacity(size);
+
+        regs.extend(args.into_iter().map(Some));
+
+        while regs.len().to_scalar() < size {
+            regs.push(None);
+        }
+
+        Self(regs)
+    }
+
+    /// New [`Registers`].
+    ///
+    /// Takes the `size` as the amount of the registers to allocate.
+    pub fn new(size: usize) -> Self {
+        let mut regs = TypedVec::<RegisterId, _>::with_capacity(size);
+
+        while regs.len().to_scalar() < size {
+            regs.push(None);
+        }
+
+        Self(regs)
+    }
+
+    /// Set the given register to the specified value.
+    ///
+    /// Panics if the register is out of bounds.
+    pub fn set(&mut self, index: RegisterId, value: Value) {
+        self.0[index] = Some(value);
+    }
+
+    /// Get a value at the given register.
+    ///
+    /// Returns `None` if the register is empty.
+    ///
+    /// Panics if the register is out of bounds.
+    pub fn get(&self, index: RegisterId) -> Option<&Value> {
+        self.0[index].as_ref()
+    }
+
+    /// Take a value at the given register and unset it.
+    ///
+    /// Returns `None` if the register is empty.
+    ///
+    /// Panics if the register is out of bounds.
+    pub fn take(&mut self, index: RegisterId) -> Option<Value> {
+        self.0[index].take()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{RegisterId, Registers};
+
+    #[test]
+    fn new_for_fn_call_populates_args_and_pads_remaining_registers() {
+        let regs = Registers::new_for_fn_call(3, [10, 20]);
+
+        assert_eq!(regs.get(RegisterId(0)), Some(&10));
+        assert_eq!(regs.get(RegisterId(1)), Some(&20));
+        assert_eq!(regs.get(RegisterId(2)), None);
+    }
+
+    #[test]
+    fn set_and_take_manage_register_contents() {
+        let mut regs = Registers::new(2);
+
+        assert_eq!(regs.get(RegisterId(1)), None);
+
+        regs.set(RegisterId(1), 99);
+
+        assert_eq!(regs.get(RegisterId(1)), Some(&99));
+        assert_eq!(*regs.get(RegisterId(1)).expect("register is set"), 99);
+
+        assert_eq!(regs.take(RegisterId(1)), Some(99));
+        assert_eq!(regs.get(RegisterId(1)), None);
+    }
+}

--- a/crates/lib/vm-runtime-core/src/runtime_state.rs
+++ b/crates/lib/vm-runtime-core/src/runtime_state.rs
@@ -1,0 +1,163 @@
+use std::collections::VecDeque;
+
+use crate::{Frame, Promise, PromiseStateId, PromiseStates, ResolvePromiseError};
+
+/// The state shape of the runtime.
+///
+/// Public struct, but the runtime itself will shield the access to
+/// the fields by holding it without public visibility.
+///
+/// The access to the runtime state is indirectly provided to the interpreters
+/// via the [`crate::CaptureRuntimeView`].
+pub struct RuntimeState<FunctionId, StateId, Value> {
+    /// The queue of the ready-to-execute frames.
+    ///
+    /// Due to the nature of the asyncrony and continuations support, we require
+    /// that at runtime all the values can be promises.
+    //
+    // TODO: replace with a more restricted interface
+    pub ready: VecDeque<Frame<FunctionId, StateId, Promise<Value>>>,
+
+    /// A state of the promises of this runtime.
+    //
+    // TODO: the promise states should be garbage-collected together with
+    // the promise values that refer to them. We can implement this without
+    // a full garbage-collector by holding the promises in a weak-rc-map
+    // or something like that.
+    pub promise_states: PromiseStates<FunctionId, StateId, Promise<Value>>,
+}
+
+impl<FunctionId, StateId, Value> RuntimeState<FunctionId, StateId, Value>
+where
+    Value: Clone,
+{
+    /// Provide an async computation value for a given promise.
+    ///
+    /// Notifies all continuations that wait on it.
+    pub fn resolve_promise(
+        &mut self,
+        promise_state_id: PromiseStateId,
+        val: Promise<Value>,
+    ) -> Result<(), ResolvePromiseError<Promise<Value>>> {
+        let continuations = self.promise_states.resolve(promise_state_id, val.clone())?;
+
+        for continuation in continuations {
+            let frame = continuation.resume(val.clone());
+            self.ready.push_back(frame);
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::VecDeque;
+
+    use super::RuntimeState;
+    use crate::{
+        Continuation, Frame, FrameKind, Promise, PromiseState, PromiseStates, RegisterId,
+        Registers, ResolvePromiseError,
+    };
+
+    fn frame(state: usize) -> Frame<&'static str, usize, Promise<i32>> {
+        Frame {
+            func: "example",
+            state,
+            regs: Registers::new(2),
+            kind: FrameKind::TopLevel,
+        }
+    }
+
+    fn continuation(
+        dst: RegisterId,
+        resume_state: usize,
+    ) -> Continuation<&'static str, usize, Promise<i32>, crate::ResumeWithValue> {
+        Continuation::capture(frame(0), resume_state, dst)
+    }
+
+    #[test]
+    fn resolve_promise_enqueues_resumed_frames_and_records_resolved_value() {
+        let mut promise_states = PromiseStates::<&'static str, usize, Promise<i32>>::new();
+        let promise_state_id = promise_states.prepare();
+        let promise_state = promise_states
+            .get_mut(promise_state_id)
+            .expect("promise state exists");
+        *promise_state = PromiseState::Waiting(vec![
+            continuation(RegisterId(0), 3),
+            continuation(RegisterId(1), 5),
+        ]);
+
+        let mut runtime = RuntimeState {
+            ready: VecDeque::new(),
+            promise_states,
+        };
+
+        runtime
+            .resolve_promise(promise_state_id, Promise::Resolved(41))
+            .expect("waiting promise should resolve");
+
+        assert_eq!(runtime.ready.len(), 2);
+
+        let PromiseState::Ready(Promise::Resolved(value)) = runtime
+            .promise_states
+            .get(promise_state_id)
+            .expect("promise state exists")
+        else {
+            panic!("promise state should be ready with a resolved value");
+        };
+        assert_eq!(*value, 41);
+
+        let first = runtime.ready.pop_front().expect("first resumed frame");
+        assert_eq!(first.state, 3);
+        let Some(Promise::Resolved(value)) = first.regs.get(RegisterId(0)) else {
+            panic!("first resumed frame should receive the resolved value");
+        };
+        assert_eq!(*value, 41);
+
+        let second = runtime.ready.pop_front().expect("second resumed frame");
+        assert_eq!(second.state, 5);
+        let Some(Promise::Resolved(value)) = second.regs.get(RegisterId(1)) else {
+            panic!("second resumed frame should receive the resolved value");
+        };
+        assert_eq!(*value, 41);
+    }
+
+    #[test]
+    fn resolve_promise_returns_error_when_promise_is_already_resolved() {
+        let mut promise_states = PromiseStates::<&'static str, usize, Promise<i32>>::new();
+        let promise_state_id = promise_states.prepare();
+        let promise_state = promise_states
+            .get_mut(promise_state_id)
+            .expect("promise state exists");
+        *promise_state = PromiseState::Ready(Promise::Resolved(7));
+
+        let mut runtime = RuntimeState {
+            ready: VecDeque::new(),
+            promise_states,
+        };
+
+        let err = runtime
+            .resolve_promise(promise_state_id, Promise::Resolved(9))
+            .expect_err("already resolved promise should reject a second value");
+
+        let ResolvePromiseError::AlreadyResolved(err) = err else {
+            panic!("duplicate resolution should surface an already-resolved error");
+        };
+
+        let Promise::Resolved(value) = err.new_value else {
+            panic!("rejected value should be returned to the caller");
+        };
+        assert_eq!(value, 9);
+        assert!(runtime.ready.is_empty());
+
+        let PromiseState::Ready(Promise::Resolved(value)) = runtime
+            .promise_states
+            .get(promise_state_id)
+            .expect("promise state exists")
+        else {
+            panic!("original resolved value should be preserved");
+        };
+        assert_eq!(*value, 7);
+    }
+}

--- a/crates/lib/vm-runtime-test/Cargo.toml
+++ b/crates/lib/vm-runtime-test/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "waymark-vm-runtime-test"
+edition = "2024"
+version.workspace = true
+publish.workspace = true
+
+[dependencies]
+waymark-vm-bytecode = { workspace = true }
+waymark-vm-bytecode-core = { workspace = true }
+waymark-vm-interpreter = { workspace = true }
+waymark-vm-runtime = { workspace = true }
+waymark-vm-runtime-core = { workspace = true }
+
+thiserror = { workspace = true }

--- a/crates/lib/vm-runtime-test/src/lib.rs
+++ b/crates/lib/vm-runtime-test/src/lib.rs
@@ -1,0 +1,157 @@
+use waymark_vm_interpreter::{ExecutionOutcome, Interpreter};
+use waymark_vm_runtime::{CallSpec, FunctionNotFoundError, Runtime};
+use waymark_vm_runtime_core::{
+    CaptureRuntimeView, Continuation, Frame, FrameKind, FullRuntimeView, Promise, PromiseState,
+    RegisterId, Registers,
+};
+
+pub use waymark_vm_bytecode_core::{FunctionId, StateId};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TestInstruction {
+    Emit(&'static str),
+    Exit,
+    Suspend {
+        dst: RegisterId,
+        resume: StateId,
+    },
+    EmitRegister(RegisterId),
+    EnqueueFrameAndExit {
+        func: FunctionId,
+        state: StateId,
+        num_regs: usize,
+    },
+    Fail(&'static str),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TestEffect {
+    Message(&'static str),
+    Value(i32),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[error("{0}")]
+pub struct TestExecutionError(pub &'static str);
+
+pub struct TestInterpreter;
+
+pub type TestExecutable = waymark_vm_bytecode::Executable<TestInstruction>;
+
+pub type TestFunction = waymark_vm_bytecode::Function<TestInstruction>;
+
+pub fn function<Instruction>(
+    num_regs: usize,
+    states: Vec<Vec<Instruction>>,
+) -> waymark_vm_bytecode::Function<Instruction> {
+    waymark_vm_bytecode::Function {
+        states: states
+            .into_iter()
+            .map(|instructions| waymark_vm_bytecode::State {
+                instructions: instructions.into_iter().collect(),
+            })
+            .collect(),
+        num_regs,
+    }
+}
+
+pub fn executable<Instruction>(
+    functions: Vec<waymark_vm_bytecode::Function<Instruction>>,
+) -> waymark_vm_bytecode::Executable<Instruction> {
+    waymark_vm_bytecode::Executable {
+        functions: functions.into_iter().collect(),
+    }
+}
+
+impl CaptureRuntimeView<TestExecutable, FunctionId, StateId, i32> for TestInterpreter {
+    type RuntimeView<'r> = FullRuntimeView<'r, TestExecutable, FunctionId, StateId, i32>;
+
+    fn capture_runtime_view<'r>(
+        view: FullRuntimeView<'r, TestExecutable, FunctionId, StateId, i32>,
+    ) -> Self::RuntimeView<'r> {
+        view
+    }
+}
+
+impl Interpreter for TestInterpreter {
+    type RuntimeView<'r> = FullRuntimeView<'r, TestExecutable, FunctionId, StateId, i32>;
+    type Frame = Frame<FunctionId, StateId, Promise<i32>>;
+    type Instruction = TestInstruction;
+    type Error = TestExecutionError;
+    type Effect = TestEffect;
+
+    fn execute<'r>(
+        &self,
+        runtime: Self::RuntimeView<'r>,
+        frame: Self::Frame,
+        instruction: &Self::Instruction,
+    ) -> Result<ExecutionOutcome<Self::Frame, Self::Effect>, Self::Error> {
+        match *instruction {
+            TestInstruction::Emit(message) => Ok(ExecutionOutcome::ExitFrameWithEffect(
+                TestEffect::Message(message),
+            )),
+            TestInstruction::Exit => Ok(ExecutionOutcome::ExitFrame),
+            TestInstruction::Suspend { dst, resume } => {
+                let FullRuntimeView { state, .. } = runtime;
+                let promise_state_id = state.promise_states.prepare();
+                let promise_state = state
+                    .promise_states
+                    .get_mut(promise_state_id)
+                    .expect("prepared promise state should exist");
+                *promise_state =
+                    PromiseState::Waiting(vec![Continuation::capture(frame, resume, dst)]);
+                Ok(ExecutionOutcome::ExitFrame)
+            }
+            TestInstruction::EmitRegister(register) => {
+                let Some(Promise::Resolved(value)) = frame.regs.get(register) else {
+                    panic!("register should hold a resolved value before emitting it");
+                };
+                Ok(ExecutionOutcome::ExitFrameWithEffect(TestEffect::Value(
+                    *value,
+                )))
+            }
+            TestInstruction::EnqueueFrameAndExit {
+                func,
+                state: next_state,
+                num_regs,
+            } => {
+                let FullRuntimeView { state, .. } = runtime;
+                state.ready.push_back(Frame {
+                    func,
+                    state: next_state,
+                    regs: Registers::new(num_regs),
+                    kind: FrameKind::TopLevel,
+                });
+                Ok(ExecutionOutcome::ExitFrame)
+            }
+            TestInstruction::Fail(message) => Err(TestExecutionError(message)),
+        }
+    }
+}
+
+pub type TestRuntime = Runtime<TestExecutable, TestInterpreter, i32>;
+
+pub fn try_runtime(
+    executable: TestExecutable,
+) -> Result<TestRuntime, FunctionNotFoundError<FunctionId>> {
+    Runtime::with_conventional_entrypoint(TestInterpreter, executable)
+}
+
+pub fn runtime(executable: TestExecutable) -> TestRuntime {
+    try_runtime(executable).expect("entrypoint should exist")
+}
+
+pub fn try_runtime_with_entrypoint(
+    executable: TestExecutable,
+    call: CallSpec<FunctionId, i32>,
+) -> Result<TestRuntime, FunctionNotFoundError<FunctionId>> {
+    Runtime::with_custom_entrypoint(TestInterpreter, executable, call)
+}
+
+pub fn runtime_with_entrypoint(
+    executable: TestExecutable,
+    call: CallSpec<FunctionId, i32>,
+) -> TestRuntime {
+    try_runtime_with_entrypoint(executable, call)
+        .expect("test executable should define the entrypoint")
+}

--- a/crates/lib/vm-runtime/Cargo.toml
+++ b/crates/lib/vm-runtime/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "waymark-vm-runtime"
+edition = "2024"
+version.workspace = true
+publish.workspace = true
+
+[dependencies]
+waymark-vm-executable = { workspace = true }
+waymark-vm-interpreter = { workspace = true }
+waymark-vm-runtime-core = { workspace = true }
+
+thiserror = { workspace = true }
+tracing = { workspace = true }
+
+[dev-dependencies]
+waymark-vm-runtime-test = { workspace = true }

--- a/crates/lib/vm-runtime/src/lib.rs
+++ b/crates/lib/vm-runtime/src/lib.rs
@@ -1,0 +1,222 @@
+//! The VM runtime.
+//!
+//! Responsible for the execution loop driving an instruction set intereter
+//! and the surface API for executing instructions of the VM bytecode programs.
+
+#![warn(missing_docs)]
+
+pub mod step;
+
+use std::collections::VecDeque;
+
+use waymark_vm_runtime_core::{
+    Frame, FrameKind, Promise, PromiseStateId, PromiseStates, Registers, ResolvePromiseError,
+    ResolvingAlreadyResolvedPromiseError, RuntimeState,
+};
+
+/// VM runtime.
+///
+/// Holds an abstract instruction set interpreter, an abstract executable
+/// capable of providing instructions from the said instruction set,
+/// and the state of the runtime required to drive the execution of
+/// the instructions forward.
+pub struct Runtime<Executable, Interpreter, Value>
+where
+    Executable: waymark_vm_executable::FunctionStates,
+{
+    interpreter: Interpreter,
+    executable: Executable,
+    state: RuntimeState<Executable::FunctionId, Executable::StateId, Value>,
+}
+
+/// A specification of a VM function call.
+pub struct CallSpec<FunctionId, Value> {
+    /// A function to call.
+    pub func: FunctionId,
+
+    /// A list of arguments to pass to the function.
+    pub args: Vec<Value>,
+}
+
+/// An error returned when to such function id is defined in the executable.
+#[derive(Debug, thiserror::Error)]
+#[error("function {function_id:?} is not found in the functions table")]
+pub struct FunctionNotFoundError<FunctionId> {
+    function_id: FunctionId,
+}
+
+impl<Executable, Interpreter, Value> Runtime<Executable, Interpreter, Value>
+where
+    Interpreter: waymark_vm_interpreter::Interpreter,
+    Executable: waymark_vm_executable::FunctionStates,
+    Executable: waymark_vm_executable::FunctionInfo,
+    Executable::FunctionId: Copy + Default,
+    Executable::StateId: Default,
+{
+    /// Create a new runtime with a conventional entrypoint.
+    ///
+    /// Conventional entrypoint is a call to a function with a default
+    /// function ID (think function 0) with empty arguments.
+    pub fn with_conventional_entrypoint(
+        interpreter: Interpreter,
+        executable: Executable,
+    ) -> Result<Self, FunctionNotFoundError<Executable::FunctionId>> {
+        Self::with_custom_entrypoint(
+            interpreter,
+            executable,
+            CallSpec {
+                func: Executable::FunctionId::default(),
+                args: Vec::new(),
+            },
+        )
+    }
+}
+
+impl<Executable, Interpreter, Value> Runtime<Executable, Interpreter, Value>
+where
+    Interpreter: waymark_vm_interpreter::Interpreter,
+    Executable: waymark_vm_executable::FunctionStates,
+    Executable: waymark_vm_executable::FunctionInfo,
+    Executable::FunctionId: Copy + Default,
+    Executable::StateId: Default,
+{
+    /// Create a new runtime with a custom entrypoint.
+    ///
+    /// Initialized the top-level frame with a call to the `func` specified
+    /// in the `call` and the list of arguments as specified by the `args`
+    /// in the `call`.
+    pub fn with_custom_entrypoint(
+        interpreter: Interpreter,
+        executable: Executable,
+        call: CallSpec<Executable::FunctionId, Value>,
+    ) -> Result<Self, FunctionNotFoundError<Executable::FunctionId>> {
+        let mut ready = VecDeque::new();
+
+        let CallSpec { func, args } = call;
+
+        let num_regs = executable
+            .function_num_regs(func)
+            .ok_or(FunctionNotFoundError { function_id: func })?;
+
+        let regs = Registers::new_for_fn_call(num_regs, args.into_iter().map(Promise::Resolved));
+
+        ready.push_back(Frame {
+            func,
+            state: Executable::StateId::default(),
+            regs,
+            kind: FrameKind::TopLevel,
+        });
+
+        let state = RuntimeState {
+            ready,
+            promise_states: PromiseStates::new(),
+        };
+
+        Ok(Self {
+            interpreter,
+            executable,
+            state,
+        })
+    }
+}
+
+/// An error of the [`Runtime::run`] function.
+#[derive(Debug, thiserror::Error)]
+pub enum RunError<InterpreterError> {
+    /// No ready frames to execute.
+    ///
+    /// Typically either when the program has completed, or when all the frames
+    /// are suspended in continuations.
+    #[error("no ready frames to execute")]
+    NoReadyFrame,
+
+    /// Step execution failed.
+    #[error("step: {0}")]
+    Step(step::Error<InterpreterError>),
+}
+
+/// A type alias shorthand for specifying runtime frames from and executable
+/// and an promise-value.
+pub type FrameFor<Executable, Value> = Frame<
+    <Executable as waymark_vm_executable::Functions>::FunctionId,
+    <Executable as waymark_vm_executable::FunctionStates>::StateId,
+    Promise<Value>,
+>;
+
+impl<Executable, Interpreter, Value> Runtime<Executable, Interpreter, Value>
+where
+    Executable: waymark_vm_executable::InstructionsProvider,
+    Executable::FunctionId: Copy,
+    Executable::StateId: Copy + PartialEq,
+    Executable: 'static,
+    Interpreter: waymark_vm_interpreter::Interpreter<
+            Frame = FrameFor<Executable, Value>,
+            Instruction = Executable::Instruction,
+        >,
+    Interpreter: for<'r> waymark_vm_runtime_core::CaptureRuntimeView<
+            Executable,
+            Executable::FunctionId,
+            Executable::StateId,
+            Value,
+            RuntimeView<'r> = <Interpreter as waymark_vm_interpreter::Interpreter>::RuntimeView<'r>,
+        >,
+    Value: 'static,
+    // Debug
+    Interpreter::Instruction: core::fmt::Debug,
+    Value: core::fmt::Debug,
+{
+    /// Run the VM steps until the next event is encountered.
+    pub fn run(&mut self) -> Result<Interpreter::Effect, RunError<Interpreter::Error>> {
+        loop {
+            let Some(frame) = self.state.ready.pop_front() else {
+                // No frames but also no valid exit either,
+                // shouldn't be possible in the valid executing flow.
+                return Err(RunError::NoReadyFrame);
+            };
+
+            let result = self.step(frame).map_err(RunError::Step)?;
+            let effect = match result {
+                step::StepOutcome::Effect(effect) => effect,
+                step::StepOutcome::Yield => continue,
+            };
+
+            return Ok(effect);
+        }
+    }
+}
+
+impl<Executable, Interpreter, Value> Runtime<Executable, Interpreter, Value>
+where
+    Executable: waymark_vm_executable::FunctionStates,
+    Value: Clone,
+{
+    /// Provide an async computation value for a given promise.
+    ///
+    /// Notifies all continuations that wait on it.
+    pub fn resolve_promise(
+        &mut self,
+        promise_state_id: PromiseStateId,
+        val: Value,
+    ) -> Result<(), ResolvePromiseError<Value>> {
+        self.state
+            .resolve_promise(promise_state_id, Promise::Resolved(val))
+            .map_err(|error| match error {
+                ResolvePromiseError::PromiseStateNotFound(error) => {
+                    ResolvePromiseError::PromiseStateNotFound(error)
+                }
+                ResolvePromiseError::AlreadyResolved(error) => {
+                    let ResolvingAlreadyResolvedPromiseError { new_value } = error;
+                    let new_value = match new_value {
+                        // We've wrapped this value with `Promise::Resolved`
+                        // ourselves just a couple lines above.
+                        // It is guaranteed to be `Promise::Resolved` here.
+                        Promise::Pending(_) => unreachable!(),
+                        Promise::Resolved(val) => val,
+                    };
+                    ResolvePromiseError::AlreadyResolved(ResolvingAlreadyResolvedPromiseError {
+                        new_value,
+                    })
+                }
+            })
+    }
+}

--- a/crates/lib/vm-runtime/src/step.rs
+++ b/crates/lib/vm-runtime/src/step.rs
@@ -1,0 +1,107 @@
+//! A single step execution logic.
+
+use crate::{FrameFor, Runtime};
+
+pub(crate) enum StepOutcome<Effect> {
+    Effect(Effect),
+    Yield,
+}
+
+/// An error of the [`Runtime::step`] function.
+#[derive(Debug, thiserror::Error)]
+pub enum Error<InterpreterError> {
+    /// An interpreter has failed executing an instruction.
+    #[error("execution: {0}")]
+    Execution(InterpreterError),
+
+    /// The current frame points at a function state that does not exist.
+    #[error("current frame references a missing function state")]
+    InvalidState,
+
+    /// No instructions left to execute.
+    ///
+    /// This is typically a mistake in the bytecode, as we should never
+    /// run out of instructions in a valid program - each state is supposed
+    /// to finish with a terminal that would consume a frame before we have
+    /// a chance to reach past the end of the instructions sequence.
+    #[error("no instructions left to execute")]
+    NoInstructions,
+}
+
+impl<Executable, Interpreter, Value> Runtime<Executable, Interpreter, Value>
+where
+    Executable: waymark_vm_executable::InstructionsProvider,
+    Executable::FunctionId: Copy,
+    Executable::StateId: Copy + PartialEq,
+    Executable: 'static,
+    Interpreter: waymark_vm_interpreter::Interpreter<
+            Frame = FrameFor<Executable, Value>,
+            Instruction = Executable::Instruction,
+        >,
+    Interpreter: for<'v> waymark_vm_runtime_core::CaptureRuntimeView<
+            Executable,
+            Executable::FunctionId,
+            Executable::StateId,
+            Value,
+            RuntimeView<'v> = <Interpreter as waymark_vm_interpreter::Interpreter>::RuntimeView<'v>,
+        >,
+    Value: 'static,
+    Interpreter::Instruction: core::fmt::Debug,
+    Value: core::fmt::Debug,
+{
+    /// Consume and execute a frame till a side-effect is encountered.
+    pub(crate) fn step(
+        &mut self,
+        mut frame: FrameFor<Executable, Value>,
+    ) -> Result<StepOutcome<Interpreter::Effect>, Error<Interpreter::Error>> {
+        let Self {
+            executable,
+            interpreter,
+            state,
+        } = self;
+
+        'state_loop: loop {
+            let instructions = executable
+                .function_state_instructions(frame.func, frame.state)
+                .ok_or(Error::InvalidState)?;
+
+            for instruction in instructions {
+                tracing::trace!(
+                    regs = ?frame.regs,
+                    frame_kind = ?frame.kind,
+                    ?instruction,
+                    "step instruction execution"
+                );
+
+                let current_state = frame.state;
+                let full_runtime_view =
+                    waymark_vm_runtime_core::FullRuntimeView { executable, state };
+                let runtime_view = Interpreter::capture_runtime_view(full_runtime_view);
+                let outcome = interpreter
+                    .execute(runtime_view, frame, instruction)
+                    .map_err(Error::Execution)?;
+
+                match outcome {
+                    waymark_vm_interpreter::ExecutionOutcome::Continue(next_frame) => {
+                        let state_changed = next_frame.state != current_state;
+                        frame = next_frame;
+
+                        if state_changed {
+                            continue 'state_loop;
+                        }
+                    }
+                    waymark_vm_interpreter::ExecutionOutcome::ExitFrame => {
+                        // Done with this frame, yield to schedule next work.
+                        return Ok(StepOutcome::Yield);
+                    }
+                    waymark_vm_interpreter::ExecutionOutcome::ExitFrameWithEffect(effect) => {
+                        // Done with this frame, but also have an effect to emit.
+                        return Ok(StepOutcome::Effect(effect));
+                    }
+                };
+            }
+
+            return Err(Error::NoInstructions);
+        }
+    }
+}

--- a/crates/lib/vm-runtime/tests/integration.rs
+++ b/crates/lib/vm-runtime/tests/integration.rs
@@ -1,0 +1,190 @@
+use waymark_vm_runtime::{CallSpec, RunError};
+use waymark_vm_runtime_core::{PromiseStateId, RegisterId, ResolvePromiseError};
+use waymark_vm_runtime_test::{
+    FunctionId, StateId, TestEffect, TestInstruction, executable, function, runtime,
+    runtime_with_entrypoint, try_runtime,
+};
+
+#[test]
+fn with_custom_entrypoint_uses_requested_function_and_arguments() {
+    let mut runtime = runtime_with_entrypoint(
+        executable(vec![
+            function(0, vec![vec![TestInstruction::Emit("wrong")]]),
+            function(3, vec![vec![TestInstruction::EmitRegister(RegisterId(1))]]),
+        ]),
+        CallSpec {
+            func: FunctionId(1),
+            args: vec![7, 9],
+        },
+    );
+
+    assert_eq!(
+        runtime.run().expect("custom entrypoint should emit"),
+        TestEffect::Value(9)
+    );
+}
+
+#[test]
+fn with_conventional_entrypoint_rejects_missing_default_function() {
+    let err = match try_runtime(executable(Vec::new())) {
+        Ok(_) => panic!("missing function 0 should fail the conventional entrypoint"),
+        Err(err) => err,
+    };
+
+    assert_eq!(
+        err.to_string(),
+        "function FunctionId(0) is not found in the functions table"
+    );
+}
+
+#[test]
+fn run_skips_yielded_frames_until_an_effect_is_emitted() {
+    let mut runtime = runtime(executable(vec![
+        function(
+            0,
+            vec![vec![TestInstruction::EnqueueFrameAndExit {
+                func: FunctionId(1),
+                state: StateId(0),
+                num_regs: 0,
+            }]],
+        ),
+        function(0, vec![vec![TestInstruction::Emit("next")]]),
+    ]));
+
+    assert_eq!(
+        runtime.run().expect("queued frame should emit"),
+        TestEffect::Message("next")
+    );
+}
+
+#[test]
+fn run_returns_step_error_when_a_state_has_no_instructions() {
+    let mut runtime = runtime_with_entrypoint(
+        executable(vec![function(0, vec![Vec::new()])]),
+        CallSpec {
+            func: FunctionId(0),
+            args: Vec::new(),
+        },
+    );
+
+    assert!(matches!(
+        runtime.run(),
+        Err(RunError::Step(
+            waymark_vm_runtime::step::Error::NoInstructions
+        ))
+    ));
+}
+
+#[test]
+fn run_returns_step_error_when_a_ready_frame_points_at_a_missing_state() {
+    let mut runtime = runtime(executable(vec![function(
+        0,
+        vec![vec![TestInstruction::EnqueueFrameAndExit {
+            func: FunctionId(0),
+            state: StateId(99),
+            num_regs: 0,
+        }]],
+    )]));
+
+    assert!(matches!(
+        runtime.run(),
+        Err(RunError::Step(
+            waymark_vm_runtime::step::Error::InvalidState
+        ))
+    ));
+}
+
+#[test]
+fn resolve_promise_resumes_a_suspended_frame_and_emits_the_resolved_value() {
+    let mut runtime = runtime(executable(vec![function(
+        1,
+        vec![
+            vec![TestInstruction::Suspend {
+                dst: RegisterId(0),
+                resume: StateId(1),
+            }],
+            vec![TestInstruction::EmitRegister(RegisterId(0))],
+        ],
+    )]));
+
+    assert!(matches!(runtime.run(), Err(RunError::NoReadyFrame)));
+
+    runtime
+        .resolve_promise(PromiseStateId(0), 41)
+        .expect("prepared promise should resolve");
+
+    assert_eq!(
+        runtime.run().expect("resumed frame should emit"),
+        TestEffect::Value(41)
+    );
+}
+
+#[test]
+fn resolve_promise_rejects_unknown_promise_ids_without_disturbing_waiting_work() {
+    let mut runtime = runtime(executable(vec![function(
+        1,
+        vec![
+            vec![TestInstruction::Suspend {
+                dst: RegisterId(0),
+                resume: StateId(1),
+            }],
+            vec![TestInstruction::EmitRegister(RegisterId(0))],
+        ],
+    )]));
+
+    assert!(matches!(runtime.run(), Err(RunError::NoReadyFrame)));
+
+    let err = runtime
+        .resolve_promise(PromiseStateId(9), 41)
+        .expect_err("unknown promise IDs should be rejected");
+
+    let ResolvePromiseError::PromiseStateNotFound(err) = err else {
+        panic!("invalid promise IDs should surface a not-found error");
+    };
+    assert_eq!(err.promise_state_id, PromiseStateId(9));
+
+    runtime
+        .resolve_promise(PromiseStateId(0), 41)
+        .expect("the waiting promise should still resolve cleanly");
+
+    assert_eq!(
+        runtime.run().expect("resumed frame should still emit"),
+        TestEffect::Value(41)
+    );
+}
+
+#[test]
+fn resolve_promise_preserves_the_first_value_when_duplicate_resolution_occurs() {
+    let mut runtime = runtime(executable(vec![function(
+        1,
+        vec![
+            vec![TestInstruction::Suspend {
+                dst: RegisterId(0),
+                resume: StateId(1),
+            }],
+            vec![TestInstruction::EmitRegister(RegisterId(0))],
+        ],
+    )]));
+
+    assert!(matches!(runtime.run(), Err(RunError::NoReadyFrame)));
+
+    runtime
+        .resolve_promise(PromiseStateId(0), 7)
+        .expect("first promise resolution should succeed");
+
+    let err = runtime
+        .resolve_promise(PromiseStateId(0), 11)
+        .expect_err("already-ready promise should reject a new value");
+
+    let ResolvePromiseError::AlreadyResolved(err) = err else {
+        panic!("duplicate resolutions should report already-resolved errors");
+    };
+
+    assert_eq!(err.new_value, 11);
+    assert_eq!(
+        runtime
+            .run()
+            .expect("resumed frame should keep the first value"),
+        TestEffect::Value(7)
+    );
+}


### PR DESCRIPTION
This PR adds the initial version if the new Virtual Machine for workflow execution.

The goal of this work is to eventually replace the current runner and DAG-based workflow executor. This is the first step in that direction, to be followed by a new compiler for workflows into this new VM's bytecode.

This design features:
- modular instructions sets support (we don't have a use case fore true modularity - so this is not that; it is, rather, just strong abstraction layers and isolation, which is very helpful for just having readable code)
- stackless coroutines and async/await support at VM/bytecode level
- register-based value storage
- explicit pull-based side-effects emission model
- tiny runtime API surface and simple and explicit run/step execution loop
- a simple API resolving the futures from the external code (~~currently requires mutable access, but maybe can be made non-mut-access based and thread-safe, we'll see~~ solved via vm-driver, fully wired up now)
- a cli for PoC demonstration and utilities (wip)
- no GC (yet), no support for referenced values (only by-move/by-copy passing can be supported without a GC of some sort)
- no type information at the VM/bytecode level (besides the variant of the Value enum)

More info on modularity:
- small runtime implementing only the abstract execution loop and pluggable per-instruction-set interpreters that hold the implementation logic for the executing instructions
- value type is abstracted, and specified at the instruction-set interpreter level (effectively allowing instruction-set interpreters to control the types of the values they want to use / support)
- type-safe trait contracts between the pieces, allowing us to express precisely what a certain part of the (rust) code has to know about the (rust) types it deals with
- code is organized such that the interpreter crates are separate from the instruction set crates, and, as an overall system part, interpreters could be dropped and replaced by a JIT compiler

---

Overall I'm pretty happy with how this implementation turned out; extending it with the full surface of the bytecode operations should be easy, and that's what I'm planning to do next, as it pretty much correlates with defining the full IR set, which is required to begin the work on the compiler.

---

Next steps and possible improvements:
- more instructions and allowed value types (scalars)
- GC and reference types
- resolved promise states cleanup (might require GC)
- `is_terminal(&self) -> bool` kind of API for the `Runtime` that would return `true` if there are no ready frames or prepared continuations; that'd cause some rewrite of the current promise states so it's posponed to later

Non-goals:
- stack unwinding and value bubbling at the VM level - we don't have stacks, and while we could technically add them it would inflate the state that we have to persist; rather than adding stacks, we can implement errors as explicit values and handle bubbling by injecting explicit bubbling instruction at the compiler level
- bytecode/VM-level type-checking - if we ever have to do the type-checking (as in for the program-defined type - as opposed to our own VM-level value-type enum, type checking for which we to either way then implementing the instructions) it has to be done at the compiler level
- instruction pointer at the frame level - we use states and state IDs for everything that that instructions are typically used for because we want to have only have explicit yield-points and continuations; this is not strictly a non-goal, but so far we've been able to avoid it, and it reduces the cognitive load as it's a competing duplicating concept