### PR TITLE
Drop unused cargo deny licenses

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -2,19 +2,7 @@
 ignore = []
 
 [licenses]
-allow = [
-  "Apache-2.0",
-  "BSD-2-Clause",
-  "BSD-3-Clause",
-  "BSL-1.0",
-  "ISC",
-  "MIT",
-  "MPL-2.0",
-  "OpenSSL",
-  "Unicode-3.0",
-  "Unicode-DFS-2016",
-  "Zlib",
-]
+allow = ["Apache-2.0", "BSD-2-Clause", "BSD-3-Clause", "BSL-1.0", "ISC", "MIT", "Unicode-3.0", "Zlib"]
 confidence-threshold = 0.8
 
 [licenses.private]


### PR DESCRIPTION
This PR gets rid of the annoying warnings at cargo deny.