### PR TITLE
Add support-test-python crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4910,6 +4910,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "waymark-support-test-python"
+version = "0.1.0"
+dependencies = [
+ "thiserror",
+ "tokio",
+ "waymark-python-workflow-ir-reader",
+ "waymark-vm-ast-old",
+ "waymark-vm-ast-old-proto",
+]
+
+[[package]]
 name = "waymark-synthetic-exception"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ waymark-observability-setup = { path = "crates/lib/observability-setup" }
 waymark-pool-status = { path = "crates/lib/pool-status" }
 waymark-prometheus-exporter-bringup = { path = "crates/lib/prometheus-exporter-bringup" }
 waymark-proto = { path = "crates/lib/proto" }
+waymark-python-workflow-ir-reader = { path = "crates/lib/python-workflow-ir-reader" }
 waymark-runloop = { path = "crates/lib/runloop" }
 waymark-runner = { path = "crates/lib/runner" }
 waymark-runner-execution-core = { path = "crates/lib/runner-execution-core" }
@@ -64,6 +65,7 @@ waymark-tokio-metrics-bringup = { path = "crates/lib/tokio-metrics-bringup" }
 waymark-utils-futures = { path = "crates/lib/utils-futures" }
 waymark-utils-tokio-channel = { path = "crates/lib/utils-tokio-channel" }
 waymark-vm-ast-old = { path = "crates/lib/vm-ast-old" }
+waymark-vm-ast-old-proto = { path = "crates/lib/vm-ast-old-proto" }
 waymark-vm-bytecode = { path = "crates/lib/vm-bytecode" }
 waymark-vm-bytecode-core = { path = "crates/lib/vm-bytecode-core" }
 waymark-vm-driver = { path = "crates/lib/vm-driver" }

--- a/crates/lib/support-test-python/Cargo.toml
+++ b/crates/lib/support-test-python/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "waymark-support-test-python"
+edition = "2024"
+version.workspace = true
+publish.workspace = true
+
+[dependencies]
+waymark-python-workflow-ir-reader = { workspace = true }
+waymark-vm-ast-old = { workspace = true }
+waymark-vm-ast-old-proto = { workspace = true }
+
+thiserror = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/crates/lib/support-test-python/src/lib.rs
+++ b/crates/lib/support-test-python/src/lib.rs
@@ -1,0 +1,32 @@
+use std::path::Path;
+
+#[derive(Debug, thiserror::Error)]
+pub enum LoadFixtureAstOldError {
+    #[error("reading workflow AST: {0}")]
+    Reader(waymark_python_workflow_ir_reader::ReadWorkflowIrError),
+
+    #[error("converting workflow AST from protobuf: {0}")]
+    Conversion(waymark_vm_ast_old_proto::ConvertError),
+}
+
+pub async fn load_fixture_ast_old(
+    path: &Path,
+) -> Result<waymark_vm_ast_old::Program, LoadFixtureAstOldError> {
+    let crate_root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let repo_root = crate_root.join("..").join("..").join("..");
+
+    let params = waymark_python_workflow_ir_reader::ReadWorkflowIrParams {
+        workflow_file: path,
+        workflow_class: None, // autodetect
+        workdir: Some(&repo_root),
+    };
+
+    let program = waymark_python_workflow_ir_reader::read_workflow_ir(params)
+        .await
+        .map_err(LoadFixtureAstOldError::Reader)?;
+
+    let program =
+        waymark_vm_ast_old_proto::convert(program).map_err(LoadFixtureAstOldError::Conversion)?;
+
+    Ok(program)
+}

--- a/crates/lib/support-test-python/tests/example.rs
+++ b/crates/lib/support-test-python/tests/example.rs
@@ -1,0 +1,31 @@
+use std::path::Path;
+
+#[tokio::test]
+async fn example() {
+    let crate_root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let repo_root = crate_root.join("..").join("..").join("..");
+
+    let program = waymark_support_test_python::load_fixture_ast_old(
+        &repo_root.join("python/tests/fixtures_actions/literal_return.py"),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(program.functions.len(), 1);
+}
+
+#[tokio::test]
+async fn file_not_found() {
+    let crate_root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let repo_root = crate_root.join("..").join("..").join("..");
+
+    let error =
+        waymark_support_test_python::load_fixture_ast_old(&repo_root.join("no_such_file.py"))
+            .await
+            .unwrap_err();
+
+    assert!(matches!(
+        error,
+        waymark_support_test_python::LoadFixtureAstOldError::Reader(_)
+    ));
+}


### PR DESCRIPTION
This PR adds support for easily loading Python workspaces at the old ast for testing purposes.