### PR TITLE
Add an assert for type-safety at python/scripts/export_workflow_ir.py

### DIFF
--- a/python/scripts/export_workflow_ir.py
+++ b/python/scripts/export_workflow_ir.py
@@ -44,6 +44,7 @@ def main() -> None:
         workflow_cls = workflow_registry.get(workflow_name.lower())
     if workflow_cls is None:
         parser.error(f"Unable to locate the workflow {workflow_name}")
+    assert workflow_cls is not None
 
     program = workflow_cls.workflow_ir()
     program_data = program.SerializeToString()


### PR DESCRIPTION
This PR "fixes" a small python types mishap. Not sure why it doesn't work as-is, but the extra assert is redundant and shouldn't be necessary (since `parser.error` is typed to never return).

Is `ty` not smart enough to know that? Idk...