### PR TITLE
Implement support for binary and unary scalar ops

### DIFF
--- a/crates/bin/vm-cli/src/integration.rs
+++ b/crates/bin/vm-cli/src/integration.rs
@@ -55,7 +55,7 @@ impl waymark_vm_interpreter_pureset::value::BinaryOps for SampleValue {
             (SampleValue::Usize(a), SampleValue::Usize(b)) => Ok(SampleValue::Usize(*a + *b)),
             _ => Err(
                 waymark_vm_interpreter_pureset::value::BinaryOperationError::UnsupportedOperation {
-                    operation: waymark_vm_interpreter_pureset::value::BinaryOperationKind::Add,
+                    operation: waymark_vm_instructions_pureset::BinaryOpKind::Add,
                 },
             ),
         }

--- a/crates/bin/vm-cli/src/integration.rs
+++ b/crates/bin/vm-cli/src/integration.rs
@@ -46,14 +46,23 @@ impl waymark_vm_interpreter_coreset::value::ShouldJump for SampleValue {
     }
 }
 
-impl waymark_vm_interpreter_pureset::value::Add for SampleValue {
-    fn add(a: &Self, b: &Self) -> Result<Self, waymark_vm_interpreter_pureset::value::AddError> {
+impl waymark_vm_interpreter_pureset::value::BinaryOps for SampleValue {
+    fn add(
+        a: &Self,
+        b: &Self,
+    ) -> Result<Self, waymark_vm_interpreter_pureset::value::BinaryOperationError> {
         match (a, b) {
-            (SampleValue::Usize(a), SampleValue::Usize(b)) => Ok(SampleValue::Usize(a + b)),
-            _ => Err(waymark_vm_interpreter_pureset::value::AddError::NotAddable),
+            (SampleValue::Usize(a), SampleValue::Usize(b)) => Ok(SampleValue::Usize(*a + *b)),
+            _ => Err(
+                waymark_vm_interpreter_pureset::value::BinaryOperationError::UnsupportedOperation {
+                    operation: waymark_vm_interpreter_pureset::value::BinaryOperationKind::Add,
+                },
+            ),
         }
     }
 }
+
+impl waymark_vm_interpreter_pureset::value::UnaryOps for SampleValue {}
 
 impl waymark_vm_interpreter_pureset::value::MakeList for SampleValue {
     fn make_list<I>(items: I) -> Result<Self, waymark_vm_interpreter_pureset::value::MakeListError>

--- a/crates/bin/vm-cli/src/sample/ast_old.rs
+++ b/crates/bin/vm-cli/src/sample/ast_old.rs
@@ -11,7 +11,11 @@ pub fn program() -> waymark_vm_ast_old::Program {
         vec![
             assignment("x", int(2)),
             assignment("y", int(3)),
-            return_stmt(Some(add(variable("x"), variable("y")))),
+            return_stmt(Some(binary_expr(
+                variable("x"),
+                waymark_vm_ast_old::BinaryOperator::Add,
+                variable("y"),
+            ))),
         ],
     );
 
@@ -25,7 +29,11 @@ pub fn program() -> waymark_vm_ast_old::Program {
         vec![
             assignment("a", function_expr("f1", vec![])),
             assignment("b", function_expr("f1", vec![])),
-            return_stmt(Some(add(variable("a"), variable("b")))),
+            return_stmt(Some(binary_expr(
+                variable("a"),
+                waymark_vm_ast_old::BinaryOperator::Add,
+                variable("b"),
+            ))),
         ],
     );
 

--- a/crates/bin/vm-cli/src/sample/bytecode.rs
+++ b/crates/bin/vm-cli/src/sample/bytecode.rs
@@ -39,11 +39,14 @@ pub fn executable() -> crate::integration::Executable {
                         value: SampleConstValue::Usize(5),
                     }
                     .into(),
-                    PureSet::Add(waymark_vm_instructions_pureset::BinaryOp {
-                        dst: RegisterId::from_scalar(2),
-                        a: RegisterId::from_scalar(1),
-                        b: RegisterId::from_scalar(2),
-                    })
+                    PureSet::Binary {
+                        kind: waymark_vm_instructions_pureset::BinaryOpKind::Add,
+                        op: waymark_vm_instructions_pureset::BinaryOp {
+                            dst: RegisterId::from_scalar(2),
+                            a: RegisterId::from_scalar(1),
+                            b: RegisterId::from_scalar(2),
+                        },
+                    }
                     .into(),
                     CoreSet::Return {
                         src: RegisterId::from_scalar(2),
@@ -92,11 +95,14 @@ pub fn executable() -> crate::integration::Executable {
             },
             State {
                 instructions: typed_vec![
-                    PureSet::Add(waymark_vm_instructions_pureset::BinaryOp {
-                        dst: RegisterId::from_scalar(4),
-                        a: RegisterId::from_scalar(2),
-                        b: RegisterId::from_scalar(3)
-                    })
+                    PureSet::Binary {
+                        kind: waymark_vm_instructions_pureset::BinaryOpKind::Add,
+                        op: waymark_vm_instructions_pureset::BinaryOp {
+                            dst: RegisterId::from_scalar(4),
+                            a: RegisterId::from_scalar(2),
+                            b: RegisterId::from_scalar(3)
+                        },
+                    }
                     .into(),
                     CoreSet::Return {
                         src: RegisterId::from_scalar(4)

--- a/crates/bin/vm-cli/src/sample/bytecode.rs
+++ b/crates/bin/vm-cli/src/sample/bytecode.rs
@@ -39,11 +39,11 @@ pub fn executable() -> crate::integration::Executable {
                         value: SampleConstValue::Usize(5),
                     }
                     .into(),
-                    PureSet::Add {
+                    PureSet::Add(waymark_vm_instructions_pureset::BinaryOp {
                         dst: RegisterId::from_scalar(2),
                         a: RegisterId::from_scalar(1),
                         b: RegisterId::from_scalar(2),
-                    }
+                    })
                     .into(),
                     CoreSet::Return {
                         src: RegisterId::from_scalar(2),
@@ -92,11 +92,11 @@ pub fn executable() -> crate::integration::Executable {
             },
             State {
                 instructions: typed_vec![
-                    PureSet::Add {
+                    PureSet::Add(waymark_vm_instructions_pureset::BinaryOp {
                         dst: RegisterId::from_scalar(4),
                         a: RegisterId::from_scalar(2),
                         b: RegisterId::from_scalar(3)
-                    }
+                    })
                     .into(),
                     CoreSet::Return {
                         src: RegisterId::from_scalar(4)

--- a/crates/lib/vm-ast-old-helpers/src/lib.rs
+++ b/crates/lib/vm-ast-old-helpers/src/lib.rs
@@ -160,11 +160,6 @@ pub fn binary_expr(left: Spanned<Expr>, op: BinaryOperator, right: Spanned<Expr>
     })
 }
 
-#[deprecated]
-pub fn add(left: Spanned<Expr>, right: Spanned<Expr>) -> Spanned<Expr> {
-    binary_expr(left, BinaryOperator::Add, right)
-}
-
 pub fn unary_expr(op: waymark_vm_ast_old::UnaryOperator, operand: Spanned<Expr>) -> Spanned<Expr> {
     spanned(Expr::UnaryOp {
         op,

--- a/crates/lib/vm-ast-old-helpers/src/lib.rs
+++ b/crates/lib/vm-ast-old-helpers/src/lib.rs
@@ -152,11 +152,23 @@ pub fn function(
     })
 }
 
-pub fn add(left: Spanned<Expr>, right: Spanned<Expr>) -> Spanned<Expr> {
+pub fn binary_expr(left: Spanned<Expr>, op: BinaryOperator, right: Spanned<Expr>) -> Spanned<Expr> {
     spanned(Expr::BinaryOp {
         left: Box::new(left),
-        op: BinaryOperator::Add,
+        op,
         right: Box::new(right),
+    })
+}
+
+#[deprecated]
+pub fn add(left: Spanned<Expr>, right: Spanned<Expr>) -> Spanned<Expr> {
+    binary_expr(left, BinaryOperator::Add, right)
+}
+
+pub fn unary_expr(op: waymark_vm_ast_old::UnaryOperator, operand: Spanned<Expr>) -> Spanned<Expr> {
+    spanned(Expr::UnaryOp {
+        op,
+        operand: Box::new(operand),
     })
 }
 

--- a/crates/lib/vm-compiler-for-ast-old/src/function/compiler/bytecode/emitter.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/function/compiler/bytecode/emitter.rs
@@ -69,6 +69,91 @@ where
         self.emit(waymark_vm_instructions_pureset::PureSet::Add { dst, a, b }.into());
     }
 
+    /// Emits a subtraction instruction.
+    pub fn emit_sub(&mut self, dst: RegisterId, a: RegisterId, b: RegisterId) {
+        self.emit(waymark_vm_instructions_pureset::PureSet::Sub { dst, a, b }.into());
+    }
+
+    /// Emits a multiplication instruction.
+    pub fn emit_mul(&mut self, dst: RegisterId, a: RegisterId, b: RegisterId) {
+        self.emit(waymark_vm_instructions_pureset::PureSet::Mul { dst, a, b }.into());
+    }
+
+    /// Emits a division instruction.
+    pub fn emit_div(&mut self, dst: RegisterId, a: RegisterId, b: RegisterId) {
+        self.emit(waymark_vm_instructions_pureset::PureSet::Div { dst, a, b }.into());
+    }
+
+    /// Emits a floor-division instruction.
+    pub fn emit_floor_div(&mut self, dst: RegisterId, a: RegisterId, b: RegisterId) {
+        self.emit(waymark_vm_instructions_pureset::PureSet::FloorDiv { dst, a, b }.into());
+    }
+
+    /// Emits a modulo instruction.
+    pub fn emit_mod(&mut self, dst: RegisterId, a: RegisterId, b: RegisterId) {
+        self.emit(waymark_vm_instructions_pureset::PureSet::Mod { dst, a, b }.into());
+    }
+
+    /// Emits an equality comparison instruction.
+    pub fn emit_eq(&mut self, dst: RegisterId, a: RegisterId, b: RegisterId) {
+        self.emit(waymark_vm_instructions_pureset::PureSet::Eq { dst, a, b }.into());
+    }
+
+    /// Emits an inequality comparison instruction.
+    pub fn emit_ne(&mut self, dst: RegisterId, a: RegisterId, b: RegisterId) {
+        self.emit(waymark_vm_instructions_pureset::PureSet::Ne { dst, a, b }.into());
+    }
+
+    /// Emits a less-than comparison instruction.
+    pub fn emit_lt(&mut self, dst: RegisterId, a: RegisterId, b: RegisterId) {
+        self.emit(waymark_vm_instructions_pureset::PureSet::Lt { dst, a, b }.into());
+    }
+
+    /// Emits a less-than-or-equal comparison instruction.
+    pub fn emit_le(&mut self, dst: RegisterId, a: RegisterId, b: RegisterId) {
+        self.emit(waymark_vm_instructions_pureset::PureSet::Le { dst, a, b }.into());
+    }
+
+    /// Emits a greater-than comparison instruction.
+    pub fn emit_gt(&mut self, dst: RegisterId, a: RegisterId, b: RegisterId) {
+        self.emit(waymark_vm_instructions_pureset::PureSet::Gt { dst, a, b }.into());
+    }
+
+    /// Emits a greater-than-or-equal comparison instruction.
+    pub fn emit_ge(&mut self, dst: RegisterId, a: RegisterId, b: RegisterId) {
+        self.emit(waymark_vm_instructions_pureset::PureSet::Ge { dst, a, b }.into());
+    }
+
+    /// Emits a membership instruction.
+    pub fn emit_in(&mut self, dst: RegisterId, a: RegisterId, b: RegisterId) {
+        self.emit(waymark_vm_instructions_pureset::PureSet::In { dst, a, b }.into());
+    }
+
+    /// Emits a negated-membership instruction.
+    pub fn emit_not_in(&mut self, dst: RegisterId, a: RegisterId, b: RegisterId) {
+        self.emit(waymark_vm_instructions_pureset::PureSet::NotIn { dst, a, b }.into());
+    }
+
+    /// Emits a logical-and instruction.
+    pub fn emit_and(&mut self, dst: RegisterId, a: RegisterId, b: RegisterId) {
+        self.emit(waymark_vm_instructions_pureset::PureSet::And { dst, a, b }.into());
+    }
+
+    /// Emits a logical-or instruction.
+    pub fn emit_or(&mut self, dst: RegisterId, a: RegisterId, b: RegisterId) {
+        self.emit(waymark_vm_instructions_pureset::PureSet::Or { dst, a, b }.into());
+    }
+
+    /// Emits a unary negation instruction.
+    pub fn emit_neg(&mut self, dst: RegisterId, src: RegisterId) {
+        self.emit(waymark_vm_instructions_pureset::PureSet::Neg { dst, src }.into());
+    }
+
+    /// Emits a logical-not instruction.
+    pub fn emit_not(&mut self, dst: RegisterId, src: RegisterId) {
+        self.emit(waymark_vm_instructions_pureset::PureSet::Not { dst, src }.into());
+    }
+
     /// Emits a list-construction instruction.
     pub fn emit_make_list(&mut self, dst: RegisterId, items: Vec<RegisterId>) {
         self.emit(waymark_vm_instructions_pureset::PureSet::MakeList { dst, items }.into());

--- a/crates/lib/vm-compiler-for-ast-old/src/function/compiler/bytecode/emitter.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/function/compiler/bytecode/emitter.rs
@@ -64,186 +64,6 @@ where
         self.emit(waymark_vm_instructions_pureset::PureSet::Copy { dst, src }.into());
     }
 
-    /// Emits an integer/string addition instruction.
-    pub fn emit_add(&mut self, dst: RegisterId, a: RegisterId, b: RegisterId) {
-        self.emit(
-            waymark_vm_instructions_pureset::PureSet::Add(
-                waymark_vm_instructions_pureset::BinaryOp { dst, a, b },
-            )
-            .into(),
-        );
-    }
-
-    /// Emits a subtraction instruction.
-    pub fn emit_sub(&mut self, dst: RegisterId, a: RegisterId, b: RegisterId) {
-        self.emit(
-            waymark_vm_instructions_pureset::PureSet::Sub(
-                waymark_vm_instructions_pureset::BinaryOp { dst, a, b },
-            )
-            .into(),
-        );
-    }
-
-    /// Emits a multiplication instruction.
-    pub fn emit_mul(&mut self, dst: RegisterId, a: RegisterId, b: RegisterId) {
-        self.emit(
-            waymark_vm_instructions_pureset::PureSet::Mul(
-                waymark_vm_instructions_pureset::BinaryOp { dst, a, b },
-            )
-            .into(),
-        );
-    }
-
-    /// Emits a division instruction.
-    pub fn emit_div(&mut self, dst: RegisterId, a: RegisterId, b: RegisterId) {
-        self.emit(
-            waymark_vm_instructions_pureset::PureSet::Div(
-                waymark_vm_instructions_pureset::BinaryOp { dst, a, b },
-            )
-            .into(),
-        );
-    }
-
-    /// Emits a floor-division instruction.
-    pub fn emit_floor_div(&mut self, dst: RegisterId, a: RegisterId, b: RegisterId) {
-        self.emit(
-            waymark_vm_instructions_pureset::PureSet::FloorDiv(
-                waymark_vm_instructions_pureset::BinaryOp { dst, a, b },
-            )
-            .into(),
-        );
-    }
-
-    /// Emits a modulo instruction.
-    pub fn emit_mod(&mut self, dst: RegisterId, a: RegisterId, b: RegisterId) {
-        self.emit(
-            waymark_vm_instructions_pureset::PureSet::Mod(
-                waymark_vm_instructions_pureset::BinaryOp { dst, a, b },
-            )
-            .into(),
-        );
-    }
-
-    /// Emits an equality comparison instruction.
-    pub fn emit_eq(&mut self, dst: RegisterId, a: RegisterId, b: RegisterId) {
-        self.emit(
-            waymark_vm_instructions_pureset::PureSet::Eq(
-                waymark_vm_instructions_pureset::BinaryOp { dst, a, b },
-            )
-            .into(),
-        );
-    }
-
-    /// Emits an inequality comparison instruction.
-    pub fn emit_ne(&mut self, dst: RegisterId, a: RegisterId, b: RegisterId) {
-        self.emit(
-            waymark_vm_instructions_pureset::PureSet::Ne(
-                waymark_vm_instructions_pureset::BinaryOp { dst, a, b },
-            )
-            .into(),
-        );
-    }
-
-    /// Emits a less-than comparison instruction.
-    pub fn emit_lt(&mut self, dst: RegisterId, a: RegisterId, b: RegisterId) {
-        self.emit(
-            waymark_vm_instructions_pureset::PureSet::Lt(
-                waymark_vm_instructions_pureset::BinaryOp { dst, a, b },
-            )
-            .into(),
-        );
-    }
-
-    /// Emits a less-than-or-equal comparison instruction.
-    pub fn emit_le(&mut self, dst: RegisterId, a: RegisterId, b: RegisterId) {
-        self.emit(
-            waymark_vm_instructions_pureset::PureSet::Le(
-                waymark_vm_instructions_pureset::BinaryOp { dst, a, b },
-            )
-            .into(),
-        );
-    }
-
-    /// Emits a greater-than comparison instruction.
-    pub fn emit_gt(&mut self, dst: RegisterId, a: RegisterId, b: RegisterId) {
-        self.emit(
-            waymark_vm_instructions_pureset::PureSet::Gt(
-                waymark_vm_instructions_pureset::BinaryOp { dst, a, b },
-            )
-            .into(),
-        );
-    }
-
-    /// Emits a greater-than-or-equal comparison instruction.
-    pub fn emit_ge(&mut self, dst: RegisterId, a: RegisterId, b: RegisterId) {
-        self.emit(
-            waymark_vm_instructions_pureset::PureSet::Ge(
-                waymark_vm_instructions_pureset::BinaryOp { dst, a, b },
-            )
-            .into(),
-        );
-    }
-
-    /// Emits a membership instruction.
-    pub fn emit_in(&mut self, dst: RegisterId, a: RegisterId, b: RegisterId) {
-        self.emit(
-            waymark_vm_instructions_pureset::PureSet::In(
-                waymark_vm_instructions_pureset::BinaryOp { dst, a, b },
-            )
-            .into(),
-        );
-    }
-
-    /// Emits a negated-membership instruction.
-    pub fn emit_not_in(&mut self, dst: RegisterId, a: RegisterId, b: RegisterId) {
-        self.emit(
-            waymark_vm_instructions_pureset::PureSet::NotIn(
-                waymark_vm_instructions_pureset::BinaryOp { dst, a, b },
-            )
-            .into(),
-        );
-    }
-
-    /// Emits a logical-and instruction.
-    pub fn emit_and(&mut self, dst: RegisterId, a: RegisterId, b: RegisterId) {
-        self.emit(
-            waymark_vm_instructions_pureset::PureSet::And(
-                waymark_vm_instructions_pureset::BinaryOp { dst, a, b },
-            )
-            .into(),
-        );
-    }
-
-    /// Emits a logical-or instruction.
-    pub fn emit_or(&mut self, dst: RegisterId, a: RegisterId, b: RegisterId) {
-        self.emit(
-            waymark_vm_instructions_pureset::PureSet::Or(
-                waymark_vm_instructions_pureset::BinaryOp { dst, a, b },
-            )
-            .into(),
-        );
-    }
-
-    /// Emits a unary negation instruction.
-    pub fn emit_neg(&mut self, dst: RegisterId, src: RegisterId) {
-        self.emit(
-            waymark_vm_instructions_pureset::PureSet::Neg(
-                waymark_vm_instructions_pureset::UnaryOp { dst, src },
-            )
-            .into(),
-        );
-    }
-
-    /// Emits a logical-not instruction.
-    pub fn emit_not(&mut self, dst: RegisterId, src: RegisterId) {
-        self.emit(
-            waymark_vm_instructions_pureset::PureSet::Not(
-                waymark_vm_instructions_pureset::UnaryOp { dst, src },
-            )
-            .into(),
-        );
-    }
-
     /// Emits a list-construction instruction.
     pub fn emit_make_list(&mut self, dst: RegisterId, items: Vec<RegisterId>) {
         self.emit(waymark_vm_instructions_pureset::PureSet::MakeList { dst, items }.into());
@@ -317,6 +137,39 @@ where
     pub fn emit_return(&mut self, src: RegisterId) {
         self.emit(waymark_vm_instructions_coreset::CoreSet::Return { src }.into());
         self.function_states.terminate();
+    }
+
+    /// Emits a binary pureset instruction with the provided operation kind.
+    pub fn emit_binary(
+        &mut self,
+        kind: waymark_vm_instructions_pureset::BinaryOpKind,
+        dst: RegisterId,
+        a: RegisterId,
+        b: RegisterId,
+    ) {
+        self.emit(
+            waymark_vm_instructions_pureset::PureSet::Binary {
+                kind,
+                op: waymark_vm_instructions_pureset::BinaryOp { dst, a, b },
+            }
+            .into(),
+        );
+    }
+
+    /// Emits a unary pureset instruction with the provided operation kind.
+    pub fn emit_unary(
+        &mut self,
+        kind: waymark_vm_instructions_pureset::UnaryOpKind,
+        dst: RegisterId,
+        src: RegisterId,
+    ) {
+        self.emit(
+            waymark_vm_instructions_pureset::PureSet::Unary {
+                kind,
+                op: waymark_vm_instructions_pureset::UnaryOp { dst, src },
+            }
+            .into(),
+        );
     }
 
     /// Appends an instruction to the current state.

--- a/crates/lib/vm-compiler-for-ast-old/src/function/compiler/bytecode/emitter.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/function/compiler/bytecode/emitter.rs
@@ -66,92 +66,182 @@ where
 
     /// Emits an integer/string addition instruction.
     pub fn emit_add(&mut self, dst: RegisterId, a: RegisterId, b: RegisterId) {
-        self.emit(waymark_vm_instructions_pureset::PureSet::Add { dst, a, b }.into());
+        self.emit(
+            waymark_vm_instructions_pureset::PureSet::Add(
+                waymark_vm_instructions_pureset::BinaryOp { dst, a, b },
+            )
+            .into(),
+        );
     }
 
     /// Emits a subtraction instruction.
     pub fn emit_sub(&mut self, dst: RegisterId, a: RegisterId, b: RegisterId) {
-        self.emit(waymark_vm_instructions_pureset::PureSet::Sub { dst, a, b }.into());
+        self.emit(
+            waymark_vm_instructions_pureset::PureSet::Sub(
+                waymark_vm_instructions_pureset::BinaryOp { dst, a, b },
+            )
+            .into(),
+        );
     }
 
     /// Emits a multiplication instruction.
     pub fn emit_mul(&mut self, dst: RegisterId, a: RegisterId, b: RegisterId) {
-        self.emit(waymark_vm_instructions_pureset::PureSet::Mul { dst, a, b }.into());
+        self.emit(
+            waymark_vm_instructions_pureset::PureSet::Mul(
+                waymark_vm_instructions_pureset::BinaryOp { dst, a, b },
+            )
+            .into(),
+        );
     }
 
     /// Emits a division instruction.
     pub fn emit_div(&mut self, dst: RegisterId, a: RegisterId, b: RegisterId) {
-        self.emit(waymark_vm_instructions_pureset::PureSet::Div { dst, a, b }.into());
+        self.emit(
+            waymark_vm_instructions_pureset::PureSet::Div(
+                waymark_vm_instructions_pureset::BinaryOp { dst, a, b },
+            )
+            .into(),
+        );
     }
 
     /// Emits a floor-division instruction.
     pub fn emit_floor_div(&mut self, dst: RegisterId, a: RegisterId, b: RegisterId) {
-        self.emit(waymark_vm_instructions_pureset::PureSet::FloorDiv { dst, a, b }.into());
+        self.emit(
+            waymark_vm_instructions_pureset::PureSet::FloorDiv(
+                waymark_vm_instructions_pureset::BinaryOp { dst, a, b },
+            )
+            .into(),
+        );
     }
 
     /// Emits a modulo instruction.
     pub fn emit_mod(&mut self, dst: RegisterId, a: RegisterId, b: RegisterId) {
-        self.emit(waymark_vm_instructions_pureset::PureSet::Mod { dst, a, b }.into());
+        self.emit(
+            waymark_vm_instructions_pureset::PureSet::Mod(
+                waymark_vm_instructions_pureset::BinaryOp { dst, a, b },
+            )
+            .into(),
+        );
     }
 
     /// Emits an equality comparison instruction.
     pub fn emit_eq(&mut self, dst: RegisterId, a: RegisterId, b: RegisterId) {
-        self.emit(waymark_vm_instructions_pureset::PureSet::Eq { dst, a, b }.into());
+        self.emit(
+            waymark_vm_instructions_pureset::PureSet::Eq(
+                waymark_vm_instructions_pureset::BinaryOp { dst, a, b },
+            )
+            .into(),
+        );
     }
 
     /// Emits an inequality comparison instruction.
     pub fn emit_ne(&mut self, dst: RegisterId, a: RegisterId, b: RegisterId) {
-        self.emit(waymark_vm_instructions_pureset::PureSet::Ne { dst, a, b }.into());
+        self.emit(
+            waymark_vm_instructions_pureset::PureSet::Ne(
+                waymark_vm_instructions_pureset::BinaryOp { dst, a, b },
+            )
+            .into(),
+        );
     }
 
     /// Emits a less-than comparison instruction.
     pub fn emit_lt(&mut self, dst: RegisterId, a: RegisterId, b: RegisterId) {
-        self.emit(waymark_vm_instructions_pureset::PureSet::Lt { dst, a, b }.into());
+        self.emit(
+            waymark_vm_instructions_pureset::PureSet::Lt(
+                waymark_vm_instructions_pureset::BinaryOp { dst, a, b },
+            )
+            .into(),
+        );
     }
 
     /// Emits a less-than-or-equal comparison instruction.
     pub fn emit_le(&mut self, dst: RegisterId, a: RegisterId, b: RegisterId) {
-        self.emit(waymark_vm_instructions_pureset::PureSet::Le { dst, a, b }.into());
+        self.emit(
+            waymark_vm_instructions_pureset::PureSet::Le(
+                waymark_vm_instructions_pureset::BinaryOp { dst, a, b },
+            )
+            .into(),
+        );
     }
 
     /// Emits a greater-than comparison instruction.
     pub fn emit_gt(&mut self, dst: RegisterId, a: RegisterId, b: RegisterId) {
-        self.emit(waymark_vm_instructions_pureset::PureSet::Gt { dst, a, b }.into());
+        self.emit(
+            waymark_vm_instructions_pureset::PureSet::Gt(
+                waymark_vm_instructions_pureset::BinaryOp { dst, a, b },
+            )
+            .into(),
+        );
     }
 
     /// Emits a greater-than-or-equal comparison instruction.
     pub fn emit_ge(&mut self, dst: RegisterId, a: RegisterId, b: RegisterId) {
-        self.emit(waymark_vm_instructions_pureset::PureSet::Ge { dst, a, b }.into());
+        self.emit(
+            waymark_vm_instructions_pureset::PureSet::Ge(
+                waymark_vm_instructions_pureset::BinaryOp { dst, a, b },
+            )
+            .into(),
+        );
     }
 
     /// Emits a membership instruction.
     pub fn emit_in(&mut self, dst: RegisterId, a: RegisterId, b: RegisterId) {
-        self.emit(waymark_vm_instructions_pureset::PureSet::In { dst, a, b }.into());
+        self.emit(
+            waymark_vm_instructions_pureset::PureSet::In(
+                waymark_vm_instructions_pureset::BinaryOp { dst, a, b },
+            )
+            .into(),
+        );
     }
 
     /// Emits a negated-membership instruction.
     pub fn emit_not_in(&mut self, dst: RegisterId, a: RegisterId, b: RegisterId) {
-        self.emit(waymark_vm_instructions_pureset::PureSet::NotIn { dst, a, b }.into());
+        self.emit(
+            waymark_vm_instructions_pureset::PureSet::NotIn(
+                waymark_vm_instructions_pureset::BinaryOp { dst, a, b },
+            )
+            .into(),
+        );
     }
 
     /// Emits a logical-and instruction.
     pub fn emit_and(&mut self, dst: RegisterId, a: RegisterId, b: RegisterId) {
-        self.emit(waymark_vm_instructions_pureset::PureSet::And { dst, a, b }.into());
+        self.emit(
+            waymark_vm_instructions_pureset::PureSet::And(
+                waymark_vm_instructions_pureset::BinaryOp { dst, a, b },
+            )
+            .into(),
+        );
     }
 
     /// Emits a logical-or instruction.
     pub fn emit_or(&mut self, dst: RegisterId, a: RegisterId, b: RegisterId) {
-        self.emit(waymark_vm_instructions_pureset::PureSet::Or { dst, a, b }.into());
+        self.emit(
+            waymark_vm_instructions_pureset::PureSet::Or(
+                waymark_vm_instructions_pureset::BinaryOp { dst, a, b },
+            )
+            .into(),
+        );
     }
 
     /// Emits a unary negation instruction.
     pub fn emit_neg(&mut self, dst: RegisterId, src: RegisterId) {
-        self.emit(waymark_vm_instructions_pureset::PureSet::Neg { dst, src }.into());
+        self.emit(
+            waymark_vm_instructions_pureset::PureSet::Neg(
+                waymark_vm_instructions_pureset::UnaryOp { dst, src },
+            )
+            .into(),
+        );
     }
 
     /// Emits a logical-not instruction.
     pub fn emit_not(&mut self, dst: RegisterId, src: RegisterId) {
-        self.emit(waymark_vm_instructions_pureset::PureSet::Not { dst, src }.into());
+        self.emit(
+            waymark_vm_instructions_pureset::PureSet::Not(
+                waymark_vm_instructions_pureset::UnaryOp { dst, src },
+            )
+            .into(),
+        );
     }
 
     /// Emits a list-construction instruction.

--- a/crates/lib/vm-compiler-for-ast-old/src/function/compiler/lowering/value.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/function/compiler/lowering/value.rs
@@ -617,7 +617,9 @@ mod tests {
         ));
         assert!(matches!(
             instructions.next(),
-            Some(InstructionSet::PureSet(PureSet::Add { dst, a, b }))
+            Some(InstructionSet::PureSet(PureSet::Add(
+                waymark_vm_instructions_pureset::BinaryOp { dst, a, b },
+            )))
                 if *dst == preferred_dst
                     && *a == RegisterId(1)
                     && *b == RegisterId(2)
@@ -980,7 +982,9 @@ mod tests {
         ));
         assert!(matches!(
             instructions.next(),
-            Some(InstructionSet::PureSet(PureSet::Add { dst, a, b }))
+            Some(InstructionSet::PureSet(PureSet::Add(
+                waymark_vm_instructions_pureset::BinaryOp { dst, a, b },
+            )))
                 if *dst == RegisterId(2)
                     && *a == RegisterId(0)
                     && *b == RegisterId(1)
@@ -994,7 +998,9 @@ mod tests {
         ));
         assert!(matches!(
             instructions.next(),
-            Some(InstructionSet::PureSet(PureSet::Add { dst, a, b }))
+            Some(InstructionSet::PureSet(PureSet::Add(
+                waymark_vm_instructions_pureset::BinaryOp { dst, a, b },
+            )))
                 if *dst == RegisterId(1)
                     && *a == RegisterId(2)
                     && *b == RegisterId(0)

--- a/crates/lib/vm-compiler-for-ast-old/src/function/compiler/lowering/value.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/function/compiler/lowering/value.rs
@@ -1,6 +1,8 @@
 //! Value lowering.
 
-use waymark_vm_ast_old::{ActionCall, Expr, FunctionCall, Literal, Spanned};
+use waymark_vm_ast_old::{
+    ActionCall, BinaryOperator, Expr, FunctionCall, Literal, Spanned, UnaryOperator,
+};
 use waymark_vm_runtime_core::RegisterId;
 
 use crate::Marked;
@@ -53,7 +55,12 @@ where
         match ExpressionPlan::build(expr)? {
             ExpressionPlan::Literal { value } => self.compile_literal(value, target),
             ExpressionPlan::Variable { name } => Ok(self.resolve_variable(name)?),
-            ExpressionPlan::Add { left, right } => self.compile_add_expr(left, right, target),
+            ExpressionPlan::BinaryOp { left, op, right } => {
+                self.compile_binary_expr(left, &op, right, target)
+            }
+            ExpressionPlan::UnaryOp { op, operand } => {
+                self.compile_unary_expr(&op, operand, target)
+            }
             ExpressionPlan::FunctionCall { call } => {
                 self.compile_call(self.plan_function_call(call)?, target)
             }
@@ -178,21 +185,36 @@ where
         Ok(dst)
     }
 
-    /// Compiles an addition expression and releases any temporary operands.
-    fn compile_add_expr(
+    /// Compiles a scalar binary expression and releases any temporary operands.
+    fn compile_binary_expr(
         &mut self,
         left: &Spanned<Expr>,
+        op: &BinaryOperator,
         right: &Spanned<Expr>,
         target: ResultTarget,
     ) -> Result<RegisterHandle, ErrorFor<Spec, Lowering>> {
         let left_register = self.compile_expr(left, ResultTarget::Allocate)?;
         let right_register = self.compile_expr(right, ResultTarget::Allocate)?;
         let dst = self.allocate_result_register(target);
-        self.context.emitter.emit_add(
+        self.emit_binary_instruction(
+            op,
             dst.register(),
             left_register.register(),
             right_register.register(),
         );
+        Ok(dst)
+    }
+
+    /// Compiles a scalar unary expression and releases its temporary operand.
+    fn compile_unary_expr(
+        &mut self,
+        op: &UnaryOperator,
+        operand: &Spanned<Expr>,
+        target: ResultTarget,
+    ) -> Result<RegisterHandle, ErrorFor<Spec, Lowering>> {
+        let operand_register = self.compile_expr(operand, ResultTarget::Allocate)?;
+        let dst = self.allocate_result_register(target);
+        self.emit_unary_instruction(op, dst.register(), operand_register.register());
         Ok(dst)
     }
 
@@ -263,6 +285,42 @@ where
         }
     }
 
+    /// Emits a scalar binary instruction for the selected operator.
+    fn emit_binary_instruction(
+        &mut self,
+        op: &BinaryOperator,
+        dst: RegisterId,
+        left: RegisterId,
+        right: RegisterId,
+    ) {
+        match op {
+            BinaryOperator::Add => self.context.emitter.emit_add(dst, left, right),
+            BinaryOperator::Sub => self.context.emitter.emit_sub(dst, left, right),
+            BinaryOperator::Mul => self.context.emitter.emit_mul(dst, left, right),
+            BinaryOperator::Div => self.context.emitter.emit_div(dst, left, right),
+            BinaryOperator::FloorDiv => self.context.emitter.emit_floor_div(dst, left, right),
+            BinaryOperator::Mod => self.context.emitter.emit_mod(dst, left, right),
+            BinaryOperator::Eq => self.context.emitter.emit_eq(dst, left, right),
+            BinaryOperator::Ne => self.context.emitter.emit_ne(dst, left, right),
+            BinaryOperator::Lt => self.context.emitter.emit_lt(dst, left, right),
+            BinaryOperator::Le => self.context.emitter.emit_le(dst, left, right),
+            BinaryOperator::Gt => self.context.emitter.emit_gt(dst, left, right),
+            BinaryOperator::Ge => self.context.emitter.emit_ge(dst, left, right),
+            BinaryOperator::In => self.context.emitter.emit_in(dst, left, right),
+            BinaryOperator::NotIn => self.context.emitter.emit_not_in(dst, left, right),
+            BinaryOperator::And => self.context.emitter.emit_and(dst, left, right),
+            BinaryOperator::Or => self.context.emitter.emit_or(dst, left, right),
+        }
+    }
+
+    /// Emits a scalar unary instruction for the selected operator.
+    fn emit_unary_instruction(&mut self, op: &UnaryOperator, dst: RegisterId, src: RegisterId) {
+        match op {
+            UnaryOperator::Neg => self.context.emitter.emit_neg(dst, src),
+            UnaryOperator::Not => self.context.emitter.emit_not(dst, src),
+        }
+    }
+
     /// Emits an await into `target_register` and advances to the resume state.
     pub fn compile_await(
         &mut self,
@@ -289,7 +347,8 @@ mod tests {
     use super::*;
 
     use index_type::IndexType;
-    use waymark_vm_ast_old_helpers::{action_call, add, function_call, int};
+    use waymark_vm_ast_old::BinaryOperator;
+    use waymark_vm_ast_old_helpers::{action_call, binary_expr, function_call, int};
     use waymark_vm_bytecode_core::{FunctionId, StateId};
     use waymark_vm_instructions_coreset::CoreSet;
     use waymark_vm_instructions_fullset::FullSet as InstructionSet;
@@ -530,7 +589,10 @@ mod tests {
             );
 
             values
-                .compile_expr(&add(int(1), int(2)), ResultTarget::Existing(preferred_dst))
+                .compile_expr(
+                    &binary_expr(int(1), BinaryOperator::Add, int(2)),
+                    ResultTarget::Existing(preferred_dst),
+                )
                 .expect("add expression with preferred dst should compile")
         };
 
@@ -890,7 +952,11 @@ mod tests {
             );
 
             values
-                .compile_expression_statement(&add(add(int(1), int(2)), int(3)))
+                .compile_expression_statement(&binary_expr(
+                    binary_expr(int(1), BinaryOperator::Add, int(2)),
+                    BinaryOperator::Add,
+                    int(3),
+                ))
                 .expect("nested add expression statement should compile");
         }
 

--- a/crates/lib/vm-compiler-for-ast-old/src/function/compiler/lowering/value.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/function/compiler/lowering/value.rs
@@ -293,32 +293,36 @@ where
         left: RegisterId,
         right: RegisterId,
     ) {
-        match op {
-            BinaryOperator::Add => self.context.emitter.emit_add(dst, left, right),
-            BinaryOperator::Sub => self.context.emitter.emit_sub(dst, left, right),
-            BinaryOperator::Mul => self.context.emitter.emit_mul(dst, left, right),
-            BinaryOperator::Div => self.context.emitter.emit_div(dst, left, right),
-            BinaryOperator::FloorDiv => self.context.emitter.emit_floor_div(dst, left, right),
-            BinaryOperator::Mod => self.context.emitter.emit_mod(dst, left, right),
-            BinaryOperator::Eq => self.context.emitter.emit_eq(dst, left, right),
-            BinaryOperator::Ne => self.context.emitter.emit_ne(dst, left, right),
-            BinaryOperator::Lt => self.context.emitter.emit_lt(dst, left, right),
-            BinaryOperator::Le => self.context.emitter.emit_le(dst, left, right),
-            BinaryOperator::Gt => self.context.emitter.emit_gt(dst, left, right),
-            BinaryOperator::Ge => self.context.emitter.emit_ge(dst, left, right),
-            BinaryOperator::In => self.context.emitter.emit_in(dst, left, right),
-            BinaryOperator::NotIn => self.context.emitter.emit_not_in(dst, left, right),
-            BinaryOperator::And => self.context.emitter.emit_and(dst, left, right),
-            BinaryOperator::Or => self.context.emitter.emit_or(dst, left, right),
-        }
+        let kind = match op {
+            BinaryOperator::Add => waymark_vm_instructions_pureset::BinaryOpKind::Add,
+            BinaryOperator::Sub => waymark_vm_instructions_pureset::BinaryOpKind::Sub,
+            BinaryOperator::Mul => waymark_vm_instructions_pureset::BinaryOpKind::Mul,
+            BinaryOperator::Div => waymark_vm_instructions_pureset::BinaryOpKind::Div,
+            BinaryOperator::FloorDiv => waymark_vm_instructions_pureset::BinaryOpKind::FloorDiv,
+            BinaryOperator::Mod => waymark_vm_instructions_pureset::BinaryOpKind::Mod,
+            BinaryOperator::Eq => waymark_vm_instructions_pureset::BinaryOpKind::Eq,
+            BinaryOperator::Ne => waymark_vm_instructions_pureset::BinaryOpKind::Ne,
+            BinaryOperator::Lt => waymark_vm_instructions_pureset::BinaryOpKind::Lt,
+            BinaryOperator::Le => waymark_vm_instructions_pureset::BinaryOpKind::Le,
+            BinaryOperator::Gt => waymark_vm_instructions_pureset::BinaryOpKind::Gt,
+            BinaryOperator::Ge => waymark_vm_instructions_pureset::BinaryOpKind::Ge,
+            BinaryOperator::In => waymark_vm_instructions_pureset::BinaryOpKind::In,
+            BinaryOperator::NotIn => waymark_vm_instructions_pureset::BinaryOpKind::NotIn,
+            BinaryOperator::And => waymark_vm_instructions_pureset::BinaryOpKind::And,
+            BinaryOperator::Or => waymark_vm_instructions_pureset::BinaryOpKind::Or,
+        };
+
+        self.context.emitter.emit_binary(kind, dst, left, right);
     }
 
     /// Emits a scalar unary instruction for the selected operator.
     fn emit_unary_instruction(&mut self, op: &UnaryOperator, dst: RegisterId, src: RegisterId) {
-        match op {
-            UnaryOperator::Neg => self.context.emitter.emit_neg(dst, src),
-            UnaryOperator::Not => self.context.emitter.emit_not(dst, src),
-        }
+        let kind = match op {
+            UnaryOperator::Neg => waymark_vm_instructions_pureset::UnaryOpKind::Neg,
+            UnaryOperator::Not => waymark_vm_instructions_pureset::UnaryOpKind::Not,
+        };
+
+        self.context.emitter.emit_unary(kind, dst, src);
     }
 
     /// Emits an await into `target_register` and advances to the resume state.
@@ -617,9 +621,10 @@ mod tests {
         ));
         assert!(matches!(
             instructions.next(),
-            Some(InstructionSet::PureSet(PureSet::Add(
-                waymark_vm_instructions_pureset::BinaryOp { dst, a, b },
-            )))
+            Some(InstructionSet::PureSet(PureSet::Binary {
+                kind: waymark_vm_instructions_pureset::BinaryOpKind::Add,
+                op: waymark_vm_instructions_pureset::BinaryOp { dst, a, b },
+            }))
                 if *dst == preferred_dst
                     && *a == RegisterId(1)
                     && *b == RegisterId(2)
@@ -982,9 +987,10 @@ mod tests {
         ));
         assert!(matches!(
             instructions.next(),
-            Some(InstructionSet::PureSet(PureSet::Add(
-                waymark_vm_instructions_pureset::BinaryOp { dst, a, b },
-            )))
+            Some(InstructionSet::PureSet(PureSet::Binary {
+                kind: waymark_vm_instructions_pureset::BinaryOpKind::Add,
+                op: waymark_vm_instructions_pureset::BinaryOp { dst, a, b },
+            }))
                 if *dst == RegisterId(2)
                     && *a == RegisterId(0)
                     && *b == RegisterId(1)
@@ -998,9 +1004,10 @@ mod tests {
         ));
         assert!(matches!(
             instructions.next(),
-            Some(InstructionSet::PureSet(PureSet::Add(
-                waymark_vm_instructions_pureset::BinaryOp { dst, a, b },
-            )))
+            Some(InstructionSet::PureSet(PureSet::Binary {
+                kind: waymark_vm_instructions_pureset::BinaryOpKind::Add,
+                op: waymark_vm_instructions_pureset::BinaryOp { dst, a, b },
+            }))
                 if *dst == RegisterId(1)
                     && *a == RegisterId(2)
                     && *b == RegisterId(0)

--- a/crates/lib/vm-compiler-for-ast-old/src/function/compiler/plan/expr.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/function/compiler/plan/expr.rs
@@ -1,6 +1,8 @@
 //! Expression planning for generic value positions.
 
-use waymark_vm_ast_old::{ActionCall, BinaryOperator, Expr, FunctionCall, Literal, Spanned};
+use waymark_vm_ast_old::{
+    ActionCall, BinaryOperator, Expr, FunctionCall, Literal, Spanned, UnaryOperator,
+};
 
 use super::Unsupported;
 
@@ -23,13 +25,25 @@ pub enum ExpressionPlan<'a> {
         name: &'a str,
     },
 
-    /// An addition expression.
-    Add {
+    /// A scalar binary expression.
+    BinaryOp {
         /// Left-hand operand.
         left: &'a Spanned<Expr>,
 
+        /// Binary operator to apply.
+        op: BinaryOperator,
+
         /// Right-hand operand.
         right: &'a Spanned<Expr>,
+    },
+
+    /// A scalar unary expression.
+    UnaryOp {
+        /// Unary operator to apply.
+        op: UnaryOperator,
+
+        /// Operand to evaluate.
+        operand: &'a Spanned<Expr>,
     },
 
     /// A call to another in-VM function.
@@ -48,9 +62,6 @@ pub enum ExpressionPlan<'a> {
 /// Expression variants that the generic value-lowering path rejects.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum UnsupportedExpressionKind {
-    /// Unary operations such as `not value`.
-    UnaryOp,
-
     /// List literals.
     List,
 
@@ -77,17 +88,16 @@ impl<'a> ExpressionPlan<'a> {
         match &expr.value {
             Expr::Literal { value } => Ok(Self::Literal { value }),
             Expr::Variable { name } => Ok(Self::Variable { name }),
-            Expr::BinaryOp { left, op, right } => {
-                if !matches!(op, BinaryOperator::Add) {
-                    return Err(Unsupported::BinaryOperator { op: op.clone() });
-                }
-
-                Ok(Self::Add { left, right })
-            }
+            Expr::BinaryOp { left, op, right } => Ok(Self::BinaryOp {
+                left,
+                op: op.clone(),
+                right,
+            }),
             Expr::FunctionCall { call } => Ok(Self::FunctionCall { call }),
             Expr::ActionCall { call } => Ok(Self::ActionCall { call }),
-            Expr::UnaryOp { .. } => Err(Unsupported::Expression {
-                kind: UnsupportedExpressionKind::UnaryOp,
+            Expr::UnaryOp { op, operand } => Ok(Self::UnaryOp {
+                op: op.clone(),
+                operand,
             }),
             Expr::List { .. } => Err(Unsupported::Expression {
                 kind: UnsupportedExpressionKind::List,
@@ -112,7 +122,6 @@ impl<'a> ExpressionPlan<'a> {
 impl core::fmt::Display for UnsupportedExpressionKind {
     fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         formatter.write_str(match self {
-            Self::UnaryOp => "UnaryOp",
             Self::List => "List",
             Self::Dict => "Dict",
             Self::Index => "Index",
@@ -126,33 +135,61 @@ impl core::fmt::Display for UnsupportedExpressionKind {
 mod tests {
     use super::*;
 
-    use waymark_vm_ast_old::{BinaryOperator, Call, DictEntry, Expr, Literal, UnaryOperator};
+    use waymark_vm_ast_old::{BinaryOperator, Call, DictEntry, Expr, UnaryOperator};
     use waymark_vm_ast_old_helpers::{
-        action_call, action_expr, add, function_expr, int, spanned, variable,
+        action_call, action_expr, function_expr, int, spanned, variable,
     };
 
     #[test]
-    fn builds_add_plan_for_supported_binary_ops() {
-        let expr = add(int(1), int(2));
+    fn builds_scalar_operator_plans() {
+        let supported_binary_ops = [
+            BinaryOperator::Add,
+            BinaryOperator::Sub,
+            BinaryOperator::Mul,
+            BinaryOperator::Div,
+            BinaryOperator::FloorDiv,
+            BinaryOperator::Mod,
+            BinaryOperator::Eq,
+            BinaryOperator::Ne,
+            BinaryOperator::Lt,
+            BinaryOperator::Le,
+            BinaryOperator::Gt,
+            BinaryOperator::Ge,
+            BinaryOperator::In,
+            BinaryOperator::NotIn,
+            BinaryOperator::And,
+            BinaryOperator::Or,
+        ];
 
-        let plan = ExpressionPlan::build(&expr).expect("add expressions should build");
+        for op in supported_binary_ops {
+            let expr = spanned(Expr::BinaryOp {
+                left: Box::new(int(1)),
+                op: op.clone(),
+                right: Box::new(int(2)),
+            });
 
-        match plan {
-            ExpressionPlan::Add { left, right } => {
-                assert!(matches!(
-                    left.value,
-                    Expr::Literal {
-                        value: Literal::Int(1),
-                    }
-                ));
-                assert!(matches!(
-                    right.value,
-                    Expr::Literal {
-                        value: Literal::Int(2),
-                    }
-                ));
-            }
-            other => panic!("unexpected expression plan {other:?}"),
+            let plan = ExpressionPlan::build(&expr).expect("binary expressions should build");
+
+            assert!(matches!(
+                plan,
+                ExpressionPlan::BinaryOp { op: actual, .. } if actual == op
+            ));
+        }
+
+        let supported_unary_ops = [UnaryOperator::Neg, UnaryOperator::Not];
+
+        for op in supported_unary_ops {
+            let expr = spanned(Expr::UnaryOp {
+                op: op.clone(),
+                operand: Box::new(int(1)),
+            });
+
+            let plan = ExpressionPlan::build(&expr).expect("unary expressions should build");
+
+            assert!(matches!(
+                plan,
+                ExpressionPlan::UnaryOp { op: actual, .. } if actual == op
+            ));
         }
     }
 
@@ -177,33 +214,8 @@ mod tests {
     }
 
     #[test]
-    fn rejects_unsupported_binary_ops() {
-        let expr = spanned(Expr::BinaryOp {
-            left: Box::new(int(1)),
-            op: BinaryOperator::Ne,
-            right: Box::new(int(2)),
-        });
-
-        let error = ExpressionPlan::build(&expr).expect_err("unsupported binary ops should fail");
-
-        assert!(matches!(
-            error,
-            Unsupported::BinaryOperator {
-                op: BinaryOperator::Ne,
-            }
-        ));
-    }
-
-    #[test]
     fn rejects_unsupported_expression_variants() {
         let unsupported = [
-            (
-                spanned(Expr::UnaryOp {
-                    op: UnaryOperator::Not,
-                    operand: Box::new(int(1)),
-                }),
-                UnsupportedExpressionKind::UnaryOp,
-            ),
             (
                 spanned(Expr::List {
                     elements: vec![int(1)],

--- a/crates/lib/vm-compiler-for-ast-old/src/function/compiler/plan/unsupported.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/function/compiler/plan/unsupported.rs
@@ -29,13 +29,6 @@ pub enum Unsupported {
     #[error("parallel expressions are only supported on the right-hand side of assignments")]
     ParallelExprOutsideAssignment,
 
-    /// A binary operator is not compiled yet.
-    #[error("binary operator `{op:?}` is not supported by the compiler yet")]
-    BinaryOperator {
-        /// The unsupported operator.
-        op: waymark_vm_ast_old::BinaryOperator,
-    },
-
     /// A function call shape cannot be represented by the current VM.
     #[error("function call `{name}` is not supported: {reason}")]
     FunctionCall {

--- a/crates/lib/vm-compiler-for-ast-old/src/lib.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/lib.rs
@@ -8,7 +8,7 @@
 //!
 //! The current compiler intentionally implements only the subset that can be
 //! represented by the existing VM instruction set: literals, variables,
-//! addition, simple assignments, conditionals, while loops,
+//! scalar binary and unary operations, simple assignments, conditionals, while loops,
 //! `break`/`continue`, returns, user function calls, and action calls.
 //!
 //! Unsupported statements and expressions are rejected with [`CompileError`]

--- a/crates/lib/vm-compiler-for-ast-old/tests/integration.rs
+++ b/crates/lib/vm-compiler-for-ast-old/tests/integration.rs
@@ -1,21 +1,26 @@
 mod support;
 
 use support::{TestValue, compile_program, runtime, runtime_with_args};
-use waymark_vm_ast_old::Call;
+use waymark_vm_ast_old::{BinaryOperator, Call, Expr, Spanned, UnaryOperator};
 use waymark_vm_ast_old_helpers::{
-    action_call, action_expr, add, assignment, assignment_targets, break_stmt, conditional_stmt,
-    continue_stmt, function, function_call, function_expr, int, parallel_expr, parallel_stmt,
-    program, return_stmt, variable, while_stmt,
+    action_call, action_expr, assignment, assignment_targets, binary_expr, break_stmt,
+    conditional_stmt, continue_stmt, function, function_call, function_expr, int, parallel_expr,
+    parallel_stmt, program, return_stmt, unary_expr, variable, while_stmt,
 };
 use waymark_vm_bytecode_core::{FunctionId, InstructionId, StateId};
 use waymark_vm_compiler_for_ast_old_test_support::TestExtCallId;
 use waymark_vm_interpreter_fullset::Effect;
 
 fn completed_int(effect: Effect<TestValue, TestExtCallId>) -> i64 {
+    match completed_value(effect) {
+        TestValue::Int(value) => value,
+        other => panic!("unexpected runtime effect: {other:?}"),
+    }
+}
+
+fn completed_value(effect: Effect<TestValue, TestExtCallId>) -> TestValue {
     match effect {
-        Effect::CoreSet(waymark_vm_interpreter_coreset::Effect::Complete(TestValue::Int(
-            value,
-        ))) => value,
+        Effect::CoreSet(waymark_vm_interpreter_coreset::Effect::Complete(value)) => value,
         other => panic!("unexpected runtime effect: {other:?}"),
     }
 }
@@ -28,7 +33,11 @@ fn compiles_assignments_and_addition_to_completion() {
         vec![
             assignment("x", int(2)),
             assignment("y", int(3)),
-            return_stmt(Some(add(variable("x"), variable("y")))),
+            return_stmt(Some(binary_expr(
+                variable("x"),
+                BinaryOperator::Add,
+                variable("y"),
+            ))),
         ],
     )]);
 
@@ -46,6 +55,240 @@ fn compiles_assignments_and_addition_to_completion() {
 }
 
 #[test]
+fn compiles_scalar_binary_operations_to_completion() {
+    struct BinaryCase {
+        name: &'static str,
+        inputs: Vec<&'static str>,
+        expr: Spanned<Expr>,
+        args: Vec<TestValue>,
+        expected: TestValue,
+    }
+
+    let cases = vec![
+        BinaryCase {
+            name: "add",
+            inputs: Vec::new(),
+            expr: binary_expr(int(2), BinaryOperator::Add, int(3)),
+            args: Vec::new(),
+            expected: TestValue::Int(5),
+        },
+        BinaryCase {
+            name: "sub",
+            inputs: Vec::new(),
+            expr: binary_expr(int(9), BinaryOperator::Sub, int(4)),
+            args: Vec::new(),
+            expected: TestValue::Int(5),
+        },
+        BinaryCase {
+            name: "mul",
+            inputs: Vec::new(),
+            expr: binary_expr(int(6), BinaryOperator::Mul, int(7)),
+            args: Vec::new(),
+            expected: TestValue::Int(42),
+        },
+        BinaryCase {
+            name: "div",
+            inputs: Vec::new(),
+            expr: binary_expr(int(8), BinaryOperator::Div, int(2)),
+            args: Vec::new(),
+            expected: TestValue::Int(4),
+        },
+        BinaryCase {
+            name: "floor div",
+            inputs: Vec::new(),
+            expr: binary_expr(int(7), BinaryOperator::FloorDiv, int(2)),
+            args: Vec::new(),
+            expected: TestValue::Int(3),
+        },
+        BinaryCase {
+            name: "mod",
+            inputs: Vec::new(),
+            expr: binary_expr(int(7), BinaryOperator::Mod, int(3)),
+            args: Vec::new(),
+            expected: TestValue::Int(1),
+        },
+        BinaryCase {
+            name: "eq",
+            inputs: Vec::new(),
+            expr: binary_expr(int(4), BinaryOperator::Eq, int(4)),
+            args: Vec::new(),
+            expected: TestValue::Bool(true),
+        },
+        BinaryCase {
+            name: "ne",
+            inputs: Vec::new(),
+            expr: binary_expr(int(4), BinaryOperator::Ne, int(5)),
+            args: Vec::new(),
+            expected: TestValue::Bool(true),
+        },
+        BinaryCase {
+            name: "lt",
+            inputs: Vec::new(),
+            expr: binary_expr(int(1), BinaryOperator::Lt, int(2)),
+            args: Vec::new(),
+            expected: TestValue::Bool(true),
+        },
+        BinaryCase {
+            name: "le",
+            inputs: Vec::new(),
+            expr: binary_expr(int(2), BinaryOperator::Le, int(2)),
+            args: Vec::new(),
+            expected: TestValue::Bool(true),
+        },
+        BinaryCase {
+            name: "gt",
+            inputs: Vec::new(),
+            expr: binary_expr(int(3), BinaryOperator::Gt, int(2)),
+            args: Vec::new(),
+            expected: TestValue::Bool(true),
+        },
+        BinaryCase {
+            name: "ge",
+            inputs: Vec::new(),
+            expr: binary_expr(int(3), BinaryOperator::Ge, int(3)),
+            args: Vec::new(),
+            expected: TestValue::Bool(true),
+        },
+        BinaryCase {
+            name: "in",
+            inputs: vec!["needle", "haystack"],
+            expr: binary_expr(variable("needle"), BinaryOperator::In, variable("haystack")),
+            args: vec![
+                TestValue::Int(2),
+                TestValue::List(vec![TestValue::Int(1), TestValue::Int(2)]),
+            ],
+            expected: TestValue::Bool(true),
+        },
+        BinaryCase {
+            name: "not in",
+            inputs: vec!["needle", "haystack"],
+            expr: binary_expr(
+                variable("needle"),
+                BinaryOperator::NotIn,
+                variable("haystack"),
+            ),
+            args: vec![
+                TestValue::Int(4),
+                TestValue::List(vec![TestValue::Int(1), TestValue::Int(2)]),
+            ],
+            expected: TestValue::Bool(true),
+        },
+        BinaryCase {
+            name: "and falsey lhs",
+            inputs: vec!["lhs", "rhs"],
+            expr: binary_expr(variable("lhs"), BinaryOperator::And, variable("rhs")),
+            args: vec![TestValue::Int(0), TestValue::Int(5)],
+            expected: TestValue::Int(0),
+        },
+        BinaryCase {
+            name: "and truthy lhs",
+            inputs: vec!["lhs", "rhs"],
+            expr: binary_expr(variable("lhs"), BinaryOperator::And, variable("rhs")),
+            args: vec![TestValue::Int(2), TestValue::Int(5)],
+            expected: TestValue::Int(5),
+        },
+        BinaryCase {
+            name: "or falsey lhs",
+            inputs: vec!["lhs", "rhs"],
+            expr: binary_expr(variable("lhs"), BinaryOperator::Or, variable("rhs")),
+            args: vec![TestValue::Int(0), TestValue::Int(5)],
+            expected: TestValue::Int(5),
+        },
+        BinaryCase {
+            name: "or truthy lhs",
+            inputs: vec!["lhs", "rhs"],
+            expr: binary_expr(variable("lhs"), BinaryOperator::Or, variable("rhs")),
+            args: vec![TestValue::Int(2), TestValue::Int(5)],
+            expected: TestValue::Int(2),
+        },
+    ];
+
+    for case in cases {
+        let program = program(vec![function(
+            "main",
+            case.inputs.as_slice(),
+            vec![return_stmt(Some(case.expr.clone()))],
+        )]);
+        let executable = compile_program(&program);
+
+        let effect = if case.args.is_empty() {
+            runtime(executable)
+                .run()
+                .unwrap_or_else(|error| panic!("{} should complete: {error:?}", case.name))
+        } else {
+            runtime_with_args(executable, case.args.clone())
+                .run()
+                .unwrap_or_else(|error| panic!("{} should complete: {error:?}", case.name))
+        };
+
+        assert_eq!(completed_value(effect), case.expected, "{}", case.name);
+    }
+}
+
+#[test]
+fn compiles_scalar_unary_operations_to_completion() {
+    struct UnaryCase {
+        name: &'static str,
+        inputs: Vec<&'static str>,
+        expr: Spanned<Expr>,
+        args: Vec<TestValue>,
+        expected: TestValue,
+    }
+
+    let cases = vec![
+        UnaryCase {
+            name: "neg",
+            inputs: Vec::new(),
+            expr: unary_expr(UnaryOperator::Neg, int(5)),
+            args: Vec::new(),
+            expected: TestValue::Int(-5),
+        },
+        UnaryCase {
+            name: "not falsey int",
+            inputs: vec!["value"],
+            expr: unary_expr(UnaryOperator::Not, variable("value")),
+            args: vec![TestValue::Int(0)],
+            expected: TestValue::Bool(true),
+        },
+        UnaryCase {
+            name: "not truthy int",
+            inputs: vec!["value"],
+            expr: unary_expr(UnaryOperator::Not, variable("value")),
+            args: vec![TestValue::Int(7)],
+            expected: TestValue::Bool(false),
+        },
+        UnaryCase {
+            name: "not empty list",
+            inputs: vec!["value"],
+            expr: unary_expr(UnaryOperator::Not, variable("value")),
+            args: vec![TestValue::List(Vec::new())],
+            expected: TestValue::Bool(true),
+        },
+    ];
+
+    for case in cases {
+        let program = program(vec![function(
+            "main",
+            case.inputs.as_slice(),
+            vec![return_stmt(Some(case.expr.clone()))],
+        )]);
+        let executable = compile_program(&program);
+
+        let effect = if case.args.is_empty() {
+            runtime(executable)
+                .run()
+                .unwrap_or_else(|error| panic!("{} should complete: {error:?}", case.name))
+        } else {
+            runtime_with_args(executable, case.args.clone())
+                .run()
+                .unwrap_or_else(|error| panic!("{} should complete: {error:?}", case.name))
+        };
+
+        assert_eq!(completed_value(effect), case.expected, "{}", case.name);
+    }
+}
+
+#[test]
 fn compiles_user_function_calls() {
     let program = program(vec![
         function(
@@ -56,7 +299,11 @@ fn compiles_user_function_calls() {
         function(
             "increment",
             &["value"],
-            vec![return_stmt(Some(add(variable("value"), int(1))))],
+            vec![return_stmt(Some(binary_expr(
+                variable("value"),
+                BinaryOperator::Add,
+                int(1),
+            )))],
         ),
     ]);
 
@@ -364,13 +611,21 @@ fn compiles_parallel_expressions_into_positional_assignments() {
                         Call::Action(action_call("fetch", vec![("value", int(4))])),
                     ]),
                 ),
-                return_stmt(Some(add(variable("left"), variable("right")))),
+                return_stmt(Some(binary_expr(
+                    variable("left"),
+                    BinaryOperator::Add,
+                    variable("right"),
+                ))),
             ],
         ),
         function(
             "child",
             &["value"],
-            vec![return_stmt(Some(add(variable("value"), int(1))))],
+            vec![return_stmt(Some(binary_expr(
+                variable("value"),
+                BinaryOperator::Add,
+                int(1),
+            )))],
         ),
     ]);
 
@@ -421,16 +676,21 @@ fn compiles_mixed_parallel_expressions_with_leading_action_before_awaiting() {
                         Call::Action(action_call("fetch_second", vec![("value", int(3))])),
                     ]),
                 ),
-                return_stmt(Some(add(
+                return_stmt(Some(binary_expr(
                     variable("first"),
-                    add(variable("second"), variable("third")),
+                    BinaryOperator::Add,
+                    binary_expr(variable("second"), BinaryOperator::Add, variable("third")),
                 ))),
             ],
         ),
         function(
             "child",
             &["value"],
-            vec![return_stmt(Some(add(variable("value"), int(1))))],
+            vec![return_stmt(Some(binary_expr(
+                variable("value"),
+                BinaryOperator::Add,
+                int(1),
+            )))],
         ),
     ]);
 
@@ -508,7 +768,11 @@ fn compiles_parallel_expressions_into_aggregate_lists() {
         function(
             "child",
             &["value"],
-            vec![return_stmt(Some(add(variable("value"), int(1))))],
+            vec![return_stmt(Some(binary_expr(
+                variable("value"),
+                BinaryOperator::Add,
+                int(1),
+            )))],
         ),
     ]);
 
@@ -557,7 +821,11 @@ fn compiles_parallel_expression_results_by_call_position() {
                     Call::Action(action_call("fetch_second", vec![("value", int(2))])),
                 ]),
             ),
-            return_stmt(Some(add(variable("first"), variable("second")))),
+            return_stmt(Some(binary_expr(
+                variable("first"),
+                BinaryOperator::Add,
+                variable("second"),
+            ))),
         ],
     )]);
 
@@ -772,7 +1040,10 @@ fn compiles_nested_conditionals_inside_while_loops() {
                     variable("count"),
                     vec![break_stmt()],
                     Vec::new(),
-                    Some(vec![assignment("count", add(variable("count"), int(1)))]),
+                    Some(vec![assignment(
+                        "count",
+                        binary_expr(variable("count"), BinaryOperator::Add, int(1)),
+                    )]),
                 )],
             ),
             return_stmt(Some(variable("count"))),

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_conditional__if_multiple_calls.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_conditional__if_multiple_calls.py__bytecode.snap
@@ -2,12 +2,160 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_conditional/if_multiple_calls.py
 ---
-Err(
-    FunctionCompiler(
-        Unsupported(
-            BinaryOperator {
-                op: Gt,
+Ok(
+    Executable {
+        functions: [
+            Function {
+                states: [
+                    State {
+                        instructions: [
+                            PureSet(
+                                LoadConst {
+                                    dst: RegisterId(
+                                        1,
+                                    ),
+                                    value: Int(
+                                        0,
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                Gt {
+                                    dst: RegisterId(
+                                        2,
+                                    ),
+                                    a: RegisterId(
+                                        0,
+                                    ),
+                                    b: RegisterId(
+                                        1,
+                                    ),
+                                },
+                            ),
+                            CoreSet(
+                                JumpIf {
+                                    target_state: StateId(
+                                        2,
+                                    ),
+                                    cond: RegisterId(
+                                        2,
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                LoadConst {
+                                    dst: RegisterId(
+                                        2,
+                                    ),
+                                    value: Int(
+                                        0,
+                                    ),
+                                },
+                            ),
+                            CoreSet(
+                                Return {
+                                    src: RegisterId(
+                                        2,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                ExtCall {
+                                    dst: RegisterId(
+                                        3,
+                                    ),
+                                    extcall_id: TestExtCallId(
+                                        "if_step_one",
+                                    ),
+                                    args: [
+                                        RegisterId(
+                                            0,
+                                        ),
+                                    ],
+                                    resume: StateId(
+                                        3,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                Await {
+                                    dst: RegisterId(
+                                        3,
+                                    ),
+                                    src: RegisterId(
+                                        3,
+                                    ),
+                                    resume: StateId(
+                                        4,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                ExtCall {
+                                    dst: RegisterId(
+                                        4,
+                                    ),
+                                    extcall_id: TestExtCallId(
+                                        "if_step_two",
+                                    ),
+                                    args: [
+                                        RegisterId(
+                                            3,
+                                        ),
+                                    ],
+                                    resume: StateId(
+                                        5,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                Await {
+                                    dst: RegisterId(
+                                        4,
+                                    ),
+                                    src: RegisterId(
+                                        4,
+                                    ),
+                                    resume: StateId(
+                                        6,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                Return {
+                                    src: RegisterId(
+                                        4,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                ],
+                num_regs: 5,
             },
-        ),
-    ),
+        ],
+    },
 )

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_conditional__if_multiple_calls.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_conditional__if_multiple_calls.py__bytecode.snap
@@ -20,17 +20,19 @@ Ok(
                                 },
                             ),
                             PureSet(
-                                Gt {
-                                    dst: RegisterId(
-                                        2,
-                                    ),
-                                    a: RegisterId(
-                                        0,
-                                    ),
-                                    b: RegisterId(
-                                        1,
-                                    ),
-                                },
+                                Gt(
+                                    BinaryOp {
+                                        dst: RegisterId(
+                                            2,
+                                        ),
+                                        a: RegisterId(
+                                            0,
+                                        ),
+                                        b: RegisterId(
+                                            1,
+                                        ),
+                                    },
+                                ),
                             ),
                             CoreSet(
                                 JumpIf {

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_conditional__if_multiple_calls.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_conditional__if_multiple_calls.py__bytecode.snap
@@ -20,8 +20,9 @@ Ok(
                                 },
                             ),
                             PureSet(
-                                Gt(
-                                    BinaryOp {
+                                Binary {
+                                    kind: Gt,
+                                    op: BinaryOp {
                                         dst: RegisterId(
                                             2,
                                         ),
@@ -32,7 +33,7 @@ Ok(
                                             1,
                                         ),
                                     },
-                                ),
+                                },
                             ),
                             CoreSet(
                                 JumpIf {

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_control_flow__if_elif_else.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_control_flow__if_elif_else.py__bytecode.snap
@@ -20,17 +20,19 @@ Ok(
                                 },
                             ),
                             PureSet(
-                                Eq {
-                                    dst: RegisterId(
-                                        2,
-                                    ),
-                                    a: RegisterId(
-                                        0,
-                                    ),
-                                    b: RegisterId(
-                                        1,
-                                    ),
-                                },
+                                Eq(
+                                    BinaryOp {
+                                        dst: RegisterId(
+                                            2,
+                                        ),
+                                        a: RegisterId(
+                                            0,
+                                        ),
+                                        b: RegisterId(
+                                            1,
+                                        ),
+                                    },
+                                ),
                             ),
                             CoreSet(
                                 JumpIf {
@@ -53,17 +55,19 @@ Ok(
                                 },
                             ),
                             PureSet(
-                                Eq {
-                                    dst: RegisterId(
-                                        1,
-                                    ),
-                                    a: RegisterId(
-                                        0,
-                                    ),
-                                    b: RegisterId(
-                                        2,
-                                    ),
-                                },
+                                Eq(
+                                    BinaryOp {
+                                        dst: RegisterId(
+                                            1,
+                                        ),
+                                        a: RegisterId(
+                                            0,
+                                        ),
+                                        b: RegisterId(
+                                            2,
+                                        ),
+                                    },
+                                ),
                             ),
                             CoreSet(
                                 JumpIf {
@@ -86,17 +90,19 @@ Ok(
                                 },
                             ),
                             PureSet(
-                                Eq {
-                                    dst: RegisterId(
-                                        2,
-                                    ),
-                                    a: RegisterId(
-                                        0,
-                                    ),
-                                    b: RegisterId(
-                                        1,
-                                    ),
-                                },
+                                Eq(
+                                    BinaryOp {
+                                        dst: RegisterId(
+                                            2,
+                                        ),
+                                        a: RegisterId(
+                                            0,
+                                        ),
+                                        b: RegisterId(
+                                            1,
+                                        ),
+                                    },
+                                ),
                             ),
                             CoreSet(
                                 JumpIf {

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_control_flow__if_elif_else.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_control_flow__if_elif_else.py__bytecode.snap
@@ -2,12 +2,308 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_control_flow/if_elif_else.py
 ---
-Err(
-    FunctionCompiler(
-        Unsupported(
-            BinaryOperator {
-                op: Eq,
+Ok(
+    Executable {
+        functions: [
+            Function {
+                states: [
+                    State {
+                        instructions: [
+                            PureSet(
+                                LoadConst {
+                                    dst: RegisterId(
+                                        1,
+                                    ),
+                                    value: Int(
+                                        1,
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                Eq {
+                                    dst: RegisterId(
+                                        2,
+                                    ),
+                                    a: RegisterId(
+                                        0,
+                                    ),
+                                    b: RegisterId(
+                                        1,
+                                    ),
+                                },
+                            ),
+                            CoreSet(
+                                JumpIf {
+                                    target_state: StateId(
+                                        2,
+                                    ),
+                                    cond: RegisterId(
+                                        2,
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                LoadConst {
+                                    dst: RegisterId(
+                                        2,
+                                    ),
+                                    value: Int(
+                                        2,
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                Eq {
+                                    dst: RegisterId(
+                                        1,
+                                    ),
+                                    a: RegisterId(
+                                        0,
+                                    ),
+                                    b: RegisterId(
+                                        2,
+                                    ),
+                                },
+                            ),
+                            CoreSet(
+                                JumpIf {
+                                    target_state: StateId(
+                                        3,
+                                    ),
+                                    cond: RegisterId(
+                                        1,
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                LoadConst {
+                                    dst: RegisterId(
+                                        1,
+                                    ),
+                                    value: Int(
+                                        3,
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                Eq {
+                                    dst: RegisterId(
+                                        2,
+                                    ),
+                                    a: RegisterId(
+                                        0,
+                                    ),
+                                    b: RegisterId(
+                                        1,
+                                    ),
+                                },
+                            ),
+                            CoreSet(
+                                JumpIf {
+                                    target_state: StateId(
+                                        4,
+                                    ),
+                                    cond: RegisterId(
+                                        2,
+                                    ),
+                                },
+                            ),
+                            CoreSet(
+                                ExtCall {
+                                    dst: RegisterId(
+                                        3,
+                                    ),
+                                    extcall_id: TestExtCallId(
+                                        "handle_default",
+                                    ),
+                                    args: [],
+                                    resume: StateId(
+                                        5,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                Return {
+                                    src: RegisterId(
+                                        3,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                ExtCall {
+                                    dst: RegisterId(
+                                        3,
+                                    ),
+                                    extcall_id: TestExtCallId(
+                                        "handle_case_a",
+                                    ),
+                                    args: [],
+                                    resume: StateId(
+                                        7,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                ExtCall {
+                                    dst: RegisterId(
+                                        3,
+                                    ),
+                                    extcall_id: TestExtCallId(
+                                        "handle_case_b",
+                                    ),
+                                    args: [],
+                                    resume: StateId(
+                                        9,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                ExtCall {
+                                    dst: RegisterId(
+                                        3,
+                                    ),
+                                    extcall_id: TestExtCallId(
+                                        "handle_case_c",
+                                    ),
+                                    args: [],
+                                    resume: StateId(
+                                        11,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                Await {
+                                    dst: RegisterId(
+                                        3,
+                                    ),
+                                    src: RegisterId(
+                                        3,
+                                    ),
+                                    resume: StateId(
+                                        6,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                Jump {
+                                    target_state: StateId(
+                                        1,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                Await {
+                                    dst: RegisterId(
+                                        3,
+                                    ),
+                                    src: RegisterId(
+                                        3,
+                                    ),
+                                    resume: StateId(
+                                        8,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                Jump {
+                                    target_state: StateId(
+                                        1,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                Await {
+                                    dst: RegisterId(
+                                        3,
+                                    ),
+                                    src: RegisterId(
+                                        3,
+                                    ),
+                                    resume: StateId(
+                                        10,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                Jump {
+                                    target_state: StateId(
+                                        1,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                Await {
+                                    dst: RegisterId(
+                                        3,
+                                    ),
+                                    src: RegisterId(
+                                        3,
+                                    ),
+                                    resume: StateId(
+                                        12,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                Jump {
+                                    target_state: StateId(
+                                        1,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                ],
+                num_regs: 4,
             },
-        ),
-    ),
+        ],
+    },
 )

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_control_flow__if_elif_else.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_control_flow__if_elif_else.py__bytecode.snap
@@ -20,8 +20,9 @@ Ok(
                                 },
                             ),
                             PureSet(
-                                Eq(
-                                    BinaryOp {
+                                Binary {
+                                    kind: Eq,
+                                    op: BinaryOp {
                                         dst: RegisterId(
                                             2,
                                         ),
@@ -32,7 +33,7 @@ Ok(
                                             1,
                                         ),
                                     },
-                                ),
+                                },
                             ),
                             CoreSet(
                                 JumpIf {
@@ -55,8 +56,9 @@ Ok(
                                 },
                             ),
                             PureSet(
-                                Eq(
-                                    BinaryOp {
+                                Binary {
+                                    kind: Eq,
+                                    op: BinaryOp {
                                         dst: RegisterId(
                                             1,
                                         ),
@@ -67,7 +69,7 @@ Ok(
                                             2,
                                         ),
                                     },
-                                ),
+                                },
                             ),
                             CoreSet(
                                 JumpIf {
@@ -90,8 +92,9 @@ Ok(
                                 },
                             ),
                             PureSet(
-                                Eq(
-                                    BinaryOp {
+                                Binary {
+                                    kind: Eq,
+                                    op: BinaryOp {
                                         dst: RegisterId(
                                             2,
                                         ),
@@ -102,7 +105,7 @@ Ok(
                                             1,
                                         ),
                                     },
-                                ),
+                                },
                             ),
                             CoreSet(
                                 JumpIf {

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_control_flow__while_simple.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_control_flow__while_simple.py__bytecode.snap
@@ -2,12 +2,130 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_control_flow/while_simple.py
 ---
-Err(
-    FunctionCompiler(
-        Unsupported(
-            BinaryOperator {
-                op: Lt,
+Ok(
+    Executable {
+        functions: [
+            Function {
+                states: [
+                    State {
+                        instructions: [
+                            PureSet(
+                                LoadConst {
+                                    dst: RegisterId(
+                                        1,
+                                    ),
+                                    value: Int(
+                                        0,
+                                    ),
+                                },
+                            ),
+                            CoreSet(
+                                Jump {
+                                    target_state: StateId(
+                                        1,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            PureSet(
+                                Lt {
+                                    dst: RegisterId(
+                                        2,
+                                    ),
+                                    a: RegisterId(
+                                        1,
+                                    ),
+                                    b: RegisterId(
+                                        0,
+                                    ),
+                                },
+                            ),
+                            CoreSet(
+                                JumpIf {
+                                    target_state: StateId(
+                                        2,
+                                    ),
+                                    cond: RegisterId(
+                                        2,
+                                    ),
+                                },
+                            ),
+                            CoreSet(
+                                Jump {
+                                    target_state: StateId(
+                                        3,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                ExtCall {
+                                    dst: RegisterId(
+                                        1,
+                                    ),
+                                    extcall_id: TestExtCallId(
+                                        "increment",
+                                    ),
+                                    args: [
+                                        RegisterId(
+                                            1,
+                                        ),
+                                    ],
+                                    resume: StateId(
+                                        4,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                Return {
+                                    src: RegisterId(
+                                        1,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                Await {
+                                    dst: RegisterId(
+                                        1,
+                                    ),
+                                    src: RegisterId(
+                                        1,
+                                    ),
+                                    resume: StateId(
+                                        5,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                Jump {
+                                    target_state: StateId(
+                                        1,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                ],
+                num_regs: 3,
             },
-        ),
-    ),
+        ],
+    },
 )

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_control_flow__while_simple.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_control_flow__while_simple.py__bytecode.snap
@@ -31,8 +31,9 @@ Ok(
                     State {
                         instructions: [
                             PureSet(
-                                Lt(
-                                    BinaryOp {
+                                Binary {
+                                    kind: Lt,
+                                    op: BinaryOp {
                                         dst: RegisterId(
                                             2,
                                         ),
@@ -43,7 +44,7 @@ Ok(
                                             0,
                                         ),
                                     },
-                                ),
+                                },
                             ),
                             CoreSet(
                                 JumpIf {

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_control_flow__while_simple.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_control_flow__while_simple.py__bytecode.snap
@@ -31,17 +31,19 @@ Ok(
                     State {
                         instructions: [
                             PureSet(
-                                Lt {
-                                    dst: RegisterId(
-                                        2,
-                                    ),
-                                    a: RegisterId(
-                                        1,
-                                    ),
-                                    b: RegisterId(
-                                        0,
-                                    ),
-                                },
+                                Lt(
+                                    BinaryOp {
+                                        dst: RegisterId(
+                                            2,
+                                        ),
+                                        a: RegisterId(
+                                            1,
+                                        ),
+                                        b: RegisterId(
+                                            0,
+                                        ),
+                                    },
+                                ),
                             ),
                             CoreSet(
                                 JumpIf {

--- a/crates/lib/vm-compiler-for-ast-old/tests/support/mod.rs
+++ b/crates/lib/vm-compiler-for-ast-old/tests/support/mod.rs
@@ -40,7 +40,7 @@ impl waymark_vm_interpreter_pureset::value::BinaryOps for TestValue {
         match (a, b) {
             (Self::Int(a), Self::Int(b)) => a.checked_add(*b).map(Self::Int).ok_or(
                 waymark_vm_interpreter_pureset::value::BinaryOperationError::ResultOutOfBounds {
-                    operation: waymark_vm_interpreter_pureset::value::BinaryOperationKind::Add,
+                    operation: waymark_vm_instructions_pureset::BinaryOpKind::Add,
                 },
             ),
             (Self::List(left), Self::List(right)) => {
@@ -50,7 +50,7 @@ impl waymark_vm_interpreter_pureset::value::BinaryOps for TestValue {
             }
             _ => Err(
                 waymark_vm_interpreter_pureset::value::BinaryOperationError::UnsupportedOperation {
-                    operation: waymark_vm_interpreter_pureset::value::BinaryOperationKind::Add,
+                    operation: waymark_vm_instructions_pureset::BinaryOpKind::Add,
                 },
             ),
         }
@@ -63,12 +63,12 @@ impl waymark_vm_interpreter_pureset::value::BinaryOps for TestValue {
         match (a, b) {
             (Self::Int(a), Self::Int(b)) => a.checked_sub(*b).map(Self::Int).ok_or(
                 waymark_vm_interpreter_pureset::value::BinaryOperationError::ResultOutOfBounds {
-                    operation: waymark_vm_interpreter_pureset::value::BinaryOperationKind::Sub,
+                    operation: waymark_vm_instructions_pureset::BinaryOpKind::Sub,
                 },
             ),
             _ => Err(
                 waymark_vm_interpreter_pureset::value::BinaryOperationError::UnsupportedOperation {
-                    operation: waymark_vm_interpreter_pureset::value::BinaryOperationKind::Sub,
+                    operation: waymark_vm_instructions_pureset::BinaryOpKind::Sub,
                 },
             ),
         }
@@ -81,12 +81,12 @@ impl waymark_vm_interpreter_pureset::value::BinaryOps for TestValue {
         match (a, b) {
             (Self::Int(a), Self::Int(b)) => a.checked_mul(*b).map(Self::Int).ok_or(
                 waymark_vm_interpreter_pureset::value::BinaryOperationError::ResultOutOfBounds {
-                    operation: waymark_vm_interpreter_pureset::value::BinaryOperationKind::Mul,
+                    operation: waymark_vm_instructions_pureset::BinaryOpKind::Mul,
                 },
             ),
             _ => Err(
                 waymark_vm_interpreter_pureset::value::BinaryOperationError::UnsupportedOperation {
-                    operation: waymark_vm_interpreter_pureset::value::BinaryOperationKind::Mul,
+                    operation: waymark_vm_instructions_pureset::BinaryOpKind::Mul,
                 },
             ),
         }
@@ -99,7 +99,7 @@ impl waymark_vm_interpreter_pureset::value::BinaryOps for TestValue {
         match (a, b) {
             (Self::Int(_), Self::Int(0)) => Err(
                 waymark_vm_interpreter_pureset::value::BinaryOperationError::DivisionByZero {
-                    operation: waymark_vm_interpreter_pureset::value::BinaryOperationKind::Div,
+                    operation: waymark_vm_instructions_pureset::BinaryOpKind::Div,
                 },
             ),
             (Self::Int(a), Self::Int(b)) => {
@@ -108,14 +108,14 @@ impl waymark_vm_interpreter_pureset::value::BinaryOps for TestValue {
                 } else {
                     Err(
                         waymark_vm_interpreter_pureset::value::BinaryOperationError::ResultOutOfBounds {
-                            operation: waymark_vm_interpreter_pureset::value::BinaryOperationKind::Div,
+                            operation: waymark_vm_instructions_pureset::BinaryOpKind::Div,
                         },
                     )
                 }
             }
             _ => Err(
                 waymark_vm_interpreter_pureset::value::BinaryOperationError::UnsupportedOperation {
-                    operation: waymark_vm_interpreter_pureset::value::BinaryOperationKind::Div,
+                    operation: waymark_vm_instructions_pureset::BinaryOpKind::Div,
                 },
             ),
         }
@@ -128,7 +128,7 @@ impl waymark_vm_interpreter_pureset::value::BinaryOps for TestValue {
         match (a, b) {
             (Self::Int(_), Self::Int(0)) => Err(
                 waymark_vm_interpreter_pureset::value::BinaryOperationError::DivisionByZero {
-                    operation: waymark_vm_interpreter_pureset::value::BinaryOperationKind::FloorDiv,
+                    operation: waymark_vm_instructions_pureset::BinaryOpKind::FloorDiv,
                 },
             ),
             (Self::Int(a), Self::Int(b)) => {
@@ -137,7 +137,7 @@ impl waymark_vm_interpreter_pureset::value::BinaryOps for TestValue {
             }
             _ => Err(
                 waymark_vm_interpreter_pureset::value::BinaryOperationError::UnsupportedOperation {
-                    operation: waymark_vm_interpreter_pureset::value::BinaryOperationKind::FloorDiv,
+                    operation: waymark_vm_instructions_pureset::BinaryOpKind::FloorDiv,
                 },
             ),
         }
@@ -150,13 +150,13 @@ impl waymark_vm_interpreter_pureset::value::BinaryOps for TestValue {
         match (a, b) {
             (Self::Int(_), Self::Int(0)) => Err(
                 waymark_vm_interpreter_pureset::value::BinaryOperationError::DivisionByZero {
-                    operation: waymark_vm_interpreter_pureset::value::BinaryOperationKind::Mod,
+                    operation: waymark_vm_instructions_pureset::BinaryOpKind::Mod,
                 },
             ),
             (Self::Int(a), Self::Int(b)) => Ok(Self::Int(*a % *b)),
             _ => Err(
                 waymark_vm_interpreter_pureset::value::BinaryOperationError::UnsupportedOperation {
-                    operation: waymark_vm_interpreter_pureset::value::BinaryOperationKind::Mod,
+                    operation: waymark_vm_instructions_pureset::BinaryOpKind::Mod,
                 },
             ),
         }
@@ -184,7 +184,7 @@ impl waymark_vm_interpreter_pureset::value::BinaryOps for TestValue {
             (Self::Int(a), Self::Int(b)) => Ok(Self::Bool(a < b)),
             _ => Err(
                 waymark_vm_interpreter_pureset::value::BinaryOperationError::UnsupportedOperation {
-                    operation: waymark_vm_interpreter_pureset::value::BinaryOperationKind::Lt,
+                    operation: waymark_vm_instructions_pureset::BinaryOpKind::Lt,
                 },
             ),
         }
@@ -198,7 +198,7 @@ impl waymark_vm_interpreter_pureset::value::BinaryOps for TestValue {
             (Self::Int(a), Self::Int(b)) => Ok(Self::Bool(a <= b)),
             _ => Err(
                 waymark_vm_interpreter_pureset::value::BinaryOperationError::UnsupportedOperation {
-                    operation: waymark_vm_interpreter_pureset::value::BinaryOperationKind::Le,
+                    operation: waymark_vm_instructions_pureset::BinaryOpKind::Le,
                 },
             ),
         }
@@ -212,7 +212,7 @@ impl waymark_vm_interpreter_pureset::value::BinaryOps for TestValue {
             (Self::Int(a), Self::Int(b)) => Ok(Self::Bool(a > b)),
             _ => Err(
                 waymark_vm_interpreter_pureset::value::BinaryOperationError::UnsupportedOperation {
-                    operation: waymark_vm_interpreter_pureset::value::BinaryOperationKind::Gt,
+                    operation: waymark_vm_instructions_pureset::BinaryOpKind::Gt,
                 },
             ),
         }
@@ -226,7 +226,7 @@ impl waymark_vm_interpreter_pureset::value::BinaryOps for TestValue {
             (Self::Int(a), Self::Int(b)) => Ok(Self::Bool(a >= b)),
             _ => Err(
                 waymark_vm_interpreter_pureset::value::BinaryOperationError::UnsupportedOperation {
-                    operation: waymark_vm_interpreter_pureset::value::BinaryOperationKind::Ge,
+                    operation: waymark_vm_instructions_pureset::BinaryOpKind::Ge,
                 },
             ),
         }
@@ -240,7 +240,7 @@ impl waymark_vm_interpreter_pureset::value::BinaryOps for TestValue {
             Self::List(items) => Ok(Self::Bool(items.iter().any(|item| item == a))),
             _ => Err(
                 waymark_vm_interpreter_pureset::value::BinaryOperationError::UnsupportedOperation {
-                    operation: waymark_vm_interpreter_pureset::value::BinaryOperationKind::In,
+                    operation: waymark_vm_instructions_pureset::BinaryOpKind::In,
                 },
             ),
         }
@@ -286,12 +286,12 @@ impl waymark_vm_interpreter_pureset::value::UnaryOps for TestValue {
         match value {
             Self::Int(value) => value.checked_neg().map(Self::Int).ok_or(
                 waymark_vm_interpreter_pureset::value::UnaryOperationError::ResultOutOfBounds {
-                    operation: waymark_vm_interpreter_pureset::value::UnaryOperationKind::Neg,
+                    operation: waymark_vm_instructions_pureset::UnaryOpKind::Neg,
                 },
             ),
             _ => Err(
                 waymark_vm_interpreter_pureset::value::UnaryOperationError::UnsupportedOperation {
-                    operation: waymark_vm_interpreter_pureset::value::UnaryOperationKind::Neg,
+                    operation: waymark_vm_instructions_pureset::UnaryOpKind::Neg,
                 },
             ),
         }

--- a/crates/lib/vm-compiler-for-ast-old/tests/support/mod.rs
+++ b/crates/lib/vm-compiler-for-ast-old/tests/support/mod.rs
@@ -10,28 +10,297 @@ pub type TestRuntime = waymark_vm_runtime::Runtime<TestExecutable, TestInterpret
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TestValue {
     Int(i64),
+    Bool(bool),
     None,
     List(Vec<TestValue>),
+}
+
+fn is_truthy(value: &TestValue) -> bool {
+    match value {
+        TestValue::Int(value) => *value != 0,
+        TestValue::Bool(value) => *value,
+        TestValue::None => false,
+        TestValue::List(items) => !items.is_empty(),
+    }
 }
 
 impl waymark_vm_interpreter_coreset::value::ShouldJump for TestValue {
     fn should_jump(
         &self,
     ) -> Result<bool, waymark_vm_interpreter_coreset::value::NotAConditionalError> {
-        Ok(match self {
-            Self::Int(value) => *value != 0,
-            Self::None => false,
-            Self::List(_) => false,
-        })
+        Ok(is_truthy(self))
     }
 }
 
-impl waymark_vm_interpreter_pureset::value::Add for TestValue {
-    fn add(a: &Self, b: &Self) -> Result<Self, waymark_vm_interpreter_pureset::value::AddError> {
+impl waymark_vm_interpreter_pureset::value::BinaryOps for TestValue {
+    fn add(
+        a: &Self,
+        b: &Self,
+    ) -> Result<Self, waymark_vm_interpreter_pureset::value::BinaryOperationError> {
         match (a, b) {
-            (Self::Int(a), Self::Int(b)) => Ok(Self::Int(a + b)),
-            _ => Err(waymark_vm_interpreter_pureset::value::AddError::NotAddable),
+            (Self::Int(a), Self::Int(b)) => a.checked_add(*b).map(Self::Int).ok_or(
+                waymark_vm_interpreter_pureset::value::BinaryOperationError::ResultOutOfBounds {
+                    operation: waymark_vm_interpreter_pureset::value::BinaryOperationKind::Add,
+                },
+            ),
+            (Self::List(left), Self::List(right)) => {
+                let mut items = left.clone();
+                items.extend(right.clone());
+                Ok(Self::List(items))
+            }
+            _ => Err(
+                waymark_vm_interpreter_pureset::value::BinaryOperationError::UnsupportedOperation {
+                    operation: waymark_vm_interpreter_pureset::value::BinaryOperationKind::Add,
+                },
+            ),
         }
+    }
+
+    fn sub(
+        a: &Self,
+        b: &Self,
+    ) -> Result<Self, waymark_vm_interpreter_pureset::value::BinaryOperationError> {
+        match (a, b) {
+            (Self::Int(a), Self::Int(b)) => a.checked_sub(*b).map(Self::Int).ok_or(
+                waymark_vm_interpreter_pureset::value::BinaryOperationError::ResultOutOfBounds {
+                    operation: waymark_vm_interpreter_pureset::value::BinaryOperationKind::Sub,
+                },
+            ),
+            _ => Err(
+                waymark_vm_interpreter_pureset::value::BinaryOperationError::UnsupportedOperation {
+                    operation: waymark_vm_interpreter_pureset::value::BinaryOperationKind::Sub,
+                },
+            ),
+        }
+    }
+
+    fn mul(
+        a: &Self,
+        b: &Self,
+    ) -> Result<Self, waymark_vm_interpreter_pureset::value::BinaryOperationError> {
+        match (a, b) {
+            (Self::Int(a), Self::Int(b)) => a.checked_mul(*b).map(Self::Int).ok_or(
+                waymark_vm_interpreter_pureset::value::BinaryOperationError::ResultOutOfBounds {
+                    operation: waymark_vm_interpreter_pureset::value::BinaryOperationKind::Mul,
+                },
+            ),
+            _ => Err(
+                waymark_vm_interpreter_pureset::value::BinaryOperationError::UnsupportedOperation {
+                    operation: waymark_vm_interpreter_pureset::value::BinaryOperationKind::Mul,
+                },
+            ),
+        }
+    }
+
+    fn div(
+        a: &Self,
+        b: &Self,
+    ) -> Result<Self, waymark_vm_interpreter_pureset::value::BinaryOperationError> {
+        match (a, b) {
+            (Self::Int(_), Self::Int(0)) => Err(
+                waymark_vm_interpreter_pureset::value::BinaryOperationError::DivisionByZero {
+                    operation: waymark_vm_interpreter_pureset::value::BinaryOperationKind::Div,
+                },
+            ),
+            (Self::Int(a), Self::Int(b)) => {
+                if *a % *b == 0 {
+                    Ok(Self::Int(*a / *b))
+                } else {
+                    Err(
+                        waymark_vm_interpreter_pureset::value::BinaryOperationError::ResultOutOfBounds {
+                            operation: waymark_vm_interpreter_pureset::value::BinaryOperationKind::Div,
+                        },
+                    )
+                }
+            }
+            _ => Err(
+                waymark_vm_interpreter_pureset::value::BinaryOperationError::UnsupportedOperation {
+                    operation: waymark_vm_interpreter_pureset::value::BinaryOperationKind::Div,
+                },
+            ),
+        }
+    }
+
+    fn floor_div(
+        a: &Self,
+        b: &Self,
+    ) -> Result<Self, waymark_vm_interpreter_pureset::value::BinaryOperationError> {
+        match (a, b) {
+            (Self::Int(_), Self::Int(0)) => Err(
+                waymark_vm_interpreter_pureset::value::BinaryOperationError::DivisionByZero {
+                    operation: waymark_vm_interpreter_pureset::value::BinaryOperationKind::FloorDiv,
+                },
+            ),
+            (Self::Int(a), Self::Int(b)) => {
+                let value = ((*a as f64) / (*b as f64)).floor();
+                Ok(Self::Int(value as i64))
+            }
+            _ => Err(
+                waymark_vm_interpreter_pureset::value::BinaryOperationError::UnsupportedOperation {
+                    operation: waymark_vm_interpreter_pureset::value::BinaryOperationKind::FloorDiv,
+                },
+            ),
+        }
+    }
+
+    fn modulo(
+        a: &Self,
+        b: &Self,
+    ) -> Result<Self, waymark_vm_interpreter_pureset::value::BinaryOperationError> {
+        match (a, b) {
+            (Self::Int(_), Self::Int(0)) => Err(
+                waymark_vm_interpreter_pureset::value::BinaryOperationError::DivisionByZero {
+                    operation: waymark_vm_interpreter_pureset::value::BinaryOperationKind::Mod,
+                },
+            ),
+            (Self::Int(a), Self::Int(b)) => Ok(Self::Int(*a % *b)),
+            _ => Err(
+                waymark_vm_interpreter_pureset::value::BinaryOperationError::UnsupportedOperation {
+                    operation: waymark_vm_interpreter_pureset::value::BinaryOperationKind::Mod,
+                },
+            ),
+        }
+    }
+
+    fn eq(
+        a: &Self,
+        b: &Self,
+    ) -> Result<Self, waymark_vm_interpreter_pureset::value::BinaryOperationError> {
+        Ok(Self::Bool(a == b))
+    }
+
+    fn ne(
+        a: &Self,
+        b: &Self,
+    ) -> Result<Self, waymark_vm_interpreter_pureset::value::BinaryOperationError> {
+        Ok(Self::Bool(a != b))
+    }
+
+    fn lt(
+        a: &Self,
+        b: &Self,
+    ) -> Result<Self, waymark_vm_interpreter_pureset::value::BinaryOperationError> {
+        match (a, b) {
+            (Self::Int(a), Self::Int(b)) => Ok(Self::Bool(a < b)),
+            _ => Err(
+                waymark_vm_interpreter_pureset::value::BinaryOperationError::UnsupportedOperation {
+                    operation: waymark_vm_interpreter_pureset::value::BinaryOperationKind::Lt,
+                },
+            ),
+        }
+    }
+
+    fn le(
+        a: &Self,
+        b: &Self,
+    ) -> Result<Self, waymark_vm_interpreter_pureset::value::BinaryOperationError> {
+        match (a, b) {
+            (Self::Int(a), Self::Int(b)) => Ok(Self::Bool(a <= b)),
+            _ => Err(
+                waymark_vm_interpreter_pureset::value::BinaryOperationError::UnsupportedOperation {
+                    operation: waymark_vm_interpreter_pureset::value::BinaryOperationKind::Le,
+                },
+            ),
+        }
+    }
+
+    fn gt(
+        a: &Self,
+        b: &Self,
+    ) -> Result<Self, waymark_vm_interpreter_pureset::value::BinaryOperationError> {
+        match (a, b) {
+            (Self::Int(a), Self::Int(b)) => Ok(Self::Bool(a > b)),
+            _ => Err(
+                waymark_vm_interpreter_pureset::value::BinaryOperationError::UnsupportedOperation {
+                    operation: waymark_vm_interpreter_pureset::value::BinaryOperationKind::Gt,
+                },
+            ),
+        }
+    }
+
+    fn ge(
+        a: &Self,
+        b: &Self,
+    ) -> Result<Self, waymark_vm_interpreter_pureset::value::BinaryOperationError> {
+        match (a, b) {
+            (Self::Int(a), Self::Int(b)) => Ok(Self::Bool(a >= b)),
+            _ => Err(
+                waymark_vm_interpreter_pureset::value::BinaryOperationError::UnsupportedOperation {
+                    operation: waymark_vm_interpreter_pureset::value::BinaryOperationKind::Ge,
+                },
+            ),
+        }
+    }
+
+    fn contains(
+        a: &Self,
+        b: &Self,
+    ) -> Result<Self, waymark_vm_interpreter_pureset::value::BinaryOperationError> {
+        match b {
+            Self::List(items) => Ok(Self::Bool(items.iter().any(|item| item == a))),
+            _ => Err(
+                waymark_vm_interpreter_pureset::value::BinaryOperationError::UnsupportedOperation {
+                    operation: waymark_vm_interpreter_pureset::value::BinaryOperationKind::In,
+                },
+            ),
+        }
+    }
+
+    fn not_contains(
+        a: &Self,
+        b: &Self,
+    ) -> Result<Self, waymark_vm_interpreter_pureset::value::BinaryOperationError> {
+        match Self::contains(a, b)? {
+            Self::Bool(value) => Ok(Self::Bool(!value)),
+            _ => unreachable!(),
+        }
+    }
+
+    fn and(
+        a: &Self,
+        b: &Self,
+    ) -> Result<Self, waymark_vm_interpreter_pureset::value::BinaryOperationError> {
+        if is_truthy(a) {
+            Ok(b.clone())
+        } else {
+            Ok(a.clone())
+        }
+    }
+
+    fn or(
+        a: &Self,
+        b: &Self,
+    ) -> Result<Self, waymark_vm_interpreter_pureset::value::BinaryOperationError> {
+        if is_truthy(a) {
+            Ok(a.clone())
+        } else {
+            Ok(b.clone())
+        }
+    }
+}
+
+impl waymark_vm_interpreter_pureset::value::UnaryOps for TestValue {
+    fn neg(
+        value: &Self,
+    ) -> Result<Self, waymark_vm_interpreter_pureset::value::UnaryOperationError> {
+        match value {
+            Self::Int(value) => value.checked_neg().map(Self::Int).ok_or(
+                waymark_vm_interpreter_pureset::value::UnaryOperationError::ResultOutOfBounds {
+                    operation: waymark_vm_interpreter_pureset::value::UnaryOperationKind::Neg,
+                },
+            ),
+            _ => Err(
+                waymark_vm_interpreter_pureset::value::UnaryOperationError::UnsupportedOperation {
+                    operation: waymark_vm_interpreter_pureset::value::UnaryOperationKind::Neg,
+                },
+            ),
+        }
+    }
+
+    fn not(
+        value: &Self,
+    ) -> Result<Self, waymark_vm_interpreter_pureset::value::UnaryOperationError> {
+        Ok(Self::Bool(!is_truthy(value)))
     }
 }
 

--- a/crates/lib/vm-instructions-pureset/src/lib.rs
+++ b/crates/lib/vm-instructions-pureset/src/lib.rs
@@ -19,6 +19,29 @@ pub trait Spec: 'static {
     type ConstValue: core::fmt::Debug;
 }
 
+/// An unary operation.
+#[derive(Debug)]
+pub struct UnaryOp<RegisterId> {
+    /// The register to store the result of the operation at.
+    pub dst: RegisterId,
+
+    /// The register that contains the operand value.
+    pub src: RegisterId,
+}
+
+/// A binary operation.
+#[derive(Debug)]
+pub struct BinaryOp<RegisterId> {
+    /// The register to store the result of the operation at.
+    pub dst: RegisterId,
+
+    /// The register that contains the first operand.
+    pub a: RegisterId,
+
+    /// The register that contains the second operand.
+    pub b: RegisterId,
+}
+
 /// Pure instructions set.
 #[derive_where(Debug)]
 pub enum PureSet<Spec: self::Spec> {
@@ -41,220 +64,58 @@ pub enum PureSet<Spec: self::Spec> {
     },
 
     /// Add two values together.
-    Add {
-        /// The register to store the addition result at.
-        dst: Spec::RegisterId,
-
-        /// The register that contains the first value for
-        /// the addition operation.
-        a: Spec::RegisterId,
-
-        /// The register that contains the second value for
-        /// the addition operation.
-        b: Spec::RegisterId,
-    },
+    Add(BinaryOp<Spec::RegisterId>),
 
     /// Subtract one value from another.
-    Sub {
-        /// The register to store the subtraction result at.
-        dst: Spec::RegisterId,
-
-        /// The register that contains the first value for
-        /// the subtraction operation.
-        a: Spec::RegisterId,
-
-        /// The register that contains the second value for
-        /// the subtraction operation.
-        b: Spec::RegisterId,
-    },
+    Sub(BinaryOp<Spec::RegisterId>),
 
     /// Multiply two values together.
-    Mul {
-        /// The register to store the multiplication result at.
-        dst: Spec::RegisterId,
-
-        /// The register that contains the first value for
-        /// the multiplication operation.
-        a: Spec::RegisterId,
-
-        /// The register that contains the second value for
-        /// the multiplication operation.
-        b: Spec::RegisterId,
-    },
+    Mul(BinaryOp<Spec::RegisterId>),
 
     /// Divide one value by another.
-    Div {
-        /// The register to store the division result at.
-        dst: Spec::RegisterId,
-
-        /// The register that contains the dividend.
-        a: Spec::RegisterId,
-
-        /// The register that contains the divisor.
-        b: Spec::RegisterId,
-    },
+    Div(BinaryOp<Spec::RegisterId>),
 
     /// Floor-divide one value by another.
-    FloorDiv {
-        /// The register to store the floor-division result at.
-        dst: Spec::RegisterId,
-
-        /// The register that contains the dividend.
-        a: Spec::RegisterId,
-
-        /// The register that contains the divisor.
-        b: Spec::RegisterId,
-    },
+    FloorDiv(BinaryOp<Spec::RegisterId>),
 
     /// Compute one value modulo another.
-    Mod {
-        /// The register to store the modulo result at.
-        dst: Spec::RegisterId,
-
-        /// The register that contains the dividend.
-        a: Spec::RegisterId,
-
-        /// The register that contains the divisor.
-        b: Spec::RegisterId,
-    },
+    Mod(BinaryOp<Spec::RegisterId>),
 
     /// Compare two values for equality.
-    Eq {
-        /// The register to store the equality result at.
-        dst: Spec::RegisterId,
-
-        /// The register that contains the left operand.
-        a: Spec::RegisterId,
-
-        /// The register that contains the right operand.
-        b: Spec::RegisterId,
-    },
+    Eq(BinaryOp<Spec::RegisterId>),
 
     /// Compare two values for inequality.
-    Ne {
-        /// The register to store the inequality result at.
-        dst: Spec::RegisterId,
-
-        /// The register that contains the left operand.
-        a: Spec::RegisterId,
-
-        /// The register that contains the right operand.
-        b: Spec::RegisterId,
-    },
+    Ne(BinaryOp<Spec::RegisterId>),
 
     /// Compare whether one value is less than another.
-    Lt {
-        /// The register to store the comparison result at.
-        dst: Spec::RegisterId,
-
-        /// The register that contains the left operand.
-        a: Spec::RegisterId,
-
-        /// The register that contains the right operand.
-        b: Spec::RegisterId,
-    },
+    Lt(BinaryOp<Spec::RegisterId>),
 
     /// Compare whether one value is less than or equal to another.
-    Le {
-        /// The register to store the comparison result at.
-        dst: Spec::RegisterId,
-
-        /// The register that contains the left operand.
-        a: Spec::RegisterId,
-
-        /// The register that contains the right operand.
-        b: Spec::RegisterId,
-    },
+    Le(BinaryOp<Spec::RegisterId>),
 
     /// Compare whether one value is greater than another.
-    Gt {
-        /// The register to store the comparison result at.
-        dst: Spec::RegisterId,
-
-        /// The register that contains the left operand.
-        a: Spec::RegisterId,
-
-        /// The register that contains the right operand.
-        b: Spec::RegisterId,
-    },
+    Gt(BinaryOp<Spec::RegisterId>),
 
     /// Compare whether one value is greater than or equal to another.
-    Ge {
-        /// The register to store the comparison result at.
-        dst: Spec::RegisterId,
-
-        /// The register that contains the left operand.
-        a: Spec::RegisterId,
-
-        /// The register that contains the right operand.
-        b: Spec::RegisterId,
-    },
+    Ge(BinaryOp<Spec::RegisterId>),
 
     /// Test whether the left operand is contained in the right operand.
-    In {
-        /// The register to store the membership result at.
-        dst: Spec::RegisterId,
-
-        /// The register that contains the candidate value.
-        a: Spec::RegisterId,
-
-        /// The register that contains the container value.
-        b: Spec::RegisterId,
-    },
+    In(BinaryOp<Spec::RegisterId>),
 
     /// Test whether the left operand is not contained in the right operand.
-    NotIn {
-        /// The register to store the membership result at.
-        dst: Spec::RegisterId,
-
-        /// The register that contains the candidate value.
-        a: Spec::RegisterId,
-
-        /// The register that contains the container value.
-        b: Spec::RegisterId,
-    },
+    NotIn(BinaryOp<Spec::RegisterId>),
 
     /// Apply Python-style logical `and` to two values.
-    And {
-        /// The register to store the logical result at.
-        dst: Spec::RegisterId,
-
-        /// The register that contains the left operand.
-        a: Spec::RegisterId,
-
-        /// The register that contains the right operand.
-        b: Spec::RegisterId,
-    },
+    And(BinaryOp<Spec::RegisterId>),
 
     /// Apply Python-style logical `or` to two values.
-    Or {
-        /// The register to store the logical result at.
-        dst: Spec::RegisterId,
-
-        /// The register that contains the left operand.
-        a: Spec::RegisterId,
-
-        /// The register that contains the right operand.
-        b: Spec::RegisterId,
-    },
+    Or(BinaryOp<Spec::RegisterId>),
 
     /// Negate a value.
-    Neg {
-        /// The register to store the negated result at.
-        dst: Spec::RegisterId,
-
-        /// The register that contains the operand value.
-        src: Spec::RegisterId,
-    },
+    Neg(UnaryOp<Spec::RegisterId>),
 
     /// Apply Python-style logical `not` to a value.
-    Not {
-        /// The register to store the logical result at.
-        dst: Spec::RegisterId,
-
-        /// The register that contains the operand value.
-        src: Spec::RegisterId,
-    },
+    Not(UnaryOp<Spec::RegisterId>),
 
     /// Build a list value from resolved registers.
     MakeList {

--- a/crates/lib/vm-instructions-pureset/src/lib.rs
+++ b/crates/lib/vm-instructions-pureset/src/lib.rs
@@ -42,6 +42,68 @@ pub struct BinaryOp<RegisterId> {
     pub b: RegisterId,
 }
 
+/// The kind of binary operation to apply.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BinaryOpKind {
+    /// Add two values together.
+    Add,
+
+    /// Subtract one value from another.
+    Sub,
+
+    /// Multiply two values together.
+    Mul,
+
+    /// Divide one value by another.
+    Div,
+
+    /// Floor-divide one value by another.
+    FloorDiv,
+
+    /// Compute one value modulo another.
+    Mod,
+
+    /// Compare two values for equality.
+    Eq,
+
+    /// Compare two values for inequality.
+    Ne,
+
+    /// Compare whether one value is less than another.
+    Lt,
+
+    /// Compare whether one value is less than or equal to another.
+    Le,
+
+    /// Compare whether one value is greater than another.
+    Gt,
+
+    /// Compare whether one value is greater than or equal to another.
+    Ge,
+
+    /// Test whether the left operand is contained in the right operand.
+    In,
+
+    /// Test whether the left operand is not contained in the right operand.
+    NotIn,
+
+    /// Apply Python-style logical `and` to two values.
+    And,
+
+    /// Apply Python-style logical `or` to two values.
+    Or,
+}
+
+/// The kind of unary operation to apply.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UnaryOpKind {
+    /// Negate a value.
+    Neg,
+
+    /// Apply Python-style logical `not` to a value.
+    Not,
+}
+
 /// Pure instructions set.
 #[derive_where(Debug)]
 pub enum PureSet<Spec: self::Spec> {
@@ -63,59 +125,23 @@ pub enum PureSet<Spec: self::Spec> {
         src: Spec::RegisterId,
     },
 
-    /// Add two values together.
-    Add(BinaryOp<Spec::RegisterId>),
+    /// Apply a binary operation to two values.
+    Binary {
+        /// The binary operation kind to apply.
+        kind: BinaryOpKind,
 
-    /// Subtract one value from another.
-    Sub(BinaryOp<Spec::RegisterId>),
+        /// The registers used by the binary operation.
+        op: BinaryOp<Spec::RegisterId>,
+    },
 
-    /// Multiply two values together.
-    Mul(BinaryOp<Spec::RegisterId>),
+    /// Apply a unary operation to a value.
+    Unary {
+        /// The unary operation kind to apply.
+        kind: UnaryOpKind,
 
-    /// Divide one value by another.
-    Div(BinaryOp<Spec::RegisterId>),
-
-    /// Floor-divide one value by another.
-    FloorDiv(BinaryOp<Spec::RegisterId>),
-
-    /// Compute one value modulo another.
-    Mod(BinaryOp<Spec::RegisterId>),
-
-    /// Compare two values for equality.
-    Eq(BinaryOp<Spec::RegisterId>),
-
-    /// Compare two values for inequality.
-    Ne(BinaryOp<Spec::RegisterId>),
-
-    /// Compare whether one value is less than another.
-    Lt(BinaryOp<Spec::RegisterId>),
-
-    /// Compare whether one value is less than or equal to another.
-    Le(BinaryOp<Spec::RegisterId>),
-
-    /// Compare whether one value is greater than another.
-    Gt(BinaryOp<Spec::RegisterId>),
-
-    /// Compare whether one value is greater than or equal to another.
-    Ge(BinaryOp<Spec::RegisterId>),
-
-    /// Test whether the left operand is contained in the right operand.
-    In(BinaryOp<Spec::RegisterId>),
-
-    /// Test whether the left operand is not contained in the right operand.
-    NotIn(BinaryOp<Spec::RegisterId>),
-
-    /// Apply Python-style logical `and` to two values.
-    And(BinaryOp<Spec::RegisterId>),
-
-    /// Apply Python-style logical `or` to two values.
-    Or(BinaryOp<Spec::RegisterId>),
-
-    /// Negate a value.
-    Neg(UnaryOp<Spec::RegisterId>),
-
-    /// Apply Python-style logical `not` to a value.
-    Not(UnaryOp<Spec::RegisterId>),
+        /// The registers used by the unary operation.
+        op: UnaryOp<Spec::RegisterId>,
+    },
 
     /// Build a list value from resolved registers.
     MakeList {

--- a/crates/lib/vm-instructions-pureset/src/lib.rs
+++ b/crates/lib/vm-instructions-pureset/src/lib.rs
@@ -54,6 +54,208 @@ pub enum PureSet<Spec: self::Spec> {
         b: Spec::RegisterId,
     },
 
+    /// Subtract one value from another.
+    Sub {
+        /// The register to store the subtraction result at.
+        dst: Spec::RegisterId,
+
+        /// The register that contains the first value for
+        /// the subtraction operation.
+        a: Spec::RegisterId,
+
+        /// The register that contains the second value for
+        /// the subtraction operation.
+        b: Spec::RegisterId,
+    },
+
+    /// Multiply two values together.
+    Mul {
+        /// The register to store the multiplication result at.
+        dst: Spec::RegisterId,
+
+        /// The register that contains the first value for
+        /// the multiplication operation.
+        a: Spec::RegisterId,
+
+        /// The register that contains the second value for
+        /// the multiplication operation.
+        b: Spec::RegisterId,
+    },
+
+    /// Divide one value by another.
+    Div {
+        /// The register to store the division result at.
+        dst: Spec::RegisterId,
+
+        /// The register that contains the dividend.
+        a: Spec::RegisterId,
+
+        /// The register that contains the divisor.
+        b: Spec::RegisterId,
+    },
+
+    /// Floor-divide one value by another.
+    FloorDiv {
+        /// The register to store the floor-division result at.
+        dst: Spec::RegisterId,
+
+        /// The register that contains the dividend.
+        a: Spec::RegisterId,
+
+        /// The register that contains the divisor.
+        b: Spec::RegisterId,
+    },
+
+    /// Compute one value modulo another.
+    Mod {
+        /// The register to store the modulo result at.
+        dst: Spec::RegisterId,
+
+        /// The register that contains the dividend.
+        a: Spec::RegisterId,
+
+        /// The register that contains the divisor.
+        b: Spec::RegisterId,
+    },
+
+    /// Compare two values for equality.
+    Eq {
+        /// The register to store the equality result at.
+        dst: Spec::RegisterId,
+
+        /// The register that contains the left operand.
+        a: Spec::RegisterId,
+
+        /// The register that contains the right operand.
+        b: Spec::RegisterId,
+    },
+
+    /// Compare two values for inequality.
+    Ne {
+        /// The register to store the inequality result at.
+        dst: Spec::RegisterId,
+
+        /// The register that contains the left operand.
+        a: Spec::RegisterId,
+
+        /// The register that contains the right operand.
+        b: Spec::RegisterId,
+    },
+
+    /// Compare whether one value is less than another.
+    Lt {
+        /// The register to store the comparison result at.
+        dst: Spec::RegisterId,
+
+        /// The register that contains the left operand.
+        a: Spec::RegisterId,
+
+        /// The register that contains the right operand.
+        b: Spec::RegisterId,
+    },
+
+    /// Compare whether one value is less than or equal to another.
+    Le {
+        /// The register to store the comparison result at.
+        dst: Spec::RegisterId,
+
+        /// The register that contains the left operand.
+        a: Spec::RegisterId,
+
+        /// The register that contains the right operand.
+        b: Spec::RegisterId,
+    },
+
+    /// Compare whether one value is greater than another.
+    Gt {
+        /// The register to store the comparison result at.
+        dst: Spec::RegisterId,
+
+        /// The register that contains the left operand.
+        a: Spec::RegisterId,
+
+        /// The register that contains the right operand.
+        b: Spec::RegisterId,
+    },
+
+    /// Compare whether one value is greater than or equal to another.
+    Ge {
+        /// The register to store the comparison result at.
+        dst: Spec::RegisterId,
+
+        /// The register that contains the left operand.
+        a: Spec::RegisterId,
+
+        /// The register that contains the right operand.
+        b: Spec::RegisterId,
+    },
+
+    /// Test whether the left operand is contained in the right operand.
+    In {
+        /// The register to store the membership result at.
+        dst: Spec::RegisterId,
+
+        /// The register that contains the candidate value.
+        a: Spec::RegisterId,
+
+        /// The register that contains the container value.
+        b: Spec::RegisterId,
+    },
+
+    /// Test whether the left operand is not contained in the right operand.
+    NotIn {
+        /// The register to store the membership result at.
+        dst: Spec::RegisterId,
+
+        /// The register that contains the candidate value.
+        a: Spec::RegisterId,
+
+        /// The register that contains the container value.
+        b: Spec::RegisterId,
+    },
+
+    /// Apply Python-style logical `and` to two values.
+    And {
+        /// The register to store the logical result at.
+        dst: Spec::RegisterId,
+
+        /// The register that contains the left operand.
+        a: Spec::RegisterId,
+
+        /// The register that contains the right operand.
+        b: Spec::RegisterId,
+    },
+
+    /// Apply Python-style logical `or` to two values.
+    Or {
+        /// The register to store the logical result at.
+        dst: Spec::RegisterId,
+
+        /// The register that contains the left operand.
+        a: Spec::RegisterId,
+
+        /// The register that contains the right operand.
+        b: Spec::RegisterId,
+    },
+
+    /// Negate a value.
+    Neg {
+        /// The register to store the negated result at.
+        dst: Spec::RegisterId,
+
+        /// The register that contains the operand value.
+        src: Spec::RegisterId,
+    },
+
+    /// Apply Python-style logical `not` to a value.
+    Not {
+        /// The register to store the logical result at.
+        dst: Spec::RegisterId,
+
+        /// The register that contains the operand value.
+        src: Spec::RegisterId,
+    },
+
     /// Build a list value from resolved registers.
     MakeList {
         /// The register to store the resulting list at.

--- a/crates/lib/vm-instructions-pureset/src/lib.rs
+++ b/crates/lib/vm-instructions-pureset/src/lib.rs
@@ -43,7 +43,7 @@ pub struct BinaryOp<RegisterId> {
 }
 
 /// The kind of binary operation to apply.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum BinaryOpKind {
     /// Add two values together.
     Add,
@@ -95,7 +95,7 @@ pub enum BinaryOpKind {
 }
 
 /// The kind of unary operation to apply.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum UnaryOpKind {
     /// Negate a value.
     Neg,
@@ -151,4 +151,36 @@ pub enum PureSet<Spec: self::Spec> {
         /// The registers to read list elements from in order.
         items: Vec<Spec::RegisterId>,
     },
+}
+
+impl core::fmt::Display for BinaryOpKind {
+    fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        formatter.write_str(match self {
+            Self::Add => "+",
+            Self::Sub => "-",
+            Self::Mul => "*",
+            Self::Div => "/",
+            Self::FloorDiv => "//",
+            Self::Mod => "%",
+            Self::Eq => "==",
+            Self::Ne => "!=",
+            Self::Lt => "<",
+            Self::Le => "<=",
+            Self::Gt => ">",
+            Self::Ge => ">=",
+            Self::In => "in",
+            Self::NotIn => "not in",
+            Self::And => "and",
+            Self::Or => "or",
+        })
+    }
+}
+
+impl core::fmt::Display for UnaryOpKind {
+    fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        formatter.write_str(match self {
+            Self::Neg => "-",
+            Self::Not => "not",
+        })
+    }
 }

--- a/crates/lib/vm-interpreter-fullset/tests/integration.rs
+++ b/crates/lib/vm-interpreter-fullset/tests/integration.rs
@@ -123,11 +123,14 @@ fn runtime_executes_pure_and_core_instructions_to_completion() {
                 value: TestConstValue::Int(3),
             }
             .into(),
-            PureSet::Add(waymark_vm_instructions_pureset::BinaryOp {
-                dst: RegisterId(2),
-                a: RegisterId(0),
-                b: RegisterId(1),
-            })
+            PureSet::Binary {
+                kind: waymark_vm_instructions_pureset::BinaryOpKind::Add,
+                op: waymark_vm_instructions_pureset::BinaryOp {
+                    dst: RegisterId(2),
+                    a: RegisterId(0),
+                    b: RegisterId(1),
+                },
+            }
             .into(),
             CoreSet::Return { src: RegisterId(2) }.into(),
         ]],
@@ -182,11 +185,14 @@ fn runtime_resumes_extcalls_and_finishes_with_pure_work() {
                     value: TestConstValue::Int(1),
                 }
                 .into(),
-                PureSet::Add(waymark_vm_instructions_pureset::BinaryOp {
-                    dst: RegisterId(3),
-                    a: RegisterId(2),
-                    b: RegisterId(3),
-                })
+                PureSet::Binary {
+                    kind: waymark_vm_instructions_pureset::BinaryOpKind::Add,
+                    op: waymark_vm_instructions_pureset::BinaryOp {
+                        dst: RegisterId(3),
+                        a: RegisterId(2),
+                        b: RegisterId(3),
+                    },
+                }
                 .into(),
                 CoreSet::Return { src: RegisterId(3) }.into(),
             ],

--- a/crates/lib/vm-interpreter-fullset/tests/integration.rs
+++ b/crates/lib/vm-interpreter-fullset/tests/integration.rs
@@ -1,6 +1,6 @@
 use waymark_vm_instructions_coreset::CoreSet;
 use waymark_vm_instructions_fullset::FullSet;
-use waymark_vm_instructions_pureset::PureSet;
+use waymark_vm_instructions_pureset::{BinaryOpKind, PureSet, UnaryOpKind};
 use waymark_vm_interpreter_fullset::{Effect, FullSetInterpreter};
 use waymark_vm_runtime::{CallSpec, Runtime};
 use waymark_vm_runtime_core::RegisterId;
@@ -63,7 +63,7 @@ impl waymark_vm_interpreter_pureset::value::BinaryOps for TestValue {
             (Self::Int(a), Self::Int(b)) => Ok(Self::Int(*a + *b)),
             _ => Err(
                 waymark_vm_interpreter_pureset::value::BinaryOperationError::UnsupportedOperation {
-                    operation: waymark_vm_interpreter_pureset::value::BinaryOperationKind::Add,
+                    operation: BinaryOpKind::Add,
                 },
             ),
         }
@@ -78,7 +78,7 @@ impl waymark_vm_interpreter_pureset::value::UnaryOps for TestValue {
             Self::Int(value) => Ok(Self::Int(-*value)),
             _ => Err(
                 waymark_vm_interpreter_pureset::value::UnaryOperationError::UnsupportedOperation {
-                    operation: waymark_vm_interpreter_pureset::value::UnaryOperationKind::Neg,
+                    operation: UnaryOpKind::Neg,
                 },
             ),
         }

--- a/crates/lib/vm-interpreter-fullset/tests/integration.rs
+++ b/crates/lib/vm-interpreter-fullset/tests/integration.rs
@@ -123,11 +123,11 @@ fn runtime_executes_pure_and_core_instructions_to_completion() {
                 value: TestConstValue::Int(3),
             }
             .into(),
-            PureSet::Add {
+            PureSet::Add(waymark_vm_instructions_pureset::BinaryOp {
                 dst: RegisterId(2),
                 a: RegisterId(0),
                 b: RegisterId(1),
-            }
+            })
             .into(),
             CoreSet::Return { src: RegisterId(2) }.into(),
         ]],
@@ -182,11 +182,11 @@ fn runtime_resumes_extcalls_and_finishes_with_pure_work() {
                     value: TestConstValue::Int(1),
                 }
                 .into(),
-                PureSet::Add {
+                PureSet::Add(waymark_vm_instructions_pureset::BinaryOp {
                     dst: RegisterId(3),
                     a: RegisterId(2),
                     b: RegisterId(3),
-                }
+                })
                 .into(),
                 CoreSet::Return { src: RegisterId(3) }.into(),
             ],

--- a/crates/lib/vm-interpreter-fullset/tests/integration.rs
+++ b/crates/lib/vm-interpreter-fullset/tests/integration.rs
@@ -34,26 +34,60 @@ struct TestExtCallId(usize);
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum TestValue {
     Int(i64),
+    Bool(bool),
     List(Vec<TestValue>),
+}
+
+fn is_truthy(value: &TestValue) -> bool {
+    match value {
+        TestValue::Int(value) => *value != 0,
+        TestValue::Bool(value) => *value,
+        TestValue::List(items) => !items.is_empty(),
+    }
 }
 
 impl waymark_vm_interpreter_coreset::value::ShouldJump for TestValue {
     fn should_jump(
         &self,
     ) -> Result<bool, waymark_vm_interpreter_coreset::value::NotAConditionalError> {
-        match self {
-            Self::Int(value) => Ok(*value != 0),
-            Self::List(_) => Err(waymark_vm_interpreter_coreset::value::NotAConditionalError),
+        Ok(is_truthy(self))
+    }
+}
+
+impl waymark_vm_interpreter_pureset::value::BinaryOps for TestValue {
+    fn add(
+        a: &Self,
+        b: &Self,
+    ) -> Result<Self, waymark_vm_interpreter_pureset::value::BinaryOperationError> {
+        match (a, b) {
+            (Self::Int(a), Self::Int(b)) => Ok(Self::Int(*a + *b)),
+            _ => Err(
+                waymark_vm_interpreter_pureset::value::BinaryOperationError::UnsupportedOperation {
+                    operation: waymark_vm_interpreter_pureset::value::BinaryOperationKind::Add,
+                },
+            ),
         }
     }
 }
 
-impl waymark_vm_interpreter_pureset::value::Add for TestValue {
-    fn add(a: &Self, b: &Self) -> Result<Self, waymark_vm_interpreter_pureset::value::AddError> {
-        match (a, b) {
-            (Self::Int(a), Self::Int(b)) => Ok(Self::Int(a + b)),
-            _ => Err(waymark_vm_interpreter_pureset::value::AddError::NotAddable),
+impl waymark_vm_interpreter_pureset::value::UnaryOps for TestValue {
+    fn neg(
+        value: &Self,
+    ) -> Result<Self, waymark_vm_interpreter_pureset::value::UnaryOperationError> {
+        match value {
+            Self::Int(value) => Ok(Self::Int(-*value)),
+            _ => Err(
+                waymark_vm_interpreter_pureset::value::UnaryOperationError::UnsupportedOperation {
+                    operation: waymark_vm_interpreter_pureset::value::UnaryOperationKind::Neg,
+                },
+            ),
         }
+    }
+
+    fn not(
+        value: &Self,
+    ) -> Result<Self, waymark_vm_interpreter_pureset::value::UnaryOperationError> {
+        Ok(Self::Bool(!is_truthy(value)))
     }
 }
 

--- a/crates/lib/vm-interpreter-pureset/src/error.rs
+++ b/crates/lib/vm-interpreter-pureset/src/error.rs
@@ -1,6 +1,6 @@
 use waymark_vm_runtime_core::{RegisterId, UnresolvedPromiseError};
 
-use crate::value::{BinaryOperationKind, UnaryOperationKind};
+use waymark_vm_instructions_pureset::{BinaryOpKind, UnaryOpKind};
 
 /// A specified of the operand position in a binary operation.
 ///
@@ -37,7 +37,7 @@ pub enum Error {
     #[error("{operand_pos} {operation} operand in register {register:?} is not initialized")]
     MissingBinaryOperand {
         /// The binary operation being evaluated.
-        operation: BinaryOperationKind,
+        operation: BinaryOpKind,
 
         /// The operand position.
         operand_pos: BinaryOperandPosition,
@@ -50,7 +50,7 @@ pub enum Error {
     #[error("{operand_pos} {operation} operand is unresolved: {source}")]
     UnresolvedBinaryOperand {
         /// The binary operation being evaluated.
-        operation: BinaryOperationKind,
+        operation: BinaryOpKind,
 
         /// The operand position.
         operand_pos: BinaryOperandPosition,
@@ -64,7 +64,7 @@ pub enum Error {
     #[error("{operation} operand in register {register:?} is not initialized")]
     MissingUnaryOperand {
         /// The unary operation being evaluated.
-        operation: UnaryOperationKind,
+        operation: UnaryOpKind,
 
         /// The register that was read.
         register: RegisterId,
@@ -74,7 +74,7 @@ pub enum Error {
     #[error("{operation} operand is unresolved: {source}")]
     UnresolvedUnaryOperand {
         /// The unary operation being evaluated.
-        operation: UnaryOperationKind,
+        operation: UnaryOpKind,
 
         /// The underlying unresolved promise error.
         #[source]
@@ -106,7 +106,7 @@ pub enum Error {
     #[error("{operation}: {source}")]
     BinaryOperation {
         /// The binary operation that failed.
-        operation: BinaryOperationKind,
+        operation: BinaryOpKind,
 
         /// The operation-specific failure.
         #[source]
@@ -117,7 +117,7 @@ pub enum Error {
     #[error("{operation}: {source}")]
     UnaryOperation {
         /// The unary operation that failed.
-        operation: UnaryOperationKind,
+        operation: UnaryOpKind,
 
         /// The operation-specific failure.
         #[source]

--- a/crates/lib/vm-interpreter-pureset/src/error.rs
+++ b/crates/lib/vm-interpreter-pureset/src/error.rs
@@ -1,5 +1,7 @@
 use waymark_vm_runtime_core::{RegisterId, UnresolvedPromiseError};
 
+use crate::value::{BinaryOperationKind, UnaryOperationKind};
+
 /// A specified of the operand position in a binary operation.
 ///
 /// Used in the errors.
@@ -31,9 +33,12 @@ pub enum Error {
         register: RegisterId,
     },
 
-    /// An `Add` instruction referenced an unset register.
-    #[error(" {operand_pos} add operand in register {register:?} is not initialized")]
-    MissingAddOperand {
+    /// A binary scalar instruction referenced an unset register.
+    #[error("{operand_pos} {operation} operand in register {register:?} is not initialized")]
+    MissingBinaryOperand {
+        /// The binary operation being evaluated.
+        operation: BinaryOperationKind,
+
         /// The operand position.
         operand_pos: BinaryOperandPosition,
 
@@ -41,11 +46,35 @@ pub enum Error {
         register: RegisterId,
     },
 
-    /// An `Add` instruction referenced an unresolved promise.
-    #[error("{operand_pos} add operand is unresolved: {source}")]
-    UnresolvedAddOperand {
+    /// A binary scalar instruction referenced an unresolved promise.
+    #[error("{operand_pos} {operation} operand is unresolved: {source}")]
+    UnresolvedBinaryOperand {
+        /// The binary operation being evaluated.
+        operation: BinaryOperationKind,
+
         /// The operand position.
         operand_pos: BinaryOperandPosition,
+
+        /// The underlying unresolved promise error.
+        #[source]
+        source: UnresolvedPromiseError,
+    },
+
+    /// A unary scalar instruction referenced an unset register.
+    #[error("{operation} operand in register {register:?} is not initialized")]
+    MissingUnaryOperand {
+        /// The unary operation being evaluated.
+        operation: UnaryOperationKind,
+
+        /// The register that was read.
+        register: RegisterId,
+    },
+
+    /// A unary scalar instruction referenced an unresolved promise.
+    #[error("{operation} operand is unresolved: {source}")]
+    UnresolvedUnaryOperand {
+        /// The unary operation being evaluated.
+        operation: UnaryOperationKind,
 
         /// The underlying unresolved promise error.
         #[source]
@@ -73,9 +102,27 @@ pub enum Error {
         source: UnresolvedPromiseError,
     },
 
-    /// Evaluating an `Add` instruction failed.
-    #[error("add: {0}")]
-    Add(#[source] crate::value::AddError),
+    /// Evaluating a binary scalar instruction failed.
+    #[error("{operation}: {source}")]
+    BinaryOperation {
+        /// The binary operation that failed.
+        operation: BinaryOperationKind,
+
+        /// The operation-specific failure.
+        #[source]
+        source: crate::value::BinaryOperationError,
+    },
+
+    /// Evaluating a unary scalar instruction failed.
+    #[error("{operation}: {source}")]
+    UnaryOperation {
+        /// The unary operation that failed.
+        operation: UnaryOperationKind,
+
+        /// The operation-specific failure.
+        #[source]
+        source: crate::value::UnaryOperationError,
+    },
 
     /// Evaluating a `MakeList` instruction failed.
     #[error("make_list: {0}")]

--- a/crates/lib/vm-interpreter-pureset/src/lib.rs
+++ b/crates/lib/vm-interpreter-pureset/src/lib.rs
@@ -15,6 +15,38 @@ pub use self::value::Value;
 
 use self::value::{BinaryOperationKind, UnaryOperationKind};
 
+impl From<waymark_vm_instructions_pureset::BinaryOpKind> for BinaryOperationKind {
+    fn from(kind: waymark_vm_instructions_pureset::BinaryOpKind) -> Self {
+        match kind {
+            waymark_vm_instructions_pureset::BinaryOpKind::Add => Self::Add,
+            waymark_vm_instructions_pureset::BinaryOpKind::Sub => Self::Sub,
+            waymark_vm_instructions_pureset::BinaryOpKind::Mul => Self::Mul,
+            waymark_vm_instructions_pureset::BinaryOpKind::Div => Self::Div,
+            waymark_vm_instructions_pureset::BinaryOpKind::FloorDiv => Self::FloorDiv,
+            waymark_vm_instructions_pureset::BinaryOpKind::Mod => Self::Mod,
+            waymark_vm_instructions_pureset::BinaryOpKind::Eq => Self::Eq,
+            waymark_vm_instructions_pureset::BinaryOpKind::Ne => Self::Ne,
+            waymark_vm_instructions_pureset::BinaryOpKind::Lt => Self::Lt,
+            waymark_vm_instructions_pureset::BinaryOpKind::Le => Self::Le,
+            waymark_vm_instructions_pureset::BinaryOpKind::Gt => Self::Gt,
+            waymark_vm_instructions_pureset::BinaryOpKind::Ge => Self::Ge,
+            waymark_vm_instructions_pureset::BinaryOpKind::In => Self::In,
+            waymark_vm_instructions_pureset::BinaryOpKind::NotIn => Self::NotIn,
+            waymark_vm_instructions_pureset::BinaryOpKind::And => Self::And,
+            waymark_vm_instructions_pureset::BinaryOpKind::Or => Self::Or,
+        }
+    }
+}
+
+impl From<waymark_vm_instructions_pureset::UnaryOpKind> for UnaryOperationKind {
+    fn from(kind: waymark_vm_instructions_pureset::UnaryOpKind) -> Self {
+        match kind {
+            waymark_vm_instructions_pureset::UnaryOpKind::Neg => Self::Neg,
+            waymark_vm_instructions_pureset::UnaryOpKind::Not => Self::Not,
+        }
+    }
+}
+
 /// An interpreter for the "pure" instructions set.
 #[derive_where(Default)]
 pub struct PureSetInterpreter<Spec, FunctionId, StateId, Value> {
@@ -58,107 +90,17 @@ where
                     .ok_or(Error::MissingCopySource { register: *src })?;
                 frame.regs.set(*dst, value.clone());
             }
-            waymark_vm_instructions_pureset::PureSet::Add(
-                waymark_vm_instructions_pureset::BinaryOp { dst, a, b },
-            ) => {
-                Self::execute_binary_operation(&mut frame, *dst, *a, *b, BinaryOperationKind::Add)?;
+            waymark_vm_instructions_pureset::PureSet::Binary {
+                kind,
+                op: waymark_vm_instructions_pureset::BinaryOp { dst, a, b },
+            } => {
+                Self::execute_binary_operation(&mut frame, *dst, *a, *b, (*kind).into())?;
             }
-            waymark_vm_instructions_pureset::PureSet::Sub(
-                waymark_vm_instructions_pureset::BinaryOp { dst, a, b },
-            ) => {
-                Self::execute_binary_operation(&mut frame, *dst, *a, *b, BinaryOperationKind::Sub)?;
-            }
-            waymark_vm_instructions_pureset::PureSet::Mul(
-                waymark_vm_instructions_pureset::BinaryOp { dst, a, b },
-            ) => {
-                Self::execute_binary_operation(&mut frame, *dst, *a, *b, BinaryOperationKind::Mul)?;
-            }
-            waymark_vm_instructions_pureset::PureSet::Div(
-                waymark_vm_instructions_pureset::BinaryOp { dst, a, b },
-            ) => {
-                Self::execute_binary_operation(&mut frame, *dst, *a, *b, BinaryOperationKind::Div)?;
-            }
-            waymark_vm_instructions_pureset::PureSet::FloorDiv(
-                waymark_vm_instructions_pureset::BinaryOp { dst, a, b },
-            ) => {
-                Self::execute_binary_operation(
-                    &mut frame,
-                    *dst,
-                    *a,
-                    *b,
-                    BinaryOperationKind::FloorDiv,
-                )?;
-            }
-            waymark_vm_instructions_pureset::PureSet::Mod(
-                waymark_vm_instructions_pureset::BinaryOp { dst, a, b },
-            ) => {
-                Self::execute_binary_operation(&mut frame, *dst, *a, *b, BinaryOperationKind::Mod)?;
-            }
-            waymark_vm_instructions_pureset::PureSet::Eq(
-                waymark_vm_instructions_pureset::BinaryOp { dst, a, b },
-            ) => {
-                Self::execute_binary_operation(&mut frame, *dst, *a, *b, BinaryOperationKind::Eq)?;
-            }
-            waymark_vm_instructions_pureset::PureSet::Ne(
-                waymark_vm_instructions_pureset::BinaryOp { dst, a, b },
-            ) => {
-                Self::execute_binary_operation(&mut frame, *dst, *a, *b, BinaryOperationKind::Ne)?;
-            }
-            waymark_vm_instructions_pureset::PureSet::Lt(
-                waymark_vm_instructions_pureset::BinaryOp { dst, a, b },
-            ) => {
-                Self::execute_binary_operation(&mut frame, *dst, *a, *b, BinaryOperationKind::Lt)?;
-            }
-            waymark_vm_instructions_pureset::PureSet::Le(
-                waymark_vm_instructions_pureset::BinaryOp { dst, a, b },
-            ) => {
-                Self::execute_binary_operation(&mut frame, *dst, *a, *b, BinaryOperationKind::Le)?;
-            }
-            waymark_vm_instructions_pureset::PureSet::Gt(
-                waymark_vm_instructions_pureset::BinaryOp { dst, a, b },
-            ) => {
-                Self::execute_binary_operation(&mut frame, *dst, *a, *b, BinaryOperationKind::Gt)?;
-            }
-            waymark_vm_instructions_pureset::PureSet::Ge(
-                waymark_vm_instructions_pureset::BinaryOp { dst, a, b },
-            ) => {
-                Self::execute_binary_operation(&mut frame, *dst, *a, *b, BinaryOperationKind::Ge)?;
-            }
-            waymark_vm_instructions_pureset::PureSet::In(
-                waymark_vm_instructions_pureset::BinaryOp { dst, a, b },
-            ) => {
-                Self::execute_binary_operation(&mut frame, *dst, *a, *b, BinaryOperationKind::In)?;
-            }
-            waymark_vm_instructions_pureset::PureSet::NotIn(
-                waymark_vm_instructions_pureset::BinaryOp { dst, a, b },
-            ) => {
-                Self::execute_binary_operation(
-                    &mut frame,
-                    *dst,
-                    *a,
-                    *b,
-                    BinaryOperationKind::NotIn,
-                )?;
-            }
-            waymark_vm_instructions_pureset::PureSet::And(
-                waymark_vm_instructions_pureset::BinaryOp { dst, a, b },
-            ) => {
-                Self::execute_binary_operation(&mut frame, *dst, *a, *b, BinaryOperationKind::And)?;
-            }
-            waymark_vm_instructions_pureset::PureSet::Or(
-                waymark_vm_instructions_pureset::BinaryOp { dst, a, b },
-            ) => {
-                Self::execute_binary_operation(&mut frame, *dst, *a, *b, BinaryOperationKind::Or)?;
-            }
-            waymark_vm_instructions_pureset::PureSet::Neg(
-                waymark_vm_instructions_pureset::UnaryOp { dst, src },
-            ) => {
-                Self::execute_unary_operation(&mut frame, *dst, *src, UnaryOperationKind::Neg)?;
-            }
-            waymark_vm_instructions_pureset::PureSet::Not(
-                waymark_vm_instructions_pureset::UnaryOp { dst, src },
-            ) => {
-                Self::execute_unary_operation(&mut frame, *dst, *src, UnaryOperationKind::Not)?;
+            waymark_vm_instructions_pureset::PureSet::Unary {
+                kind,
+                op: waymark_vm_instructions_pureset::UnaryOp { dst, src },
+            } => {
+                Self::execute_unary_operation(&mut frame, *dst, *src, (*kind).into())?;
             }
             waymark_vm_instructions_pureset::PureSet::MakeList { dst, items } => {
                 let make_list_result = with_register_values(

--- a/crates/lib/vm-interpreter-pureset/src/lib.rs
+++ b/crates/lib/vm-interpreter-pureset/src/lib.rs
@@ -13,6 +13,8 @@ use waymark_vm_runtime_core::{Frame, Promise};
 pub use self::error::*;
 pub use self::value::Value;
 
+use self::value::{BinaryOperationKind, UnaryOperationKind};
+
 /// An interpreter for the "pure" instructions set.
 #[derive_where(Default)]
 pub struct PureSetInterpreter<Spec, FunctionId, StateId, Value> {
@@ -57,30 +59,70 @@ where
                 frame.regs.set(*dst, value.clone());
             }
             waymark_vm_instructions_pureset::PureSet::Add { dst, a, b } => {
-                let x = frame.regs.get(*a).ok_or(Error::MissingAddOperand {
-                    operand_pos: BinaryOperandPosition::First,
-                    register: *a,
-                })?;
-                let x = x
-                    .require_resolved_ref()
-                    .map_err(|source| Error::UnresolvedAddOperand {
-                        operand_pos: BinaryOperandPosition::First,
-                        source,
-                    })?;
-
-                let y = frame.regs.get(*b).ok_or(Error::MissingAddOperand {
-                    operand_pos: BinaryOperandPosition::Second,
-                    register: *b,
-                })?;
-                let y = y
-                    .require_resolved_ref()
-                    .map_err(|source| Error::UnresolvedAddOperand {
-                        operand_pos: BinaryOperandPosition::Second,
-                        source,
-                    })?;
-
-                let value = Value::add(x, y).map_err(Error::Add)?;
-                frame.regs.set(*dst, Promise::Resolved(value));
+                Self::execute_binary_operation(&mut frame, *dst, *a, *b, BinaryOperationKind::Add)?;
+            }
+            waymark_vm_instructions_pureset::PureSet::Sub { dst, a, b } => {
+                Self::execute_binary_operation(&mut frame, *dst, *a, *b, BinaryOperationKind::Sub)?;
+            }
+            waymark_vm_instructions_pureset::PureSet::Mul { dst, a, b } => {
+                Self::execute_binary_operation(&mut frame, *dst, *a, *b, BinaryOperationKind::Mul)?;
+            }
+            waymark_vm_instructions_pureset::PureSet::Div { dst, a, b } => {
+                Self::execute_binary_operation(&mut frame, *dst, *a, *b, BinaryOperationKind::Div)?;
+            }
+            waymark_vm_instructions_pureset::PureSet::FloorDiv { dst, a, b } => {
+                Self::execute_binary_operation(
+                    &mut frame,
+                    *dst,
+                    *a,
+                    *b,
+                    BinaryOperationKind::FloorDiv,
+                )?;
+            }
+            waymark_vm_instructions_pureset::PureSet::Mod { dst, a, b } => {
+                Self::execute_binary_operation(&mut frame, *dst, *a, *b, BinaryOperationKind::Mod)?;
+            }
+            waymark_vm_instructions_pureset::PureSet::Eq { dst, a, b } => {
+                Self::execute_binary_operation(&mut frame, *dst, *a, *b, BinaryOperationKind::Eq)?;
+            }
+            waymark_vm_instructions_pureset::PureSet::Ne { dst, a, b } => {
+                Self::execute_binary_operation(&mut frame, *dst, *a, *b, BinaryOperationKind::Ne)?;
+            }
+            waymark_vm_instructions_pureset::PureSet::Lt { dst, a, b } => {
+                Self::execute_binary_operation(&mut frame, *dst, *a, *b, BinaryOperationKind::Lt)?;
+            }
+            waymark_vm_instructions_pureset::PureSet::Le { dst, a, b } => {
+                Self::execute_binary_operation(&mut frame, *dst, *a, *b, BinaryOperationKind::Le)?;
+            }
+            waymark_vm_instructions_pureset::PureSet::Gt { dst, a, b } => {
+                Self::execute_binary_operation(&mut frame, *dst, *a, *b, BinaryOperationKind::Gt)?;
+            }
+            waymark_vm_instructions_pureset::PureSet::Ge { dst, a, b } => {
+                Self::execute_binary_operation(&mut frame, *dst, *a, *b, BinaryOperationKind::Ge)?;
+            }
+            waymark_vm_instructions_pureset::PureSet::In { dst, a, b } => {
+                Self::execute_binary_operation(&mut frame, *dst, *a, *b, BinaryOperationKind::In)?;
+            }
+            waymark_vm_instructions_pureset::PureSet::NotIn { dst, a, b } => {
+                Self::execute_binary_operation(
+                    &mut frame,
+                    *dst,
+                    *a,
+                    *b,
+                    BinaryOperationKind::NotIn,
+                )?;
+            }
+            waymark_vm_instructions_pureset::PureSet::And { dst, a, b } => {
+                Self::execute_binary_operation(&mut frame, *dst, *a, *b, BinaryOperationKind::And)?;
+            }
+            waymark_vm_instructions_pureset::PureSet::Or { dst, a, b } => {
+                Self::execute_binary_operation(&mut frame, *dst, *a, *b, BinaryOperationKind::Or)?;
+            }
+            waymark_vm_instructions_pureset::PureSet::Neg { dst, src } => {
+                Self::execute_unary_operation(&mut frame, *dst, *src, UnaryOperationKind::Neg)?;
+            }
+            waymark_vm_instructions_pureset::PureSet::Not { dst, src } => {
+                Self::execute_unary_operation(&mut frame, *dst, *src, UnaryOperationKind::Not)?;
             }
             waymark_vm_instructions_pureset::PureSet::MakeList { dst, items } => {
                 let make_list_result = with_register_values(
@@ -105,6 +147,92 @@ where
         }
 
         Ok(ExecutionOutcome::Continue(frame))
+    }
+}
+
+impl<Spec, FunctionId, StateId, Value> PureSetInterpreter<Spec, FunctionId, StateId, Value>
+where
+    Value: value::Value,
+{
+    fn execute_binary_operation(
+        frame: &mut Frame<FunctionId, StateId, Promise<Value>>,
+        dst: waymark_vm_runtime_core::RegisterId,
+        a: waymark_vm_runtime_core::RegisterId,
+        b: waymark_vm_runtime_core::RegisterId,
+        operation: BinaryOperationKind,
+    ) -> Result<(), Error> {
+        let x = frame.regs.get(a).ok_or(Error::MissingBinaryOperand {
+            operation,
+            operand_pos: BinaryOperandPosition::First,
+            register: a,
+        })?;
+        let x = x
+            .require_resolved_ref()
+            .map_err(|source| Error::UnresolvedBinaryOperand {
+                operation,
+                operand_pos: BinaryOperandPosition::First,
+                source,
+            })?;
+
+        let y = frame.regs.get(b).ok_or(Error::MissingBinaryOperand {
+            operation,
+            operand_pos: BinaryOperandPosition::Second,
+            register: b,
+        })?;
+        let y = y
+            .require_resolved_ref()
+            .map_err(|source| Error::UnresolvedBinaryOperand {
+                operation,
+                operand_pos: BinaryOperandPosition::Second,
+                source,
+            })?;
+
+        let value = match operation {
+            BinaryOperationKind::Add => Value::add(x, y),
+            BinaryOperationKind::Sub => Value::sub(x, y),
+            BinaryOperationKind::Mul => Value::mul(x, y),
+            BinaryOperationKind::Div => Value::div(x, y),
+            BinaryOperationKind::FloorDiv => Value::floor_div(x, y),
+            BinaryOperationKind::Mod => Value::modulo(x, y),
+            BinaryOperationKind::Eq => Value::eq(x, y),
+            BinaryOperationKind::Ne => Value::ne(x, y),
+            BinaryOperationKind::Lt => Value::lt(x, y),
+            BinaryOperationKind::Le => Value::le(x, y),
+            BinaryOperationKind::Gt => Value::gt(x, y),
+            BinaryOperationKind::Ge => Value::ge(x, y),
+            BinaryOperationKind::In => Value::contains(x, y),
+            BinaryOperationKind::NotIn => Value::not_contains(x, y),
+            BinaryOperationKind::And => Value::and(x, y),
+            BinaryOperationKind::Or => Value::or(x, y),
+        }
+        .map_err(|source| Error::BinaryOperation { operation, source })?;
+
+        frame.regs.set(dst, Promise::Resolved(value));
+        Ok(())
+    }
+
+    fn execute_unary_operation(
+        frame: &mut Frame<FunctionId, StateId, Promise<Value>>,
+        dst: waymark_vm_runtime_core::RegisterId,
+        src: waymark_vm_runtime_core::RegisterId,
+        operation: UnaryOperationKind,
+    ) -> Result<(), Error> {
+        let value = frame.regs.get(src).ok_or(Error::MissingUnaryOperand {
+            operation,
+            register: src,
+        })?;
+        let value = value
+            .require_resolved_ref()
+            .map_err(|source| Error::UnresolvedUnaryOperand { operation, source })?;
+
+        let value = match operation {
+            UnaryOperationKind::Neg => Value::neg(value),
+            UnaryOperationKind::Not => Value::not(value),
+        }
+        .map_err(|source| Error::UnaryOperation { operation, source })?;
+
+        frame.regs.set(dst, Promise::Resolved(value));
+        Ok(())
     }
 }
 

--- a/crates/lib/vm-interpreter-pureset/src/lib.rs
+++ b/crates/lib/vm-interpreter-pureset/src/lib.rs
@@ -58,19 +58,29 @@ where
                     .ok_or(Error::MissingCopySource { register: *src })?;
                 frame.regs.set(*dst, value.clone());
             }
-            waymark_vm_instructions_pureset::PureSet::Add { dst, a, b } => {
+            waymark_vm_instructions_pureset::PureSet::Add(
+                waymark_vm_instructions_pureset::BinaryOp { dst, a, b },
+            ) => {
                 Self::execute_binary_operation(&mut frame, *dst, *a, *b, BinaryOperationKind::Add)?;
             }
-            waymark_vm_instructions_pureset::PureSet::Sub { dst, a, b } => {
+            waymark_vm_instructions_pureset::PureSet::Sub(
+                waymark_vm_instructions_pureset::BinaryOp { dst, a, b },
+            ) => {
                 Self::execute_binary_operation(&mut frame, *dst, *a, *b, BinaryOperationKind::Sub)?;
             }
-            waymark_vm_instructions_pureset::PureSet::Mul { dst, a, b } => {
+            waymark_vm_instructions_pureset::PureSet::Mul(
+                waymark_vm_instructions_pureset::BinaryOp { dst, a, b },
+            ) => {
                 Self::execute_binary_operation(&mut frame, *dst, *a, *b, BinaryOperationKind::Mul)?;
             }
-            waymark_vm_instructions_pureset::PureSet::Div { dst, a, b } => {
+            waymark_vm_instructions_pureset::PureSet::Div(
+                waymark_vm_instructions_pureset::BinaryOp { dst, a, b },
+            ) => {
                 Self::execute_binary_operation(&mut frame, *dst, *a, *b, BinaryOperationKind::Div)?;
             }
-            waymark_vm_instructions_pureset::PureSet::FloorDiv { dst, a, b } => {
+            waymark_vm_instructions_pureset::PureSet::FloorDiv(
+                waymark_vm_instructions_pureset::BinaryOp { dst, a, b },
+            ) => {
                 Self::execute_binary_operation(
                     &mut frame,
                     *dst,
@@ -79,31 +89,49 @@ where
                     BinaryOperationKind::FloorDiv,
                 )?;
             }
-            waymark_vm_instructions_pureset::PureSet::Mod { dst, a, b } => {
+            waymark_vm_instructions_pureset::PureSet::Mod(
+                waymark_vm_instructions_pureset::BinaryOp { dst, a, b },
+            ) => {
                 Self::execute_binary_operation(&mut frame, *dst, *a, *b, BinaryOperationKind::Mod)?;
             }
-            waymark_vm_instructions_pureset::PureSet::Eq { dst, a, b } => {
+            waymark_vm_instructions_pureset::PureSet::Eq(
+                waymark_vm_instructions_pureset::BinaryOp { dst, a, b },
+            ) => {
                 Self::execute_binary_operation(&mut frame, *dst, *a, *b, BinaryOperationKind::Eq)?;
             }
-            waymark_vm_instructions_pureset::PureSet::Ne { dst, a, b } => {
+            waymark_vm_instructions_pureset::PureSet::Ne(
+                waymark_vm_instructions_pureset::BinaryOp { dst, a, b },
+            ) => {
                 Self::execute_binary_operation(&mut frame, *dst, *a, *b, BinaryOperationKind::Ne)?;
             }
-            waymark_vm_instructions_pureset::PureSet::Lt { dst, a, b } => {
+            waymark_vm_instructions_pureset::PureSet::Lt(
+                waymark_vm_instructions_pureset::BinaryOp { dst, a, b },
+            ) => {
                 Self::execute_binary_operation(&mut frame, *dst, *a, *b, BinaryOperationKind::Lt)?;
             }
-            waymark_vm_instructions_pureset::PureSet::Le { dst, a, b } => {
+            waymark_vm_instructions_pureset::PureSet::Le(
+                waymark_vm_instructions_pureset::BinaryOp { dst, a, b },
+            ) => {
                 Self::execute_binary_operation(&mut frame, *dst, *a, *b, BinaryOperationKind::Le)?;
             }
-            waymark_vm_instructions_pureset::PureSet::Gt { dst, a, b } => {
+            waymark_vm_instructions_pureset::PureSet::Gt(
+                waymark_vm_instructions_pureset::BinaryOp { dst, a, b },
+            ) => {
                 Self::execute_binary_operation(&mut frame, *dst, *a, *b, BinaryOperationKind::Gt)?;
             }
-            waymark_vm_instructions_pureset::PureSet::Ge { dst, a, b } => {
+            waymark_vm_instructions_pureset::PureSet::Ge(
+                waymark_vm_instructions_pureset::BinaryOp { dst, a, b },
+            ) => {
                 Self::execute_binary_operation(&mut frame, *dst, *a, *b, BinaryOperationKind::Ge)?;
             }
-            waymark_vm_instructions_pureset::PureSet::In { dst, a, b } => {
+            waymark_vm_instructions_pureset::PureSet::In(
+                waymark_vm_instructions_pureset::BinaryOp { dst, a, b },
+            ) => {
                 Self::execute_binary_operation(&mut frame, *dst, *a, *b, BinaryOperationKind::In)?;
             }
-            waymark_vm_instructions_pureset::PureSet::NotIn { dst, a, b } => {
+            waymark_vm_instructions_pureset::PureSet::NotIn(
+                waymark_vm_instructions_pureset::BinaryOp { dst, a, b },
+            ) => {
                 Self::execute_binary_operation(
                     &mut frame,
                     *dst,
@@ -112,16 +140,24 @@ where
                     BinaryOperationKind::NotIn,
                 )?;
             }
-            waymark_vm_instructions_pureset::PureSet::And { dst, a, b } => {
+            waymark_vm_instructions_pureset::PureSet::And(
+                waymark_vm_instructions_pureset::BinaryOp { dst, a, b },
+            ) => {
                 Self::execute_binary_operation(&mut frame, *dst, *a, *b, BinaryOperationKind::And)?;
             }
-            waymark_vm_instructions_pureset::PureSet::Or { dst, a, b } => {
+            waymark_vm_instructions_pureset::PureSet::Or(
+                waymark_vm_instructions_pureset::BinaryOp { dst, a, b },
+            ) => {
                 Self::execute_binary_operation(&mut frame, *dst, *a, *b, BinaryOperationKind::Or)?;
             }
-            waymark_vm_instructions_pureset::PureSet::Neg { dst, src } => {
+            waymark_vm_instructions_pureset::PureSet::Neg(
+                waymark_vm_instructions_pureset::UnaryOp { dst, src },
+            ) => {
                 Self::execute_unary_operation(&mut frame, *dst, *src, UnaryOperationKind::Neg)?;
             }
-            waymark_vm_instructions_pureset::PureSet::Not { dst, src } => {
+            waymark_vm_instructions_pureset::PureSet::Not(
+                waymark_vm_instructions_pureset::UnaryOp { dst, src },
+            ) => {
                 Self::execute_unary_operation(&mut frame, *dst, *src, UnaryOperationKind::Not)?;
             }
             waymark_vm_instructions_pureset::PureSet::MakeList { dst, items } => {

--- a/crates/lib/vm-interpreter-pureset/src/lib.rs
+++ b/crates/lib/vm-interpreter-pureset/src/lib.rs
@@ -13,39 +13,7 @@ use waymark_vm_runtime_core::{Frame, Promise};
 pub use self::error::*;
 pub use self::value::Value;
 
-use self::value::{BinaryOperationKind, UnaryOperationKind};
-
-impl From<waymark_vm_instructions_pureset::BinaryOpKind> for BinaryOperationKind {
-    fn from(kind: waymark_vm_instructions_pureset::BinaryOpKind) -> Self {
-        match kind {
-            waymark_vm_instructions_pureset::BinaryOpKind::Add => Self::Add,
-            waymark_vm_instructions_pureset::BinaryOpKind::Sub => Self::Sub,
-            waymark_vm_instructions_pureset::BinaryOpKind::Mul => Self::Mul,
-            waymark_vm_instructions_pureset::BinaryOpKind::Div => Self::Div,
-            waymark_vm_instructions_pureset::BinaryOpKind::FloorDiv => Self::FloorDiv,
-            waymark_vm_instructions_pureset::BinaryOpKind::Mod => Self::Mod,
-            waymark_vm_instructions_pureset::BinaryOpKind::Eq => Self::Eq,
-            waymark_vm_instructions_pureset::BinaryOpKind::Ne => Self::Ne,
-            waymark_vm_instructions_pureset::BinaryOpKind::Lt => Self::Lt,
-            waymark_vm_instructions_pureset::BinaryOpKind::Le => Self::Le,
-            waymark_vm_instructions_pureset::BinaryOpKind::Gt => Self::Gt,
-            waymark_vm_instructions_pureset::BinaryOpKind::Ge => Self::Ge,
-            waymark_vm_instructions_pureset::BinaryOpKind::In => Self::In,
-            waymark_vm_instructions_pureset::BinaryOpKind::NotIn => Self::NotIn,
-            waymark_vm_instructions_pureset::BinaryOpKind::And => Self::And,
-            waymark_vm_instructions_pureset::BinaryOpKind::Or => Self::Or,
-        }
-    }
-}
-
-impl From<waymark_vm_instructions_pureset::UnaryOpKind> for UnaryOperationKind {
-    fn from(kind: waymark_vm_instructions_pureset::UnaryOpKind) -> Self {
-        match kind {
-            waymark_vm_instructions_pureset::UnaryOpKind::Neg => Self::Neg,
-            waymark_vm_instructions_pureset::UnaryOpKind::Not => Self::Not,
-        }
-    }
-}
+use waymark_vm_instructions_pureset::{BinaryOpKind, UnaryOpKind};
 
 /// An interpreter for the "pure" instructions set.
 #[derive_where(Default)]
@@ -94,13 +62,13 @@ where
                 kind,
                 op: waymark_vm_instructions_pureset::BinaryOp { dst, a, b },
             } => {
-                Self::execute_binary_operation(&mut frame, *dst, *a, *b, (*kind).into())?;
+                Self::execute_binary_operation(&mut frame, *dst, *a, *b, *kind)?;
             }
             waymark_vm_instructions_pureset::PureSet::Unary {
                 kind,
                 op: waymark_vm_instructions_pureset::UnaryOp { dst, src },
             } => {
-                Self::execute_unary_operation(&mut frame, *dst, *src, (*kind).into())?;
+                Self::execute_unary_operation(&mut frame, *dst, *src, *kind)?;
             }
             waymark_vm_instructions_pureset::PureSet::MakeList { dst, items } => {
                 let make_list_result = with_register_values(
@@ -137,7 +105,7 @@ where
         dst: waymark_vm_runtime_core::RegisterId,
         a: waymark_vm_runtime_core::RegisterId,
         b: waymark_vm_runtime_core::RegisterId,
-        operation: BinaryOperationKind,
+        operation: BinaryOpKind,
     ) -> Result<(), Error> {
         let x = frame.regs.get(a).ok_or(Error::MissingBinaryOperand {
             operation,
@@ -166,22 +134,22 @@ where
             })?;
 
         let value = match operation {
-            BinaryOperationKind::Add => Value::add(x, y),
-            BinaryOperationKind::Sub => Value::sub(x, y),
-            BinaryOperationKind::Mul => Value::mul(x, y),
-            BinaryOperationKind::Div => Value::div(x, y),
-            BinaryOperationKind::FloorDiv => Value::floor_div(x, y),
-            BinaryOperationKind::Mod => Value::modulo(x, y),
-            BinaryOperationKind::Eq => Value::eq(x, y),
-            BinaryOperationKind::Ne => Value::ne(x, y),
-            BinaryOperationKind::Lt => Value::lt(x, y),
-            BinaryOperationKind::Le => Value::le(x, y),
-            BinaryOperationKind::Gt => Value::gt(x, y),
-            BinaryOperationKind::Ge => Value::ge(x, y),
-            BinaryOperationKind::In => Value::contains(x, y),
-            BinaryOperationKind::NotIn => Value::not_contains(x, y),
-            BinaryOperationKind::And => Value::and(x, y),
-            BinaryOperationKind::Or => Value::or(x, y),
+            BinaryOpKind::Add => Value::add(x, y),
+            BinaryOpKind::Sub => Value::sub(x, y),
+            BinaryOpKind::Mul => Value::mul(x, y),
+            BinaryOpKind::Div => Value::div(x, y),
+            BinaryOpKind::FloorDiv => Value::floor_div(x, y),
+            BinaryOpKind::Mod => Value::modulo(x, y),
+            BinaryOpKind::Eq => Value::eq(x, y),
+            BinaryOpKind::Ne => Value::ne(x, y),
+            BinaryOpKind::Lt => Value::lt(x, y),
+            BinaryOpKind::Le => Value::le(x, y),
+            BinaryOpKind::Gt => Value::gt(x, y),
+            BinaryOpKind::Ge => Value::ge(x, y),
+            BinaryOpKind::In => Value::contains(x, y),
+            BinaryOpKind::NotIn => Value::not_contains(x, y),
+            BinaryOpKind::And => Value::and(x, y),
+            BinaryOpKind::Or => Value::or(x, y),
         }
         .map_err(|source| Error::BinaryOperation { operation, source })?;
 
@@ -193,7 +161,7 @@ where
         frame: &mut Frame<FunctionId, StateId, Promise<Value>>,
         dst: waymark_vm_runtime_core::RegisterId,
         src: waymark_vm_runtime_core::RegisterId,
-        operation: UnaryOperationKind,
+        operation: UnaryOpKind,
     ) -> Result<(), Error> {
         let value = frame.regs.get(src).ok_or(Error::MissingUnaryOperand {
             operation,
@@ -204,8 +172,8 @@ where
             .map_err(|source| Error::UnresolvedUnaryOperand { operation, source })?;
 
         let value = match operation {
-            UnaryOperationKind::Neg => Value::neg(value),
-            UnaryOperationKind::Not => Value::not(value),
+            UnaryOpKind::Neg => Value::neg(value),
+            UnaryOpKind::Not => Value::not(value),
         }
         .map_err(|source| Error::UnaryOperation { operation, source })?;
 

--- a/crates/lib/vm-interpreter-pureset/src/value.rs
+++ b/crates/lib/vm-interpreter-pureset/src/value.rs
@@ -1,79 +1,6 @@
 //! Value requirements.
 
-/// A supported binary scalar operation.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum BinaryOperationKind {
-    /// Addition.
-    Add,
-
-    /// Subtraction.
-    Sub,
-
-    /// Multiplication.
-    Mul,
-
-    /// Division.
-    Div,
-
-    /// Floor division.
-    FloorDiv,
-
-    /// Modulo.
-    Mod,
-
-    /// Equality.
-    Eq,
-
-    /// Inequality.
-    Ne,
-
-    /// Less-than comparison.
-    Lt,
-
-    /// Less-than-or-equal comparison.
-    Le,
-
-    /// Greater-than comparison.
-    Gt,
-
-    /// Greater-than-or-equal comparison.
-    Ge,
-
-    /// Membership test.
-    In,
-
-    /// Negated membership test.
-    NotIn,
-
-    /// Logical `and`.
-    And,
-
-    /// Logical `or`.
-    Or,
-}
-
-impl core::fmt::Display for BinaryOperationKind {
-    fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        formatter.write_str(match self {
-            Self::Add => "+",
-            Self::Sub => "-",
-            Self::Mul => "*",
-            Self::Div => "/",
-            Self::FloorDiv => "//",
-            Self::Mod => "%",
-            Self::Eq => "==",
-            Self::Ne => "!=",
-            Self::Lt => "<",
-            Self::Le => "<=",
-            Self::Gt => ">",
-            Self::Ge => ">=",
-            Self::In => "in",
-            Self::NotIn => "not in",
-            Self::And => "and",
-            Self::Or => "or",
-        })
-    }
-}
+use waymark_vm_instructions_pureset::{BinaryOpKind, UnaryOpKind};
 
 /// An error from a binary scalar operation.
 #[derive(Debug, thiserror::Error)]
@@ -82,41 +9,22 @@ pub enum BinaryOperationError {
     #[error("{operation} is not supported for these operands")]
     UnsupportedOperation {
         /// The unsupported operation.
-        operation: BinaryOperationKind,
+        operation: BinaryOpKind,
     },
 
     /// The result could not be represented by the value type.
     #[error("{operation} result is out of bounds")]
     ResultOutOfBounds {
         /// The operation that overflowed or otherwise could not be represented.
-        operation: BinaryOperationKind,
+        operation: BinaryOpKind,
     },
 
     /// The operation attempted to divide by zero.
     #[error("{operation} cannot divide by zero")]
     DivisionByZero {
         /// The operation that attempted division by zero.
-        operation: BinaryOperationKind,
+        operation: BinaryOpKind,
     },
-}
-
-/// A supported unary scalar operation.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum UnaryOperationKind {
-    /// Numeric negation.
-    Neg,
-
-    /// Logical negation.
-    Not,
-}
-
-impl core::fmt::Display for UnaryOperationKind {
-    fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        formatter.write_str(match self {
-            Self::Neg => "-",
-            Self::Not => "not",
-        })
-    }
 }
 
 /// An error from a unary scalar operation.
@@ -126,14 +34,14 @@ pub enum UnaryOperationError {
     #[error("{operation} is not supported for this operand")]
     UnsupportedOperation {
         /// The unsupported operation.
-        operation: UnaryOperationKind,
+        operation: UnaryOpKind,
     },
 
     /// The result could not be represented by the value type.
     #[error("{operation} result is out of bounds")]
     ResultOutOfBounds {
         /// The operation that overflowed or otherwise could not be represented.
-        operation: UnaryOperationKind,
+        operation: UnaryOpKind,
     },
 }
 
@@ -155,7 +63,7 @@ pub trait BinaryOps: Sized {
     fn add(a: &Self, b: &Self) -> Result<Self, BinaryOperationError> {
         let _ = (a, b);
         Err(BinaryOperationError::UnsupportedOperation {
-            operation: BinaryOperationKind::Add,
+            operation: BinaryOpKind::Add,
         })
     }
 
@@ -163,7 +71,7 @@ pub trait BinaryOps: Sized {
     fn sub(a: &Self, b: &Self) -> Result<Self, BinaryOperationError> {
         let _ = (a, b);
         Err(BinaryOperationError::UnsupportedOperation {
-            operation: BinaryOperationKind::Sub,
+            operation: BinaryOpKind::Sub,
         })
     }
 
@@ -171,7 +79,7 @@ pub trait BinaryOps: Sized {
     fn mul(a: &Self, b: &Self) -> Result<Self, BinaryOperationError> {
         let _ = (a, b);
         Err(BinaryOperationError::UnsupportedOperation {
-            operation: BinaryOperationKind::Mul,
+            operation: BinaryOpKind::Mul,
         })
     }
 
@@ -179,7 +87,7 @@ pub trait BinaryOps: Sized {
     fn div(a: &Self, b: &Self) -> Result<Self, BinaryOperationError> {
         let _ = (a, b);
         Err(BinaryOperationError::UnsupportedOperation {
-            operation: BinaryOperationKind::Div,
+            operation: BinaryOpKind::Div,
         })
     }
 
@@ -187,7 +95,7 @@ pub trait BinaryOps: Sized {
     fn floor_div(a: &Self, b: &Self) -> Result<Self, BinaryOperationError> {
         let _ = (a, b);
         Err(BinaryOperationError::UnsupportedOperation {
-            operation: BinaryOperationKind::FloorDiv,
+            operation: BinaryOpKind::FloorDiv,
         })
     }
 
@@ -195,7 +103,7 @@ pub trait BinaryOps: Sized {
     fn modulo(a: &Self, b: &Self) -> Result<Self, BinaryOperationError> {
         let _ = (a, b);
         Err(BinaryOperationError::UnsupportedOperation {
-            operation: BinaryOperationKind::Mod,
+            operation: BinaryOpKind::Mod,
         })
     }
 
@@ -203,7 +111,7 @@ pub trait BinaryOps: Sized {
     fn eq(a: &Self, b: &Self) -> Result<Self, BinaryOperationError> {
         let _ = (a, b);
         Err(BinaryOperationError::UnsupportedOperation {
-            operation: BinaryOperationKind::Eq,
+            operation: BinaryOpKind::Eq,
         })
     }
 
@@ -211,7 +119,7 @@ pub trait BinaryOps: Sized {
     fn ne(a: &Self, b: &Self) -> Result<Self, BinaryOperationError> {
         let _ = (a, b);
         Err(BinaryOperationError::UnsupportedOperation {
-            operation: BinaryOperationKind::Ne,
+            operation: BinaryOpKind::Ne,
         })
     }
 
@@ -219,7 +127,7 @@ pub trait BinaryOps: Sized {
     fn lt(a: &Self, b: &Self) -> Result<Self, BinaryOperationError> {
         let _ = (a, b);
         Err(BinaryOperationError::UnsupportedOperation {
-            operation: BinaryOperationKind::Lt,
+            operation: BinaryOpKind::Lt,
         })
     }
 
@@ -227,7 +135,7 @@ pub trait BinaryOps: Sized {
     fn le(a: &Self, b: &Self) -> Result<Self, BinaryOperationError> {
         let _ = (a, b);
         Err(BinaryOperationError::UnsupportedOperation {
-            operation: BinaryOperationKind::Le,
+            operation: BinaryOpKind::Le,
         })
     }
 
@@ -235,7 +143,7 @@ pub trait BinaryOps: Sized {
     fn gt(a: &Self, b: &Self) -> Result<Self, BinaryOperationError> {
         let _ = (a, b);
         Err(BinaryOperationError::UnsupportedOperation {
-            operation: BinaryOperationKind::Gt,
+            operation: BinaryOpKind::Gt,
         })
     }
 
@@ -243,7 +151,7 @@ pub trait BinaryOps: Sized {
     fn ge(a: &Self, b: &Self) -> Result<Self, BinaryOperationError> {
         let _ = (a, b);
         Err(BinaryOperationError::UnsupportedOperation {
-            operation: BinaryOperationKind::Ge,
+            operation: BinaryOpKind::Ge,
         })
     }
 
@@ -251,7 +159,7 @@ pub trait BinaryOps: Sized {
     fn contains(a: &Self, b: &Self) -> Result<Self, BinaryOperationError> {
         let _ = (a, b);
         Err(BinaryOperationError::UnsupportedOperation {
-            operation: BinaryOperationKind::In,
+            operation: BinaryOpKind::In,
         })
     }
 
@@ -259,7 +167,7 @@ pub trait BinaryOps: Sized {
     fn not_contains(a: &Self, b: &Self) -> Result<Self, BinaryOperationError> {
         let _ = (a, b);
         Err(BinaryOperationError::UnsupportedOperation {
-            operation: BinaryOperationKind::NotIn,
+            operation: BinaryOpKind::NotIn,
         })
     }
 
@@ -267,7 +175,7 @@ pub trait BinaryOps: Sized {
     fn and(a: &Self, b: &Self) -> Result<Self, BinaryOperationError> {
         let _ = (a, b);
         Err(BinaryOperationError::UnsupportedOperation {
-            operation: BinaryOperationKind::And,
+            operation: BinaryOpKind::And,
         })
     }
 
@@ -275,7 +183,7 @@ pub trait BinaryOps: Sized {
     fn or(a: &Self, b: &Self) -> Result<Self, BinaryOperationError> {
         let _ = (a, b);
         Err(BinaryOperationError::UnsupportedOperation {
-            operation: BinaryOperationKind::Or,
+            operation: BinaryOpKind::Or,
         })
     }
 }
@@ -286,7 +194,7 @@ pub trait UnaryOps: Sized {
     fn neg(value: &Self) -> Result<Self, UnaryOperationError> {
         let _ = value;
         Err(UnaryOperationError::UnsupportedOperation {
-            operation: UnaryOperationKind::Neg,
+            operation: UnaryOpKind::Neg,
         })
     }
 
@@ -294,7 +202,7 @@ pub trait UnaryOps: Sized {
     fn not(value: &Self) -> Result<Self, UnaryOperationError> {
         let _ = value;
         Err(UnaryOperationError::UnsupportedOperation {
-            operation: UnaryOperationKind::Not,
+            operation: UnaryOpKind::Not,
         })
     }
 }

--- a/crates/lib/vm-interpreter-pureset/src/value.rs
+++ b/crates/lib/vm-interpreter-pureset/src/value.rs
@@ -1,15 +1,140 @@
 //! Value requirements.
 
-/// An error from [`Value::add`].
-#[derive(Debug, thiserror::Error)]
-pub enum AddError {
-    /// At least one operand did not support addition.
-    #[error("adding non-addable values")]
-    NotAddable,
+/// A supported binary scalar operation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum BinaryOperationKind {
+    /// Addition.
+    Add,
 
-    /// The addition result could not be represented by the value type.
-    #[error("addition result is out of bounds")]
-    ResultOutOfBounds,
+    /// Subtraction.
+    Sub,
+
+    /// Multiplication.
+    Mul,
+
+    /// Division.
+    Div,
+
+    /// Floor division.
+    FloorDiv,
+
+    /// Modulo.
+    Mod,
+
+    /// Equality.
+    Eq,
+
+    /// Inequality.
+    Ne,
+
+    /// Less-than comparison.
+    Lt,
+
+    /// Less-than-or-equal comparison.
+    Le,
+
+    /// Greater-than comparison.
+    Gt,
+
+    /// Greater-than-or-equal comparison.
+    Ge,
+
+    /// Membership test.
+    In,
+
+    /// Negated membership test.
+    NotIn,
+
+    /// Logical `and`.
+    And,
+
+    /// Logical `or`.
+    Or,
+}
+
+impl core::fmt::Display for BinaryOperationKind {
+    fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        formatter.write_str(match self {
+            Self::Add => "+",
+            Self::Sub => "-",
+            Self::Mul => "*",
+            Self::Div => "/",
+            Self::FloorDiv => "//",
+            Self::Mod => "%",
+            Self::Eq => "==",
+            Self::Ne => "!=",
+            Self::Lt => "<",
+            Self::Le => "<=",
+            Self::Gt => ">",
+            Self::Ge => ">=",
+            Self::In => "in",
+            Self::NotIn => "not in",
+            Self::And => "and",
+            Self::Or => "or",
+        })
+    }
+}
+
+/// An error from a binary scalar operation.
+#[derive(Debug, thiserror::Error)]
+pub enum BinaryOperationError {
+    /// The current value type does not support this operation for the operands.
+    #[error("{operation} is not supported for these operands")]
+    UnsupportedOperation {
+        /// The unsupported operation.
+        operation: BinaryOperationKind,
+    },
+
+    /// The result could not be represented by the value type.
+    #[error("{operation} result is out of bounds")]
+    ResultOutOfBounds {
+        /// The operation that overflowed or otherwise could not be represented.
+        operation: BinaryOperationKind,
+    },
+
+    /// The operation attempted to divide by zero.
+    #[error("{operation} cannot divide by zero")]
+    DivisionByZero {
+        /// The operation that attempted division by zero.
+        operation: BinaryOperationKind,
+    },
+}
+
+/// A supported unary scalar operation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum UnaryOperationKind {
+    /// Numeric negation.
+    Neg,
+
+    /// Logical negation.
+    Not,
+}
+
+impl core::fmt::Display for UnaryOperationKind {
+    fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        formatter.write_str(match self {
+            Self::Neg => "-",
+            Self::Not => "not",
+        })
+    }
+}
+
+/// An error from a unary scalar operation.
+#[derive(Debug, thiserror::Error)]
+pub enum UnaryOperationError {
+    /// The current value type does not support this operation for the operand.
+    #[error("{operation} is not supported for this operand")]
+    UnsupportedOperation {
+        /// The unsupported operation.
+        operation: UnaryOperationKind,
+    },
+
+    /// The result could not be represented by the value type.
+    #[error("{operation} result is out of bounds")]
+    ResultOutOfBounds {
+        /// The operation that overflowed or otherwise could not be represented.
+        operation: UnaryOperationKind,
+    },
 }
 
 /// An error from [`MakeList::make_list`].
@@ -24,10 +149,154 @@ pub enum MakeListError {
     ResultOutOfBounds,
 }
 
-/// Add two values together and obtain a sum of them.
-pub trait Add: Sized {
-    /// Add two resolved values and return the resulting value.
-    fn add(a: &Self, b: &Self) -> Result<Self, AddError>;
+/// Apply binary scalar operations to resolved values.
+pub trait BinaryOps: Sized {
+    /// Add two resolved values together.
+    fn add(a: &Self, b: &Self) -> Result<Self, BinaryOperationError> {
+        let _ = (a, b);
+        Err(BinaryOperationError::UnsupportedOperation {
+            operation: BinaryOperationKind::Add,
+        })
+    }
+
+    /// Subtract the right value from the left value.
+    fn sub(a: &Self, b: &Self) -> Result<Self, BinaryOperationError> {
+        let _ = (a, b);
+        Err(BinaryOperationError::UnsupportedOperation {
+            operation: BinaryOperationKind::Sub,
+        })
+    }
+
+    /// Multiply two resolved values together.
+    fn mul(a: &Self, b: &Self) -> Result<Self, BinaryOperationError> {
+        let _ = (a, b);
+        Err(BinaryOperationError::UnsupportedOperation {
+            operation: BinaryOperationKind::Mul,
+        })
+    }
+
+    /// Divide the left value by the right value.
+    fn div(a: &Self, b: &Self) -> Result<Self, BinaryOperationError> {
+        let _ = (a, b);
+        Err(BinaryOperationError::UnsupportedOperation {
+            operation: BinaryOperationKind::Div,
+        })
+    }
+
+    /// Floor-divide the left value by the right value.
+    fn floor_div(a: &Self, b: &Self) -> Result<Self, BinaryOperationError> {
+        let _ = (a, b);
+        Err(BinaryOperationError::UnsupportedOperation {
+            operation: BinaryOperationKind::FloorDiv,
+        })
+    }
+
+    /// Compute the left value modulo the right value.
+    fn modulo(a: &Self, b: &Self) -> Result<Self, BinaryOperationError> {
+        let _ = (a, b);
+        Err(BinaryOperationError::UnsupportedOperation {
+            operation: BinaryOperationKind::Mod,
+        })
+    }
+
+    /// Compare two resolved values for equality.
+    fn eq(a: &Self, b: &Self) -> Result<Self, BinaryOperationError> {
+        let _ = (a, b);
+        Err(BinaryOperationError::UnsupportedOperation {
+            operation: BinaryOperationKind::Eq,
+        })
+    }
+
+    /// Compare two resolved values for inequality.
+    fn ne(a: &Self, b: &Self) -> Result<Self, BinaryOperationError> {
+        let _ = (a, b);
+        Err(BinaryOperationError::UnsupportedOperation {
+            operation: BinaryOperationKind::Ne,
+        })
+    }
+
+    /// Compare whether the left value is less than the right value.
+    fn lt(a: &Self, b: &Self) -> Result<Self, BinaryOperationError> {
+        let _ = (a, b);
+        Err(BinaryOperationError::UnsupportedOperation {
+            operation: BinaryOperationKind::Lt,
+        })
+    }
+
+    /// Compare whether the left value is less than or equal to the right value.
+    fn le(a: &Self, b: &Self) -> Result<Self, BinaryOperationError> {
+        let _ = (a, b);
+        Err(BinaryOperationError::UnsupportedOperation {
+            operation: BinaryOperationKind::Le,
+        })
+    }
+
+    /// Compare whether the left value is greater than the right value.
+    fn gt(a: &Self, b: &Self) -> Result<Self, BinaryOperationError> {
+        let _ = (a, b);
+        Err(BinaryOperationError::UnsupportedOperation {
+            operation: BinaryOperationKind::Gt,
+        })
+    }
+
+    /// Compare whether the left value is greater than or equal to the right value.
+    fn ge(a: &Self, b: &Self) -> Result<Self, BinaryOperationError> {
+        let _ = (a, b);
+        Err(BinaryOperationError::UnsupportedOperation {
+            operation: BinaryOperationKind::Ge,
+        })
+    }
+
+    /// Test whether the left value is contained in the right value.
+    fn contains(a: &Self, b: &Self) -> Result<Self, BinaryOperationError> {
+        let _ = (a, b);
+        Err(BinaryOperationError::UnsupportedOperation {
+            operation: BinaryOperationKind::In,
+        })
+    }
+
+    /// Test whether the left value is not contained in the right value.
+    fn not_contains(a: &Self, b: &Self) -> Result<Self, BinaryOperationError> {
+        let _ = (a, b);
+        Err(BinaryOperationError::UnsupportedOperation {
+            operation: BinaryOperationKind::NotIn,
+        })
+    }
+
+    /// Apply Python-style logical `and` to two resolved values.
+    fn and(a: &Self, b: &Self) -> Result<Self, BinaryOperationError> {
+        let _ = (a, b);
+        Err(BinaryOperationError::UnsupportedOperation {
+            operation: BinaryOperationKind::And,
+        })
+    }
+
+    /// Apply Python-style logical `or` to two resolved values.
+    fn or(a: &Self, b: &Self) -> Result<Self, BinaryOperationError> {
+        let _ = (a, b);
+        Err(BinaryOperationError::UnsupportedOperation {
+            operation: BinaryOperationKind::Or,
+        })
+    }
+}
+
+/// Apply unary scalar operations to resolved values.
+pub trait UnaryOps: Sized {
+    /// Negate the resolved operand value.
+    fn neg(value: &Self) -> Result<Self, UnaryOperationError> {
+        let _ = value;
+        Err(UnaryOperationError::UnsupportedOperation {
+            operation: UnaryOperationKind::Neg,
+        })
+    }
+
+    /// Apply Python-style logical `not` to the resolved operand value.
+    fn not(value: &Self) -> Result<Self, UnaryOperationError> {
+        let _ = value;
+        Err(UnaryOperationError::UnsupportedOperation {
+            operation: UnaryOperationKind::Not,
+        })
+    }
 }
 
 /// Build a list value from a sequence of resolved items.
@@ -39,6 +308,6 @@ pub trait MakeList: Sized {
 }
 
 /// A unifying trait for all value requirements.
-pub trait Value: Add + MakeList {}
+pub trait Value: BinaryOps + UnaryOps + MakeList {}
 
-impl<T> Value for T where T: Add + MakeList {}
+impl<T> Value for T where T: BinaryOps + UnaryOps + MakeList {}

--- a/crates/lib/vm-interpreter-pureset/tests/integration.rs
+++ b/crates/lib/vm-interpreter-pureset/tests/integration.rs
@@ -22,6 +22,7 @@ enum TestConstValue {
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum TestValue {
     Int(i64),
+    Bool(bool),
     Text(&'static str),
     List(Vec<TestValue>),
 }
@@ -35,12 +36,49 @@ impl From<TestConstValue> for TestValue {
     }
 }
 
-impl waymark_vm_interpreter_pureset::value::Add for TestValue {
-    fn add(a: &Self, b: &Self) -> Result<Self, waymark_vm_interpreter_pureset::value::AddError> {
+fn is_truthy(value: &TestValue) -> bool {
+    match value {
+        TestValue::Int(value) => *value != 0,
+        TestValue::Bool(value) => *value,
+        TestValue::Text(value) => !value.is_empty(),
+        TestValue::List(items) => !items.is_empty(),
+    }
+}
+
+impl waymark_vm_interpreter_pureset::value::BinaryOps for TestValue {
+    fn add(
+        a: &Self,
+        b: &Self,
+    ) -> Result<Self, waymark_vm_interpreter_pureset::value::BinaryOperationError> {
         match (a, b) {
-            (Self::Int(a), Self::Int(b)) => Ok(Self::Int(a + b)),
-            _ => Err(waymark_vm_interpreter_pureset::value::AddError::NotAddable),
+            (Self::Int(a), Self::Int(b)) => Ok(Self::Int(*a + *b)),
+            _ => Err(
+                waymark_vm_interpreter_pureset::value::BinaryOperationError::UnsupportedOperation {
+                    operation: waymark_vm_interpreter_pureset::value::BinaryOperationKind::Add,
+                },
+            ),
         }
+    }
+}
+
+impl waymark_vm_interpreter_pureset::value::UnaryOps for TestValue {
+    fn neg(
+        value: &Self,
+    ) -> Result<Self, waymark_vm_interpreter_pureset::value::UnaryOperationError> {
+        match value {
+            Self::Int(value) => Ok(Self::Int(-*value)),
+            _ => Err(
+                waymark_vm_interpreter_pureset::value::UnaryOperationError::UnsupportedOperation {
+                    operation: waymark_vm_interpreter_pureset::value::UnaryOperationKind::Neg,
+                },
+            ),
+        }
+    }
+
+    fn not(
+        value: &Self,
+    ) -> Result<Self, waymark_vm_interpreter_pureset::value::UnaryOperationError> {
+        Ok(Self::Bool(!is_truthy(value)))
     }
 }
 
@@ -230,7 +268,14 @@ fn runtime_surfaces_add_errors_from_the_pureset_interpreter() {
     assert!(matches!(
         runtime.run(),
         Err(RunError::Step(waymark_vm_runtime::step::Error::Execution(
-            Error::Add(waymark_vm_interpreter_pureset::value::AddError::NotAddable)
+            Error::BinaryOperation {
+                operation: waymark_vm_interpreter_pureset::value::BinaryOperationKind::Add,
+                source:
+                    waymark_vm_interpreter_pureset::value::BinaryOperationError::UnsupportedOperation {
+                        operation:
+                            waymark_vm_interpreter_pureset::value::BinaryOperationKind::Add,
+                    },
+            }
         )))
     ));
 }
@@ -266,12 +311,44 @@ fn runtime_surfaces_unresolved_add_operand_errors_from_the_pureset_interpreter()
     assert!(matches!(
         runtime.run(),
         Err(RunError::Step(waymark_vm_runtime::step::Error::Execution(
-            Error::UnresolvedAddOperand {
+            Error::UnresolvedBinaryOperand {
+                operation: waymark_vm_interpreter_pureset::value::BinaryOperationKind::Add,
                 operand_pos: BinaryOperandPosition::First,
                 source: waymark_vm_runtime_core::UnresolvedPromiseError { promise_state_id },
             }
         ))) if promise_state_id == PromiseStateId(7)
     ));
+}
+
+#[test]
+fn runtime_executes_unary_not_to_a_terminal_effect() {
+    let executable = executable(vec![function::<RuntimeInstruction>(
+        2,
+        vec![vec![
+            PureSet::LoadConst {
+                dst: RegisterId(0),
+                value: TestConstValue::Int(0),
+            }
+            .into(),
+            PureSet::Not {
+                dst: RegisterId(1),
+                src: RegisterId(0),
+            }
+            .into(),
+            RuntimeInstruction::EmitRegister(RegisterId(1)),
+        ]],
+    )]);
+
+    let mut runtime =
+        Runtime::with_conventional_entrypoint(RuntimeInterpreter::default(), executable)
+            .expect("function 0 should exist");
+
+    assert_eq!(
+        runtime
+            .run()
+            .expect("runtime should emit the unary-not result"),
+        TestValue::Bool(true)
+    );
 }
 
 #[test]

--- a/crates/lib/vm-interpreter-pureset/tests/integration.rs
+++ b/crates/lib/vm-interpreter-pureset/tests/integration.rs
@@ -183,11 +183,11 @@ fn runtime_executes_load_const_and_add_to_a_terminal_effect() {
                 value: TestConstValue::Int(3),
             }
             .into(),
-            PureSet::Add {
+            PureSet::Add(waymark_vm_instructions_pureset::BinaryOp {
                 dst: RegisterId(2),
                 a: RegisterId(0),
                 b: RegisterId(1),
-            }
+            })
             .into(),
             RuntimeInstruction::EmitRegister(RegisterId(2)),
         ]],
@@ -251,11 +251,11 @@ fn runtime_surfaces_add_errors_from_the_pureset_interpreter() {
                 value: TestConstValue::Int(3),
             }
             .into(),
-            PureSet::Add {
+            PureSet::Add(waymark_vm_instructions_pureset::BinaryOp {
                 dst: RegisterId(0),
                 a: RegisterId(0),
                 b: RegisterId(1),
-            }
+            })
             .into(),
             RuntimeInstruction::EmitRegister(RegisterId(0)),
         ]],
@@ -294,11 +294,11 @@ fn runtime_surfaces_unresolved_add_operand_errors_from_the_pureset_interpreter()
                 value: TestConstValue::Int(3),
             }
             .into(),
-            PureSet::Add {
+            PureSet::Add(waymark_vm_instructions_pureset::BinaryOp {
                 dst: RegisterId(0),
                 a: RegisterId(0),
                 b: RegisterId(1),
-            }
+            })
             .into(),
             RuntimeInstruction::EmitRegister(RegisterId(0)),
         ]],
@@ -330,10 +330,10 @@ fn runtime_executes_unary_not_to_a_terminal_effect() {
                 value: TestConstValue::Int(0),
             }
             .into(),
-            PureSet::Not {
+            PureSet::Not(waymark_vm_instructions_pureset::UnaryOp {
                 dst: RegisterId(1),
                 src: RegisterId(0),
-            }
+            })
             .into(),
             RuntimeInstruction::EmitRegister(RegisterId(1)),
         ]],

--- a/crates/lib/vm-interpreter-pureset/tests/integration.rs
+++ b/crates/lib/vm-interpreter-pureset/tests/integration.rs
@@ -183,11 +183,14 @@ fn runtime_executes_load_const_and_add_to_a_terminal_effect() {
                 value: TestConstValue::Int(3),
             }
             .into(),
-            PureSet::Add(waymark_vm_instructions_pureset::BinaryOp {
-                dst: RegisterId(2),
-                a: RegisterId(0),
-                b: RegisterId(1),
-            })
+            PureSet::Binary {
+                kind: waymark_vm_instructions_pureset::BinaryOpKind::Add,
+                op: waymark_vm_instructions_pureset::BinaryOp {
+                    dst: RegisterId(2),
+                    a: RegisterId(0),
+                    b: RegisterId(1),
+                },
+            }
             .into(),
             RuntimeInstruction::EmitRegister(RegisterId(2)),
         ]],
@@ -251,11 +254,14 @@ fn runtime_surfaces_add_errors_from_the_pureset_interpreter() {
                 value: TestConstValue::Int(3),
             }
             .into(),
-            PureSet::Add(waymark_vm_instructions_pureset::BinaryOp {
-                dst: RegisterId(0),
-                a: RegisterId(0),
-                b: RegisterId(1),
-            })
+            PureSet::Binary {
+                kind: waymark_vm_instructions_pureset::BinaryOpKind::Add,
+                op: waymark_vm_instructions_pureset::BinaryOp {
+                    dst: RegisterId(0),
+                    a: RegisterId(0),
+                    b: RegisterId(1),
+                },
+            }
             .into(),
             RuntimeInstruction::EmitRegister(RegisterId(0)),
         ]],
@@ -294,11 +300,14 @@ fn runtime_surfaces_unresolved_add_operand_errors_from_the_pureset_interpreter()
                 value: TestConstValue::Int(3),
             }
             .into(),
-            PureSet::Add(waymark_vm_instructions_pureset::BinaryOp {
-                dst: RegisterId(0),
-                a: RegisterId(0),
-                b: RegisterId(1),
-            })
+            PureSet::Binary {
+                kind: waymark_vm_instructions_pureset::BinaryOpKind::Add,
+                op: waymark_vm_instructions_pureset::BinaryOp {
+                    dst: RegisterId(0),
+                    a: RegisterId(0),
+                    b: RegisterId(1),
+                },
+            }
             .into(),
             RuntimeInstruction::EmitRegister(RegisterId(0)),
         ]],
@@ -330,10 +339,13 @@ fn runtime_executes_unary_not_to_a_terminal_effect() {
                 value: TestConstValue::Int(0),
             }
             .into(),
-            PureSet::Not(waymark_vm_instructions_pureset::UnaryOp {
-                dst: RegisterId(1),
-                src: RegisterId(0),
-            })
+            PureSet::Unary {
+                kind: waymark_vm_instructions_pureset::UnaryOpKind::Not,
+                op: waymark_vm_instructions_pureset::UnaryOp {
+                    dst: RegisterId(1),
+                    src: RegisterId(0),
+                },
+            }
             .into(),
             RuntimeInstruction::EmitRegister(RegisterId(1)),
         ]],

--- a/crates/lib/vm-interpreter-pureset/tests/integration.rs
+++ b/crates/lib/vm-interpreter-pureset/tests/integration.rs
@@ -1,4 +1,4 @@
-use waymark_vm_instructions_pureset::PureSet;
+use waymark_vm_instructions_pureset::{BinaryOpKind, PureSet, UnaryOpKind};
 use waymark_vm_interpreter::ExecutionOutcome;
 use waymark_vm_interpreter_pureset::{BinaryOperandPosition, Error, PureSetInterpreter};
 use waymark_vm_runtime::{RunError, Runtime};
@@ -54,7 +54,7 @@ impl waymark_vm_interpreter_pureset::value::BinaryOps for TestValue {
             (Self::Int(a), Self::Int(b)) => Ok(Self::Int(*a + *b)),
             _ => Err(
                 waymark_vm_interpreter_pureset::value::BinaryOperationError::UnsupportedOperation {
-                    operation: waymark_vm_interpreter_pureset::value::BinaryOperationKind::Add,
+                    operation: BinaryOpKind::Add,
                 },
             ),
         }
@@ -69,7 +69,7 @@ impl waymark_vm_interpreter_pureset::value::UnaryOps for TestValue {
             Self::Int(value) => Ok(Self::Int(-*value)),
             _ => Err(
                 waymark_vm_interpreter_pureset::value::UnaryOperationError::UnsupportedOperation {
-                    operation: waymark_vm_interpreter_pureset::value::UnaryOperationKind::Neg,
+                    operation: UnaryOpKind::Neg,
                 },
             ),
         }
@@ -275,11 +275,10 @@ fn runtime_surfaces_add_errors_from_the_pureset_interpreter() {
         runtime.run(),
         Err(RunError::Step(waymark_vm_runtime::step::Error::Execution(
             Error::BinaryOperation {
-                operation: waymark_vm_interpreter_pureset::value::BinaryOperationKind::Add,
+                operation: BinaryOpKind::Add,
                 source:
                     waymark_vm_interpreter_pureset::value::BinaryOperationError::UnsupportedOperation {
-                        operation:
-                            waymark_vm_interpreter_pureset::value::BinaryOperationKind::Add,
+                        operation: BinaryOpKind::Add,
                     },
             }
         )))
@@ -321,7 +320,7 @@ fn runtime_surfaces_unresolved_add_operand_errors_from_the_pureset_interpreter()
         runtime.run(),
         Err(RunError::Step(waymark_vm_runtime::step::Error::Execution(
             Error::UnresolvedBinaryOperand {
-                operation: waymark_vm_interpreter_pureset::value::BinaryOperationKind::Add,
+                operation: BinaryOpKind::Add,
                 operand_pos: BinaryOperandPosition::First,
                 source: waymark_vm_runtime_core::UnresolvedPromiseError { promise_state_id },
             }


### PR DESCRIPTION
This PR goes in after #398 and add support for binary and unary operations to the VM.