### PR TITLE
Proper VM extcalls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5178,9 +5178,11 @@ dependencies = [
  "waymark-vm-compiler-for-ast-old-core",
  "waymark-vm-driver",
  "waymark-vm-instructions-coreset",
+ "waymark-vm-instructions-extcallset",
  "waymark-vm-instructions-fullset",
  "waymark-vm-instructions-pureset",
  "waymark-vm-interpreter-coreset",
+ "waymark-vm-interpreter-extcallset",
  "waymark-vm-interpreter-fullset",
  "waymark-vm-interpreter-pureset",
  "waymark-vm-runtime",
@@ -5206,9 +5208,11 @@ dependencies = [
  "waymark-vm-compiler-for-ast-old-core",
  "waymark-vm-compiler-for-ast-old-test-support",
  "waymark-vm-instructions-coreset",
+ "waymark-vm-instructions-extcallset",
  "waymark-vm-instructions-fullset",
  "waymark-vm-instructions-pureset",
  "waymark-vm-interpreter-coreset",
+ "waymark-vm-interpreter-extcallset",
  "waymark-vm-interpreter-fullset",
  "waymark-vm-interpreter-pureset",
  "waymark-vm-runtime",
@@ -5223,6 +5227,7 @@ dependencies = [
  "waymark-vm-bytecode",
  "waymark-vm-bytecode-core",
  "waymark-vm-instructions-coreset",
+ "waymark-vm-instructions-extcallset",
  "waymark-vm-instructions-fullset",
  "waymark-vm-instructions-pureset",
  "waymark-vm-runtime-core",
@@ -5236,6 +5241,7 @@ dependencies = [
  "waymark-vm-bytecode-core",
  "waymark-vm-compiler-for-ast-old-core",
  "waymark-vm-instructions-coreset",
+ "waymark-vm-instructions-extcallset",
  "waymark-vm-instructions-pureset",
  "waymark-vm-runtime-core",
 ]
@@ -5265,11 +5271,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "waymark-vm-instructions-extcallset"
+version = "0.1.0"
+dependencies = [
+ "derive-where",
+]
+
+[[package]]
 name = "waymark-vm-instructions-fullset"
 version = "0.1.0"
 dependencies = [
  "derive-where",
  "waymark-vm-instructions-coreset",
+ "waymark-vm-instructions-extcallset",
  "waymark-vm-instructions-pureset",
 ]
 
@@ -5299,6 +5313,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "waymark-vm-interpreter-extcallset"
+version = "0.1.0"
+dependencies = [
+ "derive-where",
+ "thiserror",
+ "waymark-vm-instructions-extcallset",
+ "waymark-vm-interpreter",
+ "waymark-vm-runtime",
+ "waymark-vm-runtime-core",
+ "waymark-vm-runtime-test",
+]
+
+[[package]]
 name = "waymark-vm-interpreter-fullset"
 version = "0.1.0"
 dependencies = [
@@ -5306,10 +5333,12 @@ dependencies = [
  "thiserror",
  "waymark-vm-executable",
  "waymark-vm-instructions-coreset",
+ "waymark-vm-instructions-extcallset",
  "waymark-vm-instructions-fullset",
  "waymark-vm-instructions-pureset",
  "waymark-vm-interpreter",
  "waymark-vm-interpreter-coreset",
+ "waymark-vm-interpreter-extcallset",
  "waymark-vm-interpreter-pureset",
  "waymark-vm-runtime",
  "waymark-vm-runtime-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,10 +76,12 @@ waymark-vm-compiler-for-ast-old-test-support = { path = "crates/lib/vm-compiler-
 waymark-vm-driver = { path = "crates/lib/vm-driver" }
 waymark-vm-executable = { path = "crates/lib/vm-executable" }
 waymark-vm-instructions-coreset = { path = "crates/lib/vm-instructions-coreset" }
+waymark-vm-instructions-extcallset = { path = "crates/lib/vm-instructions-extcallset" }
 waymark-vm-instructions-fullset = { path = "crates/lib/vm-instructions-fullset" }
 waymark-vm-instructions-pureset = { path = "crates/lib/vm-instructions-pureset" }
 waymark-vm-interpreter = { path = "crates/lib/vm-interpreter" }
 waymark-vm-interpreter-coreset = { path = "crates/lib/vm-interpreter-coreset" }
+waymark-vm-interpreter-extcallset = { path = "crates/lib/vm-interpreter-extcallset" }
 waymark-vm-interpreter-fullset = { path = "crates/lib/vm-interpreter-fullset" }
 waymark-vm-interpreter-pureset = { path = "crates/lib/vm-interpreter-pureset" }
 waymark-vm-interpreter-utils = { path = "crates/lib/vm-interpreter-utils" }

--- a/crates/bin/vm-cli/Cargo.toml
+++ b/crates/bin/vm-cli/Cargo.toml
@@ -14,9 +14,11 @@ waymark-vm-compiler-for-ast-old = { workspace = true }
 waymark-vm-compiler-for-ast-old-core = { workspace = true }
 waymark-vm-driver = { workspace = true }
 waymark-vm-instructions-coreset = { workspace = true }
+waymark-vm-instructions-extcallset = { workspace = true }
 waymark-vm-instructions-fullset = { workspace = true }
 waymark-vm-instructions-pureset = { workspace = true }
 waymark-vm-interpreter-coreset = { workspace = true }
+waymark-vm-interpreter-extcallset = { workspace = true }
 waymark-vm-interpreter-fullset = { workspace = true }
 waymark-vm-interpreter-pureset = { workspace = true }
 waymark-vm-runtime = { workspace = true }

--- a/crates/bin/vm-cli/src/integration.rs
+++ b/crates/bin/vm-cli/src/integration.rs
@@ -16,7 +16,7 @@ impl waymark_vm_instructions_coreset::Spec for SampleSpec {
 impl waymark_vm_instructions_extcallset::Spec for SampleSpec {
     type RegisterId = waymark_vm_runtime_core::RegisterId;
     type StateId = waymark_vm_bytecode_core::StateId;
-    type ExtCallId = SampleExtCallId;
+    type ActionRef = SampleActionRef;
 }
 
 impl waymark_vm_instructions_pureset::Spec for SampleSpec {
@@ -36,7 +36,7 @@ pub enum SampleValue {
 }
 
 #[derive(Debug, Clone)]
-pub struct SampleExtCallId(#[allow(dead_code)] pub usize);
+pub struct SampleActionRef(#[allow(dead_code)] pub usize);
 
 impl waymark_vm_interpreter_coreset::value::ShouldJump for SampleValue {
     fn should_jump(
@@ -91,14 +91,14 @@ pub struct UnsupportedLoweringError;
 
 impl<Spec> waymark_vm_compiler_for_ast_old_core::lowering::ExtCallSet<Spec> for SampleLowering
 where
-    Spec: waymark_vm_instructions_extcallset::Spec<ExtCallId = SampleExtCallId>,
+    Spec: waymark_vm_instructions_extcallset::Spec<ActionRef = SampleActionRef>,
 {
     type ActionError = UnsupportedLoweringError;
 
     fn lower_action(
         _call: &waymark_vm_ast_old::ActionCall,
-    ) -> Result<Spec::ExtCallId, Self::ActionError> {
-        Ok(SampleExtCallId(1337))
+    ) -> Result<Spec::ActionRef, Self::ActionError> {
+        Ok(SampleActionRef(1337))
     }
 }
 

--- a/crates/bin/vm-cli/src/integration.rs
+++ b/crates/bin/vm-cli/src/integration.rs
@@ -10,8 +10,13 @@ pub struct SampleLowering;
 impl waymark_vm_instructions_coreset::Spec for SampleSpec {
     type RegisterId = waymark_vm_runtime_core::RegisterId;
     type FunctionId = waymark_vm_bytecode_core::FunctionId;
-    type ExtCallId = SampleExtCallId;
     type StateId = waymark_vm_bytecode_core::StateId;
+}
+
+impl waymark_vm_instructions_extcallset::Spec for SampleSpec {
+    type RegisterId = waymark_vm_runtime_core::RegisterId;
+    type StateId = waymark_vm_bytecode_core::StateId;
+    type ExtCallId = SampleExtCallId;
 }
 
 impl waymark_vm_instructions_pureset::Spec for SampleSpec {
@@ -84,9 +89,9 @@ impl From<SampleConstValue> for SampleValue {
 #[error("unsupported lowering")]
 pub struct UnsupportedLoweringError;
 
-impl<Spec> waymark_vm_compiler_for_ast_old_core::lowering::CoreSet<Spec> for SampleLowering
+impl<Spec> waymark_vm_compiler_for_ast_old_core::lowering::ExtCallSet<Spec> for SampleLowering
 where
-    Spec: waymark_vm_instructions_coreset::Spec<ExtCallId = SampleExtCallId>,
+    Spec: waymark_vm_instructions_extcallset::Spec<ExtCallId = SampleExtCallId>,
 {
     type ActionError = UnsupportedLoweringError;
 

--- a/crates/bin/vm-cli/src/run.rs
+++ b/crates/bin/vm-cli/src/run.rs
@@ -40,7 +40,9 @@ pub async fn run(
                             completion_tx.send(value).unwrap();
                             break;
                         }
-                        waymark_vm_interpreter_coreset::Effect::ExtCall {
+                    },
+                    waymark_vm_interpreter_fullset::Effect::ExtCallSet(effect) => match effect {
+                        waymark_vm_interpreter_extcallset::Effect::ExtCall {
                             promise_state_id,
                             extcall_id,
                             args,

--- a/crates/bin/vm-cli/src/run.rs
+++ b/crates/bin/vm-cli/src/run.rs
@@ -42,13 +42,13 @@ pub async fn run(
                         }
                     },
                     waymark_vm_interpreter_fullset::Effect::ExtCallSet(effect) => match effect {
-                        waymark_vm_interpreter_extcallset::Effect::ExtCall {
+                        waymark_vm_interpreter_extcallset::Effect::ActionCall {
                             promise_state_id,
-                            extcall_id,
+                            action_ref,
                             args,
                         } => {
                             tracing::info!(
-                                ?extcall_id,
+                                ?action_ref,
                                 ?promise_state_id,
                                 ?args,
                                 "extcall received"
@@ -61,7 +61,7 @@ pub async fn run(
 
                                     let value = integration::SampleValue::Usize(42);
                                     tracing::info!(
-                                        ?extcall_id,
+                                        ?action_ref,
                                         ?promise_state_id,
                                         ?args,
                                         ?value,

--- a/crates/bin/vm-cli/src/sample/bytecode.rs
+++ b/crates/bin/vm-cli/src/sample/bytecode.rs
@@ -8,15 +8,15 @@ pub fn executable() -> crate::integration::Executable {
     use waymark_vm_instructions_pureset::PureSet;
     use waymark_vm_runtime_core::RegisterId;
 
-    // function 1: f() = await ExtCall(SampleExtCallId(42)) + 5
+    // function 1: f() = await ActionCall(SampleActionRef(42)) + 5
     let f1 = Function {
         num_regs: 3,
         states: typed_vec![
             State {
                 instructions: typed_vec![
-                    ExtCallSet::ExtCall {
+                    ExtCallSet::ActionCall {
                         dst: RegisterId::from_scalar(0),
-                        extcall_id: SampleExtCallId(42),
+                        action_ref: SampleActionRef(42),
                         args: vec![],
                         resume: StateId::from_scalar(1),
                     }

--- a/crates/bin/vm-cli/src/sample/bytecode.rs
+++ b/crates/bin/vm-cli/src/sample/bytecode.rs
@@ -4,6 +4,7 @@ pub fn executable() -> crate::integration::Executable {
     use waymark_vm_bytecode::*;
     use waymark_vm_bytecode_core::*;
     use waymark_vm_instructions_coreset::CoreSet;
+    use waymark_vm_instructions_extcallset::ExtCallSet;
     use waymark_vm_instructions_pureset::PureSet;
     use waymark_vm_runtime_core::RegisterId;
 
@@ -13,7 +14,7 @@ pub fn executable() -> crate::integration::Executable {
         states: typed_vec![
             State {
                 instructions: typed_vec![
-                    CoreSet::ExtCall {
+                    ExtCallSet::ExtCall {
                         dst: RegisterId::from_scalar(0),
                         extcall_id: SampleExtCallId(42),
                         args: vec![],

--- a/crates/lib/vm-compiler-for-ast-old-core/Cargo.toml
+++ b/crates/lib/vm-compiler-for-ast-old-core/Cargo.toml
@@ -9,6 +9,7 @@ waymark-vm-ast-old = { workspace = true }
 waymark-vm-bytecode = { workspace = true }
 waymark-vm-bytecode-core = { workspace = true }
 waymark-vm-instructions-coreset = { workspace = true }
+waymark-vm-instructions-extcallset = { workspace = true }
 waymark-vm-instructions-fullset = { workspace = true }
 waymark-vm-instructions-pureset = { workspace = true }
 waymark-vm-runtime-core = { workspace = true }

--- a/crates/lib/vm-compiler-for-ast-old-core/src/lib.rs
+++ b/crates/lib/vm-compiler-for-ast-old-core/src/lib.rs
@@ -15,6 +15,9 @@ pub trait SpecRequirements:
         RegisterId = waymark_vm_runtime_core::RegisterId,
         FunctionId = waymark_vm_bytecode_core::FunctionId,
         StateId = waymark_vm_bytecode_core::StateId,
+    > + waymark_vm_instructions_extcallset::Spec<
+        RegisterId = waymark_vm_runtime_core::RegisterId,
+        StateId = waymark_vm_bytecode_core::StateId,
     > + waymark_vm_instructions_pureset::Spec
     + waymark_vm_instructions_fullset::Spec
 {
@@ -24,6 +27,9 @@ impl<T> SpecRequirements for T where
     T: waymark_vm_instructions_coreset::Spec<
             RegisterId = waymark_vm_runtime_core::RegisterId,
             FunctionId = waymark_vm_bytecode_core::FunctionId,
+            StateId = waymark_vm_bytecode_core::StateId,
+        > + waymark_vm_instructions_extcallset::Spec<
+            RegisterId = waymark_vm_runtime_core::RegisterId,
             StateId = waymark_vm_bytecode_core::StateId,
         > + waymark_vm_instructions_pureset::Spec
         + waymark_vm_instructions_fullset::Spec

--- a/crates/lib/vm-compiler-for-ast-old-core/src/lowering.rs
+++ b/crates/lib/vm-compiler-for-ast-old-core/src/lowering.rs
@@ -1,10 +1,10 @@
 //! Lowering interfaces.
 
-/// [`waymark_vm_instructions_coreset`] lowering from [`waymark_vm_ast_old`]
+/// [`waymark_vm_instructions_extcallset`] lowering from [`waymark_vm_ast_old`]
 /// specification.
-pub trait CoreSet<Spec>
+pub trait ExtCallSet<Spec>
 where
-    Spec: waymark_vm_instructions_coreset::Spec,
+    Spec: waymark_vm_instructions_extcallset::Spec,
 {
     /// Error returned when lowering an action call fails.
     type ActionError;
@@ -12,7 +12,7 @@ where
     /// Lowers one AST action call into the target spec's extcall identifier.
     fn lower_action(
         call: &waymark_vm_ast_old::ActionCall,
-    ) -> Result<<Spec as waymark_vm_instructions_coreset::Spec>::ExtCallId, Self::ActionError>;
+    ) -> Result<<Spec as waymark_vm_instructions_extcallset::Spec>::ExtCallId, Self::ActionError>;
 }
 
 /// [`waymark_vm_instructions_pureset`] lowering from [`waymark_vm_ast_old`]
@@ -30,9 +30,8 @@ where
     ) -> Result<<Spec as waymark_vm_instructions_pureset::Spec>::ConstValue, Self::LiteralError>;
 }
 
-/// [`waymark_vm_instructions_fullset`] lowering from [`waymark_vm_ast_old`]
-/// specification.
-pub trait FullSet<Spec>: CoreSet<Spec> + PureSet<Spec>
+/// Combined lowering for the full instruction set.
+pub trait FullSet<Spec>: ExtCallSet<Spec> + PureSet<Spec>
 where
     Spec: waymark_vm_instructions_fullset::Spec,
 {
@@ -40,7 +39,7 @@ where
 
 impl<Spec, T> FullSet<Spec> for T
 where
-    T: CoreSet<Spec> + PureSet<Spec>,
+    T: ExtCallSet<Spec> + PureSet<Spec>,
     Spec: waymark_vm_instructions_fullset::Spec,
 {
 }

--- a/crates/lib/vm-compiler-for-ast-old-core/src/lowering.rs
+++ b/crates/lib/vm-compiler-for-ast-old-core/src/lowering.rs
@@ -9,10 +9,10 @@ where
     /// Error returned when lowering an action call fails.
     type ActionError;
 
-    /// Lowers one AST action call into the target spec's extcall identifier.
+    /// Lowers one AST action call into the target spec's action reference.
     fn lower_action(
         call: &waymark_vm_ast_old::ActionCall,
-    ) -> Result<<Spec as waymark_vm_instructions_extcallset::Spec>::ExtCallId, Self::ActionError>;
+    ) -> Result<<Spec as waymark_vm_instructions_extcallset::Spec>::ActionRef, Self::ActionError>;
 }
 
 /// [`waymark_vm_instructions_pureset`] lowering from [`waymark_vm_ast_old`]

--- a/crates/lib/vm-compiler-for-ast-old-test-support/Cargo.toml
+++ b/crates/lib/vm-compiler-for-ast-old-test-support/Cargo.toml
@@ -9,5 +9,6 @@ waymark-vm-ast-old = { workspace = true }
 waymark-vm-bytecode-core = { workspace = true }
 waymark-vm-compiler-for-ast-old-core = { workspace = true }
 waymark-vm-instructions-coreset = { workspace = true }
+waymark-vm-instructions-extcallset = { workspace = true }
 waymark-vm-instructions-pureset = { workspace = true }
 waymark-vm-runtime-core = { workspace = true }

--- a/crates/lib/vm-compiler-for-ast-old-test-support/src/lib.rs
+++ b/crates/lib/vm-compiler-for-ast-old-test-support/src/lib.rs
@@ -47,6 +47,11 @@ impl waymark_vm_instructions_coreset::Spec for TestSpec {
     type RegisterId = waymark_vm_runtime_core::RegisterId;
     type FunctionId = waymark_vm_bytecode_core::FunctionId;
     type StateId = waymark_vm_bytecode_core::StateId;
+}
+
+impl waymark_vm_instructions_extcallset::Spec for TestSpec {
+    type RegisterId = waymark_vm_runtime_core::RegisterId;
+    type StateId = waymark_vm_bytecode_core::StateId;
     type ExtCallId = TestExtCallId;
 }
 
@@ -61,9 +66,9 @@ pub type TestExecutable = waymark_vm_compiler_for_ast_old_core::ExecutableFor<Te
 /// Lowering implementation used by compiler tests.
 pub struct TestLowering;
 
-impl<Spec> waymark_vm_compiler_for_ast_old_core::lowering::CoreSet<Spec> for TestLowering
+impl<Spec> waymark_vm_compiler_for_ast_old_core::lowering::ExtCallSet<Spec> for TestLowering
 where
-    Spec: waymark_vm_instructions_coreset::Spec<ExtCallId = TestExtCallId>,
+    Spec: waymark_vm_instructions_extcallset::Spec<ExtCallId = TestExtCallId>,
 {
     type ActionError = TestActionError;
 

--- a/crates/lib/vm-compiler-for-ast-old-test-support/src/lib.rs
+++ b/crates/lib/vm-compiler-for-ast-old-test-support/src/lib.rs
@@ -18,9 +18,9 @@ pub enum TestConstValue {
     None,
 }
 
-/// Extcall identifier used by the test VM spec.
+/// Action reference used by the test VM spec.
 #[derive(Debug, Clone)]
-pub struct TestExtCallId(
+pub struct TestActionRef(
     /// Action name captured from the AST call.
     pub String,
 );
@@ -52,7 +52,7 @@ impl waymark_vm_instructions_coreset::Spec for TestSpec {
 impl waymark_vm_instructions_extcallset::Spec for TestSpec {
     type RegisterId = waymark_vm_runtime_core::RegisterId;
     type StateId = waymark_vm_bytecode_core::StateId;
-    type ExtCallId = TestExtCallId;
+    type ActionRef = TestActionRef;
 }
 
 impl waymark_vm_instructions_pureset::Spec for TestSpec {
@@ -68,12 +68,12 @@ pub struct TestLowering;
 
 impl<Spec> waymark_vm_compiler_for_ast_old_core::lowering::ExtCallSet<Spec> for TestLowering
 where
-    Spec: waymark_vm_instructions_extcallset::Spec<ExtCallId = TestExtCallId>,
+    Spec: waymark_vm_instructions_extcallset::Spec<ActionRef = TestActionRef>,
 {
     type ActionError = TestActionError;
 
-    fn lower_action(call: &ActionCall) -> Result<Spec::ExtCallId, Self::ActionError> {
-        Ok(TestExtCallId(call.action_name.clone()))
+    fn lower_action(call: &ActionCall) -> Result<Spec::ActionRef, Self::ActionError> {
+        Ok(TestActionRef(call.action_name.clone()))
     }
 }
 

--- a/crates/lib/vm-compiler-for-ast-old/Cargo.toml
+++ b/crates/lib/vm-compiler-for-ast-old/Cargo.toml
@@ -10,6 +10,7 @@ waymark-vm-bytecode = { workspace = true }
 waymark-vm-bytecode-core = { workspace = true }
 waymark-vm-compiler-for-ast-old-core = { workspace = true }
 waymark-vm-instructions-coreset = { workspace = true }
+waymark-vm-instructions-extcallset = { workspace = true }
 waymark-vm-instructions-fullset = { workspace = true }
 waymark-vm-instructions-pureset = { workspace = true }
 waymark-vm-runtime-core = { workspace = true }
@@ -23,6 +24,7 @@ waymark-support-test-python = { workspace = true }
 waymark-vm-ast-old-helpers = { workspace = true }
 waymark-vm-compiler-for-ast-old-test-support = { workspace = true }
 waymark-vm-interpreter-coreset = { workspace = true }
+waymark-vm-interpreter-extcallset = { workspace = true }
 waymark-vm-interpreter-fullset = { workspace = true }
 waymark-vm-interpreter-pureset = { workspace = true }
 waymark-vm-runtime = { workspace = true }

--- a/crates/lib/vm-compiler-for-ast-old/src/function/compiler.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/function/compiler.rs
@@ -73,7 +73,7 @@ use super::table::FunctionTable;
 /// Concrete function-compiler error type for a spec and lowering pair.
 type ErrorFor<Spec, Lowering> = Error<
     <Lowering as waymark_vm_compiler_for_ast_old_core::lowering::PureSet<Spec>>::LiteralError,
-    <Lowering as waymark_vm_compiler_for_ast_old_core::lowering::CoreSet<Spec>>::ActionError,
+    <Lowering as waymark_vm_compiler_for_ast_old_core::lowering::ExtCallSet<Spec>>::ActionError,
 >;
 
 /// Lowers one AST function body into VM bytecode.

--- a/crates/lib/vm-compiler-for-ast-old/src/function/compiler/bytecode/emitter.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/function/compiler/bytecode/emitter.rs
@@ -90,12 +90,12 @@ where
     pub fn emit_extcall(
         &mut self,
         dst: Marked<RegisterId, PromiseMarker>,
-        extcall_id: <Spec as waymark_vm_instructions_coreset::Spec>::ExtCallId,
+        extcall_id: <Spec as waymark_vm_instructions_extcallset::Spec>::ExtCallId,
         args: Vec<RegisterId>,
         resume: StateId,
     ) {
         self.emit(
-            waymark_vm_instructions_coreset::CoreSet::ExtCall {
+            waymark_vm_instructions_extcallset::ExtCallSet::ExtCall {
                 dst: *dst,
                 extcall_id,
                 args,

--- a/crates/lib/vm-compiler-for-ast-old/src/function/compiler/bytecode/emitter.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/function/compiler/bytecode/emitter.rs
@@ -90,14 +90,14 @@ where
     pub fn emit_extcall(
         &mut self,
         dst: Marked<RegisterId, PromiseMarker>,
-        extcall_id: <Spec as waymark_vm_instructions_extcallset::Spec>::ExtCallId,
+        action_ref: <Spec as waymark_vm_instructions_extcallset::Spec>::ActionRef,
         args: Vec<RegisterId>,
         resume: StateId,
     ) {
         self.emit(
-            waymark_vm_instructions_extcallset::ExtCallSet::ExtCall {
+            waymark_vm_instructions_extcallset::ExtCallSet::ActionCall {
                 dst: *dst,
-                extcall_id,
+                action_ref,
                 args,
                 resume,
             }

--- a/crates/lib/vm-compiler-for-ast-old/src/function/compiler/error.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/function/compiler/error.rs
@@ -54,7 +54,7 @@ pub enum Error<LiteralLoweringError, ActionLoweringError> {
     #[error("literal lowering failed")]
     LiteralLowering(#[source] LiteralLoweringError),
 
-    /// Lowering an action call into the target VM extcall identifier failed.
+    /// Lowering an action call into the target VM action reference failed.
     #[error("lowering action `{action_name}` failed")]
     ActionLowering {
         /// The action name being lowered.

--- a/crates/lib/vm-compiler-for-ast-old/src/function/compiler/lowering/value.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/function/compiler/lowering/value.rs
@@ -144,7 +144,7 @@ where
         call: ActionCallPlanFor<'_, Spec>,
         dst: &Marked<RegisterHandle, PromiseMarker>,
     ) -> Result<(), ErrorFor<Spec, Lowering>> {
-        let (extcall_id, kwargs) = call.into_parts();
+        let (action_ref, kwargs) = call.into_parts();
         let args = compile_expr_registers(
             kwargs,
             |kwarg| &kwarg.value,
@@ -156,7 +156,7 @@ where
 
         self.context
             .emitter
-            .emit_extcall(dst.marked(), extcall_id, arg_registers, resume_state);
+            .emit_extcall(dst.marked(), action_ref, arg_registers, resume_state);
 
         drop(args);
 
@@ -365,7 +365,7 @@ mod tests {
         bytecode::emitter::FunctionEmitter,
         env::{FlowState, LocalFrame},
         test_helpers::{
-            TestConstValue, TestExtCallId, TestLowering, TestSpec, build_function_table,
+            TestActionRef, TestConstValue, TestLowering, TestSpec, build_function_table,
         },
     };
 
@@ -471,13 +471,13 @@ mod tests {
         ));
         assert!(matches!(
             start_instructions.next(),
-            Some(InstructionSet::ExtCallSet(ExtCallSet::ExtCall {
+            Some(InstructionSet::ExtCallSet(ExtCallSet::ActionCall {
                 dst,
-                extcall_id: TestExtCallId(extcall_id),
+                action_ref: TestActionRef(action_ref),
                 args,
                 resume,
             })) if *dst == RegisterId(0)
-                && extcall_id == "fetch"
+                && action_ref == "fetch"
                 && args == &[RegisterId(1)]
                 && *resume == StateId(1)
         ));
@@ -737,13 +737,13 @@ mod tests {
         ));
         assert!(matches!(
             start_instructions.next(),
-            Some(InstructionSet::ExtCallSet(ExtCallSet::ExtCall {
+            Some(InstructionSet::ExtCallSet(ExtCallSet::ActionCall {
                 dst,
-                extcall_id: TestExtCallId(extcall_id),
+                action_ref: TestActionRef(action_ref),
                 args,
                 resume,
             })) if *dst == preferred_dst
-                && *extcall_id == "fetch"
+                && *action_ref == "fetch"
                 && args == &[RegisterId(1)]
                 && *resume == StateId(1)
         ));
@@ -839,13 +839,13 @@ mod tests {
         let mut first_state_instructions = states[StateId(0)].instructions.iter();
         assert!(matches!(
             first_state_instructions.next(),
-            Some(InstructionSet::ExtCallSet(ExtCallSet::ExtCall {
+            Some(InstructionSet::ExtCallSet(ExtCallSet::ActionCall {
                 dst,
-                extcall_id: TestExtCallId(extcall_id),
+                action_ref: TestActionRef(action_ref),
                 args,
                 resume,
             })) if *dst == RegisterId(0)
-                && *extcall_id == "fetch_first"
+                && *action_ref == "fetch_first"
                 && args.is_empty()
                 && *resume == StateId(1)
         ));
@@ -854,13 +854,13 @@ mod tests {
         let mut third_state_instructions = states[StateId(2)].instructions.iter();
         assert!(matches!(
             third_state_instructions.next(),
-            Some(InstructionSet::ExtCallSet(ExtCallSet::ExtCall {
+            Some(InstructionSet::ExtCallSet(ExtCallSet::ActionCall {
                 dst,
-                extcall_id: TestExtCallId(extcall_id),
+                action_ref: TestActionRef(action_ref),
                 args,
                 resume,
             })) if *dst == RegisterId(0)
-                && *extcall_id == "fetch_second"
+                && *action_ref == "fetch_second"
                 && args.is_empty()
                 && *resume == StateId(3)
         ));
@@ -906,13 +906,13 @@ mod tests {
         ));
         assert!(matches!(
             first_state_instructions.next(),
-            Some(InstructionSet::ExtCallSet(ExtCallSet::ExtCall {
+            Some(InstructionSet::ExtCallSet(ExtCallSet::ActionCall {
                 dst,
-                extcall_id: TestExtCallId(extcall_id),
+                action_ref: TestActionRef(action_ref),
                 args,
                 resume,
             })) if *dst == RegisterId(0)
-                && *extcall_id == "fetch_first"
+                && *action_ref == "fetch_first"
                 && args == &[RegisterId(1)]
                 && *resume == StateId(1)
         ));
@@ -928,13 +928,13 @@ mod tests {
         ));
         assert!(matches!(
             third_state_instructions.next(),
-            Some(InstructionSet::ExtCallSet(ExtCallSet::ExtCall {
+            Some(InstructionSet::ExtCallSet(ExtCallSet::ActionCall {
                 dst,
-                extcall_id: TestExtCallId(extcall_id),
+                action_ref: TestActionRef(action_ref),
                 args,
                 resume,
             })) if *dst == RegisterId(0)
-                && *extcall_id == "fetch_second"
+                && *action_ref == "fetch_second"
                 && args == &[RegisterId(1)]
                 && *resume == StateId(3)
         ));

--- a/crates/lib/vm-compiler-for-ast-old/src/function/compiler/lowering/value.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/function/compiler/lowering/value.rs
@@ -355,6 +355,7 @@ mod tests {
     use waymark_vm_ast_old_helpers::{action_call, binary_expr, function_call, int};
     use waymark_vm_bytecode_core::{FunctionId, StateId};
     use waymark_vm_instructions_coreset::CoreSet;
+    use waymark_vm_instructions_extcallset::ExtCallSet;
     use waymark_vm_instructions_fullset::FullSet as InstructionSet;
     use waymark_vm_instructions_pureset::PureSet;
     use waymark_vm_runtime_core::RegisterId;
@@ -470,7 +471,7 @@ mod tests {
         ));
         assert!(matches!(
             start_instructions.next(),
-            Some(InstructionSet::CoreSet(CoreSet::ExtCall {
+            Some(InstructionSet::ExtCallSet(ExtCallSet::ExtCall {
                 dst,
                 extcall_id: TestExtCallId(extcall_id),
                 args,
@@ -736,7 +737,7 @@ mod tests {
         ));
         assert!(matches!(
             start_instructions.next(),
-            Some(InstructionSet::CoreSet(CoreSet::ExtCall {
+            Some(InstructionSet::ExtCallSet(ExtCallSet::ExtCall {
                 dst,
                 extcall_id: TestExtCallId(extcall_id),
                 args,
@@ -838,7 +839,7 @@ mod tests {
         let mut first_state_instructions = states[StateId(0)].instructions.iter();
         assert!(matches!(
             first_state_instructions.next(),
-            Some(InstructionSet::CoreSet(CoreSet::ExtCall {
+            Some(InstructionSet::ExtCallSet(ExtCallSet::ExtCall {
                 dst,
                 extcall_id: TestExtCallId(extcall_id),
                 args,
@@ -853,7 +854,7 @@ mod tests {
         let mut third_state_instructions = states[StateId(2)].instructions.iter();
         assert!(matches!(
             third_state_instructions.next(),
-            Some(InstructionSet::CoreSet(CoreSet::ExtCall {
+            Some(InstructionSet::ExtCallSet(ExtCallSet::ExtCall {
                 dst,
                 extcall_id: TestExtCallId(extcall_id),
                 args,
@@ -905,7 +906,7 @@ mod tests {
         ));
         assert!(matches!(
             first_state_instructions.next(),
-            Some(InstructionSet::CoreSet(CoreSet::ExtCall {
+            Some(InstructionSet::ExtCallSet(ExtCallSet::ExtCall {
                 dst,
                 extcall_id: TestExtCallId(extcall_id),
                 args,
@@ -927,7 +928,7 @@ mod tests {
         ));
         assert!(matches!(
             third_state_instructions.next(),
-            Some(InstructionSet::CoreSet(CoreSet::ExtCall {
+            Some(InstructionSet::ExtCallSet(ExtCallSet::ExtCall {
                 dst,
                 extcall_id: TestExtCallId(extcall_id),
                 args,

--- a/crates/lib/vm-compiler-for-ast-old/src/function/compiler/plan/call.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/function/compiler/plan/call.rs
@@ -20,11 +20,11 @@ pub struct FunctionCallPlan<'a> {
     args: &'a [Spanned<Expr>],
 }
 
-/// A validated action call with a lowered extcall identifier.
+/// A validated action call with a lowered action reference.
 #[derive(Debug)]
-pub struct ActionCallPlan<'a, ExtCallId> {
-    /// Lowered extcall id for the action invocation.
-    extcall_id: ExtCallId,
+pub struct ActionCallPlan<'a, ActionRef> {
+    /// Lowered action reference for the action invocation.
+    action_ref: ActionRef,
 
     /// Keyword arguments forwarded to the action.
     kwargs: &'a [Kwarg],
@@ -32,21 +32,21 @@ pub struct ActionCallPlan<'a, ExtCallId> {
 
 /// A normalized call plan for either a function call or an action call.
 #[derive(Debug)]
-pub enum CallPlan<'a, ExtCallId> {
+pub enum CallPlan<'a, ActionRef> {
     /// A call into another user-defined function.
     Function(FunctionCallPlan<'a>),
 
     /// A call into an external action.
-    Action(ActionCallPlan<'a, ExtCallId>),
+    Action(ActionCallPlan<'a, ActionRef>),
 }
 
 /// Action-call plan specialized to a VM spec.
 pub type ActionCallPlanFor<'a, Spec> =
-    ActionCallPlan<'a, <Spec as waymark_vm_instructions_extcallset::Spec>::ExtCallId>;
+    ActionCallPlan<'a, <Spec as waymark_vm_instructions_extcallset::Spec>::ActionRef>;
 
 /// Generic call plan specialized to a VM spec.
 pub type CallPlanFor<'a, Spec> =
-    CallPlan<'a, <Spec as waymark_vm_instructions_extcallset::Spec>::ExtCallId>;
+    CallPlan<'a, <Spec as waymark_vm_instructions_extcallset::Spec>::ActionRef>;
 
 /// Reasons a function-call shape cannot be represented by this compiler.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -112,33 +112,33 @@ impl<'a> FunctionCallPlan<'a> {
     }
 }
 
-impl<'a, ExtCallId> ActionCallPlan<'a, ExtCallId> {
-    /// Lowers an action call into the target spec's extcall identifier.
+impl<'a, ActionRef> ActionCallPlan<'a, ActionRef> {
+    /// Lowers an action call into the target spec's action.
     pub fn lower<Spec, Lowering, LiteralLoweringError>(
         call: &'a ActionCall,
     ) -> Result<Self, Error<LiteralLoweringError, Lowering::ActionError>>
     where
-        Spec: waymark_vm_instructions_extcallset::Spec<ExtCallId = ExtCallId>,
+        Spec: waymark_vm_instructions_extcallset::Spec<ActionRef = ActionRef>,
         Lowering: lowering::ExtCallSet<Spec>,
     {
-        let extcall_id = Lowering::lower_action(call).map_err(|error| Error::ActionLowering {
+        let action_ref = Lowering::lower_action(call).map_err(|error| Error::ActionLowering {
             action_name: call.action_name.clone(),
             error,
         })?;
 
         Ok(Self {
-            extcall_id,
+            action_ref,
             kwargs: &call.kwargs,
         })
     }
 
-    /// Returns the lowered extcall id and original keyword arguments.
-    pub fn into_parts(self) -> (ExtCallId, &'a [Kwarg]) {
-        (self.extcall_id, self.kwargs)
+    /// Returns the lowered action reference and original keyword arguments.
+    pub fn into_parts(self) -> (ActionRef, &'a [Kwarg]) {
+        (self.action_ref, self.kwargs)
     }
 }
 
-impl<'a, ExtCallId> CallPlan<'a, ExtCallId> {
+impl<'a, ActionRef> CallPlan<'a, ActionRef> {
     /// Builds a plan for a user-function call.
     pub fn build_function<LiteralLoweringError, ActionLoweringError>(
         call: &'a FunctionCall,
@@ -155,7 +155,7 @@ impl<'a, ExtCallId> CallPlan<'a, ExtCallId> {
         call: &'a ActionCall,
     ) -> Result<Self, Error<LiteralLoweringError, Lowering::ActionError>>
     where
-        Spec: waymark_vm_instructions_extcallset::Spec<ExtCallId = ExtCallId>,
+        Spec: waymark_vm_instructions_extcallset::Spec<ActionRef = ActionRef>,
         Lowering: lowering::ExtCallSet<Spec>,
     {
         Ok(Self::Action(ActionCallPlan::lower::<Spec, Lowering, _>(
@@ -169,7 +169,7 @@ impl<'a, ExtCallId> CallPlan<'a, ExtCallId> {
         function_table: &FunctionTable,
     ) -> Result<Self, Error<LiteralLoweringError, Lowering::ActionError>>
     where
-        Spec: waymark_vm_instructions_extcallset::Spec<ExtCallId = ExtCallId>,
+        Spec: waymark_vm_instructions_extcallset::Spec<ActionRef = ActionRef>,
         Lowering: lowering::ExtCallSet<Spec>,
     {
         match call {
@@ -184,7 +184,7 @@ impl<'a, ExtCallId> CallPlan<'a, ExtCallId> {
         function_table: &FunctionTable,
     ) -> Result<NEVec<Self>, Error<LiteralLoweringError, Lowering::ActionError>>
     where
-        Spec: waymark_vm_instructions_extcallset::Spec<ExtCallId = ExtCallId>,
+        Spec: waymark_vm_instructions_extcallset::Spec<ActionRef = ActionRef>,
         Lowering: lowering::ExtCallSet<Spec>,
     {
         calls
@@ -233,7 +233,7 @@ mod tests {
     use crate::function::compiler::{
         Error,
         test_helpers::{
-            TestActionError, TestExtCallId, TestLowering, TestSpec, build_function_table,
+            TestActionError, TestActionRef, TestLowering, TestSpec, build_function_table,
         },
     };
 
@@ -242,7 +242,7 @@ mod tests {
     impl lowering::ExtCallSet<TestSpec> for FailingLowering {
         type ActionError = TestActionError;
 
-        fn lower_action(_call: &ActionCall) -> Result<TestExtCallId, Self::ActionError> {
+        fn lower_action(_call: &ActionCall) -> Result<TestActionRef, Self::ActionError> {
             Err(TestActionError::Unsupported)
         }
     }
@@ -375,15 +375,15 @@ mod tests {
         let call = action_call("notify", Vec::new());
         let planned_call = ActionCallPlan::lower::<TestSpec, TestLowering, ()>(&call)
             .expect("supported action should lower");
-        let (extcall_id, kwargs) = planned_call.into_parts();
+        let (action_ref, kwargs) = planned_call.into_parts();
 
-        assert!(matches!(extcall_id, TestExtCallId(name) if name == "notify"));
+        assert!(matches!(action_ref, TestActionRef(name) if name == "notify"));
         assert!(kwargs.is_empty());
     }
 
     #[test]
     fn preserves_action_lowering_errors() {
-        let error = ActionCallPlan::<TestExtCallId>::lower::<TestSpec, FailingLowering, ()>(
+        let error = ActionCallPlan::<TestActionRef>::lower::<TestSpec, FailingLowering, ()>(
             &action_call("notify", Vec::new()),
         )
         .expect_err("unsupported action should fail");

--- a/crates/lib/vm-compiler-for-ast-old/src/function/compiler/plan/call.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/function/compiler/plan/call.rs
@@ -42,11 +42,11 @@ pub enum CallPlan<'a, ExtCallId> {
 
 /// Action-call plan specialized to a VM spec.
 pub type ActionCallPlanFor<'a, Spec> =
-    ActionCallPlan<'a, <Spec as waymark_vm_instructions_coreset::Spec>::ExtCallId>;
+    ActionCallPlan<'a, <Spec as waymark_vm_instructions_extcallset::Spec>::ExtCallId>;
 
 /// Generic call plan specialized to a VM spec.
 pub type CallPlanFor<'a, Spec> =
-    CallPlan<'a, <Spec as waymark_vm_instructions_coreset::Spec>::ExtCallId>;
+    CallPlan<'a, <Spec as waymark_vm_instructions_extcallset::Spec>::ExtCallId>;
 
 /// Reasons a function-call shape cannot be represented by this compiler.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -118,8 +118,8 @@ impl<'a, ExtCallId> ActionCallPlan<'a, ExtCallId> {
         call: &'a ActionCall,
     ) -> Result<Self, Error<LiteralLoweringError, Lowering::ActionError>>
     where
-        Spec: waymark_vm_instructions_coreset::Spec<ExtCallId = ExtCallId>,
-        Lowering: lowering::CoreSet<Spec>,
+        Spec: waymark_vm_instructions_extcallset::Spec<ExtCallId = ExtCallId>,
+        Lowering: lowering::ExtCallSet<Spec>,
     {
         let extcall_id = Lowering::lower_action(call).map_err(|error| Error::ActionLowering {
             action_name: call.action_name.clone(),
@@ -155,8 +155,8 @@ impl<'a, ExtCallId> CallPlan<'a, ExtCallId> {
         call: &'a ActionCall,
     ) -> Result<Self, Error<LiteralLoweringError, Lowering::ActionError>>
     where
-        Spec: waymark_vm_instructions_coreset::Spec<ExtCallId = ExtCallId>,
-        Lowering: lowering::CoreSet<Spec>,
+        Spec: waymark_vm_instructions_extcallset::Spec<ExtCallId = ExtCallId>,
+        Lowering: lowering::ExtCallSet<Spec>,
     {
         Ok(Self::Action(ActionCallPlan::lower::<Spec, Lowering, _>(
             call,
@@ -169,8 +169,8 @@ impl<'a, ExtCallId> CallPlan<'a, ExtCallId> {
         function_table: &FunctionTable,
     ) -> Result<Self, Error<LiteralLoweringError, Lowering::ActionError>>
     where
-        Spec: waymark_vm_instructions_coreset::Spec<ExtCallId = ExtCallId>,
-        Lowering: lowering::CoreSet<Spec>,
+        Spec: waymark_vm_instructions_extcallset::Spec<ExtCallId = ExtCallId>,
+        Lowering: lowering::ExtCallSet<Spec>,
     {
         match call {
             Call::Function(call) => Self::build_function(call, function_table),
@@ -184,8 +184,8 @@ impl<'a, ExtCallId> CallPlan<'a, ExtCallId> {
         function_table: &FunctionTable,
     ) -> Result<NEVec<Self>, Error<LiteralLoweringError, Lowering::ActionError>>
     where
-        Spec: waymark_vm_instructions_coreset::Spec<ExtCallId = ExtCallId>,
-        Lowering: lowering::CoreSet<Spec>,
+        Spec: waymark_vm_instructions_extcallset::Spec<ExtCallId = ExtCallId>,
+        Lowering: lowering::ExtCallSet<Spec>,
     {
         calls
             .into_nonempty_iter()
@@ -239,7 +239,7 @@ mod tests {
 
     struct FailingLowering;
 
-    impl lowering::CoreSet<TestSpec> for FailingLowering {
+    impl lowering::ExtCallSet<TestSpec> for FailingLowering {
         type ActionError = TestActionError;
 
         fn lower_action(_call: &ActionCall) -> Result<TestExtCallId, Self::ActionError> {

--- a/crates/lib/vm-compiler-for-ast-old/src/function/compiler/test_helpers.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/function/compiler/test_helpers.rs
@@ -3,7 +3,7 @@ use waymark_vm_ast_old_helpers::{function, program};
 use super::super::table::FunctionTable;
 
 pub(crate) use waymark_vm_compiler_for_ast_old_test_support::{
-    TestActionError, TestConstValue, TestExtCallId, TestLowering, TestSpec,
+    TestActionError, TestActionRef, TestConstValue, TestLowering, TestSpec,
 };
 
 pub(crate) fn build_function_table() -> FunctionTable {

--- a/crates/lib/vm-compiler-for-ast-old/src/lib.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/lib.rs
@@ -52,7 +52,7 @@ pub enum CompileError<LiteralLoweringError, ActionLoweringError> {
 /// The [`CompileError`] alias for binding it to lowering.
 pub type CompileErrorFor<Spec, Lowering> = CompileError<
     <Lowering as lowering::PureSet<Spec>>::LiteralError,
-    <Lowering as lowering::CoreSet<Spec>>::ActionError,
+    <Lowering as lowering::ExtCallSet<Spec>>::ActionError,
 >;
 
 /// Compile an old AST program into VM bytecode.

--- a/crates/lib/vm-compiler-for-ast-old/src/tests.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/tests.rs
@@ -25,9 +25,9 @@ enum UnitTestActionLoweringError {
 
 struct ActionFailingLowering;
 
-impl<Spec> lowering::CoreSet<Spec> for ActionFailingLowering
+impl<Spec> lowering::ExtCallSet<Spec> for ActionFailingLowering
 where
-    Spec: waymark_vm_instructions_coreset::Spec<ExtCallId = TestExtCallId>,
+    Spec: waymark_vm_instructions_extcallset::Spec<ExtCallId = TestExtCallId>,
 {
     type ActionError = UnitTestActionLoweringError;
 

--- a/crates/lib/vm-compiler-for-ast-old/src/tests.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/tests.rs
@@ -6,7 +6,7 @@ use waymark_vm_ast_old_helpers::{
 };
 use waymark_vm_compiler_for_ast_old_core::lowering;
 use waymark_vm_compiler_for_ast_old_test_support::{
-    TestConstValue, TestExtCallId, TestLiteralError as TestLiteralLoweringError, TestLowering,
+    TestActionRef, TestConstValue, TestLiteralError as TestLiteralLoweringError, TestLowering,
     TestSpec,
 };
 use waymark_vm_instructions_fullset::FullSet;
@@ -27,11 +27,11 @@ struct ActionFailingLowering;
 
 impl<Spec> lowering::ExtCallSet<Spec> for ActionFailingLowering
 where
-    Spec: waymark_vm_instructions_extcallset::Spec<ExtCallId = TestExtCallId>,
+    Spec: waymark_vm_instructions_extcallset::Spec<ActionRef = TestActionRef>,
 {
     type ActionError = UnitTestActionLoweringError;
 
-    fn lower_action(_call: &ActionCall) -> Result<Spec::ExtCallId, Self::ActionError> {
+    fn lower_action(_call: &ActionCall) -> Result<Spec::ActionRef, Self::ActionError> {
         Err(UnitTestActionLoweringError::UnsupportedAction)
     }
 }

--- a/crates/lib/vm-compiler-for-ast-old/tests/integration.rs
+++ b/crates/lib/vm-compiler-for-ast-old/tests/integration.rs
@@ -8,17 +8,17 @@ use waymark_vm_ast_old_helpers::{
     parallel_stmt, program, return_stmt, unary_expr, variable, while_stmt,
 };
 use waymark_vm_bytecode_core::{FunctionId, InstructionId, StateId};
-use waymark_vm_compiler_for_ast_old_test_support::TestExtCallId;
+use waymark_vm_compiler_for_ast_old_test_support::TestActionRef;
 use waymark_vm_interpreter_fullset::Effect;
 
-fn completed_int(effect: Effect<TestValue, TestExtCallId>) -> i64 {
+fn completed_int(effect: Effect<TestValue, TestActionRef>) -> i64 {
     match completed_value(effect) {
         TestValue::Int(value) => value,
         other => panic!("unexpected runtime effect: {other:?}"),
     }
 }
 
-fn completed_value(effect: Effect<TestValue, TestExtCallId>) -> TestValue {
+fn completed_value(effect: Effect<TestValue, TestActionRef>) -> TestValue {
     match effect {
         Effect::CoreSet(waymark_vm_interpreter_coreset::Effect::Complete(value)) => value,
         other => panic!("unexpected runtime effect: {other:?}"),
@@ -337,12 +337,12 @@ fn compiles_action_calls_into_extcalls() {
     let effect = runtime.run().expect("program should emit an extcall");
 
     let promise_state_id = match effect {
-        Effect::ExtCallSet(waymark_vm_interpreter_extcallset::Effect::ExtCall {
+        Effect::ExtCallSet(waymark_vm_interpreter_extcallset::Effect::ActionCall {
             promise_state_id,
-            extcall_id,
+            action_ref,
             args,
         }) => {
-            assert!(matches!(&extcall_id, TestExtCallId(name) if name == "fetch"));
+            assert!(matches!(&action_ref, TestActionRef(name) if name == "fetch"));
             assert_eq!(args, vec![TestValue::Int(41)]);
             promise_state_id
         }
@@ -421,7 +421,7 @@ fn compiles_parallel_blocks_to_fan_out_before_awaiting() {
     assert!(matches!(
         extcall,
         waymark_vm_instructions_fullset::FullSet::ExtCallSet(
-            waymark_vm_instructions_extcallset::ExtCallSet::ExtCall { resume, .. }
+            waymark_vm_instructions_extcallset::ExtCallSet::ActionCall { resume, .. }
         ) if *resume == StateId(1)
     ));
     assert!(matches!(
@@ -453,12 +453,12 @@ fn compiles_parallel_action_blocks_with_multiple_outstanding_extcalls() {
         .run()
         .expect("first run should emit the first extcall")
     {
-        Effect::ExtCallSet(waymark_vm_interpreter_extcallset::Effect::ExtCall {
+        Effect::ExtCallSet(waymark_vm_interpreter_extcallset::Effect::ActionCall {
             promise_state_id,
-            extcall_id,
+            action_ref,
             args,
         }) => {
-            assert!(matches!(&extcall_id, TestExtCallId(name) if name == "fetch_first"));
+            assert!(matches!(&action_ref, TestActionRef(name) if name == "fetch_first"));
             assert_eq!(args, vec![TestValue::Int(1)]);
             promise_state_id
         }
@@ -469,12 +469,12 @@ fn compiles_parallel_action_blocks_with_multiple_outstanding_extcalls() {
         .run()
         .expect("second run should emit the second extcall")
     {
-        Effect::ExtCallSet(waymark_vm_interpreter_extcallset::Effect::ExtCall {
+        Effect::ExtCallSet(waymark_vm_interpreter_extcallset::Effect::ActionCall {
             promise_state_id,
-            extcall_id,
+            action_ref,
             args,
         }) => {
-            assert!(matches!(&extcall_id, TestExtCallId(name) if name == "fetch_second"));
+            assert!(matches!(&action_ref, TestActionRef(name) if name == "fetch_second"));
             assert_eq!(args, vec![TestValue::Int(2)]);
             promise_state_id
         }
@@ -529,12 +529,12 @@ fn compiles_mixed_parallel_blocks_with_leading_action_before_awaiting() {
         .run()
         .expect("first run should emit the first extcall")
     {
-        Effect::ExtCallSet(waymark_vm_interpreter_extcallset::Effect::ExtCall {
+        Effect::ExtCallSet(waymark_vm_interpreter_extcallset::Effect::ActionCall {
             promise_state_id,
-            extcall_id,
+            action_ref,
             args,
         }) => {
-            assert!(matches!(&extcall_id, TestExtCallId(name) if name == "fetch_first"));
+            assert!(matches!(&action_ref, TestActionRef(name) if name == "fetch_first"));
             assert_eq!(args, vec![TestValue::Int(1)]);
             promise_state_id
         }
@@ -545,12 +545,12 @@ fn compiles_mixed_parallel_blocks_with_leading_action_before_awaiting() {
         .run()
         .expect("second run should emit the second extcall before awaiting the first")
     {
-        Effect::ExtCallSet(waymark_vm_interpreter_extcallset::Effect::ExtCall {
+        Effect::ExtCallSet(waymark_vm_interpreter_extcallset::Effect::ActionCall {
             promise_state_id,
-            extcall_id,
+            action_ref,
             args,
         }) => {
-            assert!(matches!(&extcall_id, TestExtCallId(name) if name == "fetch_second"));
+            assert!(matches!(&action_ref, TestActionRef(name) if name == "fetch_second"));
             assert_eq!(args, vec![TestValue::Int(3)]);
             promise_state_id
         }
@@ -633,12 +633,12 @@ fn compiles_parallel_expressions_into_positional_assignments() {
     let mut runtime = runtime(executable);
 
     let promise_state_id = match runtime.run().expect("program should emit an extcall") {
-        Effect::ExtCallSet(waymark_vm_interpreter_extcallset::Effect::ExtCall {
+        Effect::ExtCallSet(waymark_vm_interpreter_extcallset::Effect::ActionCall {
             promise_state_id,
-            extcall_id,
+            action_ref,
             args,
         }) => {
-            assert!(matches!(&extcall_id, TestExtCallId(name) if name == "fetch"));
+            assert!(matches!(&action_ref, TestActionRef(name) if name == "fetch"));
             assert_eq!(args, vec![TestValue::Int(4)]);
             promise_state_id
         }
@@ -701,12 +701,12 @@ fn compiles_mixed_parallel_expressions_with_leading_action_before_awaiting() {
         .run()
         .expect("first run should emit the first extcall")
     {
-        Effect::ExtCallSet(waymark_vm_interpreter_extcallset::Effect::ExtCall {
+        Effect::ExtCallSet(waymark_vm_interpreter_extcallset::Effect::ActionCall {
             promise_state_id,
-            extcall_id,
+            action_ref,
             args,
         }) => {
-            assert!(matches!(&extcall_id, TestExtCallId(name) if name == "fetch_first"));
+            assert!(matches!(&action_ref, TestActionRef(name) if name == "fetch_first"));
             assert_eq!(args, vec![TestValue::Int(1)]);
             promise_state_id
         }
@@ -717,12 +717,12 @@ fn compiles_mixed_parallel_expressions_with_leading_action_before_awaiting() {
         .run()
         .expect("second run should emit the second extcall before awaiting the first")
     {
-        Effect::ExtCallSet(waymark_vm_interpreter_extcallset::Effect::ExtCall {
+        Effect::ExtCallSet(waymark_vm_interpreter_extcallset::Effect::ActionCall {
             promise_state_id,
-            extcall_id,
+            action_ref,
             args,
         }) => {
-            assert!(matches!(&extcall_id, TestExtCallId(name) if name == "fetch_second"));
+            assert!(matches!(&action_ref, TestActionRef(name) if name == "fetch_second"));
             assert_eq!(args, vec![TestValue::Int(3)]);
             promise_state_id
         }
@@ -780,12 +780,12 @@ fn compiles_parallel_expressions_into_aggregate_lists() {
     let mut runtime = runtime(executable);
 
     let promise_state_id = match runtime.run().expect("program should emit an extcall") {
-        Effect::ExtCallSet(waymark_vm_interpreter_extcallset::Effect::ExtCall {
+        Effect::ExtCallSet(waymark_vm_interpreter_extcallset::Effect::ActionCall {
             promise_state_id,
-            extcall_id,
+            action_ref,
             args,
         }) => {
-            assert!(matches!(&extcall_id, TestExtCallId(name) if name == "fetch"));
+            assert!(matches!(&action_ref, TestActionRef(name) if name == "fetch"));
             assert_eq!(args, vec![TestValue::Int(4)]);
             promise_state_id
         }
@@ -836,12 +836,12 @@ fn compiles_parallel_expression_results_by_call_position() {
         .run()
         .expect("first run should emit the first extcall")
     {
-        Effect::ExtCallSet(waymark_vm_interpreter_extcallset::Effect::ExtCall {
+        Effect::ExtCallSet(waymark_vm_interpreter_extcallset::Effect::ActionCall {
             promise_state_id,
-            extcall_id,
+            action_ref,
             args,
         }) => {
-            assert!(matches!(&extcall_id, TestExtCallId(name) if name == "fetch_first"));
+            assert!(matches!(&action_ref, TestActionRef(name) if name == "fetch_first"));
             assert_eq!(args, vec![TestValue::Int(1)]);
             promise_state_id
         }
@@ -852,12 +852,12 @@ fn compiles_parallel_expression_results_by_call_position() {
         .run()
         .expect("second run should emit the second extcall")
     {
-        Effect::ExtCallSet(waymark_vm_interpreter_extcallset::Effect::ExtCall {
+        Effect::ExtCallSet(waymark_vm_interpreter_extcallset::Effect::ActionCall {
             promise_state_id,
-            extcall_id,
+            action_ref,
             args,
         }) => {
-            assert!(matches!(&extcall_id, TestExtCallId(name) if name == "fetch_second"));
+            assert!(matches!(&action_ref, TestActionRef(name) if name == "fetch_second"));
             assert_eq!(args, vec![TestValue::Int(2)]);
             promise_state_id
         }

--- a/crates/lib/vm-compiler-for-ast-old/tests/integration.rs
+++ b/crates/lib/vm-compiler-for-ast-old/tests/integration.rs
@@ -337,7 +337,7 @@ fn compiles_action_calls_into_extcalls() {
     let effect = runtime.run().expect("program should emit an extcall");
 
     let promise_state_id = match effect {
-        Effect::CoreSet(waymark_vm_interpreter_coreset::Effect::ExtCall {
+        Effect::ExtCallSet(waymark_vm_interpreter_extcallset::Effect::ExtCall {
             promise_state_id,
             extcall_id,
             args,
@@ -420,8 +420,8 @@ fn compiles_parallel_blocks_to_fan_out_before_awaiting() {
     ));
     assert!(matches!(
         extcall,
-        waymark_vm_instructions_fullset::FullSet::CoreSet(
-            waymark_vm_instructions_coreset::CoreSet::ExtCall { resume, .. }
+        waymark_vm_instructions_fullset::FullSet::ExtCallSet(
+            waymark_vm_instructions_extcallset::ExtCallSet::ExtCall { resume, .. }
         ) if *resume == StateId(1)
     ));
     assert!(matches!(
@@ -453,7 +453,7 @@ fn compiles_parallel_action_blocks_with_multiple_outstanding_extcalls() {
         .run()
         .expect("first run should emit the first extcall")
     {
-        Effect::CoreSet(waymark_vm_interpreter_coreset::Effect::ExtCall {
+        Effect::ExtCallSet(waymark_vm_interpreter_extcallset::Effect::ExtCall {
             promise_state_id,
             extcall_id,
             args,
@@ -469,7 +469,7 @@ fn compiles_parallel_action_blocks_with_multiple_outstanding_extcalls() {
         .run()
         .expect("second run should emit the second extcall")
     {
-        Effect::CoreSet(waymark_vm_interpreter_coreset::Effect::ExtCall {
+        Effect::ExtCallSet(waymark_vm_interpreter_extcallset::Effect::ExtCall {
             promise_state_id,
             extcall_id,
             args,
@@ -529,7 +529,7 @@ fn compiles_mixed_parallel_blocks_with_leading_action_before_awaiting() {
         .run()
         .expect("first run should emit the first extcall")
     {
-        Effect::CoreSet(waymark_vm_interpreter_coreset::Effect::ExtCall {
+        Effect::ExtCallSet(waymark_vm_interpreter_extcallset::Effect::ExtCall {
             promise_state_id,
             extcall_id,
             args,
@@ -545,7 +545,7 @@ fn compiles_mixed_parallel_blocks_with_leading_action_before_awaiting() {
         .run()
         .expect("second run should emit the second extcall before awaiting the first")
     {
-        Effect::CoreSet(waymark_vm_interpreter_coreset::Effect::ExtCall {
+        Effect::ExtCallSet(waymark_vm_interpreter_extcallset::Effect::ExtCall {
             promise_state_id,
             extcall_id,
             args,
@@ -633,7 +633,7 @@ fn compiles_parallel_expressions_into_positional_assignments() {
     let mut runtime = runtime(executable);
 
     let promise_state_id = match runtime.run().expect("program should emit an extcall") {
-        Effect::CoreSet(waymark_vm_interpreter_coreset::Effect::ExtCall {
+        Effect::ExtCallSet(waymark_vm_interpreter_extcallset::Effect::ExtCall {
             promise_state_id,
             extcall_id,
             args,
@@ -701,7 +701,7 @@ fn compiles_mixed_parallel_expressions_with_leading_action_before_awaiting() {
         .run()
         .expect("first run should emit the first extcall")
     {
-        Effect::CoreSet(waymark_vm_interpreter_coreset::Effect::ExtCall {
+        Effect::ExtCallSet(waymark_vm_interpreter_extcallset::Effect::ExtCall {
             promise_state_id,
             extcall_id,
             args,
@@ -717,7 +717,7 @@ fn compiles_mixed_parallel_expressions_with_leading_action_before_awaiting() {
         .run()
         .expect("second run should emit the second extcall before awaiting the first")
     {
-        Effect::CoreSet(waymark_vm_interpreter_coreset::Effect::ExtCall {
+        Effect::ExtCallSet(waymark_vm_interpreter_extcallset::Effect::ExtCall {
             promise_state_id,
             extcall_id,
             args,
@@ -780,7 +780,7 @@ fn compiles_parallel_expressions_into_aggregate_lists() {
     let mut runtime = runtime(executable);
 
     let promise_state_id = match runtime.run().expect("program should emit an extcall") {
-        Effect::CoreSet(waymark_vm_interpreter_coreset::Effect::ExtCall {
+        Effect::ExtCallSet(waymark_vm_interpreter_extcallset::Effect::ExtCall {
             promise_state_id,
             extcall_id,
             args,
@@ -836,7 +836,7 @@ fn compiles_parallel_expression_results_by_call_position() {
         .run()
         .expect("first run should emit the first extcall")
     {
-        Effect::CoreSet(waymark_vm_interpreter_coreset::Effect::ExtCall {
+        Effect::ExtCallSet(waymark_vm_interpreter_extcallset::Effect::ExtCall {
             promise_state_id,
             extcall_id,
             args,
@@ -852,7 +852,7 @@ fn compiles_parallel_expression_results_by_call_position() {
         .run()
         .expect("second run should emit the second extcall")
     {
-        Effect::CoreSet(waymark_vm_interpreter_coreset::Effect::ExtCall {
+        Effect::ExtCallSet(waymark_vm_interpreter_extcallset::Effect::ExtCall {
             promise_state_id,
             extcall_id,
             args,

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_actions__action_mixed_args.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_actions__action_mixed_args.py__bytecode.snap
@@ -39,7 +39,7 @@ Ok(
                                     ),
                                 },
                             ),
-                            CoreSet(
+                            ExtCallSet(
                                 ExtCall {
                                     dst: RegisterId(
                                         0,

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_actions__action_mixed_args.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_actions__action_mixed_args.py__bytecode.snap
@@ -40,11 +40,11 @@ Ok(
                                 },
                             ),
                             ExtCallSet(
-                                ExtCall {
+                                ActionCall {
                                     dst: RegisterId(
                                         0,
                                     ),
-                                    extcall_id: TestExtCallId(
+                                    action_ref: TestActionRef(
                                         "compute_value",
                                     ),
                                     args: [

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_actions__action_positional_args.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_actions__action_positional_args.py__bytecode.snap
@@ -30,11 +30,11 @@ Ok(
                                 },
                             ),
                             ExtCallSet(
-                                ExtCall {
+                                ActionCall {
                                     dst: RegisterId(
                                         0,
                                     ),
-                                    extcall_id: TestExtCallId(
+                                    action_ref: TestActionRef(
                                         "add_numbers",
                                     ),
                                     args: [

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_actions__action_positional_args.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_actions__action_positional_args.py__bytecode.snap
@@ -29,7 +29,7 @@ Ok(
                                     ),
                                 },
                             ),
-                            CoreSet(
+                            ExtCallSet(
                                 ExtCall {
                                     dst: RegisterId(
                                         0,

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_actions__action_return.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_actions__action_return.py__bytecode.snap
@@ -10,11 +10,11 @@ Ok(
                     State {
                         instructions: [
                             ExtCallSet(
-                                ExtCall {
+                                ActionCall {
                                     dst: RegisterId(
                                         1,
                                     ),
-                                    extcall_id: TestExtCallId(
+                                    action_ref: TestActionRef(
                                         "compute_result",
                                     ),
                                     args: [

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_actions__action_return.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_actions__action_return.py__bytecode.snap
@@ -9,7 +9,7 @@ Ok(
                 states: [
                     State {
                         instructions: [
-                            CoreSet(
+                            ExtCallSet(
                                 ExtCall {
                                     dst: RegisterId(
                                         1,

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_actions__action_variable_args.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_actions__action_variable_args.py__bytecode.snap
@@ -9,7 +9,7 @@ Ok(
                 states: [
                     State {
                         instructions: [
-                            CoreSet(
+                            ExtCallSet(
                                 ExtCall {
                                     dst: RegisterId(
                                         1,
@@ -44,7 +44,7 @@ Ok(
                     },
                     State {
                         instructions: [
-                            CoreSet(
+                            ExtCallSet(
                                 ExtCall {
                                     dst: RegisterId(
                                         2,

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_actions__action_variable_args.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_actions__action_variable_args.py__bytecode.snap
@@ -10,11 +10,11 @@ Ok(
                     State {
                         instructions: [
                             ExtCallSet(
-                                ExtCall {
+                                ActionCall {
                                     dst: RegisterId(
                                         1,
                                     ),
-                                    extcall_id: TestExtCallId(
+                                    action_ref: TestActionRef(
                                         "get_base_value",
                                     ),
                                     args: [],
@@ -45,11 +45,11 @@ Ok(
                     State {
                         instructions: [
                             ExtCallSet(
-                                ExtCall {
+                                ActionCall {
                                     dst: RegisterId(
                                         2,
                                     ),
-                                    extcall_id: TestExtCallId(
+                                    action_ref: TestActionRef(
                                         "multiply_by",
                                     ),
                                     args: [

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_actions__literal_return.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_actions__literal_return.py__bytecode.snap
@@ -9,7 +9,7 @@ Ok(
                 states: [
                     State {
                         instructions: [
-                            CoreSet(
+                            ExtCallSet(
                                 ExtCall {
                                     dst: RegisterId(
                                         0,

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_actions__literal_return.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_actions__literal_return.py__bytecode.snap
@@ -10,11 +10,11 @@ Ok(
                     State {
                         instructions: [
                             ExtCallSet(
-                                ExtCall {
+                                ActionCall {
                                     dst: RegisterId(
                                         0,
                                     ),
-                                    extcall_id: TestExtCallId(
+                                    action_ref: TestActionRef(
                                         "do_something",
                                     ),
                                     args: [],

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_actions__simple_action.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_actions__simple_action.py__bytecode.snap
@@ -10,11 +10,11 @@ Ok(
                     State {
                         instructions: [
                             ExtCallSet(
-                                ExtCall {
+                                ActionCall {
                                     dst: RegisterId(
                                         1,
                                     ),
-                                    extcall_id: TestExtCallId(
+                                    action_ref: TestActionRef(
                                         "process",
                                     ),
                                     args: [

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_actions__simple_action.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_actions__simple_action.py__bytecode.snap
@@ -9,7 +9,7 @@ Ok(
                 states: [
                     State {
                         instructions: [
-                            CoreSet(
+                            ExtCallSet(
                                 ExtCall {
                                     dst: RegisterId(
                                         1,

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_actions__variable_return.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_actions__variable_return.py__bytecode.snap
@@ -10,11 +10,11 @@ Ok(
                     State {
                         instructions: [
                             ExtCallSet(
-                                ExtCall {
+                                ActionCall {
                                     dst: RegisterId(
                                         1,
                                     ),
-                                    extcall_id: TestExtCallId(
+                                    action_ref: TestActionRef(
                                         "compute_result_for_variable_return",
                                     ),
                                     args: [

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_actions__variable_return.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_actions__variable_return.py__bytecode.snap
@@ -9,7 +9,7 @@ Ok(
                 states: [
                     State {
                         instructions: [
-                            CoreSet(
+                            ExtCallSet(
                                 ExtCall {
                                     dst: RegisterId(
                                         1,

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_conditional__if_await_action_condition.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_conditional__if_await_action_condition.py__bytecode.snap
@@ -10,11 +10,11 @@ Ok(
                     State {
                         instructions: [
                             ExtCallSet(
-                                ExtCall {
+                                ActionCall {
                                     dst: RegisterId(
                                         1,
                                     ),
-                                    extcall_id: TestExtCallId(
+                                    action_ref: TestActionRef(
                                         "is_even",
                                     ),
                                     args: [

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_conditional__if_await_action_condition.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_conditional__if_await_action_condition.py__bytecode.snap
@@ -9,7 +9,7 @@ Ok(
                 states: [
                     State {
                         instructions: [
-                            CoreSet(
+                            ExtCallSet(
                                 ExtCall {
                                     dst: RegisterId(
                                         1,

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_conditional__if_multiple_calls.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_conditional__if_multiple_calls.py__bytecode.snap
@@ -69,7 +69,7 @@ Ok(
                     },
                     State {
                         instructions: [
-                            CoreSet(
+                            ExtCallSet(
                                 ExtCall {
                                     dst: RegisterId(
                                         3,
@@ -108,7 +108,7 @@ Ok(
                     },
                     State {
                         instructions: [
-                            CoreSet(
+                            ExtCallSet(
                                 ExtCall {
                                     dst: RegisterId(
                                         4,

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_conditional__if_multiple_calls.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_conditional__if_multiple_calls.py__bytecode.snap
@@ -70,11 +70,11 @@ Ok(
                     State {
                         instructions: [
                             ExtCallSet(
-                                ExtCall {
+                                ActionCall {
                                     dst: RegisterId(
                                         3,
                                     ),
-                                    extcall_id: TestExtCallId(
+                                    action_ref: TestActionRef(
                                         "if_step_one",
                                     ),
                                     args: [
@@ -109,11 +109,11 @@ Ok(
                     State {
                         instructions: [
                             ExtCallSet(
-                                ExtCall {
+                                ActionCall {
                                     dst: RegisterId(
                                         4,
                                     ),
-                                    extcall_id: TestExtCallId(
+                                    action_ref: TestActionRef(
                                         "if_step_two",
                                     ),
                                     args: [

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_control_flow__if_elif_else.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_control_flow__if_elif_else.py__bytecode.snap
@@ -117,7 +117,7 @@ Ok(
                                     ),
                                 },
                             ),
-                            CoreSet(
+                            ExtCallSet(
                                 ExtCall {
                                     dst: RegisterId(
                                         3,
@@ -146,7 +146,7 @@ Ok(
                     },
                     State {
                         instructions: [
-                            CoreSet(
+                            ExtCallSet(
                                 ExtCall {
                                     dst: RegisterId(
                                         3,
@@ -164,7 +164,7 @@ Ok(
                     },
                     State {
                         instructions: [
-                            CoreSet(
+                            ExtCallSet(
                                 ExtCall {
                                     dst: RegisterId(
                                         3,
@@ -182,7 +182,7 @@ Ok(
                     },
                     State {
                         instructions: [
-                            CoreSet(
+                            ExtCallSet(
                                 ExtCall {
                                     dst: RegisterId(
                                         3,

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_control_flow__if_elif_else.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_control_flow__if_elif_else.py__bytecode.snap
@@ -118,11 +118,11 @@ Ok(
                                 },
                             ),
                             ExtCallSet(
-                                ExtCall {
+                                ActionCall {
                                     dst: RegisterId(
                                         3,
                                     ),
-                                    extcall_id: TestExtCallId(
+                                    action_ref: TestActionRef(
                                         "handle_default",
                                     ),
                                     args: [],
@@ -147,11 +147,11 @@ Ok(
                     State {
                         instructions: [
                             ExtCallSet(
-                                ExtCall {
+                                ActionCall {
                                     dst: RegisterId(
                                         3,
                                     ),
-                                    extcall_id: TestExtCallId(
+                                    action_ref: TestActionRef(
                                         "handle_case_a",
                                     ),
                                     args: [],
@@ -165,11 +165,11 @@ Ok(
                     State {
                         instructions: [
                             ExtCallSet(
-                                ExtCall {
+                                ActionCall {
                                     dst: RegisterId(
                                         3,
                                     ),
-                                    extcall_id: TestExtCallId(
+                                    action_ref: TestActionRef(
                                         "handle_case_b",
                                     ),
                                     args: [],
@@ -183,11 +183,11 @@ Ok(
                     State {
                         instructions: [
                             ExtCallSet(
-                                ExtCall {
+                                ActionCall {
                                     dst: RegisterId(
                                         3,
                                     ),
-                                    extcall_id: TestExtCallId(
+                                    action_ref: TestActionRef(
                                         "handle_case_c",
                                     ),
                                     args: [],

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_control_flow__if_multi_action.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_control_flow__if_multi_action.py__bytecode.snap
@@ -20,11 +20,11 @@ Ok(
                                 },
                             ),
                             ExtCallSet(
-                                ExtCall {
+                                ActionCall {
                                     dst: RegisterId(
                                         1,
                                     ),
-                                    extcall_id: TestExtCallId(
+                                    action_ref: TestActionRef(
                                         "action_else_1",
                                     ),
                                     args: [],
@@ -49,11 +49,11 @@ Ok(
                     State {
                         instructions: [
                             ExtCallSet(
-                                ExtCall {
+                                ActionCall {
                                     dst: RegisterId(
                                         4,
                                     ),
-                                    extcall_id: TestExtCallId(
+                                    action_ref: TestActionRef(
                                         "action_if_1",
                                     ),
                                     args: [],
@@ -84,11 +84,11 @@ Ok(
                     State {
                         instructions: [
                             ExtCallSet(
-                                ExtCall {
+                                ActionCall {
                                     dst: RegisterId(
                                         2,
                                     ),
-                                    extcall_id: TestExtCallId(
+                                    action_ref: TestActionRef(
                                         "action_else_2",
                                     ),
                                     args: [
@@ -161,11 +161,11 @@ Ok(
                     State {
                         instructions: [
                             ExtCallSet(
-                                ExtCall {
+                                ActionCall {
                                     dst: RegisterId(
                                         5,
                                     ),
-                                    extcall_id: TestExtCallId(
+                                    action_ref: TestActionRef(
                                         "action_if_2",
                                     ),
                                     args: [

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_control_flow__if_multi_action.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_control_flow__if_multi_action.py__bytecode.snap
@@ -19,7 +19,7 @@ Ok(
                                     ),
                                 },
                             ),
-                            CoreSet(
+                            ExtCallSet(
                                 ExtCall {
                                     dst: RegisterId(
                                         1,
@@ -48,7 +48,7 @@ Ok(
                     },
                     State {
                         instructions: [
-                            CoreSet(
+                            ExtCallSet(
                                 ExtCall {
                                     dst: RegisterId(
                                         4,
@@ -83,7 +83,7 @@ Ok(
                     },
                     State {
                         instructions: [
-                            CoreSet(
+                            ExtCallSet(
                                 ExtCall {
                                     dst: RegisterId(
                                         2,
@@ -160,7 +160,7 @@ Ok(
                     },
                     State {
                         instructions: [
-                            CoreSet(
+                            ExtCallSet(
                                 ExtCall {
                                     dst: RegisterId(
                                         5,

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_control_flow__if_simple.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_control_flow__if_simple.py__bytecode.snap
@@ -20,11 +20,11 @@ Ok(
                                 },
                             ),
                             ExtCallSet(
-                                ExtCall {
+                                ActionCall {
                                     dst: RegisterId(
                                         1,
                                     ),
-                                    extcall_id: TestExtCallId(
+                                    action_ref: TestActionRef(
                                         "handle_false_case",
                                     ),
                                     args: [],
@@ -49,11 +49,11 @@ Ok(
                     State {
                         instructions: [
                             ExtCallSet(
-                                ExtCall {
+                                ActionCall {
                                     dst: RegisterId(
                                         1,
                                     ),
-                                    extcall_id: TestExtCallId(
+                                    action_ref: TestActionRef(
                                         "handle_true_case",
                                     ),
                                     args: [],

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_control_flow__if_simple.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_control_flow__if_simple.py__bytecode.snap
@@ -19,7 +19,7 @@ Ok(
                                     ),
                                 },
                             ),
-                            CoreSet(
+                            ExtCallSet(
                                 ExtCall {
                                     dst: RegisterId(
                                         1,
@@ -48,7 +48,7 @@ Ok(
                     },
                     State {
                         instructions: [
-                            CoreSet(
+                            ExtCallSet(
                                 ExtCall {
                                     dst: RegisterId(
                                         1,

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_control_flow__while_simple.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_control_flow__while_simple.py__bytecode.snap
@@ -67,7 +67,7 @@ Ok(
                     },
                     State {
                         instructions: [
-                            CoreSet(
+                            ExtCallSet(
                                 ExtCall {
                                     dst: RegisterId(
                                         1,

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_control_flow__while_simple.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_control_flow__while_simple.py__bytecode.snap
@@ -68,11 +68,11 @@ Ok(
                     State {
                         instructions: [
                             ExtCallSet(
-                                ExtCall {
+                                ActionCall {
                                     dst: RegisterId(
                                         1,
                                     ),
-                                    extcall_id: TestExtCallId(
+                                    action_ref: TestActionRef(
                                         "increment",
                                     ),
                                     args: [

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_nested.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_nested.py__bytecode.snap
@@ -10,11 +10,11 @@ Ok(
                     State {
                         instructions: [
                             ExtCallSet(
-                                ExtCall {
+                                ActionCall {
                                     dst: RegisterId(
                                         1,
                                     ),
-                                    extcall_id: TestExtCallId(
+                                    action_ref: TestActionRef(
                                         "fetch_a",
                                     ),
                                     args: [],
@@ -28,11 +28,11 @@ Ok(
                     State {
                         instructions: [
                             ExtCallSet(
-                                ExtCall {
+                                ActionCall {
                                     dst: RegisterId(
                                         2,
                                     ),
-                                    extcall_id: TestExtCallId(
+                                    action_ref: TestActionRef(
                                         "fetch_b",
                                     ),
                                     args: [],
@@ -95,11 +95,11 @@ Ok(
                                 },
                             ),
                             ExtCallSet(
-                                ExtCall {
+                                ActionCall {
                                     dst: RegisterId(
                                         3,
                                     ),
-                                    extcall_id: TestExtCallId(
+                                    action_ref: TestActionRef(
                                         "combine",
                                     ),
                                     args: [

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_nested.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_nested.py__bytecode.snap
@@ -9,7 +9,7 @@ Ok(
                 states: [
                     State {
                         instructions: [
-                            CoreSet(
+                            ExtCallSet(
                                 ExtCall {
                                     dst: RegisterId(
                                         1,
@@ -27,7 +27,7 @@ Ok(
                     },
                     State {
                         instructions: [
-                            CoreSet(
+                            ExtCallSet(
                                 ExtCall {
                                     dst: RegisterId(
                                         2,
@@ -94,7 +94,7 @@ Ok(
                                     ],
                                 },
                             ),
-                            CoreSet(
+                            ExtCallSet(
                                 ExtCall {
                                     dst: RegisterId(
                                         3,

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_to_variable.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_to_variable.py__bytecode.snap
@@ -9,7 +9,7 @@ Ok(
                 states: [
                     State {
                         instructions: [
-                            CoreSet(
+                            ExtCallSet(
                                 ExtCall {
                                     dst: RegisterId(
                                         1,
@@ -27,7 +27,7 @@ Ok(
                     },
                     State {
                         instructions: [
-                            CoreSet(
+                            ExtCallSet(
                                 ExtCall {
                                     dst: RegisterId(
                                         2,
@@ -45,7 +45,7 @@ Ok(
                     },
                     State {
                         instructions: [
-                            CoreSet(
+                            ExtCallSet(
                                 ExtCall {
                                     dst: RegisterId(
                                         3,

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_to_variable.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_to_variable.py__bytecode.snap
@@ -10,11 +10,11 @@ Ok(
                     State {
                         instructions: [
                             ExtCallSet(
-                                ExtCall {
+                                ActionCall {
                                     dst: RegisterId(
                                         1,
                                     ),
-                                    extcall_id: TestExtCallId(
+                                    action_ref: TestActionRef(
                                         "fetch_value_1",
                                     ),
                                     args: [],
@@ -28,11 +28,11 @@ Ok(
                     State {
                         instructions: [
                             ExtCallSet(
-                                ExtCall {
+                                ActionCall {
                                     dst: RegisterId(
                                         2,
                                     ),
-                                    extcall_id: TestExtCallId(
+                                    action_ref: TestActionRef(
                                         "fetch_value_2",
                                     ),
                                     args: [],
@@ -46,11 +46,11 @@ Ok(
                     State {
                         instructions: [
                             ExtCallSet(
-                                ExtCall {
+                                ActionCall {
                                     dst: RegisterId(
                                         3,
                                     ),
-                                    extcall_id: TestExtCallId(
+                                    action_ref: TestActionRef(
                                         "fetch_value_3",
                                     ),
                                     args: [],

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_tuple_unpack.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_tuple_unpack.py__bytecode.snap
@@ -20,11 +20,11 @@ Ok(
                                 },
                             ),
                             ExtCallSet(
-                                ExtCall {
+                                ActionCall {
                                     dst: RegisterId(
                                         2,
                                     ),
-                                    extcall_id: TestExtCallId(
+                                    action_ref: TestActionRef(
                                         "compute_factorial",
                                     ),
                                     args: [
@@ -52,11 +52,11 @@ Ok(
                                 },
                             ),
                             ExtCallSet(
-                                ExtCall {
+                                ActionCall {
                                     dst: RegisterId(
                                         3,
                                     ),
-                                    extcall_id: TestExtCallId(
+                                    action_ref: TestActionRef(
                                         "compute_fibonacci",
                                     ),
                                     args: [
@@ -108,11 +108,11 @@ Ok(
                     State {
                         instructions: [
                             ExtCallSet(
-                                ExtCall {
+                                ActionCall {
                                     dst: RegisterId(
                                         5,
                                     ),
-                                    extcall_id: TestExtCallId(
+                                    action_ref: TestActionRef(
                                         "summarize_math",
                                     ),
                                     args: [

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_tuple_unpack.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_tuple_unpack.py__bytecode.snap
@@ -19,7 +19,7 @@ Ok(
                                     ),
                                 },
                             ),
-                            CoreSet(
+                            ExtCallSet(
                                 ExtCall {
                                     dst: RegisterId(
                                         2,
@@ -51,7 +51,7 @@ Ok(
                                     ),
                                 },
                             ),
-                            CoreSet(
+                            ExtCallSet(
                                 ExtCall {
                                     dst: RegisterId(
                                         3,
@@ -107,7 +107,7 @@ Ok(
                     },
                     State {
                         instructions: [
-                            CoreSet(
+                            ExtCallSet(
                                 ExtCall {
                                     dst: RegisterId(
                                         5,

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_policy__instance_attr_policies.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_policy__instance_attr_policies.py__bytecode.snap
@@ -9,7 +9,7 @@ Ok(
                 states: [
                     State {
                         instructions: [
-                            CoreSet(
+                            ExtCallSet(
                                 ExtCall {
                                     dst: RegisterId(
                                         1,
@@ -48,7 +48,7 @@ Ok(
                     },
                     State {
                         instructions: [
-                            CoreSet(
+                            ExtCallSet(
                                 ExtCall {
                                     dst: RegisterId(
                                         2,
@@ -87,7 +87,7 @@ Ok(
                     },
                     State {
                         instructions: [
-                            CoreSet(
+                            ExtCallSet(
                                 ExtCall {
                                     dst: RegisterId(
                                         3,

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_policy__instance_attr_policies.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_policy__instance_attr_policies.py__bytecode.snap
@@ -10,11 +10,11 @@ Ok(
                     State {
                         instructions: [
                             ExtCallSet(
-                                ExtCall {
+                                ActionCall {
                                     dst: RegisterId(
                                         1,
                                     ),
-                                    extcall_id: TestExtCallId(
+                                    action_ref: TestActionRef(
                                         "action_with_instance_retry",
                                     ),
                                     args: [
@@ -49,11 +49,11 @@ Ok(
                     State {
                         instructions: [
                             ExtCallSet(
-                                ExtCall {
+                                ActionCall {
                                     dst: RegisterId(
                                         2,
                                     ),
-                                    extcall_id: TestExtCallId(
+                                    action_ref: TestActionRef(
                                         "action_with_instance_timeout",
                                     ),
                                     args: [
@@ -88,11 +88,11 @@ Ok(
                     State {
                         instructions: [
                             ExtCallSet(
-                                ExtCall {
+                                ActionCall {
                                     dst: RegisterId(
                                         3,
                                     ),
-                                    extcall_id: TestExtCallId(
+                                    action_ref: TestActionRef(
                                         "action_with_both_policies",
                                     ),
                                     args: [

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_policy__policy_variations.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_policy__policy_variations.py__bytecode.snap
@@ -10,11 +10,11 @@ Ok(
                     State {
                         instructions: [
                             ExtCallSet(
-                                ExtCall {
+                                ActionCall {
                                     dst: RegisterId(
                                         1,
                                     ),
-                                    extcall_id: TestExtCallId(
+                                    action_ref: TestActionRef(
                                         "action_with_timeout_int",
                                     ),
                                     args: [
@@ -49,11 +49,11 @@ Ok(
                     State {
                         instructions: [
                             ExtCallSet(
-                                ExtCall {
+                                ActionCall {
                                     dst: RegisterId(
                                         2,
                                     ),
-                                    extcall_id: TestExtCallId(
+                                    action_ref: TestActionRef(
                                         "action_with_timeout_minutes",
                                     ),
                                     args: [
@@ -88,11 +88,11 @@ Ok(
                     State {
                         instructions: [
                             ExtCallSet(
-                                ExtCall {
+                                ActionCall {
                                     dst: RegisterId(
                                         3,
                                     ),
-                                    extcall_id: TestExtCallId(
+                                    action_ref: TestActionRef(
                                         "action_with_retry_backoff",
                                     ),
                                     args: [
@@ -127,11 +127,11 @@ Ok(
                     State {
                         instructions: [
                             ExtCallSet(
-                                ExtCall {
+                                ActionCall {
                                     dst: RegisterId(
                                         4,
                                     ),
-                                    extcall_id: TestExtCallId(
+                                    action_ref: TestActionRef(
                                         "action_with_retry_exceptions",
                                     ),
                                     args: [
@@ -166,11 +166,11 @@ Ok(
                     State {
                         instructions: [
                             ExtCallSet(
-                                ExtCall {
+                                ActionCall {
                                     dst: RegisterId(
                                         5,
                                     ),
-                                    extcall_id: TestExtCallId(
+                                    action_ref: TestActionRef(
                                         "action_with_retry_default",
                                     ),
                                     args: [
@@ -205,11 +205,11 @@ Ok(
                     State {
                         instructions: [
                             ExtCallSet(
-                                ExtCall {
+                                ActionCall {
                                     dst: RegisterId(
                                         6,
                                     ),
-                                    extcall_id: TestExtCallId(
+                                    action_ref: TestActionRef(
                                         "action_with_timeout_hours",
                                     ),
                                     args: [
@@ -244,11 +244,11 @@ Ok(
                     State {
                         instructions: [
                             ExtCallSet(
-                                ExtCall {
+                                ActionCall {
                                     dst: RegisterId(
                                         7,
                                     ),
-                                    extcall_id: TestExtCallId(
+                                    action_ref: TestActionRef(
                                         "action_with_timeout_days",
                                     ),
                                     args: [

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_policy__policy_variations.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_policy__policy_variations.py__bytecode.snap
@@ -9,7 +9,7 @@ Ok(
                 states: [
                     State {
                         instructions: [
-                            CoreSet(
+                            ExtCallSet(
                                 ExtCall {
                                     dst: RegisterId(
                                         1,
@@ -48,7 +48,7 @@ Ok(
                     },
                     State {
                         instructions: [
-                            CoreSet(
+                            ExtCallSet(
                                 ExtCall {
                                     dst: RegisterId(
                                         2,
@@ -87,7 +87,7 @@ Ok(
                     },
                     State {
                         instructions: [
-                            CoreSet(
+                            ExtCallSet(
                                 ExtCall {
                                     dst: RegisterId(
                                         3,
@@ -126,7 +126,7 @@ Ok(
                     },
                     State {
                         instructions: [
-                            CoreSet(
+                            ExtCallSet(
                                 ExtCall {
                                     dst: RegisterId(
                                         4,
@@ -165,7 +165,7 @@ Ok(
                     },
                     State {
                         instructions: [
-                            CoreSet(
+                            ExtCallSet(
                                 ExtCall {
                                     dst: RegisterId(
                                         5,
@@ -204,7 +204,7 @@ Ok(
                     },
                     State {
                         instructions: [
-                            CoreSet(
+                            ExtCallSet(
                                 ExtCall {
                                     dst: RegisterId(
                                         6,
@@ -243,7 +243,7 @@ Ok(
                     },
                     State {
                         instructions: [
-                            CoreSet(
+                            ExtCallSet(
                                 ExtCall {
                                     dst: RegisterId(
                                         7,

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_side_effects__side_effect_action.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_side_effects__side_effect_action.py__bytecode.snap
@@ -9,7 +9,7 @@ Ok(
                 states: [
                     State {
                         instructions: [
-                            CoreSet(
+                            ExtCallSet(
                                 ExtCall {
                                     dst: RegisterId(
                                         0,

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_side_effects__side_effect_action.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_side_effects__side_effect_action.py__bytecode.snap
@@ -10,11 +10,11 @@ Ok(
                     State {
                         instructions: [
                             ExtCallSet(
-                                ExtCall {
+                                ActionCall {
                                     dst: RegisterId(
                                         0,
                                     ),
-                                    extcall_id: TestExtCallId(
+                                    action_ref: TestActionRef(
                                         "side_effect",
                                     ),
                                     args: [],

--- a/crates/lib/vm-instructions-coreset/src/lib.rs
+++ b/crates/lib/vm-instructions-coreset/src/lib.rs
@@ -1,7 +1,7 @@
 //! The "core" instruction set for the VM.
 //!
-//! Responsible for representing function calls, returns, awaits, control flow
-//! and extcalls.
+//! Responsible for representing function calls, returns, awaits, and control
+//! flow.
 //!
 //! Minimal core functionality of the VM.
 
@@ -19,9 +19,6 @@ pub trait Spec: 'static {
 
     /// The type used to refer to the executable function sub-states.
     type StateId: core::fmt::Debug;
-
-    /// The type used to refer to the extcalls.
-    type ExtCallId: core::fmt::Debug;
 }
 
 /// The core instructions set.
@@ -41,25 +38,6 @@ pub enum CoreSet<Spec: self::Spec> {
         /// The registers in the current frame to take the arguments to pass to
         /// the function from.
         args: Vec<Spec::RegisterId>,
-    },
-
-    /// Start an extcall execution.
-    ///
-    /// External calls are always asynchronous by nature.
-    ExtCall {
-        /// The resiter in the current frame to assign the promise for this
-        /// new call completion.
-        dst: Spec::RegisterId,
-
-        /// The ID of the extcall to invoke.
-        extcall_id: Spec::ExtCallId,
-
-        /// The registers in the current frame to take the arguments to pass to
-        /// the extcall from.
-        args: Vec<Spec::RegisterId>,
-
-        /// The state to resume the execution from after invoking the extcall.
-        resume: Spec::StateId,
     },
 
     /// Suspend the execution until a promise is resolved.

--- a/crates/lib/vm-instructions-extcallset/Cargo.toml
+++ b/crates/lib/vm-instructions-extcallset/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "waymark-vm-instructions-extcallset"
+edition = "2024"
+version.workspace = true
+publish.workspace = true
+
+[dependencies]
+derive-where = { workspace = true }

--- a/crates/lib/vm-instructions-extcallset/src/lib.rs
+++ b/crates/lib/vm-instructions-extcallset/src/lib.rs
@@ -14,23 +14,23 @@ pub trait Spec: 'static {
     /// The type used to refer to the executable function sub-states.
     type StateId: core::fmt::Debug;
 
-    /// The type used to refer to the extcalls.
-    type ExtCallId: core::fmt::Debug;
+    /// The type used to refer to an action.
+    type ActionRef: core::fmt::Debug;
 }
 
 /// The external-call instructions set.
 #[derive_where(Debug)]
 pub enum ExtCallSet<Spec: self::Spec> {
-    /// Start an extcall execution.
+    /// Start an action call execution.
     ///
     /// External calls are always asynchronous by nature.
-    ExtCall {
-        /// The resiter in the current frame to assign the promise for this
+    ActionCall {
+        /// The register in the current frame to assign the promise for this
         /// new call completion.
         dst: Spec::RegisterId,
 
-        /// The ID of the extcall to invoke.
-        extcall_id: Spec::ExtCallId,
+        /// The action to invoke.
+        action_ref: Spec::ActionRef,
 
         /// The registers in the current frame to take the arguments to pass to
         /// the extcall from.

--- a/crates/lib/vm-instructions-extcallset/src/lib.rs
+++ b/crates/lib/vm-instructions-extcallset/src/lib.rs
@@ -1,0 +1,42 @@
+//! The "extcall" instruction set for the VM.
+//!
+//! Responsible for representing asynchronous operations that suspend execution.
+
+#![warn(missing_docs)]
+
+use derive_where::derive_where;
+
+/// The spec for required data types for the [`ExtCallSet`].
+pub trait Spec: 'static {
+    /// The type used to refer to the registers.
+    type RegisterId: core::fmt::Debug;
+
+    /// The type used to refer to the executable function sub-states.
+    type StateId: core::fmt::Debug;
+
+    /// The type used to refer to the extcalls.
+    type ExtCallId: core::fmt::Debug;
+}
+
+/// The external-call instructions set.
+#[derive_where(Debug)]
+pub enum ExtCallSet<Spec: self::Spec> {
+    /// Start an extcall execution.
+    ///
+    /// External calls are always asynchronous by nature.
+    ExtCall {
+        /// The resiter in the current frame to assign the promise for this
+        /// new call completion.
+        dst: Spec::RegisterId,
+
+        /// The ID of the extcall to invoke.
+        extcall_id: Spec::ExtCallId,
+
+        /// The registers in the current frame to take the arguments to pass to
+        /// the extcall from.
+        args: Vec<Spec::RegisterId>,
+
+        /// The state to resume the execution from after invoking the extcall.
+        resume: Spec::StateId,
+    },
+}

--- a/crates/lib/vm-instructions-fullset/Cargo.toml
+++ b/crates/lib/vm-instructions-fullset/Cargo.toml
@@ -6,6 +6,7 @@ publish.workspace = true
 
 [dependencies]
 waymark-vm-instructions-coreset = { workspace = true }
+waymark-vm-instructions-extcallset = { workspace = true }
 waymark-vm-instructions-pureset = { workspace = true }
 
 derive-where = { workspace = true }

--- a/crates/lib/vm-instructions-fullset/src/lib.rs
+++ b/crates/lib/vm-instructions-fullset/src/lib.rs
@@ -1,6 +1,6 @@
 //! The "full" instruction set for the VM.
 //!
-//! Merges together all the instruction sets, so far "core" and "pure".
+//! Merges together the "core", "extcall", and "pure" instruction sets.
 
 #![warn(missing_docs)]
 
@@ -9,7 +9,10 @@ use derive_where::derive_where;
 /// The spec for required data types for the [`FullSet`].
 pub trait Spec:
     waymark_vm_instructions_coreset::Spec
-    + waymark_vm_instructions_pureset::Spec<
+    + waymark_vm_instructions_extcallset::Spec<
+        RegisterId = <Self as waymark_vm_instructions_coreset::Spec>::RegisterId,
+        StateId = <Self as waymark_vm_instructions_coreset::Spec>::StateId,
+    > + waymark_vm_instructions_pureset::Spec<
         RegisterId = <Self as waymark_vm_instructions_coreset::Spec>::RegisterId,
     >
 {
@@ -17,7 +20,10 @@ pub trait Spec:
 
 impl<T> Spec for T where
     T: waymark_vm_instructions_coreset::Spec
-        + waymark_vm_instructions_pureset::Spec<
+        + waymark_vm_instructions_extcallset::Spec<
+            RegisterId = <Self as waymark_vm_instructions_coreset::Spec>::RegisterId,
+            StateId = <Self as waymark_vm_instructions_coreset::Spec>::StateId,
+        > + waymark_vm_instructions_pureset::Spec<
             RegisterId = <Self as waymark_vm_instructions_coreset::Spec>::RegisterId,
         >
 {
@@ -29,6 +35,9 @@ pub enum FullSet<Spec: self::Spec> {
     /// Core instructions set.
     CoreSet(waymark_vm_instructions_coreset::CoreSet<Spec>),
 
+    /// External-call instructions set.
+    ExtCallSet(waymark_vm_instructions_extcallset::ExtCallSet<Spec>),
+
     /// Pure instructions set.
     PureSet(waymark_vm_instructions_pureset::PureSet<Spec>),
 }
@@ -36,6 +45,14 @@ pub enum FullSet<Spec: self::Spec> {
 impl<Spec: self::Spec> From<waymark_vm_instructions_coreset::CoreSet<Spec>> for FullSet<Spec> {
     fn from(value: waymark_vm_instructions_coreset::CoreSet<Spec>) -> Self {
         Self::CoreSet(value)
+    }
+}
+
+impl<Spec: self::Spec> From<waymark_vm_instructions_extcallset::ExtCallSet<Spec>>
+    for FullSet<Spec>
+{
+    fn from(value: waymark_vm_instructions_extcallset::ExtCallSet<Spec>) -> Self {
+        Self::ExtCallSet(value)
     }
 }
 

--- a/crates/lib/vm-interpreter-coreset/src/error.rs
+++ b/crates/lib/vm-interpreter-coreset/src/error.rs
@@ -3,10 +3,6 @@ use waymark_vm_runtime_core::{PromiseStateNotFoundError, UnresolvedPromiseError}
 /// The error for the [`crate::CoreSetInterpreter`].
 #[derive(Debug, thiserror::Error)]
 pub enum Error<Spec: waymark_vm_instructions_coreset::Spec> {
-    /// Invoking an extcall failed.
-    #[error("extcall: {0}")]
-    ExtCall(#[source] ExtCallError),
-
     /// Awaiting a promise failed.
     #[error("await: {0}")]
     Await(#[source] AwaitError),
@@ -53,21 +49,6 @@ pub enum JumpIfError {
     /// The resolved condition value could not be interpreted as conditional.
     #[error("condition check: {0}")]
     ConditionCheck(#[source] crate::value::NotAConditionalError),
-}
-
-/// Errors produced while preparing an extcall invocation.
-#[derive(Debug, thiserror::Error)]
-pub enum ExtCallError {
-    /// An extcall argument still held an unresolved promise.
-    #[error("unresolved promise argument at position {arg_pos}: {source}")]
-    UnresolvedPromiseArgument {
-        /// The zero-based argument position that failed to resolve.
-        arg_pos: usize,
-
-        /// The underlying unresolved promise error for the argument.
-        #[source]
-        source: UnresolvedPromiseError,
-    },
 }
 
 /// Errors produced while returning from a frame.

--- a/crates/lib/vm-interpreter-coreset/src/lib.rs
+++ b/crates/lib/vm-interpreter-coreset/src/lib.rs
@@ -8,7 +8,7 @@ pub mod value;
 use derive_where::derive_where;
 use waymark_vm_interpreter::ExecutionOutcome;
 use waymark_vm_runtime_core::{
-    Continuation, Frame, FrameKind, Promise, PromiseState, PromiseStateId, Registers, RuntimeState,
+    Continuation, Frame, FrameKind, Promise, PromiseState, Registers, RuntimeState,
 };
 
 pub use self::error::*;
@@ -31,22 +31,9 @@ pub struct RuntimeView<'r, Executable, FunctionId, StateId, Value> {
 
 /// The effect for the [`CoreSetInterpreter`].
 #[derive(Debug)]
-pub enum Effect<Value, ExtCallId> {
+pub enum Effect<Value> {
     /// Program execution is complete.
     Complete(Value),
-
-    /// Extcall invocation is requested.
-    ExtCall {
-        /// The ID of the promise to resolve with the resulting value when
-        /// the extcall completes.
-        promise_state_id: PromiseStateId,
-
-        /// The ID of the extcall to invoke from the extcall table.
-        extcall_id: ExtCallId,
-
-        /// Args to pass to the extcall.
-        args: Vec<Value>,
-    },
 }
 
 impl<Spec, Executable, Value> waymark_vm_interpreter::Interpreter
@@ -57,7 +44,6 @@ where
     Spec: waymark_vm_instructions_coreset::Spec<RegisterId = waymark_vm_runtime_core::RegisterId>,
     Spec::FunctionId: Copy,
     Spec::StateId: Copy + Default,
-    Spec::ExtCallId: Clone,
     Value: self::Value,
     Value: Clone,
     Value: 'static,
@@ -66,7 +52,7 @@ where
     type Frame = Frame<Spec::FunctionId, Spec::StateId, Promise<Value>>;
     type Instruction = waymark_vm_instructions_coreset::CoreSet<Spec>;
     type Error = Error<Spec>;
-    type Effect = Effect<Value, Spec::ExtCallId>;
+    type Effect = Effect<Value>;
 
     fn execute<'r>(
         &self,
@@ -110,41 +96,6 @@ where
                 };
 
                 state.ready.push_back(new_frame);
-            }
-            waymark_vm_instructions_coreset::CoreSet::ExtCall {
-                dst,
-                extcall_id,
-                args,
-                resume,
-            } => {
-                let args = args
-                    .iter()
-                    .enumerate()
-                    .map(|(arg_pos, register)| {
-                        let value = frame.regs[*register].clone();
-
-                        value.require_resolved().map_err(|err| {
-                            ExtCallError::UnresolvedPromiseArgument {
-                                arg_pos,
-                                source: err,
-                            }
-                        })
-                    })
-                    .collect::<Result<_, _>>()
-                    .map_err(Error::ExtCall)?;
-
-                let promise_state_id = state.promise_states.prepare();
-                frame.regs.set(*dst, Promise::Pending(promise_state_id));
-
-                frame.state = *resume;
-
-                state.ready.push_front(frame);
-
-                return Ok(ExecutionOutcome::ExitFrameWithEffect(Effect::ExtCall {
-                    promise_state_id,
-                    extcall_id: extcall_id.clone(),
-                    args,
-                }));
             }
             waymark_vm_instructions_coreset::CoreSet::Await { dst, src, resume } => {
                 match &frame.regs[*src] {

--- a/crates/lib/vm-interpreter-coreset/tests/integration.rs
+++ b/crates/lib/vm-interpreter-coreset/tests/integration.rs
@@ -10,12 +10,8 @@ struct TestSpec;
 impl waymark_vm_instructions_coreset::Spec for TestSpec {
     type RegisterId = RegisterId;
     type FunctionId = FunctionId;
-    type ExtCallId = TestExtCallId;
     type StateId = StateId;
 }
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct TestExtCallId(usize);
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum TestValue {
@@ -69,67 +65,8 @@ fn runtime_executes_call_await_and_return_to_completion() {
         .run()
         .expect("runtime should complete after the nested call resolves");
 
-    match effect {
-        Effect::Complete(value) => assert_eq!(value, TestValue::Int(7)),
-        Effect::ExtCall { .. } => panic!("program should not emit an extcall"),
-    }
-}
-
-#[test]
-fn runtime_emits_extcall_and_completes_after_resolution() {
-    let executable = executable(vec![function(
-        3,
-        vec![
-            vec![CoreSet::ExtCall {
-                dst: RegisterId(1),
-                extcall_id: TestExtCallId(5),
-                args: vec![RegisterId(0)],
-                resume: StateId(1),
-            }],
-            vec![CoreSet::Await {
-                dst: RegisterId(2),
-                src: RegisterId(1),
-                resume: StateId(2),
-            }],
-            vec![CoreSet::Return { src: RegisterId(2) }],
-        ],
-    )]);
-
-    let mut runtime = Runtime::with_custom_entrypoint(
-        CoreSetInterpreter::<TestSpec, _, TestValue>::default(),
-        executable,
-        CallSpec {
-            func: FunctionId(0),
-            args: vec![TestValue::Int(13)],
-        },
-    )
-    .expect("function 0 should exist");
-
-    let promise_state_id = match runtime.run().expect("first run should emit the extcall") {
-        Effect::ExtCall {
-            promise_state_id,
-            extcall_id,
-            args,
-        } => {
-            assert_eq!(extcall_id, TestExtCallId(5));
-            assert_eq!(args, vec![TestValue::Int(13)]);
-            promise_state_id
-        }
-        Effect::Complete(_) => panic!("runtime should suspend on the extcall first"),
-    };
-
-    runtime
-        .resolve_promise(promise_state_id, TestValue::Int(41))
-        .expect("extcall promise should resolve cleanly");
-
-    let effect = runtime
-        .run()
-        .expect("runtime should complete after the promise resolves");
-
-    match effect {
-        Effect::Complete(value) => assert_eq!(value, TestValue::Int(41)),
-        Effect::ExtCall { .. } => panic!("resolved extcall should not emit another extcall"),
-    }
+    let Effect::Complete(value) = effect;
+    assert_eq!(value, TestValue::Int(7));
 }
 
 #[test]
@@ -162,8 +99,6 @@ fn runtime_follows_jump_and_jump_if_before_returning() {
         .run()
         .expect("runtime should follow the branch states to completion");
 
-    match effect {
-        Effect::Complete(value) => assert_eq!(value, TestValue::Int(9)),
-        Effect::ExtCall { .. } => panic!("branching program should not emit an extcall"),
-    }
+    let Effect::Complete(value) = effect;
+    assert_eq!(value, TestValue::Int(9));
 }

--- a/crates/lib/vm-interpreter-extcallset/Cargo.toml
+++ b/crates/lib/vm-interpreter-extcallset/Cargo.toml
@@ -1,19 +1,12 @@
 [package]
-name = "waymark-vm-interpreter-fullset"
+name = "waymark-vm-interpreter-extcallset"
 edition = "2024"
 version.workspace = true
 publish.workspace = true
 
 [dependencies]
-waymark-vm-executable = { workspace = true }
-waymark-vm-instructions-coreset = { workspace = true }
 waymark-vm-instructions-extcallset = { workspace = true }
-waymark-vm-instructions-fullset = { workspace = true }
-waymark-vm-instructions-pureset = { workspace = true }
 waymark-vm-interpreter = { workspace = true }
-waymark-vm-interpreter-coreset = { workspace = true }
-waymark-vm-interpreter-extcallset = { workspace = true }
-waymark-vm-interpreter-pureset = { workspace = true }
 waymark-vm-runtime-core = { workspace = true }
 
 derive-where = { workspace = true }

--- a/crates/lib/vm-interpreter-extcallset/src/error.rs
+++ b/crates/lib/vm-interpreter-extcallset/src/error.rs
@@ -1,0 +1,24 @@
+use waymark_vm_runtime_core::UnresolvedPromiseError;
+
+/// The error for the [`crate::ExtCallSetInterpreter`].
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// Invoking an extcall failed.
+    #[error("extcall: {0}")]
+    ExtCall(#[source] ExtCallError),
+}
+
+/// Errors produced while preparing an extcall invocation.
+#[derive(Debug, thiserror::Error)]
+pub enum ExtCallError {
+    /// An extcall argument still held an unresolved promise.
+    #[error("unresolved promise argument at position {arg_pos}: {source}")]
+    UnresolvedPromiseArgument {
+        /// The zero-based argument position that failed to resolve.
+        arg_pos: usize,
+
+        /// The underlying unresolved promise error for the argument.
+        #[source]
+        source: UnresolvedPromiseError,
+    },
+}

--- a/crates/lib/vm-interpreter-extcallset/src/lib.rs
+++ b/crates/lib/vm-interpreter-extcallset/src/lib.rs
@@ -1,0 +1,128 @@
+//! The interpreter for the "extcall" instructions set.
+
+#![warn(missing_docs)]
+
+mod error;
+
+use derive_where::derive_where;
+use waymark_vm_interpreter::ExecutionOutcome;
+use waymark_vm_runtime_core::{Frame, Promise, PromiseStateId, RuntimeState};
+
+pub use self::error::*;
+
+/// An interpreter for the "extcall" instructions set.
+#[derive_where(Default)]
+pub struct ExtCallSetInterpreter<Spec, FunctionId, StateId, Value> {
+    phantom_data: core::marker::PhantomData<(Spec, FunctionId, StateId, Value)>,
+}
+
+/// The runtime view for the [`ExtCallSetInterpreter`].
+pub struct RuntimeView<'r, FunctionId, StateId, Value> {
+    /// The runtime state access.
+    pub state: &'r mut RuntimeState<FunctionId, StateId, Value>,
+}
+
+/// The effect for the [`ExtCallSetInterpreter`].
+#[derive(Debug)]
+pub enum Effect<Value, ExtCallId> {
+    /// Extcall invocation is requested.
+    ExtCall {
+        /// The ID of the promise to resolve with the resulting value when
+        /// the extcall completes.
+        promise_state_id: PromiseStateId,
+
+        /// The ID of the extcall to invoke from the extcall table.
+        extcall_id: ExtCallId,
+
+        /// Args to pass to the extcall.
+        args: Vec<Value>,
+    },
+}
+
+impl<Spec, FunctionId, StateId, Value> waymark_vm_interpreter::Interpreter
+    for ExtCallSetInterpreter<Spec, FunctionId, StateId, Value>
+where
+    Spec: waymark_vm_instructions_extcallset::Spec<
+            RegisterId = waymark_vm_runtime_core::RegisterId,
+            StateId = StateId,
+        > + 'static,
+    FunctionId: 'static,
+    StateId: Copy + 'static,
+    Spec::ExtCallId: Clone,
+    Value: Clone + 'static,
+{
+    type RuntimeView<'r> = RuntimeView<'r, FunctionId, StateId, Value>;
+    type Frame = Frame<FunctionId, StateId, Promise<Value>>;
+    type Instruction = waymark_vm_instructions_extcallset::ExtCallSet<Spec>;
+    type Error = Error;
+    type Effect = Effect<Value, Spec::ExtCallId>;
+
+    fn execute<'r>(
+        &self,
+        runtime_view: Self::RuntimeView<'r>,
+        mut frame: Frame<FunctionId, StateId, Promise<Value>>,
+        instruction: &Self::Instruction,
+    ) -> Result<
+        ExecutionOutcome<Frame<FunctionId, StateId, Promise<Value>>, Self::Effect>,
+        Self::Error,
+    > {
+        let Self::RuntimeView { state } = runtime_view;
+
+        match instruction {
+            waymark_vm_instructions_extcallset::ExtCallSet::ExtCall {
+                dst,
+                extcall_id,
+                args,
+                resume,
+            } => {
+                let args = args
+                    .iter()
+                    .enumerate()
+                    .map(|(arg_pos, register)| {
+                        let value = frame.regs[*register].clone();
+
+                        value.require_resolved().map_err(|source| {
+                            Error::ExtCall(ExtCallError::UnresolvedPromiseArgument {
+                                arg_pos,
+                                source,
+                            })
+                        })
+                    })
+                    .collect::<Result<_, _>>()?;
+
+                let promise_state_id = state.promise_states.prepare();
+                frame.regs.set(*dst, Promise::Pending(promise_state_id));
+
+                frame.state = *resume;
+
+                state.ready.push_front(frame);
+
+                Ok(ExecutionOutcome::ExitFrameWithEffect(Effect::ExtCall {
+                    promise_state_id,
+                    extcall_id: extcall_id.clone(),
+                    args,
+                }))
+            }
+        }
+    }
+}
+
+impl<Spec, Executable, FunctionId, StateId, Value>
+    waymark_vm_runtime_core::CaptureRuntimeView<Executable, FunctionId, StateId, Value>
+    for ExtCallSetInterpreter<Spec, FunctionId, StateId, Value>
+{
+    type RuntimeView<'v>
+        = RuntimeView<'v, FunctionId, StateId, Value>
+    where
+        Executable: 'v,
+        FunctionId: 'v,
+        StateId: 'v,
+        Value: 'v;
+
+    fn capture_runtime_view<'r>(
+        view: waymark_vm_runtime_core::FullRuntimeView<'r, Executable, FunctionId, StateId, Value>,
+    ) -> Self::RuntimeView<'r> {
+        let waymark_vm_runtime_core::FullRuntimeView { state, .. } = view;
+        RuntimeView { state }
+    }
+}

--- a/crates/lib/vm-interpreter-extcallset/src/lib.rs
+++ b/crates/lib/vm-interpreter-extcallset/src/lib.rs
@@ -24,17 +24,17 @@ pub struct RuntimeView<'r, FunctionId, StateId, Value> {
 
 /// The effect for the [`ExtCallSetInterpreter`].
 #[derive(Debug)]
-pub enum Effect<Value, ExtCallId> {
-    /// Extcall invocation is requested.
-    ExtCall {
+pub enum Effect<Value, ActionRef> {
+    /// Action call invocation is requested.
+    ActionCall {
         /// The ID of the promise to resolve with the resulting value when
-        /// the extcall completes.
+        /// the action call completes.
         promise_state_id: PromiseStateId,
 
-        /// The ID of the extcall to invoke from the extcall table.
-        extcall_id: ExtCallId,
+        /// The action to invoke.
+        action_ref: ActionRef,
 
-        /// Args to pass to the extcall.
+        /// Args to pass to the action call.
         args: Vec<Value>,
     },
 }
@@ -48,14 +48,14 @@ where
         > + 'static,
     FunctionId: 'static,
     StateId: Copy + 'static,
-    Spec::ExtCallId: Clone,
+    Spec::ActionRef: Clone,
     Value: Clone + 'static,
 {
     type RuntimeView<'r> = RuntimeView<'r, FunctionId, StateId, Value>;
     type Frame = Frame<FunctionId, StateId, Promise<Value>>;
     type Instruction = waymark_vm_instructions_extcallset::ExtCallSet<Spec>;
     type Error = Error;
-    type Effect = Effect<Value, Spec::ExtCallId>;
+    type Effect = Effect<Value, Spec::ActionRef>;
 
     fn execute<'r>(
         &self,
@@ -69,9 +69,9 @@ where
         let Self::RuntimeView { state } = runtime_view;
 
         match instruction {
-            waymark_vm_instructions_extcallset::ExtCallSet::ExtCall {
+            waymark_vm_instructions_extcallset::ExtCallSet::ActionCall {
                 dst,
-                extcall_id,
+                action_ref,
                 args,
                 resume,
             } => {
@@ -97,9 +97,9 @@ where
 
                 state.ready.push_front(frame);
 
-                Ok(ExecutionOutcome::ExitFrameWithEffect(Effect::ExtCall {
+                Ok(ExecutionOutcome::ExitFrameWithEffect(Effect::ActionCall {
                     promise_state_id,
-                    extcall_id: extcall_id.clone(),
+                    action_ref: action_ref.clone(),
                     args,
                 }))
             }

--- a/crates/lib/vm-interpreter-extcallset/tests/integration.rs
+++ b/crates/lib/vm-interpreter-extcallset/tests/integration.rs
@@ -1,0 +1,148 @@
+use waymark_vm_instructions_extcallset::ExtCallSet;
+use waymark_vm_interpreter::ExecutionOutcome;
+use waymark_vm_interpreter_extcallset::{Effect, ExtCallSetInterpreter, RuntimeView};
+use waymark_vm_runtime::{CallSpec, Runtime};
+use waymark_vm_runtime_core::{
+    CaptureRuntimeView, Frame, FullRuntimeView, Promise, PromiseState, PromiseStateId, RegisterId,
+};
+use waymark_vm_runtime_test::{FunctionId, StateId, executable, function};
+
+#[derive(Debug)]
+struct TestSpec;
+
+impl waymark_vm_instructions_extcallset::Spec for TestSpec {
+    type RegisterId = RegisterId;
+    type StateId = StateId;
+    type ExtCallId = usize;
+}
+
+#[derive(Debug)]
+enum RuntimeInstruction {
+    ExtCall(ExtCallSet<TestSpec>),
+    InspectPending(RegisterId),
+}
+
+impl From<ExtCallSet<TestSpec>> for RuntimeInstruction {
+    fn from(value: ExtCallSet<TestSpec>) -> Self {
+        Self::ExtCall(value)
+    }
+}
+
+#[derive(Debug)]
+enum TestEffect {
+    ExtCall(Effect<i32, usize>),
+    PendingPromiseStateId(PromiseStateId),
+}
+
+#[derive(Default)]
+struct RuntimeInterpreter {
+    extcall: ExtCallSetInterpreter<TestSpec, FunctionId, StateId, i32>,
+}
+
+impl<Executable> CaptureRuntimeView<Executable, FunctionId, StateId, i32> for RuntimeInterpreter {
+    type RuntimeView<'r>
+        = RuntimeView<'r, FunctionId, StateId, i32>
+    where
+        Executable: 'r,
+        FunctionId: 'r,
+        StateId: 'r,
+        i32: 'r;
+
+    fn capture_runtime_view<'r>(
+        view: FullRuntimeView<'r, Executable, FunctionId, StateId, i32>,
+    ) -> Self::RuntimeView<'r> {
+        let FullRuntimeView { state, .. } = view;
+        RuntimeView { state }
+    }
+}
+
+impl waymark_vm_interpreter::Interpreter for RuntimeInterpreter {
+    type RuntimeView<'r> = RuntimeView<'r, FunctionId, StateId, i32>;
+    type Frame = Frame<FunctionId, StateId, Promise<i32>>;
+    type Instruction = RuntimeInstruction;
+    type Error = waymark_vm_interpreter_extcallset::Error;
+    type Effect = TestEffect;
+
+    fn execute<'r>(
+        &self,
+        runtime_view: Self::RuntimeView<'r>,
+        frame: Self::Frame,
+        instruction: &Self::Instruction,
+    ) -> Result<ExecutionOutcome<Self::Frame, Self::Effect>, Self::Error> {
+        match instruction {
+            RuntimeInstruction::ExtCall(instruction) => {
+                waymark_vm_interpreter::Interpreter::execute(
+                    &self.extcall,
+                    runtime_view,
+                    frame,
+                    instruction,
+                )
+                .map(|outcome| outcome.map_effect(TestEffect::ExtCall))
+            }
+            RuntimeInstruction::InspectPending(register) => {
+                let RuntimeView { state } = runtime_view;
+
+                let Promise::Pending(promise_state_id) = frame.regs[*register].clone() else {
+                    panic!("register should hold the extcall's pending promise");
+                };
+
+                assert!(matches!(
+                    state.promise_states.get(promise_state_id),
+                    Ok(PromiseState::Waiting(waiters)) if waiters.is_empty()
+                ));
+
+                Ok(ExecutionOutcome::ExitFrameWithEffect(
+                    TestEffect::PendingPromiseStateId(promise_state_id),
+                ))
+            }
+        }
+    }
+}
+
+#[test]
+fn runtime_emits_an_extcall_effect_and_queues_the_resumed_frame() {
+    let mut runtime = Runtime::with_custom_entrypoint(
+        RuntimeInterpreter::default(),
+        executable(vec![function::<RuntimeInstruction>(
+            2,
+            vec![
+                vec![
+                    ExtCallSet::ExtCall {
+                        dst: RegisterId(1),
+                        extcall_id: 7,
+                        args: vec![RegisterId(0)],
+                        resume: StateId(1),
+                    }
+                    .into(),
+                ],
+                vec![RuntimeInstruction::InspectPending(RegisterId(1))],
+            ],
+        )]),
+        CallSpec {
+            func: FunctionId(0),
+            args: vec![41],
+        },
+    )
+    .expect("function 0 should exist");
+
+    let TestEffect::ExtCall(Effect::ExtCall {
+        promise_state_id,
+        extcall_id,
+        args,
+    }) = runtime.run().expect("first run should emit the extcall")
+    else {
+        panic!("first run should emit an extcall effect");
+    };
+
+    assert_eq!(extcall_id, 7);
+    assert_eq!(args, vec![41]);
+
+    let TestEffect::PendingPromiseStateId(resumed_promise_state_id) = runtime
+        .run()
+        .expect("second run should execute the resumed frame")
+    else {
+        panic!("second run should inspect the resumed pending promise");
+    };
+
+    assert_eq!(resumed_promise_state_id, promise_state_id);
+}

--- a/crates/lib/vm-interpreter-extcallset/tests/integration.rs
+++ b/crates/lib/vm-interpreter-extcallset/tests/integration.rs
@@ -13,7 +13,7 @@ struct TestSpec;
 impl waymark_vm_instructions_extcallset::Spec for TestSpec {
     type RegisterId = RegisterId;
     type StateId = StateId;
-    type ExtCallId = usize;
+    type ActionRef = usize;
 }
 
 #[derive(Debug)]
@@ -30,7 +30,7 @@ impl From<ExtCallSet<TestSpec>> for RuntimeInstruction {
 
 #[derive(Debug)]
 enum TestEffect {
-    ExtCall(Effect<i32, usize>),
+    ActionCall(Effect<i32, usize>),
     PendingPromiseStateId(PromiseStateId),
 }
 
@@ -77,13 +77,13 @@ impl waymark_vm_interpreter::Interpreter for RuntimeInterpreter {
                     frame,
                     instruction,
                 )
-                .map(|outcome| outcome.map_effect(TestEffect::ExtCall))
+                .map(|outcome| outcome.map_effect(TestEffect::ActionCall))
             }
             RuntimeInstruction::InspectPending(register) => {
                 let RuntimeView { state } = runtime_view;
 
                 let Promise::Pending(promise_state_id) = frame.regs[*register].clone() else {
-                    panic!("register should hold the extcall's pending promise");
+                    panic!("register should hold the action call's pending promise");
                 };
 
                 assert!(matches!(
@@ -100,16 +100,16 @@ impl waymark_vm_interpreter::Interpreter for RuntimeInterpreter {
 }
 
 #[test]
-fn runtime_emits_an_extcall_effect_and_queues_the_resumed_frame() {
+fn runtime_emits_an_action_call_and_queues_the_resumed_frame() {
     let mut runtime = Runtime::with_custom_entrypoint(
         RuntimeInterpreter::default(),
         executable(vec![function::<RuntimeInstruction>(
             2,
             vec![
                 vec![
-                    ExtCallSet::ExtCall {
+                    ExtCallSet::ActionCall {
                         dst: RegisterId(1),
-                        extcall_id: 7,
+                        action_ref: 7,
                         args: vec![RegisterId(0)],
                         resume: StateId(1),
                     }
@@ -125,16 +125,18 @@ fn runtime_emits_an_extcall_effect_and_queues_the_resumed_frame() {
     )
     .expect("function 0 should exist");
 
-    let TestEffect::ExtCall(Effect::ExtCall {
+    let TestEffect::ActionCall(Effect::ActionCall {
         promise_state_id,
-        extcall_id,
+        action_ref,
         args,
-    }) = runtime.run().expect("first run should emit the extcall")
+    }) = runtime
+        .run()
+        .expect("first run should emit the action call")
     else {
-        panic!("first run should emit an extcall effect");
+        panic!("first run should emit an action call");
     };
 
-    assert_eq!(extcall_id, 7);
+    assert_eq!(action_ref, 7);
     assert_eq!(args, vec![41]);
 
     let TestEffect::PendingPromiseStateId(resumed_promise_state_id) = runtime

--- a/crates/lib/vm-interpreter-fullset/src/error.rs
+++ b/crates/lib/vm-interpreter-fullset/src/error.rs
@@ -5,6 +5,10 @@ pub enum Error<Spec: waymark_vm_instructions_fullset::Spec> {
     #[error(transparent)]
     CoreSet(#[from] waymark_vm_interpreter_coreset::Error<Spec>),
 
+    /// Executing an extcallset instruction failed.
+    #[error(transparent)]
+    ExtCallSet(#[from] waymark_vm_interpreter_extcallset::Error),
+
     /// Executing a pureset instruction failed.
     #[error(transparent)]
     PureSet(#[from] waymark_vm_interpreter_pureset::Error),

--- a/crates/lib/vm-interpreter-fullset/src/lib.rs
+++ b/crates/lib/vm-interpreter-fullset/src/lib.rs
@@ -14,7 +14,7 @@ pub use self::value::Value;
 
 type FunctionIdFor<Spec> = <Spec as waymark_vm_instructions_coreset::Spec>::FunctionId;
 type StateIdFor<Spec> = <Spec as waymark_vm_instructions_coreset::Spec>::StateId;
-type ExtCallIdFor<Spec> = <Spec as waymark_vm_instructions_extcallset::Spec>::ExtCallId;
+type ActionRefFor<Spec> = <Spec as waymark_vm_instructions_extcallset::Spec>::ActionRef;
 
 /// An interpreter for the "full" instructions set.
 #[derive_where(Default)]
@@ -44,12 +44,12 @@ pub use waymark_vm_runtime_core::FullRuntimeView as RuntimeView;
 
 /// The effect for the [`FullSetInterpreter`].
 #[derive(Debug)]
-pub enum Effect<Value, ExtCallId> {
+pub enum Effect<Value, ActionRef> {
     /// An effect produced while executing a coreset instruction.
     CoreSet(waymark_vm_interpreter_coreset::Effect<Value>),
 
     /// An effect produced while executing an extcallset instruction.
-    ExtCallSet(waymark_vm_interpreter_extcallset::Effect<Value, ExtCallId>),
+    ExtCallSet(waymark_vm_interpreter_extcallset::Effect<Value, ActionRef>),
 
     /// An impossible effect produced while executing a pureset instruction.
     PureSet(core::convert::Infallible),
@@ -70,7 +70,7 @@ where
     Spec: 'static,
     FunctionIdFor<Spec>: Copy,
     StateIdFor<Spec>: Copy + Default,
-    ExtCallIdFor<Spec>: Clone,
+    ActionRefFor<Spec>: Clone,
     Value: Clone + 'static,
     Value: waymark_vm_interpreter_coreset::Value,
     Value: waymark_vm_interpreter_pureset::Value,
@@ -81,7 +81,7 @@ where
     type Frame = Frame<FunctionIdFor<Spec>, StateIdFor<Spec>, Promise<Value>>;
     type Instruction = waymark_vm_instructions_fullset::FullSet<Spec>;
     type Error = Error<Spec>;
-    type Effect = Effect<Value, ExtCallIdFor<Spec>>;
+    type Effect = Effect<Value, ActionRefFor<Spec>>;
 
     fn execute<'r>(
         &self,

--- a/crates/lib/vm-interpreter-fullset/src/lib.rs
+++ b/crates/lib/vm-interpreter-fullset/src/lib.rs
@@ -12,17 +12,29 @@ use waymark_vm_runtime_core::{CaptureRuntimeView as _, Frame, Promise};
 pub use self::error::*;
 pub use self::value::Value;
 
+type FunctionIdFor<Spec> = <Spec as waymark_vm_instructions_coreset::Spec>::FunctionId;
+type StateIdFor<Spec> = <Spec as waymark_vm_instructions_coreset::Spec>::StateId;
+type ExtCallIdFor<Spec> = <Spec as waymark_vm_instructions_extcallset::Spec>::ExtCallId;
+
 /// An interpreter for the "full" instructions set.
 #[derive_where(Default)]
 pub struct FullSetInterpreter<Spec: waymark_vm_instructions_fullset::Spec, Executable, Value> {
     /// The coreset interpreter used for core instructions.
     pub core_set: waymark_vm_interpreter_coreset::CoreSetInterpreter<Spec, Executable, Value>,
 
+    /// The extcallset interpreter used for extcall instructions.
+    pub extcall_set: waymark_vm_interpreter_extcallset::ExtCallSetInterpreter<
+        Spec,
+        FunctionIdFor<Spec>,
+        StateIdFor<Spec>,
+        Value,
+    >,
+
     /// The pureset interpreter used for pure instructions.
     pub pure_set: waymark_vm_interpreter_pureset::PureSetInterpreter<
         Spec,
-        Spec::FunctionId,
-        Spec::StateId,
+        FunctionIdFor<Spec>,
+        StateIdFor<Spec>,
         Value,
     >,
 }
@@ -34,7 +46,10 @@ pub use waymark_vm_runtime_core::FullRuntimeView as RuntimeView;
 #[derive(Debug)]
 pub enum Effect<Value, ExtCallId> {
     /// An effect produced while executing a coreset instruction.
-    CoreSet(waymark_vm_interpreter_coreset::Effect<Value, ExtCallId>),
+    CoreSet(waymark_vm_interpreter_coreset::Effect<Value>),
+
+    /// An effect produced while executing an extcallset instruction.
+    ExtCallSet(waymark_vm_interpreter_extcallset::Effect<Value, ExtCallId>),
 
     /// An impossible effect produced while executing a pureset instruction.
     PureSet(core::convert::Infallible),
@@ -45,31 +60,39 @@ impl<Spec, Executable, Value> waymark_vm_interpreter::Interpreter
 where
     Spec: waymark_vm_instructions_fullset::Spec,
     Executable: 'static,
-    Executable: waymark_vm_executable::FunctionInfo<FunctionId = Spec::FunctionId>,
+    Executable: waymark_vm_executable::FunctionInfo<FunctionId = FunctionIdFor<Spec>>,
     Spec: waymark_vm_instructions_coreset::Spec<RegisterId = waymark_vm_runtime_core::RegisterId>,
+    Spec: waymark_vm_instructions_extcallset::Spec<
+            RegisterId = waymark_vm_runtime_core::RegisterId,
+            StateId = StateIdFor<Spec>,
+        >,
     Spec: waymark_vm_instructions_pureset::Spec<RegisterId = waymark_vm_runtime_core::RegisterId>,
     Spec: 'static,
-    Spec::FunctionId: Copy,
-    Spec::StateId: Copy + Default,
-    Spec::ExtCallId: Clone,
+    FunctionIdFor<Spec>: Copy,
+    StateIdFor<Spec>: Copy + Default,
+    ExtCallIdFor<Spec>: Clone,
     Value: Clone + 'static,
     Value: waymark_vm_interpreter_coreset::Value,
     Value: waymark_vm_interpreter_pureset::Value,
     Spec::ConstValue: Clone + Into<Value>,
 {
-    type RuntimeView<'r> = RuntimeView<'r, Executable, Spec::FunctionId, Spec::StateId, Value>;
-    type Frame = Frame<Spec::FunctionId, Spec::StateId, Promise<Value>>;
+    type RuntimeView<'r> =
+        RuntimeView<'r, Executable, FunctionIdFor<Spec>, StateIdFor<Spec>, Value>;
+    type Frame = Frame<FunctionIdFor<Spec>, StateIdFor<Spec>, Promise<Value>>;
     type Instruction = waymark_vm_instructions_fullset::FullSet<Spec>;
     type Error = Error<Spec>;
-    type Effect = Effect<Value, Spec::ExtCallId>;
+    type Effect = Effect<Value, ExtCallIdFor<Spec>>;
 
     fn execute<'r>(
         &self,
         runtime_view: Self::RuntimeView<'r>,
-        frame: Frame<Spec::FunctionId, Spec::StateId, Promise<Value>>,
+        frame: Frame<FunctionIdFor<Spec>, StateIdFor<Spec>, Promise<Value>>,
         instruction: &Self::Instruction,
     ) -> Result<
-        ExecutionOutcome<Frame<Spec::FunctionId, Spec::StateId, Promise<Value>>, Self::Effect>,
+        ExecutionOutcome<
+            Frame<FunctionIdFor<Spec>, StateIdFor<Spec>, Promise<Value>>,
+            Self::Effect,
+        >,
         Self::Error,
     > {
         Ok(match instruction {
@@ -83,12 +106,23 @@ where
                     .execute(runtime_view, frame, instruction)?
                     .map_effect(Effect::CoreSet)
             }
+            waymark_vm_instructions_fullset::FullSet::ExtCallSet(instruction) => {
+                let runtime_view = waymark_vm_interpreter_extcallset::ExtCallSetInterpreter::<
+                    Spec,
+                    FunctionIdFor<Spec>,
+                    StateIdFor<Spec>,
+                    Value,
+                >::capture_runtime_view(runtime_view);
+                self.extcall_set
+                    .execute(runtime_view, frame, instruction)?
+                    .map_effect(Effect::ExtCallSet)
+            }
             waymark_vm_instructions_fullset::FullSet::PureSet(instruction) => {
                 #[allow(clippy::let_unit_value)]
                 let runtime_view = waymark_vm_interpreter_pureset::PureSetInterpreter::<
                     Spec,
-                    Spec::FunctionId,
-                    Spec::StateId,
+                    FunctionIdFor<Spec>,
+                    StateIdFor<Spec>,
                     Value,
                 >::capture_runtime_view(runtime_view);
                 self.pure_set
@@ -100,17 +134,22 @@ where
 }
 
 impl<Spec: waymark_vm_instructions_fullset::Spec, Executable: 'static, Value: 'static>
-    waymark_vm_runtime_core::CaptureRuntimeView<Executable, Spec::FunctionId, Spec::StateId, Value>
-    for FullSetInterpreter<Spec, Executable, Value>
+    waymark_vm_runtime_core::CaptureRuntimeView<
+        Executable,
+        FunctionIdFor<Spec>,
+        StateIdFor<Spec>,
+        Value,
+    > for FullSetInterpreter<Spec, Executable, Value>
 {
-    type RuntimeView<'v> = RuntimeView<'v, Executable, Spec::FunctionId, Spec::StateId, Value>;
+    type RuntimeView<'v> =
+        RuntimeView<'v, Executable, FunctionIdFor<Spec>, StateIdFor<Spec>, Value>;
 
     fn capture_runtime_view<'r>(
         view: waymark_vm_runtime_core::FullRuntimeView<
             'r,
             Executable,
-            Spec::FunctionId,
-            Spec::StateId,
+            FunctionIdFor<Spec>,
+            StateIdFor<Spec>,
             Value,
         >,
     ) -> Self::RuntimeView<'r> {

--- a/crates/lib/vm-interpreter-fullset/tests/integration.rs
+++ b/crates/lib/vm-interpreter-fullset/tests/integration.rs
@@ -21,7 +21,7 @@ impl waymark_vm_instructions_coreset::Spec for TestSpec {
 impl waymark_vm_instructions_extcallset::Spec for TestSpec {
     type RegisterId = RegisterId;
     type StateId = StateId;
-    type ExtCallId = TestExtCallId;
+    type ActionRef = TestActionRef;
 }
 
 impl waymark_vm_instructions_pureset::Spec for TestSpec {
@@ -35,7 +35,7 @@ enum TestConstValue {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-struct TestExtCallId(usize);
+struct TestActionRef(usize);
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum TestValue {
@@ -156,8 +156,8 @@ fn runtime_executes_pure_and_core_instructions_to_completion() {
         Effect::CoreSet(waymark_vm_interpreter_coreset::Effect::Complete(value)) => {
             assert_eq!(value, TestValue::Int(5));
         }
-        Effect::ExtCallSet(waymark_vm_interpreter_extcallset::Effect::ExtCall { .. }) => {
-            panic!("program should not emit an extcall")
+        Effect::ExtCallSet(waymark_vm_interpreter_extcallset::Effect::ActionCall { .. }) => {
+            panic!("program should not emit an action call")
         }
         Effect::PureSet(effect) => match effect {},
     }
@@ -169,9 +169,9 @@ fn runtime_resumes_extcalls_and_finishes_with_pure_work() {
         4,
         vec![
             vec![
-                ExtCallSet::ExtCall {
+                ExtCallSet::ActionCall {
                     dst: RegisterId(1),
-                    extcall_id: TestExtCallId(7),
+                    action_ref: TestActionRef(7),
                     args: vec![RegisterId(0)],
                     resume: StateId(1),
                 }
@@ -215,38 +215,40 @@ fn runtime_resumes_extcalls_and_finishes_with_pure_work() {
     )
     .expect("function 0 should exist");
 
-    let effect = runtime.run().expect("first run should emit the extcall");
+    let effect = runtime
+        .run()
+        .expect("first run should emit the action call");
 
     let promise_state_id = match effect {
-        Effect::ExtCallSet(waymark_vm_interpreter_extcallset::Effect::ExtCall {
+        Effect::ExtCallSet(waymark_vm_interpreter_extcallset::Effect::ActionCall {
             promise_state_id,
-            extcall_id,
+            action_ref,
             args,
         }) => {
-            assert_eq!(extcall_id, TestExtCallId(7));
+            assert_eq!(action_ref, TestActionRef(7));
             assert_eq!(args, vec![TestValue::Int(41)]);
             promise_state_id
         }
         Effect::CoreSet(waymark_vm_interpreter_coreset::Effect::Complete(_)) => {
-            panic!("program should suspend on the extcall before completion")
+            panic!("program should suspend on the action call before completion")
         }
         Effect::PureSet(effect) => match effect {},
     };
 
     runtime
         .resolve_promise(promise_state_id, TestValue::Int(41))
-        .expect("extcall promise should resolve cleanly");
+        .expect("action call promise should resolve cleanly");
 
     let effect = runtime
         .run()
-        .expect("second run should finish after resuming the extcall");
+        .expect("second run should finish after resuming the action call");
 
     match effect {
         Effect::CoreSet(waymark_vm_interpreter_coreset::Effect::Complete(value)) => {
             assert_eq!(value, TestValue::Int(42));
         }
-        Effect::ExtCallSet(waymark_vm_interpreter_extcallset::Effect::ExtCall { .. }) => {
-            panic!("resolved extcall should not emit another extcall")
+        Effect::ExtCallSet(waymark_vm_interpreter_extcallset::Effect::ActionCall { .. }) => {
+            panic!("resolved action call should not emit another action call")
         }
         Effect::PureSet(effect) => match effect {},
     }

--- a/crates/lib/vm-interpreter-fullset/tests/integration.rs
+++ b/crates/lib/vm-interpreter-fullset/tests/integration.rs
@@ -1,4 +1,5 @@
 use waymark_vm_instructions_coreset::CoreSet;
+use waymark_vm_instructions_extcallset::ExtCallSet;
 use waymark_vm_instructions_fullset::FullSet;
 use waymark_vm_instructions_pureset::{BinaryOpKind, PureSet, UnaryOpKind};
 use waymark_vm_interpreter_fullset::{Effect, FullSetInterpreter};
@@ -14,8 +15,13 @@ struct TestSpec;
 impl waymark_vm_instructions_coreset::Spec for TestSpec {
     type RegisterId = RegisterId;
     type FunctionId = FunctionId;
-    type ExtCallId = TestExtCallId;
     type StateId = StateId;
+}
+
+impl waymark_vm_instructions_extcallset::Spec for TestSpec {
+    type RegisterId = RegisterId;
+    type StateId = StateId;
+    type ExtCallId = TestExtCallId;
 }
 
 impl waymark_vm_instructions_pureset::Spec for TestSpec {
@@ -150,7 +156,7 @@ fn runtime_executes_pure_and_core_instructions_to_completion() {
         Effect::CoreSet(waymark_vm_interpreter_coreset::Effect::Complete(value)) => {
             assert_eq!(value, TestValue::Int(5));
         }
-        Effect::CoreSet(waymark_vm_interpreter_coreset::Effect::ExtCall { .. }) => {
+        Effect::ExtCallSet(waymark_vm_interpreter_extcallset::Effect::ExtCall { .. }) => {
             panic!("program should not emit an extcall")
         }
         Effect::PureSet(effect) => match effect {},
@@ -163,7 +169,7 @@ fn runtime_resumes_extcalls_and_finishes_with_pure_work() {
         4,
         vec![
             vec![
-                CoreSet::ExtCall {
+                ExtCallSet::ExtCall {
                     dst: RegisterId(1),
                     extcall_id: TestExtCallId(7),
                     args: vec![RegisterId(0)],
@@ -212,7 +218,7 @@ fn runtime_resumes_extcalls_and_finishes_with_pure_work() {
     let effect = runtime.run().expect("first run should emit the extcall");
 
     let promise_state_id = match effect {
-        Effect::CoreSet(waymark_vm_interpreter_coreset::Effect::ExtCall {
+        Effect::ExtCallSet(waymark_vm_interpreter_extcallset::Effect::ExtCall {
             promise_state_id,
             extcall_id,
             args,
@@ -239,7 +245,7 @@ fn runtime_resumes_extcalls_and_finishes_with_pure_work() {
         Effect::CoreSet(waymark_vm_interpreter_coreset::Effect::Complete(value)) => {
             assert_eq!(value, TestValue::Int(42));
         }
-        Effect::CoreSet(waymark_vm_interpreter_coreset::Effect::ExtCall { .. }) => {
+        Effect::ExtCallSet(waymark_vm_interpreter_extcallset::Effect::ExtCall { .. }) => {
             panic!("resolved extcall should not emit another extcall")
         }
         Effect::PureSet(effect) => match effect {},


### PR DESCRIPTION
This PR refactors the extcalls to be a separate instructions set and makes the action call an explicit variant of an extcall. This properly corresponds to the initial design draft and makes way for adding other planned extcalls (like `sleep`)