### PR TITLE
Implement support for sleep at the VM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5318,6 +5318,7 @@ version = "0.1.0"
 dependencies = [
  "derive-where",
  "thiserror",
+ "waymark-nonzero-duration",
  "waymark-vm-instructions-extcallset",
  "waymark-vm-interpreter",
  "waymark-vm-runtime",
@@ -5331,6 +5332,7 @@ version = "0.1.0"
 dependencies = [
  "derive-where",
  "thiserror",
+ "waymark-nonzero-duration",
  "waymark-vm-executable",
  "waymark-vm-instructions-coreset",
  "waymark-vm-instructions-extcallset",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5200,6 +5200,7 @@ dependencies = [
  "nonempty-collections",
  "thiserror",
  "tokio",
+ "waymark-nonzero-duration",
  "waymark-support-test-python",
  "waymark-vm-ast-old",
  "waymark-vm-ast-old-helpers",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5170,6 +5170,7 @@ dependencies = [
  "tokio",
  "tracing",
  "waymark-fn-main-common",
+ "waymark-nonzero-duration",
  "waymark-vm-ast-old",
  "waymark-vm-ast-old-helpers",
  "waymark-vm-bytecode",

--- a/crates/bin/vm-cli/Cargo.toml
+++ b/crates/bin/vm-cli/Cargo.toml
@@ -6,6 +6,7 @@ publish.workspace = true
 
 [dependencies]
 waymark-fn-main-common = { workspace = true }
+waymark-nonzero-duration = { workspace = true }
 waymark-vm-ast-old = { workspace = true }
 waymark-vm-ast-old-helpers = { workspace = true }
 waymark-vm-bytecode = { workspace = true }

--- a/crates/bin/vm-cli/src/integration.rs
+++ b/crates/bin/vm-cli/src/integration.rs
@@ -1,3 +1,5 @@
+use waymark_nonzero_duration::NonZeroDuration;
+
 pub type InstructionSet = waymark_vm_instructions_fullset::FullSet<SampleSpec>;
 
 pub type Executable = waymark_vm_bytecode::Executable<InstructionSet>;
@@ -38,6 +40,18 @@ pub enum SampleValue {
 #[derive(Debug, Clone)]
 pub struct SampleActionRef(#[allow(dead_code)] pub usize);
 
+#[derive(Debug, thiserror::Error)]
+pub enum SampleSleepDurationError {
+    #[error("the value cannot be used as a sleep duration")]
+    UnsupportedValue,
+
+    #[error("sleep duration must be non-zero")]
+    Zero,
+
+    #[error("sleep duration is out of range")]
+    OutOfRange,
+}
+
 impl waymark_vm_interpreter_coreset::value::ShouldJump for SampleValue {
     fn should_jump(
         &self,
@@ -75,6 +89,20 @@ impl waymark_vm_interpreter_pureset::value::MakeList for SampleValue {
         I: IntoIterator<Item = Self>,
     {
         Ok(SampleValue::List(items.into_iter().collect()))
+    }
+}
+
+impl waymark_vm_interpreter_extcallset::value::SleepDuration for SampleValue {
+    type Error = SampleSleepDurationError;
+
+    fn to_sleep_duration(&self) -> Result<NonZeroDuration, Self::Error> {
+        match self {
+            SampleValue::Usize(seconds) => {
+                let seconds: u64 = (*seconds).try_into().map_err(|_| Self::Error::OutOfRange)?;
+                NonZeroDuration::from_secs(seconds).ok_or(Self::Error::Zero)
+            }
+            SampleValue::List(_) => Err(Self::Error::UnsupportedValue),
+        }
     }
 }
 

--- a/crates/bin/vm-cli/src/run.rs
+++ b/crates/bin/vm-cli/src/run.rs
@@ -74,6 +74,26 @@ pub async fn run(
                                 }
                             });
                         }
+                        waymark_vm_interpreter_extcallset::Effect::Sleep {
+                            promise_state_id,
+                            duration,
+                        } => {
+                            tracing::info!(?promise_state_id, ?duration, "sleep received");
+
+                            tokio::spawn({
+                                let promise_resolutions_tx = promise_resolutions_tx.clone();
+                                async move {
+                                    tokio::time::sleep(duration.get()).await;
+
+                                    let value = integration::SampleValue::Usize(0);
+                                    tracing::info!(?promise_state_id, ?value, "resolving sleep");
+                                    promise_resolutions_tx
+                                        .send((promise_state_id, value))
+                                        .await
+                                        .unwrap();
+                                }
+                            });
+                        }
                     },
                 }
             }

--- a/crates/lib/vm-ast-old-helpers/src/lib.rs
+++ b/crates/lib/vm-ast-old-helpers/src/lib.rs
@@ -122,6 +122,10 @@ pub fn continue_stmt() -> Spanned<Statement> {
     spanned(Statement::Continue)
 }
 
+pub fn sleep_stmt(duration: Spanned<Expr>) -> Spanned<Statement> {
+    spanned(Statement::Sleep { duration })
+}
+
 pub fn for_stmt(
     loop_vars: &[&str],
     iterable: Spanned<Expr>,

--- a/crates/lib/vm-ast-old-proto/src/lib.rs
+++ b/crates/lib/vm-ast-old-proto/src/lib.rs
@@ -144,7 +144,7 @@ impl Convert<ast::Statement> for Converter {
                 }
             }
             ast::statement::Kind::SleepStmt(sleep_stmt) => vm_ast::Statement::Sleep {
-                duration: convert_optional_owned(sleep_stmt.duration)?,
+                duration: convert_required(sleep_stmt.duration, "SleepStmt.duration")?,
             },
         };
 

--- a/crates/lib/vm-ast-old-proto/src/tests.rs
+++ b/crates/lib/vm-ast-old-proto/src/tests.rs
@@ -114,6 +114,25 @@ fn returns_missing_field_error() {
 }
 
 #[test]
+fn returns_missing_sleep_duration_error() {
+    let statement = ast::Statement {
+        kind: Some(ast::statement::Kind::SleepStmt(ast::SleepStmt {
+            duration: None,
+        })),
+        span: span(1),
+    };
+
+    let error = convert(statement).expect_err("missing sleep duration should fail conversion");
+
+    assert_eq!(
+        error,
+        ConvertError::MissingField {
+            field: "SleepStmt.duration"
+        }
+    );
+}
+
+#[test]
 fn returns_invalid_enum_error() {
     let expr = ast::Expr {
         kind: Some(ast::expr::Kind::FunctionCall(ast::FunctionCall {

--- a/crates/lib/vm-ast-old/src/lib.rs
+++ b/crates/lib/vm-ast-old/src/lib.rs
@@ -67,7 +67,7 @@ pub enum Statement {
     Break,
     Continue,
     Sleep {
-        duration: Option<Spanned<Expr>>,
+        duration: Spanned<Expr>,
     },
 }
 

--- a/crates/lib/vm-compiler-for-ast-old/Cargo.toml
+++ b/crates/lib/vm-compiler-for-ast-old/Cargo.toml
@@ -20,6 +20,7 @@ nonempty-collections = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
+waymark-nonzero-duration = { workspace = true }
 waymark-support-test-python = { workspace = true }
 waymark-vm-ast-old-helpers = { workspace = true }
 waymark-vm-compiler-for-ast-old-test-support = { workspace = true }

--- a/crates/lib/vm-compiler-for-ast-old/src/function/compiler/bytecode/emitter.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/function/compiler/bytecode/emitter.rs
@@ -105,6 +105,23 @@ where
         );
     }
 
+    /// Emits a sleep instruction that resumes at `resume`.
+    pub fn emit_sleep(
+        &mut self,
+        dst: Marked<RegisterId, PromiseMarker>,
+        duration: RegisterId,
+        resume: StateId,
+    ) {
+        self.emit(
+            waymark_vm_instructions_extcallset::ExtCallSet::Sleep {
+                dst: *dst,
+                duration,
+                resume,
+            }
+            .into(),
+        );
+    }
+
     /// Emits an await instruction for a promise register.
     pub fn emit_await(
         &mut self,

--- a/crates/lib/vm-compiler-for-ast-old/src/function/compiler/lowering/statement.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/function/compiler/lowering/statement.rs
@@ -94,6 +94,9 @@ where
             StatementPlan::Expr { expr } => {
                 self.value_compiler().compile_expression_statement(expr)?;
             }
+            StatementPlan::Sleep { duration } => {
+                self.value_compiler().compile_sleep_statement(duration)?;
+            }
             StatementPlan::ParallelBlock { calls } => {
                 self.parallel_compiler().compile_block(calls)?;
             }

--- a/crates/lib/vm-compiler-for-ast-old/src/function/compiler/lowering/value.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/function/compiler/lowering/value.rs
@@ -84,6 +84,20 @@ where
         Ok(())
     }
 
+    /// Compiles a sleep statement as a dedicated async suspension point.
+    pub fn compile_sleep_statement(
+        &mut self,
+        duration: &Spanned<Expr>,
+    ) -> Result<(), ErrorFor<Spec, Lowering>> {
+        let promise_register = Marked::mark(self.allocate_result_register(ResultTarget::Allocate));
+        let result_register = promise_register.register();
+
+        self.compile_sleep_start(duration, &promise_register)?;
+        self.compile_await(result_register, &promise_register);
+
+        Ok(())
+    }
+
     /// Compiles a return statement.
     pub fn compile_return_statement(
         &mut self,
@@ -159,6 +173,25 @@ where
             .emit_extcall(dst.marked(), action_ref, arg_registers, resume_state);
 
         drop(args);
+
+        self.context.emitter.switch_to(resume_state);
+
+        Ok(())
+    }
+
+    /// Starts a sleep suspension into the given promise register.
+    pub fn compile_sleep_start(
+        &mut self,
+        duration: &Spanned<Expr>,
+        dst: &Marked<RegisterHandle, PromiseMarker>,
+    ) -> Result<(), ErrorFor<Spec, Lowering>> {
+        let duration_register = self.compile_expr(duration, ResultTarget::Allocate)?;
+
+        let resume_state = self.reserve_state();
+
+        self.context
+            .emitter
+            .emit_sleep(dst.marked(), duration_register.register(), resume_state);
 
         self.context.emitter.switch_to(resume_state);
 
@@ -479,6 +512,64 @@ mod tests {
             })) if *dst == RegisterId(0)
                 && action_ref == "fetch"
                 && args == &[RegisterId(1)]
+                && *resume == StateId(1)
+        ));
+        assert!(start_instructions.next().is_none());
+
+        let mut resume_instructions = states[StateId(1)].instructions.iter();
+        assert!(matches!(
+            resume_instructions.next(),
+            Some(InstructionSet::CoreSet(CoreSet::Await { dst, src, resume }))
+                if *dst == RegisterId(0)
+                    && *src == RegisterId(0)
+                    && *resume == StateId(2)
+        ));
+        assert!(resume_instructions.next().is_none());
+    }
+
+    #[test]
+    fn sleep_statements_emit_sleep_then_await_in_resume_state() {
+        let function_table = build_function_table();
+        let mut emitter = FunctionEmitter::<TestSpec>::new();
+        let mut local_frame = LocalFrame::new();
+        let mut flow_state = FlowState::new();
+        let duration = int(2);
+
+        {
+            let mut values = ValueCompiler::<TestSpec, TestLowering>::new(
+                CompilerContextMut::new(
+                    &function_table,
+                    &mut emitter,
+                    &mut local_frame,
+                    &mut flow_state,
+                )
+                .into_ref(),
+            );
+
+            values
+                .compile_sleep_statement(&duration)
+                .expect("sleep statement should compile");
+        }
+
+        let states = emitter.finish();
+        assert_eq!(states.len().to_scalar(), 3);
+
+        let mut start_instructions = states[StateId(0)].instructions.iter();
+        assert!(matches!(
+            start_instructions.next(),
+            Some(InstructionSet::PureSet(PureSet::LoadConst {
+                dst,
+                value: TestConstValue::Int(2),
+            })) if *dst == RegisterId(1)
+        ));
+        assert!(matches!(
+            start_instructions.next(),
+            Some(InstructionSet::ExtCallSet(ExtCallSet::Sleep {
+                dst,
+                duration,
+                resume,
+            })) if *dst == RegisterId(0)
+                && *duration == RegisterId(1)
                 && *resume == StateId(1)
         ));
         assert!(start_instructions.next().is_none());

--- a/crates/lib/vm-compiler-for-ast-old/src/function/compiler/plan/statement.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/function/compiler/plan/statement.rs
@@ -43,6 +43,12 @@ where
         expr: &'a Spanned<Expr>,
     },
 
+    /// Suspend execution until the requested duration elapses.
+    Sleep {
+        /// Duration expression forwarded to the sleep runtime.
+        duration: &'a Spanned<Expr>,
+    },
+
     /// Execute calls in parallel without assignment targets.
     ParallelBlock {
         /// Calls to start in parallel.
@@ -88,9 +94,6 @@ pub enum UnsupportedStatementKind {
 
     /// `try`/`except` blocks.
     TryExcept,
-
-    /// Sleep statements.
-    Sleep,
 }
 
 impl<'a, Spec> StatementPlan<'a, Spec>
@@ -112,6 +115,7 @@ where
                 value: value.as_ref(),
             }),
             Statement::ExprStmt { expr } => Ok(Self::Expr { expr }),
+            Statement::Sleep { duration } => Ok(Self::Sleep { duration }),
             Statement::ParallelBlock { calls } => Ok(Self::ParallelBlock {
                 calls: build_parallel_call_plans::<Spec, Lowering>(calls, function_table)?,
             }),
@@ -139,10 +143,6 @@ where
                 kind: UnsupportedStatementKind::TryExcept,
             }
             .into()),
-            Statement::Sleep { .. } => Err(Unsupported::Statement {
-                kind: UnsupportedStatementKind::Sleep,
-            }
-            .into()),
         }
     }
 }
@@ -153,7 +153,6 @@ impl core::fmt::Display for UnsupportedStatementKind {
             Self::SpreadAction => "SpreadAction",
             Self::ForLoop => "ForLoop",
             Self::TryExcept => "TryExcept",
-            Self::Sleep => "Sleep",
         })
     }
 }
@@ -165,7 +164,7 @@ mod tests {
     use waymark_vm_ast_old::{Spanned, Statement};
     use waymark_vm_ast_old_helpers::{
         action_call, action_stmt, assignment, block, break_stmt, conditional_stmt, continue_stmt,
-        int, parallel_stmt, return_stmt, spanned, variable, while_stmt,
+        int, parallel_stmt, return_stmt, sleep_stmt, spanned, variable, while_stmt,
     };
 
     use crate::function::compiler::{
@@ -182,6 +181,7 @@ mod tests {
         let expr = spanned(Statement::ExprStmt {
             expr: variable("value"),
         });
+        let sleep = sleep_stmt(int(1));
 
         assert!(matches!(
             StatementPlan::<TestSpec>::build::<TestLowering>(&assignment.value, &function_table)
@@ -202,6 +202,11 @@ mod tests {
             StatementPlan::<TestSpec>::build::<TestLowering>(&expr.value, &function_table)
                 .expect("expr statements should build"),
             StatementPlan::Expr { .. }
+        ));
+        assert!(matches!(
+            StatementPlan::<TestSpec>::build::<TestLowering>(&sleep.value, &function_table)
+                .expect("sleep statements should build"),
+            StatementPlan::Sleep { .. }
         ));
     }
 
@@ -267,12 +272,6 @@ mod tests {
                     try_block: block(Vec::new()),
                 }),
                 UnsupportedStatementKind::TryExcept,
-            ),
-            (
-                spanned(Statement::Sleep {
-                    duration: Some(int(1)),
-                }),
-                UnsupportedStatementKind::Sleep,
             ),
         ];
 

--- a/crates/lib/vm-compiler-for-ast-old/tests/integration.rs
+++ b/crates/lib/vm-compiler-for-ast-old/tests/integration.rs
@@ -1,11 +1,13 @@
 mod support;
 
 use support::{TestValue, compile_program, runtime, runtime_with_args};
+
+use waymark_nonzero_duration::NonZeroDuration;
 use waymark_vm_ast_old::{BinaryOperator, Call, Expr, Spanned, UnaryOperator};
 use waymark_vm_ast_old_helpers::{
     action_call, action_expr, assignment, assignment_targets, binary_expr, break_stmt,
     conditional_stmt, continue_stmt, function, function_call, function_expr, int, parallel_expr,
-    parallel_stmt, program, return_stmt, unary_expr, variable, while_stmt,
+    parallel_stmt, program, return_stmt, sleep_stmt, unary_expr, variable, while_stmt,
 };
 use waymark_vm_bytecode_core::{FunctionId, InstructionId, StateId};
 use waymark_vm_compiler_for_ast_old_test_support::TestActionRef;
@@ -363,6 +365,42 @@ fn compiles_action_calls_into_extcalls() {
         ))) => assert_eq!(value, 42),
         other => panic!("unexpected second runtime effect: {other:?}"),
     }
+}
+
+#[test]
+fn compiles_sleep_statements_into_resumable_sleep_effects() {
+    let program = program(vec![function(
+        "main",
+        &[],
+        vec![sleep_stmt(int(2)), return_stmt(Some(int(7)))],
+    )]);
+
+    let executable = compile_program(&program);
+    let mut runtime = runtime(executable);
+
+    let promise_state_id = match runtime.run().expect("program should emit a sleep effect") {
+        Effect::ExtCallSet(waymark_vm_interpreter_extcallset::Effect::Sleep {
+            promise_state_id,
+            duration,
+        }) => {
+            assert_eq!(duration, NonZeroDuration::from_secs(2).unwrap());
+            promise_state_id
+        }
+        other => panic!("unexpected first runtime effect: {other:?}"),
+    };
+
+    runtime
+        .resolve_promise(promise_state_id, TestValue::None)
+        .expect("sleep promise should resolve");
+
+    assert_eq!(
+        completed_int(
+            runtime
+                .run()
+                .expect("program should complete after sleep resolves")
+        ),
+        7
+    );
 }
 
 #[test]

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_sleep__sleep_aliased_import.py__ast.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_sleep__sleep_aliased_import.py__ast.snap
@@ -55,21 +55,19 @@ Program {
                             },
                             Spanned {
                                 value: Sleep {
-                                    duration: Some(
-                                        Spanned {
-                                            value: Literal {
-                                                value: Int(
-                                                    3,
-                                                ),
-                                            },
-                                            span: Span {
-                                                start_line: 3,
-                                                start_col: 22,
-                                                end_line: 3,
-                                                end_col: 23,
-                                            },
+                                    duration: Spanned {
+                                        value: Literal {
+                                            value: Int(
+                                                3,
+                                            ),
                                         },
-                                    ),
+                                        span: Span {
+                                            start_line: 3,
+                                            start_col: 22,
+                                            end_line: 3,
+                                            end_col: 23,
+                                        },
+                                    },
                                 },
                                 span: Span {
                                     start_line: 3,

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_sleep__sleep_aliased_import.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_sleep__sleep_aliased_import.py__bytecode.snap
@@ -2,12 +2,143 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_sleep/sleep_aliased_import.py
 ---
-Err(
-    FunctionCompiler(
-        Unsupported(
-            Statement {
-                kind: Sleep,
+Ok(
+    Executable {
+        functions: [
+            Function {
+                states: [
+                    State {
+                        instructions: [
+                            ExtCallSet(
+                                ActionCall {
+                                    dst: RegisterId(
+                                        0,
+                                    ),
+                                    action_ref: TestActionRef(
+                                        "get_value_aliased_import",
+                                    ),
+                                    args: [],
+                                    resume: StateId(
+                                        1,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                Await {
+                                    dst: RegisterId(
+                                        0,
+                                    ),
+                                    src: RegisterId(
+                                        0,
+                                    ),
+                                    resume: StateId(
+                                        2,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            PureSet(
+                                LoadConst {
+                                    dst: RegisterId(
+                                        2,
+                                    ),
+                                    value: Int(
+                                        3,
+                                    ),
+                                },
+                            ),
+                            ExtCallSet(
+                                Sleep {
+                                    dst: RegisterId(
+                                        1,
+                                    ),
+                                    duration: RegisterId(
+                                        2,
+                                    ),
+                                    resume: StateId(
+                                        3,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                Await {
+                                    dst: RegisterId(
+                                        1,
+                                    ),
+                                    src: RegisterId(
+                                        1,
+                                    ),
+                                    resume: StateId(
+                                        4,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            ExtCallSet(
+                                ActionCall {
+                                    dst: RegisterId(
+                                        3,
+                                    ),
+                                    action_ref: TestActionRef(
+                                        "format_done_aliased_import",
+                                    ),
+                                    args: [
+                                        RegisterId(
+                                            0,
+                                        ),
+                                    ],
+                                    resume: StateId(
+                                        5,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                Await {
+                                    dst: RegisterId(
+                                        3,
+                                    ),
+                                    src: RegisterId(
+                                        3,
+                                    ),
+                                    resume: StateId(
+                                        6,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                Return {
+                                    src: RegisterId(
+                                        3,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                ],
+                num_regs: 4,
             },
-        ),
-    ),
+        ],
+    },
 )

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_sleep__sleep_from_import.py__ast.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_sleep__sleep_from_import.py__ast.snap
@@ -55,21 +55,19 @@ Program {
                             },
                             Spanned {
                                 value: Sleep {
-                                    duration: Some(
-                                        Spanned {
-                                            value: Literal {
-                                                value: Int(
-                                                    2,
-                                                ),
-                                            },
-                                            span: Span {
-                                                start_line: 3,
-                                                start_col: 16,
-                                                end_line: 3,
-                                                end_col: 17,
-                                            },
+                                    duration: Spanned {
+                                        value: Literal {
+                                            value: Int(
+                                                2,
+                                            ),
                                         },
-                                    ),
+                                        span: Span {
+                                            start_line: 3,
+                                            start_col: 16,
+                                            end_line: 3,
+                                            end_col: 17,
+                                        },
+                                    },
                                 },
                                 span: Span {
                                     start_line: 3,

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_sleep__sleep_from_import.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_sleep__sleep_from_import.py__bytecode.snap
@@ -2,12 +2,143 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_sleep/sleep_from_import.py
 ---
-Err(
-    FunctionCompiler(
-        Unsupported(
-            Statement {
-                kind: Sleep,
+Ok(
+    Executable {
+        functions: [
+            Function {
+                states: [
+                    State {
+                        instructions: [
+                            ExtCallSet(
+                                ActionCall {
+                                    dst: RegisterId(
+                                        0,
+                                    ),
+                                    action_ref: TestActionRef(
+                                        "get_value_from_import",
+                                    ),
+                                    args: [],
+                                    resume: StateId(
+                                        1,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                Await {
+                                    dst: RegisterId(
+                                        0,
+                                    ),
+                                    src: RegisterId(
+                                        0,
+                                    ),
+                                    resume: StateId(
+                                        2,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            PureSet(
+                                LoadConst {
+                                    dst: RegisterId(
+                                        2,
+                                    ),
+                                    value: Int(
+                                        2,
+                                    ),
+                                },
+                            ),
+                            ExtCallSet(
+                                Sleep {
+                                    dst: RegisterId(
+                                        1,
+                                    ),
+                                    duration: RegisterId(
+                                        2,
+                                    ),
+                                    resume: StateId(
+                                        3,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                Await {
+                                    dst: RegisterId(
+                                        1,
+                                    ),
+                                    src: RegisterId(
+                                        1,
+                                    ),
+                                    resume: StateId(
+                                        4,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            ExtCallSet(
+                                ActionCall {
+                                    dst: RegisterId(
+                                        3,
+                                    ),
+                                    action_ref: TestActionRef(
+                                        "format_done_from_import",
+                                    ),
+                                    args: [
+                                        RegisterId(
+                                            0,
+                                        ),
+                                    ],
+                                    resume: StateId(
+                                        5,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                Await {
+                                    dst: RegisterId(
+                                        3,
+                                    ),
+                                    src: RegisterId(
+                                        3,
+                                    ),
+                                    resume: StateId(
+                                        6,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                Return {
+                                    src: RegisterId(
+                                        3,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                ],
+                num_regs: 4,
             },
-        ),
-    ),
+        ],
+    },
 )

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_sleep__sleep_import_asyncio.py__ast.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_sleep__sleep_import_asyncio.py__ast.snap
@@ -55,21 +55,19 @@ Program {
                             },
                             Spanned {
                                 value: Sleep {
-                                    duration: Some(
-                                        Spanned {
-                                            value: Literal {
-                                                value: Int(
-                                                    1,
-                                                ),
-                                            },
-                                            span: Span {
-                                                start_line: 3,
-                                                start_col: 24,
-                                                end_line: 3,
-                                                end_col: 25,
-                                            },
+                                    duration: Spanned {
+                                        value: Literal {
+                                            value: Int(
+                                                1,
+                                            ),
                                         },
-                                    ),
+                                        span: Span {
+                                            start_line: 3,
+                                            start_col: 24,
+                                            end_line: 3,
+                                            end_col: 25,
+                                        },
+                                    },
                                 },
                                 span: Span {
                                     start_line: 3,

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_sleep__sleep_import_asyncio.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_sleep__sleep_import_asyncio.py__bytecode.snap
@@ -2,12 +2,143 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_sleep/sleep_import_asyncio.py
 ---
-Err(
-    FunctionCompiler(
-        Unsupported(
-            Statement {
-                kind: Sleep,
+Ok(
+    Executable {
+        functions: [
+            Function {
+                states: [
+                    State {
+                        instructions: [
+                            ExtCallSet(
+                                ActionCall {
+                                    dst: RegisterId(
+                                        0,
+                                    ),
+                                    action_ref: TestActionRef(
+                                        "get_value_asyncio_import",
+                                    ),
+                                    args: [],
+                                    resume: StateId(
+                                        1,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                Await {
+                                    dst: RegisterId(
+                                        0,
+                                    ),
+                                    src: RegisterId(
+                                        0,
+                                    ),
+                                    resume: StateId(
+                                        2,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            PureSet(
+                                LoadConst {
+                                    dst: RegisterId(
+                                        2,
+                                    ),
+                                    value: Int(
+                                        1,
+                                    ),
+                                },
+                            ),
+                            ExtCallSet(
+                                Sleep {
+                                    dst: RegisterId(
+                                        1,
+                                    ),
+                                    duration: RegisterId(
+                                        2,
+                                    ),
+                                    resume: StateId(
+                                        3,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                Await {
+                                    dst: RegisterId(
+                                        1,
+                                    ),
+                                    src: RegisterId(
+                                        1,
+                                    ),
+                                    resume: StateId(
+                                        4,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            ExtCallSet(
+                                ActionCall {
+                                    dst: RegisterId(
+                                        3,
+                                    ),
+                                    action_ref: TestActionRef(
+                                        "format_done_asyncio_import",
+                                    ),
+                                    args: [
+                                        RegisterId(
+                                            0,
+                                        ),
+                                    ],
+                                    resume: StateId(
+                                        5,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                Await {
+                                    dst: RegisterId(
+                                        3,
+                                    ),
+                                    src: RegisterId(
+                                        3,
+                                    ),
+                                    resume: StateId(
+                                        6,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                Return {
+                                    src: RegisterId(
+                                        3,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                ],
+                num_regs: 4,
             },
-        ),
-    ),
+        ],
+    },
 )

--- a/crates/lib/vm-compiler-for-ast-old/tests/support/mod.rs
+++ b/crates/lib/vm-compiler-for-ast-old/tests/support/mod.rs
@@ -1,3 +1,4 @@
+use waymark_nonzero_duration::NonZeroDuration;
 use waymark_vm_compiler_for_ast_old_test_support::{
     TestConstValue, TestExecutable, TestLowering, TestSpec,
 };
@@ -6,6 +7,18 @@ type TestInterpreter =
     waymark_vm_interpreter_fullset::FullSetInterpreter<TestSpec, TestExecutable, TestValue>;
 
 pub type TestRuntime = waymark_vm_runtime::Runtime<TestExecutable, TestInterpreter, TestValue>;
+
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum TestSleepDurationError {
+    #[error("the value cannot be used as a sleep duration")]
+    UnsupportedValue,
+
+    #[error("sleep duration must be non-zero")]
+    Zero,
+
+    #[error("sleep duration cannot be negative")]
+    Negative,
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TestValue {
@@ -310,6 +323,20 @@ impl waymark_vm_interpreter_pureset::value::MakeList for TestValue {
         I: IntoIterator<Item = Self>,
     {
         Ok(Self::List(items.into_iter().collect()))
+    }
+}
+
+impl waymark_vm_interpreter_extcallset::value::SleepDuration for TestValue {
+    type Error = TestSleepDurationError;
+
+    fn to_sleep_duration(&self) -> Result<NonZeroDuration, Self::Error> {
+        match self {
+            Self::Int(value) => {
+                let seconds: u64 = (*value).try_into().map_err(|_| Self::Error::Negative)?;
+                NonZeroDuration::from_secs(seconds).ok_or(Self::Error::Zero)
+            }
+            Self::Bool(_) | Self::None | Self::List(_) => Err(Self::Error::UnsupportedValue),
+        }
     }
 }
 

--- a/crates/lib/vm-instructions-extcallset/src/lib.rs
+++ b/crates/lib/vm-instructions-extcallset/src/lib.rs
@@ -39,4 +39,17 @@ pub enum ExtCallSet<Spec: self::Spec> {
         /// The state to resume the execution from after invoking the extcall.
         resume: Spec::StateId,
     },
+
+    /// Start a sleep suspension.
+    Sleep {
+        /// The register in the current frame to assign the promise for this
+        /// sleep completion.
+        dst: Spec::RegisterId,
+
+        /// Register holding the requested sleep duration.
+        duration: Spec::RegisterId,
+
+        /// The state to resume the execution from after starting the sleep.
+        resume: Spec::StateId,
+    },
 }

--- a/crates/lib/vm-interpreter-extcallset/Cargo.toml
+++ b/crates/lib/vm-interpreter-extcallset/Cargo.toml
@@ -5,6 +5,7 @@ version.workspace = true
 publish.workspace = true
 
 [dependencies]
+waymark-nonzero-duration = { workspace = true }
 waymark-vm-instructions-extcallset = { workspace = true }
 waymark-vm-interpreter = { workspace = true }
 waymark-vm-runtime-core = { workspace = true }

--- a/crates/lib/vm-interpreter-extcallset/src/error.rs
+++ b/crates/lib/vm-interpreter-extcallset/src/error.rs
@@ -2,16 +2,20 @@ use waymark_vm_runtime_core::UnresolvedPromiseError;
 
 /// The error for the [`crate::ExtCallSetInterpreter`].
 #[derive(Debug, thiserror::Error)]
-pub enum Error {
-    /// Invoking an extcall failed.
-    #[error("extcall: {0}")]
-    ExtCall(#[source] ExtCallError),
+pub enum Error<Value: crate::Value> {
+    /// Preparing an action call failed.
+    #[error("action call: {0}")]
+    ActionCall(#[source] ActionCallError),
+
+    /// Preparing a sleep suspension failed.
+    #[error("sleep: {0}")]
+    Sleep(#[source] SleepError<<Value as crate::value::SleepDuration>::Error>),
 }
 
-/// Errors produced while preparing an extcall invocation.
+/// Errors produced while preparing an action call invocation.
 #[derive(Debug, thiserror::Error)]
-pub enum ExtCallError {
-    /// An extcall argument still held an unresolved promise.
+pub enum ActionCallError {
+    /// An action-call argument still held an unresolved promise.
     #[error("unresolved promise argument at position {arg_pos}: {source}")]
     UnresolvedPromiseArgument {
         /// The zero-based argument position that failed to resolve.
@@ -20,5 +24,25 @@ pub enum ExtCallError {
         /// The underlying unresolved promise error for the argument.
         #[source]
         source: UnresolvedPromiseError,
+    },
+}
+
+/// Errors produced while preparing a sleep suspension.
+#[derive(Debug, thiserror::Error)]
+pub enum SleepError<DurationError> {
+    /// The requested sleep duration still held an unresolved promise.
+    #[error("unresolved promise duration: {source}")]
+    UnresolvedPromiseDuration {
+        /// The underlying unresolved promise error for the duration.
+        #[source]
+        source: UnresolvedPromiseError,
+    },
+
+    /// The resolved duration value could not be converted to a concrete delay.
+    #[error("invalid sleep duration: {source}")]
+    InvalidDuration {
+        /// The underlying value-conversion failure.
+        #[source]
+        source: DurationError,
     },
 }

--- a/crates/lib/vm-interpreter-extcallset/src/lib.rs
+++ b/crates/lib/vm-interpreter-extcallset/src/lib.rs
@@ -3,12 +3,15 @@
 #![warn(missing_docs)]
 
 mod error;
+pub mod value;
 
 use derive_where::derive_where;
+use waymark_nonzero_duration::NonZeroDuration;
 use waymark_vm_interpreter::ExecutionOutcome;
-use waymark_vm_runtime_core::{Frame, Promise, PromiseStateId, RuntimeState};
+use waymark_vm_runtime_core::{Frame, Promise, PromiseStateId, RegisterId, RuntimeState};
 
 pub use self::error::*;
+pub use self::value::Value;
 
 /// An interpreter for the "extcall" instructions set.
 #[derive_where(Default)]
@@ -37,6 +40,28 @@ pub enum Effect<Value, ActionRef> {
         /// Args to pass to the action call.
         args: Vec<Value>,
     },
+
+    /// Sleep suspension is requested.
+    Sleep {
+        /// The ID of the promise to resolve when the sleep finishes.
+        promise_state_id: PromiseStateId,
+
+        /// Requested sleep duration.
+        duration: NonZeroDuration,
+    },
+}
+
+fn suspend_frame<FunctionId, StateId, Value>(
+    state: &mut RuntimeState<FunctionId, StateId, Value>,
+    mut frame: Frame<FunctionId, StateId, Promise<Value>>,
+    dst: RegisterId,
+    resume: StateId,
+) -> PromiseStateId {
+    let promise_state_id = state.promise_states.prepare();
+    frame.regs.set(dst, Promise::Pending(promise_state_id));
+    frame.state = resume;
+    state.ready.push_front(frame);
+    promise_state_id
 }
 
 impl<Spec, FunctionId, StateId, Value> waymark_vm_interpreter::Interpreter
@@ -49,18 +74,18 @@ where
     FunctionId: 'static,
     StateId: Copy + 'static,
     Spec::ActionRef: Clone,
-    Value: Clone + 'static,
+    Value: self::value::Value + Clone + 'static,
 {
     type RuntimeView<'r> = RuntimeView<'r, FunctionId, StateId, Value>;
     type Frame = Frame<FunctionId, StateId, Promise<Value>>;
     type Instruction = waymark_vm_instructions_extcallset::ExtCallSet<Spec>;
-    type Error = Error;
+    type Error = Error<Value>;
     type Effect = Effect<Value, Spec::ActionRef>;
 
     fn execute<'r>(
         &self,
         runtime_view: Self::RuntimeView<'r>,
-        mut frame: Frame<FunctionId, StateId, Promise<Value>>,
+        frame: Frame<FunctionId, StateId, Promise<Value>>,
         instruction: &Self::Instruction,
     ) -> Result<
         ExecutionOutcome<Frame<FunctionId, StateId, Promise<Value>>, Self::Effect>,
@@ -82,7 +107,7 @@ where
                         let value = frame.regs[*register].clone();
 
                         value.require_resolved().map_err(|source| {
-                            Error::ExtCall(ExtCallError::UnresolvedPromiseArgument {
+                            Error::ActionCall(ActionCallError::UnresolvedPromiseArgument {
                                 arg_pos,
                                 source,
                             })
@@ -90,17 +115,35 @@ where
                     })
                     .collect::<Result<_, _>>()?;
 
-                let promise_state_id = state.promise_states.prepare();
-                frame.regs.set(*dst, Promise::Pending(promise_state_id));
-
-                frame.state = *resume;
-
-                state.ready.push_front(frame);
+                let promise_state_id = suspend_frame(state, frame, *dst, *resume);
 
                 Ok(ExecutionOutcome::ExitFrameWithEffect(Effect::ActionCall {
                     promise_state_id,
                     action_ref: action_ref.clone(),
                     args,
+                }))
+            }
+            waymark_vm_instructions_extcallset::ExtCallSet::Sleep {
+                dst,
+                duration,
+                resume,
+            } => {
+                let value = frame.regs[*duration]
+                    .clone()
+                    .require_resolved()
+                    .map_err(|source| {
+                        Error::Sleep(SleepError::UnresolvedPromiseDuration { source })
+                    })?;
+
+                let duration = value
+                    .to_sleep_duration()
+                    .map_err(|source| Error::Sleep(SleepError::InvalidDuration { source }))?;
+
+                let promise_state_id = suspend_frame(state, frame, *dst, *resume);
+
+                Ok(ExecutionOutcome::ExitFrameWithEffect(Effect::Sleep {
+                    promise_state_id,
+                    duration,
                 }))
             }
         }

--- a/crates/lib/vm-interpreter-extcallset/src/value.rs
+++ b/crates/lib/vm-interpreter-extcallset/src/value.rs
@@ -1,0 +1,17 @@
+//! Value requirements.
+
+use waymark_nonzero_duration::NonZeroDuration;
+
+/// Convert a resolved VM value into a sleep duration.
+pub trait SleepDuration {
+    /// The implementation-specific error returned when conversion fails.
+    type Error: std::error::Error + 'static;
+
+    /// Convert the value into a [`NonZeroDuration`].
+    fn to_sleep_duration(&self) -> Result<NonZeroDuration, Self::Error>;
+}
+
+/// A unifying trait for extcallset value requirements.
+pub trait Value: SleepDuration {}
+
+impl<T> Value for T where T: SleepDuration {}

--- a/crates/lib/vm-interpreter-extcallset/tests/integration.rs
+++ b/crates/lib/vm-interpreter-extcallset/tests/integration.rs
@@ -1,7 +1,10 @@
+use waymark_nonzero_duration::NonZeroDuration;
 use waymark_vm_instructions_extcallset::ExtCallSet;
 use waymark_vm_interpreter::ExecutionOutcome;
-use waymark_vm_interpreter_extcallset::{Effect, ExtCallSetInterpreter, RuntimeView};
-use waymark_vm_runtime::{CallSpec, Runtime};
+use waymark_vm_interpreter_extcallset::{
+    Effect, Error as InterpreterError, ExtCallSetInterpreter, RuntimeView, SleepError,
+};
+use waymark_vm_runtime::{CallSpec, RunError, Runtime};
 use waymark_vm_runtime_core::{
     CaptureRuntimeView, Frame, FullRuntimeView, Promise, PromiseState, PromiseStateId, RegisterId,
 };
@@ -14,6 +17,27 @@ impl waymark_vm_instructions_extcallset::Spec for TestSpec {
     type RegisterId = RegisterId;
     type StateId = StateId;
     type ActionRef = usize;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct TestValue(i32);
+
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+enum TestSleepDurationError {
+    #[error("sleep duration cannot be negative")]
+    Negative,
+
+    #[error("sleep duration must be non-zero")]
+    Zero,
+}
+
+impl waymark_vm_interpreter_extcallset::value::SleepDuration for TestValue {
+    type Error = TestSleepDurationError;
+
+    fn to_sleep_duration(&self) -> Result<NonZeroDuration, Self::Error> {
+        let seconds: u64 = self.0.try_into().map_err(|_| Self::Error::Negative)?;
+        NonZeroDuration::from_secs(seconds).ok_or(Self::Error::Zero)
+    }
 }
 
 #[derive(Debug)]
@@ -30,26 +54,28 @@ impl From<ExtCallSet<TestSpec>> for RuntimeInstruction {
 
 #[derive(Debug)]
 enum TestEffect {
-    ActionCall(Effect<i32, usize>),
+    ExtCallSet(Effect<TestValue, usize>),
     PendingPromiseStateId(PromiseStateId),
 }
 
 #[derive(Default)]
 struct RuntimeInterpreter {
-    extcall: ExtCallSetInterpreter<TestSpec, FunctionId, StateId, i32>,
+    extcall: ExtCallSetInterpreter<TestSpec, FunctionId, StateId, TestValue>,
 }
 
-impl<Executable> CaptureRuntimeView<Executable, FunctionId, StateId, i32> for RuntimeInterpreter {
+impl<Executable> CaptureRuntimeView<Executable, FunctionId, StateId, TestValue>
+    for RuntimeInterpreter
+{
     type RuntimeView<'r>
-        = RuntimeView<'r, FunctionId, StateId, i32>
+        = RuntimeView<'r, FunctionId, StateId, TestValue>
     where
         Executable: 'r,
         FunctionId: 'r,
         StateId: 'r,
-        i32: 'r;
+        TestValue: 'r;
 
     fn capture_runtime_view<'r>(
-        view: FullRuntimeView<'r, Executable, FunctionId, StateId, i32>,
+        view: FullRuntimeView<'r, Executable, FunctionId, StateId, TestValue>,
     ) -> Self::RuntimeView<'r> {
         let FullRuntimeView { state, .. } = view;
         RuntimeView { state }
@@ -57,10 +83,10 @@ impl<Executable> CaptureRuntimeView<Executable, FunctionId, StateId, i32> for Ru
 }
 
 impl waymark_vm_interpreter::Interpreter for RuntimeInterpreter {
-    type RuntimeView<'r> = RuntimeView<'r, FunctionId, StateId, i32>;
-    type Frame = Frame<FunctionId, StateId, Promise<i32>>;
+    type RuntimeView<'r> = RuntimeView<'r, FunctionId, StateId, TestValue>;
+    type Frame = Frame<FunctionId, StateId, Promise<TestValue>>;
     type Instruction = RuntimeInstruction;
-    type Error = waymark_vm_interpreter_extcallset::Error;
+    type Error = InterpreterError<TestValue>;
     type Effect = TestEffect;
 
     fn execute<'r>(
@@ -77,13 +103,13 @@ impl waymark_vm_interpreter::Interpreter for RuntimeInterpreter {
                     frame,
                     instruction,
                 )
-                .map(|outcome| outcome.map_effect(TestEffect::ActionCall))
+                .map(|outcome| outcome.map_effect(TestEffect::ExtCallSet))
             }
             RuntimeInstruction::InspectPending(register) => {
                 let RuntimeView { state } = runtime_view;
 
                 let Promise::Pending(promise_state_id) = frame.regs[*register].clone() else {
-                    panic!("register should hold the action call's pending promise");
+                    panic!("register should hold the suspended operation's pending promise");
                 };
 
                 assert!(matches!(
@@ -120,12 +146,12 @@ fn runtime_emits_an_action_call_and_queues_the_resumed_frame() {
         )]),
         CallSpec {
             func: FunctionId(0),
-            args: vec![41],
+            args: vec![TestValue(41)],
         },
     )
     .expect("function 0 should exist");
 
-    let TestEffect::ActionCall(Effect::ActionCall {
+    let TestEffect::ExtCallSet(Effect::ActionCall {
         promise_state_id,
         action_ref,
         args,
@@ -137,7 +163,7 @@ fn runtime_emits_an_action_call_and_queues_the_resumed_frame() {
     };
 
     assert_eq!(action_ref, 7);
-    assert_eq!(args, vec![41]);
+    assert_eq!(args, vec![TestValue(41)]);
 
     let TestEffect::PendingPromiseStateId(resumed_promise_state_id) = runtime
         .run()
@@ -147,4 +173,83 @@ fn runtime_emits_an_action_call_and_queues_the_resumed_frame() {
     };
 
     assert_eq!(resumed_promise_state_id, promise_state_id);
+}
+
+#[test]
+fn runtime_emits_a_sleep_effect_and_queues_the_resumed_frame() {
+    let mut runtime = Runtime::with_custom_entrypoint(
+        RuntimeInterpreter::default(),
+        executable(vec![function::<RuntimeInstruction>(
+            2,
+            vec![
+                vec![
+                    ExtCallSet::Sleep {
+                        dst: RegisterId(1),
+                        duration: RegisterId(0),
+                        resume: StateId(1),
+                    }
+                    .into(),
+                ],
+                vec![RuntimeInstruction::InspectPending(RegisterId(1))],
+            ],
+        )]),
+        CallSpec {
+            func: FunctionId(0),
+            args: vec![TestValue(5)],
+        },
+    )
+    .expect("function 0 should exist");
+
+    let TestEffect::ExtCallSet(Effect::Sleep {
+        promise_state_id,
+        duration,
+    }) = runtime
+        .run()
+        .expect("first run should emit the sleep effect")
+    else {
+        panic!("first run should emit a sleep effect");
+    };
+
+    assert_eq!(duration, NonZeroDuration::from_secs(5).unwrap());
+
+    let TestEffect::PendingPromiseStateId(resumed_promise_state_id) = runtime
+        .run()
+        .expect("second run should execute the resumed frame")
+    else {
+        panic!("second run should inspect the resumed pending promise");
+    };
+
+    assert_eq!(resumed_promise_state_id, promise_state_id);
+}
+
+#[test]
+fn runtime_surfaces_invalid_sleep_duration_errors_from_the_interpreter() {
+    let mut runtime = Runtime::with_custom_entrypoint(
+        RuntimeInterpreter::default(),
+        executable(vec![function::<RuntimeInstruction>(
+            2,
+            vec![vec![
+                ExtCallSet::Sleep {
+                    dst: RegisterId(1),
+                    duration: RegisterId(0),
+                    resume: StateId(1),
+                }
+                .into(),
+            ]],
+        )]),
+        CallSpec {
+            func: FunctionId(0),
+            args: vec![TestValue(0)],
+        },
+    )
+    .expect("function 0 should exist");
+
+    assert!(matches!(
+        runtime.run(),
+        Err(RunError::Step(waymark_vm_runtime::step::Error::Execution(
+            InterpreterError::Sleep(SleepError::InvalidDuration {
+                source: TestSleepDurationError::Zero,
+            })
+        )))
+    ));
 }

--- a/crates/lib/vm-interpreter-fullset/Cargo.toml
+++ b/crates/lib/vm-interpreter-fullset/Cargo.toml
@@ -20,5 +20,6 @@ derive-where = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
+waymark-nonzero-duration = { workspace = true }
 waymark-vm-runtime = { workspace = true }
 waymark-vm-runtime-test = { workspace = true }

--- a/crates/lib/vm-interpreter-fullset/src/error.rs
+++ b/crates/lib/vm-interpreter-fullset/src/error.rs
@@ -1,13 +1,13 @@
 /// The error for the [`crate::FullSetInterpreter`].
 #[derive(Debug, thiserror::Error)]
-pub enum Error<Spec: waymark_vm_instructions_fullset::Spec> {
+pub enum Error<Spec: waymark_vm_instructions_fullset::Spec, Value: crate::Value> {
     /// Executing a coreset instruction failed.
     #[error(transparent)]
     CoreSet(#[from] waymark_vm_interpreter_coreset::Error<Spec>),
 
     /// Executing an extcallset instruction failed.
     #[error(transparent)]
-    ExtCallSet(#[from] waymark_vm_interpreter_extcallset::Error),
+    ExtCallSet(#[from] waymark_vm_interpreter_extcallset::Error<Value>),
 
     /// Executing a pureset instruction failed.
     #[error(transparent)]

--- a/crates/lib/vm-interpreter-fullset/src/lib.rs
+++ b/crates/lib/vm-interpreter-fullset/src/lib.rs
@@ -73,6 +73,7 @@ where
     ActionRefFor<Spec>: Clone,
     Value: Clone + 'static,
     Value: waymark_vm_interpreter_coreset::Value,
+    Value: waymark_vm_interpreter_extcallset::Value,
     Value: waymark_vm_interpreter_pureset::Value,
     Spec::ConstValue: Clone + Into<Value>,
 {
@@ -80,7 +81,7 @@ where
         RuntimeView<'r, Executable, FunctionIdFor<Spec>, StateIdFor<Spec>, Value>;
     type Frame = Frame<FunctionIdFor<Spec>, StateIdFor<Spec>, Promise<Value>>;
     type Instruction = waymark_vm_instructions_fullset::FullSet<Spec>;
-    type Error = Error<Spec>;
+    type Error = Error<Spec, Value>;
     type Effect = Effect<Value, ActionRefFor<Spec>>;
 
     fn execute<'r>(

--- a/crates/lib/vm-interpreter-fullset/src/value.rs
+++ b/crates/lib/vm-interpreter-fullset/src/value.rs
@@ -2,11 +2,15 @@
 
 /// A unifying trait for all value requirements.
 pub trait Value:
-    waymark_vm_interpreter_coreset::Value + waymark_vm_interpreter_pureset::Value
+    waymark_vm_interpreter_coreset::Value
+    + waymark_vm_interpreter_extcallset::Value
+    + waymark_vm_interpreter_pureset::Value
 {
 }
 
 impl<T> Value for T where
-    T: waymark_vm_interpreter_coreset::Value + waymark_vm_interpreter_pureset::Value
+    T: waymark_vm_interpreter_coreset::Value
+        + waymark_vm_interpreter_extcallset::Value
+        + waymark_vm_interpreter_pureset::Value
 {
 }

--- a/crates/lib/vm-interpreter-fullset/tests/integration.rs
+++ b/crates/lib/vm-interpreter-fullset/tests/integration.rs
@@ -1,3 +1,4 @@
+use waymark_nonzero_duration::NonZeroDuration;
 use waymark_vm_instructions_coreset::CoreSet;
 use waymark_vm_instructions_extcallset::ExtCallSet;
 use waymark_vm_instructions_fullset::FullSet;
@@ -36,6 +37,18 @@ enum TestConstValue {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct TestActionRef(usize);
+
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+enum TestSleepDurationError {
+    #[error("the value cannot be used as a sleep duration")]
+    UnsupportedValue,
+
+    #[error("sleep duration must be non-zero")]
+    Zero,
+
+    #[error("sleep duration cannot be negative")]
+    Negative,
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum TestValue {
@@ -106,6 +119,20 @@ impl waymark_vm_interpreter_pureset::value::MakeList for TestValue {
     }
 }
 
+impl waymark_vm_interpreter_extcallset::value::SleepDuration for TestValue {
+    type Error = TestSleepDurationError;
+
+    fn to_sleep_duration(&self) -> Result<NonZeroDuration, Self::Error> {
+        match self {
+            Self::Int(value) => {
+                let seconds: u64 = (*value).try_into().map_err(|_| Self::Error::Negative)?;
+                NonZeroDuration::from_secs(seconds).ok_or(Self::Error::Zero)
+            }
+            Self::Bool(_) | Self::List(_) => Err(Self::Error::UnsupportedValue),
+        }
+    }
+}
+
 impl From<TestConstValue> for TestValue {
     fn from(value: TestConstValue) -> Self {
         match value {
@@ -158,6 +185,95 @@ fn runtime_executes_pure_and_core_instructions_to_completion() {
         }
         Effect::ExtCallSet(waymark_vm_interpreter_extcallset::Effect::ActionCall { .. }) => {
             panic!("program should not emit an action call")
+        }
+        Effect::ExtCallSet(waymark_vm_interpreter_extcallset::Effect::Sleep { .. }) => {
+            panic!("program should not emit a sleep effect")
+        }
+        Effect::PureSet(effect) => match effect {},
+    }
+}
+
+#[test]
+fn runtime_resumes_sleep_effects_and_finishes_with_pure_work() {
+    let executable = executable(vec![function::<Instruction>(
+        4,
+        vec![
+            vec![
+                PureSet::LoadConst {
+                    dst: RegisterId(0),
+                    value: TestConstValue::Int(2),
+                }
+                .into(),
+                ExtCallSet::Sleep {
+                    dst: RegisterId(1),
+                    duration: RegisterId(0),
+                    resume: StateId(1),
+                }
+                .into(),
+            ],
+            vec![
+                CoreSet::Await {
+                    dst: RegisterId(2),
+                    src: RegisterId(1),
+                    resume: StateId(2),
+                }
+                .into(),
+            ],
+            vec![
+                PureSet::LoadConst {
+                    dst: RegisterId(3),
+                    value: TestConstValue::Int(7),
+                }
+                .into(),
+                CoreSet::Return { src: RegisterId(3) }.into(),
+            ],
+        ],
+    )]);
+
+    let mut runtime = Runtime::with_conventional_entrypoint(
+        FullSetInterpreter::<TestSpec, _, TestValue>::default(),
+        executable,
+    )
+    .expect("function 0 should exist");
+
+    let effect = runtime
+        .run()
+        .expect("first run should emit the sleep effect");
+
+    let promise_state_id = match effect {
+        Effect::ExtCallSet(waymark_vm_interpreter_extcallset::Effect::Sleep {
+            promise_state_id,
+            duration,
+        }) => {
+            assert_eq!(duration, NonZeroDuration::from_secs(2).unwrap());
+            promise_state_id
+        }
+        Effect::CoreSet(waymark_vm_interpreter_coreset::Effect::Complete(_)) => {
+            panic!("program should suspend on sleep before completion")
+        }
+        Effect::ExtCallSet(waymark_vm_interpreter_extcallset::Effect::ActionCall { .. }) => {
+            panic!("program should emit a sleep effect, not an action call")
+        }
+        Effect::PureSet(effect) => match effect {},
+    };
+
+    runtime
+        .resolve_promise(promise_state_id, TestValue::Int(0))
+        .expect("sleep promise should resolve cleanly");
+
+    let effect = runtime
+        .run()
+        .expect("second run should finish after resuming sleep");
+
+    match effect {
+        Effect::CoreSet(waymark_vm_interpreter_coreset::Effect::Complete(value)) => {
+            assert_eq!(value, TestValue::Int(7));
+        }
+        Effect::ExtCallSet(waymark_vm_interpreter_extcallset::Effect::ActionCall { .. }) => {
+            panic!("resolved sleep should not emit an action call")
+        }
+        Effect::ExtCallSet(waymark_vm_interpreter_extcallset::Effect::Sleep { .. }) => {
+            panic!("resolved sleep should not emit another sleep effect")
         }
         Effect::PureSet(effect) => match effect {},
     }
@@ -232,6 +348,9 @@ fn runtime_resumes_extcalls_and_finishes_with_pure_work() {
         Effect::CoreSet(waymark_vm_interpreter_coreset::Effect::Complete(_)) => {
             panic!("program should suspend on the action call before completion")
         }
+        Effect::ExtCallSet(waymark_vm_interpreter_extcallset::Effect::Sleep { .. }) => {
+            panic!("program should suspend on an extcall, not a sleep effect")
+        }
         Effect::PureSet(effect) => match effect {},
     };
 
@@ -249,6 +368,9 @@ fn runtime_resumes_extcalls_and_finishes_with_pure_work() {
         }
         Effect::ExtCallSet(waymark_vm_interpreter_extcallset::Effect::ActionCall { .. }) => {
             panic!("resolved action call should not emit another action call")
+        }
+        Effect::ExtCallSet(waymark_vm_interpreter_extcallset::Effect::Sleep { .. }) => {
+            panic!("resolved extcall should not emit a sleep effect")
         }
         Effect::PureSet(effect) => match effect {},
     }


### PR DESCRIPTION
This PR adds a new `sleep` instruction in the extcalls set, and implements the compiler support for it.

The implementation utilizes our nonzero duration wrapper at the interpreter level.

 We don't support `sleep(0)` as an immediate "yield"s just yet. This is something we'd want to eventually support - but perhaps with a separate, explicit instruction instead of just sleep + await.