### PR TITLE
Add dict and list creation support (and all pre-requisites)

### DIFF
--- a/crates/lib/vm-ast-old-helpers/src/lib.rs
+++ b/crates/lib/vm-ast-old-helpers/src/lib.rs
@@ -39,6 +39,12 @@ pub fn float(value: f64) -> Spanned<Expr> {
     })
 }
 
+pub fn string(value: &str) -> Spanned<Expr> {
+    spanned(Expr::Literal {
+        value: Literal::String(value.to_owned()),
+    })
+}
+
 pub fn variable(name: &str) -> Spanned<Expr> {
     spanned(Expr::Variable {
         name: name.to_owned(),

--- a/crates/lib/vm-compiler-for-ast-old/src/function/compiler/bytecode/emitter.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/function/compiler/bytecode/emitter.rs
@@ -69,6 +69,15 @@ where
         self.emit(waymark_vm_instructions_pureset::PureSet::MakeList { dst, items }.into());
     }
 
+    /// Emits a dictionary-construction instruction.
+    pub fn emit_make_dict(
+        &mut self,
+        dst: RegisterId,
+        entries: Vec<waymark_vm_instructions_pureset::DictEntry<RegisterId>>,
+    ) {
+        self.emit(waymark_vm_instructions_pureset::PureSet::MakeDict { dst, entries }.into());
+    }
+
     /// Emits a user-function call that writes a promise register.
     pub fn emit_call(
         &mut self,

--- a/crates/lib/vm-compiler-for-ast-old/src/function/compiler/lowering/value.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/function/compiler/lowering/value.rs
@@ -1,7 +1,7 @@
 //! Value lowering.
 
 use waymark_vm_ast_old::{
-    ActionCall, BinaryOperator, Expr, FunctionCall, Literal, Spanned, UnaryOperator,
+    ActionCall, BinaryOperator, DictEntry, Expr, FunctionCall, Literal, Spanned, UnaryOperator,
 };
 use waymark_vm_runtime_core::RegisterId;
 
@@ -61,6 +61,8 @@ where
             ExpressionPlan::UnaryOp { op, operand } => {
                 self.compile_unary_expr(&op, operand, target)
             }
+            ExpressionPlan::List { elements } => self.compile_list_expr(elements, target),
+            ExpressionPlan::Dict { entries } => self.compile_dict_expr(entries, target),
             ExpressionPlan::FunctionCall { call } => {
                 self.compile_call(self.plan_function_call(call)?, target)
             }
@@ -251,6 +253,58 @@ where
         Ok(dst)
     }
 
+    /// Compiles a list literal from recursively evaluated items.
+    fn compile_list_expr(
+        &mut self,
+        elements: &[Spanned<Expr>],
+        target: ResultTarget,
+    ) -> Result<RegisterHandle, ErrorFor<Spec, Lowering>> {
+        let item_registers = compile_expr_registers(
+            elements,
+            |element| element,
+            |element| self.compile_expr(element, ResultTarget::Allocate),
+        )?;
+        let dst = self.allocate_result_register(target);
+
+        self.context.emitter.emit_make_list(
+            dst.register(),
+            item_registers
+                .iter()
+                .map(RegisterHandle::register)
+                .collect(),
+        );
+
+        Ok(dst)
+    }
+
+    /// Compiles a dictionary literal from recursively evaluated key-value pairs.
+    fn compile_dict_expr(
+        &mut self,
+        entries: &[DictEntry],
+        target: ResultTarget,
+    ) -> Result<RegisterHandle, ErrorFor<Spec, Lowering>> {
+        let mut entry_registers = Vec::with_capacity(entries.len());
+        let mut compiled_entries = Vec::with_capacity(entries.len());
+
+        for entry in entries {
+            let key = self.compile_expr(&entry.key, ResultTarget::Allocate)?;
+            let value = self.compile_expr(&entry.value, ResultTarget::Allocate)?;
+
+            compiled_entries.push(waymark_vm_instructions_pureset::DictEntry {
+                key: key.register(),
+                value: value.register(),
+            });
+            entry_registers.push((key, value));
+        }
+
+        let dst = self.allocate_result_register(target);
+        self.context
+            .emitter
+            .emit_make_dict(dst.register(), compiled_entries);
+
+        Ok(dst)
+    }
+
     /// Compiles a call and awaits its result.
     fn compile_call(
         &mut self,
@@ -384,8 +438,8 @@ mod tests {
     use super::*;
 
     use index_type::IndexType;
-    use waymark_vm_ast_old::BinaryOperator;
-    use waymark_vm_ast_old_helpers::{action_call, binary_expr, function_call, int};
+    use waymark_vm_ast_old::{BinaryOperator, DictEntry, Expr};
+    use waymark_vm_ast_old_helpers::{action_call, binary_expr, function_call, int, spanned};
     use waymark_vm_bytecode_core::{FunctionId, StateId};
     use waymark_vm_instructions_coreset::CoreSet;
     use waymark_vm_instructions_extcallset::ExtCallSet;
@@ -1030,6 +1084,118 @@ mod tests {
                 && *resume == StateId(3)
         ));
         assert!(third_state_instructions.next().is_none());
+    }
+
+    #[test]
+    fn list_expressions_emit_make_list() {
+        let function_table = build_function_table();
+        let mut emitter = FunctionEmitter::<TestSpec>::new();
+        let mut local_frame = LocalFrame::new();
+        let mut flow_state = FlowState::new();
+        let expr = spanned(Expr::List {
+            elements: vec![int(1), int(2)],
+        });
+
+        let dst = {
+            let mut values = ValueCompiler::<TestSpec, TestLowering>::new(
+                CompilerContextMut::new(
+                    &function_table,
+                    &mut emitter,
+                    &mut local_frame,
+                    &mut flow_state,
+                )
+                .into_ref(),
+            );
+
+            values
+                .compile_expr(&expr, ResultTarget::Allocate)
+                .expect("list expression should compile")
+        };
+
+        let states = emitter.finish();
+        assert_eq!(dst.register(), RegisterId(2));
+        assert_eq!(local_frame.num_registers(), 3);
+
+        let mut instructions = states[StateId(0)].instructions.iter();
+        assert!(matches!(
+            instructions.next(),
+            Some(InstructionSet::PureSet(PureSet::LoadConst {
+                dst,
+                value: TestConstValue::Int(1),
+            })) if *dst == RegisterId(0)
+        ));
+        assert!(matches!(
+            instructions.next(),
+            Some(InstructionSet::PureSet(PureSet::LoadConst {
+                dst,
+                value: TestConstValue::Int(2),
+            })) if *dst == RegisterId(1)
+        ));
+        assert!(matches!(
+            instructions.next(),
+            Some(InstructionSet::PureSet(PureSet::MakeList { dst, items }))
+                if *dst == RegisterId(2) && items == &[RegisterId(0), RegisterId(1)]
+        ));
+        assert!(instructions.next().is_none());
+    }
+
+    #[test]
+    fn dict_expressions_emit_make_dict() {
+        let function_table = build_function_table();
+        let mut emitter = FunctionEmitter::<TestSpec>::new();
+        let mut local_frame = LocalFrame::new();
+        let mut flow_state = FlowState::new();
+        let expr = spanned(Expr::Dict {
+            entries: vec![DictEntry {
+                key: int(1),
+                value: int(2),
+            }],
+        });
+
+        let dst = {
+            let mut values = ValueCompiler::<TestSpec, TestLowering>::new(
+                CompilerContextMut::new(
+                    &function_table,
+                    &mut emitter,
+                    &mut local_frame,
+                    &mut flow_state,
+                )
+                .into_ref(),
+            );
+
+            values
+                .compile_expr(&expr, ResultTarget::Allocate)
+                .expect("dict expression should compile")
+        };
+
+        let states = emitter.finish();
+        assert_eq!(dst.register(), RegisterId(2));
+        assert_eq!(local_frame.num_registers(), 3);
+
+        let mut instructions = states[StateId(0)].instructions.iter();
+        assert!(matches!(
+            instructions.next(),
+            Some(InstructionSet::PureSet(PureSet::LoadConst {
+                dst,
+                value: TestConstValue::Int(1),
+            })) if *dst == RegisterId(0)
+        ));
+        assert!(matches!(
+            instructions.next(),
+            Some(InstructionSet::PureSet(PureSet::LoadConst {
+                dst,
+                value: TestConstValue::Int(2),
+            })) if *dst == RegisterId(1)
+        ));
+        assert!(matches!(
+            instructions.next(),
+            Some(InstructionSet::PureSet(PureSet::MakeDict { dst, entries }))
+                if *dst == RegisterId(2)
+                    && entries.len() == 1
+                    && entries[0].key == RegisterId(0)
+                    && entries[0].value == RegisterId(1)
+        ));
+        assert!(instructions.next().is_none());
     }
 
     #[test]

--- a/crates/lib/vm-compiler-for-ast-old/src/function/compiler/plan/expr.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/function/compiler/plan/expr.rs
@@ -1,7 +1,7 @@
 //! Expression planning for generic value positions.
 
 use waymark_vm_ast_old::{
-    ActionCall, BinaryOperator, Expr, FunctionCall, Literal, Spanned, UnaryOperator,
+    ActionCall, BinaryOperator, DictEntry, Expr, FunctionCall, Literal, Spanned, UnaryOperator,
 };
 
 use super::Unsupported;
@@ -46,6 +46,18 @@ pub enum ExpressionPlan<'a> {
         operand: &'a Spanned<Expr>,
     },
 
+    /// A list literal.
+    List {
+        /// List items in source order.
+        elements: &'a [Spanned<Expr>],
+    },
+
+    /// A dictionary literal.
+    Dict {
+        /// Dictionary entries in source order.
+        entries: &'a [DictEntry],
+    },
+
     /// A call to another in-VM function.
     FunctionCall {
         /// Function-call payload from the AST.
@@ -62,12 +74,6 @@ pub enum ExpressionPlan<'a> {
 /// Expression variants that the generic value-lowering path rejects.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum UnsupportedExpressionKind {
-    /// List literals.
-    List,
-
-    /// Dictionary literals.
-    Dict,
-
     /// Indexing expressions such as `items[0]`.
     Index,
 
@@ -99,12 +105,8 @@ impl<'a> ExpressionPlan<'a> {
                 op: op.clone(),
                 operand,
             }),
-            Expr::List { .. } => Err(Unsupported::Expression {
-                kind: UnsupportedExpressionKind::List,
-            }),
-            Expr::Dict { .. } => Err(Unsupported::Expression {
-                kind: UnsupportedExpressionKind::Dict,
-            }),
+            Expr::List { elements } => Ok(Self::List { elements }),
+            Expr::Dict { entries } => Ok(Self::Dict { entries }),
             Expr::Index { .. } => Err(Unsupported::Expression {
                 kind: UnsupportedExpressionKind::Index,
             }),
@@ -122,8 +124,6 @@ impl<'a> ExpressionPlan<'a> {
 impl core::fmt::Display for UnsupportedExpressionKind {
     fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         formatter.write_str(match self {
-            Self::List => "List",
-            Self::Dict => "Dict",
             Self::Index => "Index",
             Self::Dot => "Dot",
             Self::SpreadExpr => "SpreadExpr",
@@ -198,6 +198,15 @@ mod tests {
         let variable_expr = variable("value");
         let function_expr = function_expr("child", vec![int(1)]);
         let action_expr = action_expr("fetch", vec![("value", int(2))]);
+        let list_expr = spanned(Expr::List {
+            elements: vec![int(1), int(2)],
+        });
+        let dict_expr = spanned(Expr::Dict {
+            entries: vec![DictEntry {
+                key: int(1),
+                value: int(2),
+            }],
+        });
 
         assert!(matches!(
             ExpressionPlan::build(&variable_expr).expect("variables should build"),
@@ -211,26 +220,19 @@ mod tests {
             ExpressionPlan::build(&action_expr).expect("action calls should build"),
             ExpressionPlan::ActionCall { call } if call.action_name == "fetch"
         ));
+        assert!(matches!(
+            ExpressionPlan::build(&list_expr).expect("lists should build"),
+            ExpressionPlan::List { elements } if elements.len() == 2
+        ));
+        assert!(matches!(
+            ExpressionPlan::build(&dict_expr).expect("dicts should build"),
+            ExpressionPlan::Dict { entries } if entries.len() == 1
+        ));
     }
 
     #[test]
     fn rejects_unsupported_expression_variants() {
         let unsupported = [
-            (
-                spanned(Expr::List {
-                    elements: vec![int(1)],
-                }),
-                UnsupportedExpressionKind::List,
-            ),
-            (
-                spanned(Expr::Dict {
-                    entries: vec![DictEntry {
-                        key: int(1),
-                        value: int(2),
-                    }],
-                }),
-                UnsupportedExpressionKind::Dict,
-            ),
             (
                 spanned(Expr::Index {
                     object: Box::new(variable("items")),

--- a/crates/lib/vm-compiler-for-ast-old/tests/integration.rs
+++ b/crates/lib/vm-compiler-for-ast-old/tests/integration.rs
@@ -7,8 +7,8 @@ use waymark_vm_ast_old::{BinaryOperator, Call, Expr, Literal, Spanned, UnaryOper
 use waymark_vm_ast_old_helpers::{
     action_call, action_expr, assignment, assignment_targets, binary_expr, break_stmt,
     conditional_stmt, continue_stmt, float, function, function_call, function_expr, int,
-    parallel_expr, parallel_stmt, program, return_stmt, sleep_stmt, spanned, unary_expr, variable,
-    while_stmt,
+    parallel_expr, parallel_stmt, program, return_stmt, sleep_stmt, spanned, string, unary_expr,
+    variable, while_stmt,
 };
 use waymark_vm_bytecode_core::{FunctionId, InstructionId, StateId};
 use waymark_vm_compiler_for_ast_old_test_support::TestActionRef;
@@ -411,6 +411,37 @@ fn compiles_action_calls_into_extcalls() {
         ))) => assert_eq!(value, 42),
         other => panic!("unexpected second runtime effect: {other:?}"),
     }
+}
+
+#[test]
+fn compiles_nested_dict_and_list_literals_to_completion() {
+    let program = program(vec![function(
+        "main",
+        &[],
+        vec![return_stmt(Some(spanned(Expr::Dict {
+            entries: vec![waymark_vm_ast_old::DictEntry {
+                key: string("key"),
+                value: spanned(Expr::List {
+                    elements: vec![int(2), int(3)],
+                }),
+            }],
+        })))],
+    )]);
+
+    let executable = compile_program(&program);
+    let mut runtime = runtime(executable);
+
+    assert_eq!(
+        completed_value(runtime.run().expect("program should complete")),
+        TestValue::Dict(
+            [(
+                "key".to_owned(),
+                TestValue::List(vec![TestValue::Int(2), TestValue::Int(3)]),
+            )]
+            .into_iter()
+            .collect()
+        )
+    );
 }
 
 #[test]

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_comprehension__dict_comprehension_assignment.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_comprehension__dict_comprehension_assignment.py__bytecode.snap
@@ -5,8 +5,8 @@ expression: bytecode for python/tests/fixtures_comprehension/dict_comprehension_
 Err(
     FunctionCompiler(
         Unsupported(
-            Expression {
-                kind: Dict,
+            Statement {
+                kind: ForLoop,
             },
         ),
     ),

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_comprehension__dict_comprehension_tuple.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_comprehension__dict_comprehension_tuple.py__bytecode.snap
@@ -5,8 +5,8 @@ expression: bytecode for python/tests/fixtures_comprehension/dict_comprehension_
 Err(
     FunctionCompiler(
         Unsupported(
-            Expression {
-                kind: Dict,
+            Statement {
+                kind: ForLoop,
             },
         ),
     ),

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_comprehension__list_comprehension_assignment.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_comprehension__list_comprehension_assignment.py__bytecode.snap
@@ -5,8 +5,8 @@ expression: bytecode for python/tests/fixtures_comprehension/list_comprehension_
 Err(
     FunctionCompiler(
         Unsupported(
-            Expression {
-                kind: List,
+            Statement {
+                kind: ForLoop,
             },
         ),
     ),

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_comprehension__list_comprehension_ifexp.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_comprehension__list_comprehension_ifexp.py__bytecode.snap
@@ -5,8 +5,8 @@ expression: bytecode for python/tests/fixtures_comprehension/list_comprehension_
 Err(
     FunctionCompiler(
         Unsupported(
-            Expression {
-                kind: List,
+            Statement {
+                kind: ForLoop,
             },
         ),
     ),

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_control_flow__for_multi_action.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_control_flow__for_multi_action.py__bytecode.snap
@@ -5,8 +5,8 @@ expression: bytecode for python/tests/fixtures_control_flow/for_multi_action.py
 Err(
     FunctionCompiler(
         Unsupported(
-            Expression {
-                kind: List,
+            Statement {
+                kind: ForLoop,
             },
         ),
     ),

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_control_flow__for_simple.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_control_flow__for_simple.py__bytecode.snap
@@ -5,8 +5,8 @@ expression: bytecode for python/tests/fixtures_control_flow/for_simple.py
 Err(
     FunctionCompiler(
         Unsupported(
-            Expression {
-                kind: List,
+            Statement {
+                kind: ForLoop,
             },
         ),
     ),

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_control_flow__if_with_accumulator.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_control_flow__if_with_accumulator.py__bytecode.snap
@@ -6,7 +6,7 @@ Err(
     FunctionCompiler(
         Unsupported(
             Expression {
-                kind: List,
+                kind: Index,
             },
         ),
     ),

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_for_loop__for_concat_accumulator.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_for_loop__for_concat_accumulator.py__bytecode.snap
@@ -5,8 +5,8 @@ expression: bytecode for python/tests/fixtures_for_loop/for_concat_accumulator.p
 Err(
     FunctionCompiler(
         Unsupported(
-            Expression {
-                kind: List,
+            Statement {
+                kind: ForLoop,
             },
         ),
     ),

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_for_loop__for_dict_accumulator.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_for_loop__for_dict_accumulator.py__bytecode.snap
@@ -5,8 +5,8 @@ expression: bytecode for python/tests/fixtures_for_loop/for_dict_accumulator.py
 Err(
     FunctionCompiler(
         Unsupported(
-            Expression {
-                kind: Dict,
+            Statement {
+                kind: ForLoop,
             },
         ),
     ),

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_for_loop__for_multi_accumulator.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_for_loop__for_multi_accumulator.py__bytecode.snap
@@ -5,8 +5,8 @@ expression: bytecode for python/tests/fixtures_for_loop/for_multi_accumulator.py
 Err(
     FunctionCompiler(
         Unsupported(
-            Expression {
-                kind: List,
+            Statement {
+                kind: ForLoop,
             },
         ),
     ),

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_for_loop__for_multiple_calls.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_for_loop__for_multiple_calls.py__bytecode.snap
@@ -5,8 +5,8 @@ expression: bytecode for python/tests/fixtures_for_loop/for_multiple_calls.py
 Err(
     FunctionCompiler(
         Unsupported(
-            Expression {
-                kind: List,
+            Statement {
+                kind: ForLoop,
             },
         ),
     ),

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_for_loop__for_single_accumulator.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_for_loop__for_single_accumulator.py__bytecode.snap
@@ -5,8 +5,8 @@ expression: bytecode for python/tests/fixtures_for_loop/for_single_accumulator.p
 Err(
     FunctionCompiler(
         Unsupported(
-            Expression {
-                kind: List,
+            Statement {
+                kind: ForLoop,
             },
         ),
     ),

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_for_loop__for_with_append.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_for_loop__for_with_append.py__bytecode.snap
@@ -5,8 +5,8 @@ expression: bytecode for python/tests/fixtures_for_loop/for_with_append.py
 Err(
     FunctionCompiler(
         Unsupported(
-            Expression {
-                kind: List,
+            Statement {
+                kind: ForLoop,
             },
         ),
     ),

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_generator_filter.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_generator_filter.py__bytecode.snap
@@ -5,8 +5,8 @@ expression: bytecode for python/tests/fixtures_gather/gather_generator_filter.py
 Err(
     FunctionCompiler(
         Unsupported(
-            Expression {
-                kind: List,
+            Statement {
+                kind: ForLoop,
             },
         ),
     ),

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_listcomp_filter.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_listcomp_filter.py__bytecode.snap
@@ -5,8 +5,8 @@ expression: bytecode for python/tests/fixtures_gather/gather_listcomp_filter.py
 Err(
     FunctionCompiler(
         Unsupported(
-            Expression {
-                kind: List,
+            Statement {
+                kind: ForLoop,
             },
         ),
     ),

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_simple.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_simple.py__bytecode.snap
@@ -2,12 +2,110 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_gather/gather_simple.py
 ---
-Err(
-    FunctionCompiler(
-        Unsupported(
-            Expression {
-                kind: List,
+Ok(
+    Executable {
+        functions: [
+            Function {
+                states: [
+                    State {
+                        instructions: [
+                            ExtCallSet(
+                                ActionCall {
+                                    dst: RegisterId(
+                                        2,
+                                    ),
+                                    action_ref: TestActionRef(
+                                        "action_a",
+                                    ),
+                                    args: [],
+                                    resume: StateId(
+                                        1,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            ExtCallSet(
+                                ActionCall {
+                                    dst: RegisterId(
+                                        3,
+                                    ),
+                                    action_ref: TestActionRef(
+                                        "action_b",
+                                    ),
+                                    args: [],
+                                    resume: StateId(
+                                        2,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                Await {
+                                    dst: RegisterId(
+                                        0,
+                                    ),
+                                    src: RegisterId(
+                                        2,
+                                    ),
+                                    resume: StateId(
+                                        3,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                Await {
+                                    dst: RegisterId(
+                                        1,
+                                    ),
+                                    src: RegisterId(
+                                        3,
+                                    ),
+                                    resume: StateId(
+                                        4,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            PureSet(
+                                MakeList {
+                                    dst: RegisterId(
+                                        3,
+                                    ),
+                                    items: [
+                                        RegisterId(
+                                            0,
+                                        ),
+                                        RegisterId(
+                                            1,
+                                        ),
+                                    ],
+                                },
+                            ),
+                            CoreSet(
+                                Return {
+                                    src: RegisterId(
+                                        3,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                ],
+                num_regs: 4,
             },
-        ),
-    ),
+        ],
+    },
 )

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_with_args.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_with_args.py__bytecode.snap
@@ -2,12 +2,118 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_gather/gather_with_args.py
 ---
-Err(
-    FunctionCompiler(
-        Unsupported(
-            Expression {
-                kind: List,
+Ok(
+    Executable {
+        functions: [
+            Function {
+                states: [
+                    State {
+                        instructions: [
+                            ExtCallSet(
+                                ActionCall {
+                                    dst: RegisterId(
+                                        3,
+                                    ),
+                                    action_ref: TestActionRef(
+                                        "compute_square",
+                                    ),
+                                    args: [
+                                        RegisterId(
+                                            0,
+                                        ),
+                                    ],
+                                    resume: StateId(
+                                        1,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            ExtCallSet(
+                                ActionCall {
+                                    dst: RegisterId(
+                                        4,
+                                    ),
+                                    action_ref: TestActionRef(
+                                        "compute_cube",
+                                    ),
+                                    args: [
+                                        RegisterId(
+                                            0,
+                                        ),
+                                    ],
+                                    resume: StateId(
+                                        2,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                Await {
+                                    dst: RegisterId(
+                                        1,
+                                    ),
+                                    src: RegisterId(
+                                        3,
+                                    ),
+                                    resume: StateId(
+                                        3,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                Await {
+                                    dst: RegisterId(
+                                        2,
+                                    ),
+                                    src: RegisterId(
+                                        4,
+                                    ),
+                                    resume: StateId(
+                                        4,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            PureSet(
+                                MakeList {
+                                    dst: RegisterId(
+                                        4,
+                                    ),
+                                    items: [
+                                        RegisterId(
+                                            1,
+                                        ),
+                                        RegisterId(
+                                            2,
+                                        ),
+                                    ],
+                                },
+                            ),
+                            CoreSet(
+                                Return {
+                                    src: RegisterId(
+                                        4,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                ],
+                num_regs: 5,
             },
-        ),
-    ),
+        ],
+    },
 )

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_models__dataclass_action_arg.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_models__dataclass_action_arg.py__bytecode.snap
@@ -6,7 +6,7 @@ Err(
     FunctionCompiler(
         Unsupported(
             Expression {
-                kind: Dict,
+                kind: Dot,
             },
         ),
     ),

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_models__dataclass_positional.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_models__dataclass_positional.py__bytecode.snap
@@ -2,12 +2,140 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_models/dataclass_positional.py
 ---
-Err(
-    FunctionCompiler(
-        Unsupported(
-            Expression {
-                kind: Dict,
+Ok(
+    Executable {
+        functions: [
+            Function {
+                states: [
+                    State {
+                        instructions: [
+                            ExtCallSet(
+                                ActionCall {
+                                    dst: RegisterId(
+                                        0,
+                                    ),
+                                    action_ref: TestActionRef(
+                                        "get_x",
+                                    ),
+                                    args: [],
+                                    resume: StateId(
+                                        1,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                Await {
+                                    dst: RegisterId(
+                                        0,
+                                    ),
+                                    src: RegisterId(
+                                        0,
+                                    ),
+                                    resume: StateId(
+                                        2,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            ExtCallSet(
+                                ActionCall {
+                                    dst: RegisterId(
+                                        1,
+                                    ),
+                                    action_ref: TestActionRef(
+                                        "get_y",
+                                    ),
+                                    args: [],
+                                    resume: StateId(
+                                        3,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                Await {
+                                    dst: RegisterId(
+                                        1,
+                                    ),
+                                    src: RegisterId(
+                                        1,
+                                    ),
+                                    resume: StateId(
+                                        4,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            PureSet(
+                                LoadConst {
+                                    dst: RegisterId(
+                                        3,
+                                    ),
+                                    value: String(
+                                        "x",
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                LoadConst {
+                                    dst: RegisterId(
+                                        4,
+                                    ),
+                                    value: String(
+                                        "y",
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                MakeDict {
+                                    dst: RegisterId(
+                                        2,
+                                    ),
+                                    entries: [
+                                        DictEntry {
+                                            key: RegisterId(
+                                                3,
+                                            ),
+                                            value: RegisterId(
+                                                0,
+                                            ),
+                                        },
+                                        DictEntry {
+                                            key: RegisterId(
+                                                4,
+                                            ),
+                                            value: RegisterId(
+                                                1,
+                                            ),
+                                        },
+                                    ],
+                                },
+                            ),
+                            CoreSet(
+                                Return {
+                                    src: RegisterId(
+                                        2,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                ],
+                num_regs: 5,
             },
-        ),
-    ),
+        ],
+    },
 )

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_models__dataclass_simple.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_models__dataclass_simple.py__bytecode.snap
@@ -2,12 +2,115 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_models/dataclass_simple.py
 ---
-Err(
-    FunctionCompiler(
-        Unsupported(
-            Expression {
-                kind: Dict,
+Ok(
+    Executable {
+        functions: [
+            Function {
+                states: [
+                    State {
+                        instructions: [
+                            ExtCallSet(
+                                ActionCall {
+                                    dst: RegisterId(
+                                        0,
+                                    ),
+                                    action_ref: TestActionRef(
+                                        "fetch_value",
+                                    ),
+                                    args: [],
+                                    resume: StateId(
+                                        1,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                Await {
+                                    dst: RegisterId(
+                                        0,
+                                    ),
+                                    src: RegisterId(
+                                        0,
+                                    ),
+                                    resume: StateId(
+                                        2,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            PureSet(
+                                LoadConst {
+                                    dst: RegisterId(
+                                        2,
+                                    ),
+                                    value: String(
+                                        "value",
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                LoadConst {
+                                    dst: RegisterId(
+                                        3,
+                                    ),
+                                    value: String(
+                                        "message",
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                LoadConst {
+                                    dst: RegisterId(
+                                        4,
+                                    ),
+                                    value: String(
+                                        "done",
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                MakeDict {
+                                    dst: RegisterId(
+                                        1,
+                                    ),
+                                    entries: [
+                                        DictEntry {
+                                            key: RegisterId(
+                                                2,
+                                            ),
+                                            value: RegisterId(
+                                                0,
+                                            ),
+                                        },
+                                        DictEntry {
+                                            key: RegisterId(
+                                                3,
+                                            ),
+                                            value: RegisterId(
+                                                4,
+                                            ),
+                                        },
+                                    ],
+                                },
+                            ),
+                            CoreSet(
+                                Return {
+                                    src: RegisterId(
+                                        1,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                ],
+                num_regs: 5,
             },
-        ),
-    ),
+        ],
+    },
 )

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_models__dataclass_with_defaults.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_models__dataclass_with_defaults.py__bytecode.snap
@@ -2,12 +2,143 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_models/dataclass_with_defaults.py
 ---
-Err(
-    FunctionCompiler(
-        Unsupported(
-            Expression {
-                kind: Dict,
+Ok(
+    Executable {
+        functions: [
+            Function {
+                states: [
+                    State {
+                        instructions: [
+                            ExtCallSet(
+                                ActionCall {
+                                    dst: RegisterId(
+                                        0,
+                                    ),
+                                    action_ref: TestActionRef(
+                                        "get_result",
+                                    ),
+                                    args: [],
+                                    resume: StateId(
+                                        1,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                Await {
+                                    dst: RegisterId(
+                                        0,
+                                    ),
+                                    src: RegisterId(
+                                        0,
+                                    ),
+                                    resume: StateId(
+                                        2,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            PureSet(
+                                LoadConst {
+                                    dst: RegisterId(
+                                        2,
+                                    ),
+                                    value: String(
+                                        "value",
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                LoadConst {
+                                    dst: RegisterId(
+                                        3,
+                                    ),
+                                    value: String(
+                                        "status",
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                LoadConst {
+                                    dst: RegisterId(
+                                        4,
+                                    ),
+                                    value: String(
+                                        "pending",
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                LoadConst {
+                                    dst: RegisterId(
+                                        5,
+                                    ),
+                                    value: String(
+                                        "retry_count",
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                LoadConst {
+                                    dst: RegisterId(
+                                        6,
+                                    ),
+                                    value: Int(
+                                        0,
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                MakeDict {
+                                    dst: RegisterId(
+                                        1,
+                                    ),
+                                    entries: [
+                                        DictEntry {
+                                            key: RegisterId(
+                                                2,
+                                            ),
+                                            value: RegisterId(
+                                                0,
+                                            ),
+                                        },
+                                        DictEntry {
+                                            key: RegisterId(
+                                                3,
+                                            ),
+                                            value: RegisterId(
+                                                4,
+                                            ),
+                                        },
+                                        DictEntry {
+                                            key: RegisterId(
+                                                5,
+                                            ),
+                                            value: RegisterId(
+                                                6,
+                                            ),
+                                        },
+                                    ],
+                                },
+                            ),
+                            CoreSet(
+                                Return {
+                                    src: RegisterId(
+                                        1,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                ],
+                num_regs: 7,
             },
-        ),
-    ),
+        ],
+    },
 )

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_models__pydantic_action_arg.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_models__pydantic_action_arg.py__bytecode.snap
@@ -6,7 +6,7 @@ Err(
     FunctionCompiler(
         Unsupported(
             Expression {
-                kind: Dict,
+                kind: Dot,
             },
         ),
     ),

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_models__pydantic_nested.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_models__pydantic_nested.py__bytecode.snap
@@ -2,12 +2,115 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_models/pydantic_nested.py
 ---
-Err(
-    FunctionCompiler(
-        Unsupported(
-            Expression {
-                kind: Dict,
+Ok(
+    Executable {
+        functions: [
+            Function {
+                states: [
+                    State {
+                        instructions: [
+                            ExtCallSet(
+                                ActionCall {
+                                    dst: RegisterId(
+                                        0,
+                                    ),
+                                    action_ref: TestActionRef(
+                                        "get_coordinates",
+                                    ),
+                                    args: [],
+                                    resume: StateId(
+                                        1,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                Await {
+                                    dst: RegisterId(
+                                        0,
+                                    ),
+                                    src: RegisterId(
+                                        0,
+                                    ),
+                                    resume: StateId(
+                                        2,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            PureSet(
+                                LoadConst {
+                                    dst: RegisterId(
+                                        2,
+                                    ),
+                                    value: String(
+                                        "name",
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                LoadConst {
+                                    dst: RegisterId(
+                                        3,
+                                    ),
+                                    value: String(
+                                        "test",
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                LoadConst {
+                                    dst: RegisterId(
+                                        4,
+                                    ),
+                                    value: String(
+                                        "inner",
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                MakeDict {
+                                    dst: RegisterId(
+                                        1,
+                                    ),
+                                    entries: [
+                                        DictEntry {
+                                            key: RegisterId(
+                                                2,
+                                            ),
+                                            value: RegisterId(
+                                                3,
+                                            ),
+                                        },
+                                        DictEntry {
+                                            key: RegisterId(
+                                                4,
+                                            ),
+                                            value: RegisterId(
+                                                0,
+                                            ),
+                                        },
+                                    ],
+                                },
+                            ),
+                            CoreSet(
+                                Return {
+                                    src: RegisterId(
+                                        1,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                ],
+                num_regs: 5,
             },
-        ),
-    ),
+        ],
+    },
 )

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_models__pydantic_return_direct.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_models__pydantic_return_direct.py__bytecode.snap
@@ -2,12 +2,90 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_models/pydantic_return_direct.py
 ---
-Err(
-    FunctionCompiler(
-        Unsupported(
-            Expression {
-                kind: Dict,
+Ok(
+    Executable {
+        functions: [
+            Function {
+                states: [
+                    State {
+                        instructions: [
+                            PureSet(
+                                LoadConst {
+                                    dst: RegisterId(
+                                        0,
+                                    ),
+                                    value: String(
+                                        "value",
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                LoadConst {
+                                    dst: RegisterId(
+                                        1,
+                                    ),
+                                    value: Int(
+                                        1,
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                LoadConst {
+                                    dst: RegisterId(
+                                        2,
+                                    ),
+                                    value: String(
+                                        "message",
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                LoadConst {
+                                    dst: RegisterId(
+                                        3,
+                                    ),
+                                    value: String(
+                                        "ok",
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                MakeDict {
+                                    dst: RegisterId(
+                                        4,
+                                    ),
+                                    entries: [
+                                        DictEntry {
+                                            key: RegisterId(
+                                                0,
+                                            ),
+                                            value: RegisterId(
+                                                1,
+                                            ),
+                                        },
+                                        DictEntry {
+                                            key: RegisterId(
+                                                2,
+                                            ),
+                                            value: RegisterId(
+                                                3,
+                                            ),
+                                        },
+                                    ],
+                                },
+                            ),
+                            CoreSet(
+                                Return {
+                                    src: RegisterId(
+                                        4,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                ],
+                num_regs: 5,
             },
-        ),
-    ),
+        ],
+    },
 )

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_models__pydantic_simple.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_models__pydantic_simple.py__bytecode.snap
@@ -2,12 +2,115 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_models/pydantic_simple.py
 ---
-Err(
-    FunctionCompiler(
-        Unsupported(
-            Expression {
-                kind: Dict,
+Ok(
+    Executable {
+        functions: [
+            Function {
+                states: [
+                    State {
+                        instructions: [
+                            ExtCallSet(
+                                ActionCall {
+                                    dst: RegisterId(
+                                        0,
+                                    ),
+                                    action_ref: TestActionRef(
+                                        "get_value",
+                                    ),
+                                    args: [],
+                                    resume: StateId(
+                                        1,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                Await {
+                                    dst: RegisterId(
+                                        0,
+                                    ),
+                                    src: RegisterId(
+                                        0,
+                                    ),
+                                    resume: StateId(
+                                        2,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            PureSet(
+                                LoadConst {
+                                    dst: RegisterId(
+                                        2,
+                                    ),
+                                    value: String(
+                                        "value",
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                LoadConst {
+                                    dst: RegisterId(
+                                        3,
+                                    ),
+                                    value: String(
+                                        "message",
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                LoadConst {
+                                    dst: RegisterId(
+                                        4,
+                                    ),
+                                    value: String(
+                                        "success",
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                MakeDict {
+                                    dst: RegisterId(
+                                        1,
+                                    ),
+                                    entries: [
+                                        DictEntry {
+                                            key: RegisterId(
+                                                2,
+                                            ),
+                                            value: RegisterId(
+                                                0,
+                                            ),
+                                        },
+                                        DictEntry {
+                                            key: RegisterId(
+                                                3,
+                                            ),
+                                            value: RegisterId(
+                                                4,
+                                            ),
+                                        },
+                                    ],
+                                },
+                            ),
+                            CoreSet(
+                                Return {
+                                    src: RegisterId(
+                                        1,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                ],
+                num_regs: 5,
             },
-        ),
-    ),
+        ],
+    },
 )

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_models__pydantic_with_defaults.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_models__pydantic_with_defaults.py__bytecode.snap
@@ -2,12 +2,143 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_models/pydantic_with_defaults.py
 ---
-Err(
-    FunctionCompiler(
-        Unsupported(
-            Expression {
-                kind: Dict,
+Ok(
+    Executable {
+        functions: [
+            Function {
+                states: [
+                    State {
+                        instructions: [
+                            ExtCallSet(
+                                ActionCall {
+                                    dst: RegisterId(
+                                        0,
+                                    ),
+                                    action_ref: TestActionRef(
+                                        "compute_value",
+                                    ),
+                                    args: [],
+                                    resume: StateId(
+                                        1,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                Await {
+                                    dst: RegisterId(
+                                        0,
+                                    ),
+                                    src: RegisterId(
+                                        0,
+                                    ),
+                                    resume: StateId(
+                                        2,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            PureSet(
+                                LoadConst {
+                                    dst: RegisterId(
+                                        2,
+                                    ),
+                                    value: String(
+                                        "value",
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                LoadConst {
+                                    dst: RegisterId(
+                                        3,
+                                    ),
+                                    value: String(
+                                        "status",
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                LoadConst {
+                                    dst: RegisterId(
+                                        4,
+                                    ),
+                                    value: String(
+                                        "ok",
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                LoadConst {
+                                    dst: RegisterId(
+                                        5,
+                                    ),
+                                    value: String(
+                                        "count",
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                LoadConst {
+                                    dst: RegisterId(
+                                        6,
+                                    ),
+                                    value: Int(
+                                        0,
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                MakeDict {
+                                    dst: RegisterId(
+                                        1,
+                                    ),
+                                    entries: [
+                                        DictEntry {
+                                            key: RegisterId(
+                                                2,
+                                            ),
+                                            value: RegisterId(
+                                                0,
+                                            ),
+                                        },
+                                        DictEntry {
+                                            key: RegisterId(
+                                                3,
+                                            ),
+                                            value: RegisterId(
+                                                4,
+                                            ),
+                                        },
+                                        DictEntry {
+                                            key: RegisterId(
+                                                5,
+                                            ),
+                                            value: RegisterId(
+                                                6,
+                                            ),
+                                        },
+                                    ],
+                                },
+                            ),
+                            CoreSet(
+                                Return {
+                                    src: RegisterId(
+                                        1,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                ],
+                num_regs: 7,
             },
-        ),
-    ),
+        ],
+    },
 )

--- a/crates/lib/vm-instructions-pureset/src/lib.rs
+++ b/crates/lib/vm-instructions-pureset/src/lib.rs
@@ -104,6 +104,16 @@ pub enum UnaryOpKind {
     Not,
 }
 
+/// One dictionary entry.
+#[derive(Debug)]
+pub struct DictEntry<RegisterId> {
+    /// The register that contains the entry key.
+    pub key: RegisterId,
+
+    /// The register that contains the entry value.
+    pub value: RegisterId,
+}
+
 /// Pure instructions set.
 #[derive_where(Debug)]
 pub enum PureSet<Spec: self::Spec> {
@@ -150,6 +160,15 @@ pub enum PureSet<Spec: self::Spec> {
 
         /// The registers to read list elements from in order.
         items: Vec<Spec::RegisterId>,
+    },
+
+    /// Build a dictionary value from resolved key and value registers.
+    MakeDict {
+        /// The register to store the resulting dictionary at.
+        dst: Spec::RegisterId,
+
+        /// The dictionary entries to read in source order.
+        entries: Vec<DictEntry<Spec::RegisterId>>,
     },
 }
 

--- a/crates/lib/vm-interpreter-fullset/tests/integration.rs
+++ b/crates/lib/vm-interpreter-fullset/tests/integration.rs
@@ -119,6 +119,18 @@ impl waymark_vm_interpreter_pureset::value::MakeList for TestValue {
     }
 }
 
+impl waymark_vm_interpreter_pureset::value::MakeDict for TestValue {
+    fn make_dict<I>(
+        entries: I,
+    ) -> Result<Self, waymark_vm_interpreter_pureset::value::MakeDictError>
+    where
+        I: IntoIterator<Item = (Self, Self)>,
+    {
+        let _ = entries;
+        Err(waymark_vm_interpreter_pureset::value::MakeDictError::NotDictable)
+    }
+}
+
 impl waymark_vm_interpreter_extcallset::value::SleepDuration for TestValue {
     type Error = TestSleepDurationError;
 

--- a/crates/lib/vm-interpreter-pureset/src/error.rs
+++ b/crates/lib/vm-interpreter-pureset/src/error.rs
@@ -102,6 +102,48 @@ pub enum Error {
         source: UnresolvedPromiseError,
     },
 
+    /// A `MakeDict` instruction referenced an unset key register.
+    #[error("dict entry {entry_pos} key in register {register:?} is not initialized")]
+    MissingDictKey {
+        /// The zero-based dictionary entry position.
+        entry_pos: usize,
+
+        /// The register that was read.
+        register: RegisterId,
+    },
+
+    /// A `MakeDict` instruction referenced an unresolved key promise.
+    #[error("dict entry {entry_pos} key is unresolved: {source}")]
+    UnresolvedDictKey {
+        /// The zero-based dictionary entry position.
+        entry_pos: usize,
+
+        /// The underlying unresolved promise error.
+        #[source]
+        source: UnresolvedPromiseError,
+    },
+
+    /// A `MakeDict` instruction referenced an unset value register.
+    #[error("dict entry {entry_pos} value in register {register:?} is not initialized")]
+    MissingDictValue {
+        /// The zero-based dictionary entry position.
+        entry_pos: usize,
+
+        /// The register that was read.
+        register: RegisterId,
+    },
+
+    /// A `MakeDict` instruction referenced an unresolved value promise.
+    #[error("dict entry {entry_pos} value is unresolved: {source}")]
+    UnresolvedDictValue {
+        /// The zero-based dictionary entry position.
+        entry_pos: usize,
+
+        /// The underlying unresolved promise error.
+        #[source]
+        source: UnresolvedPromiseError,
+    },
+
     /// Evaluating a binary scalar instruction failed.
     #[error("{operation}: {source}")]
     BinaryOperation {
@@ -127,4 +169,8 @@ pub enum Error {
     /// Evaluating a `MakeList` instruction failed.
     #[error("make_list: {0}")]
     MakeList(#[source] crate::value::MakeListError),
+
+    /// Evaluating a `MakeDict` instruction failed.
+    #[error("make_dict: {0}")]
+    MakeDict(#[source] crate::value::MakeDictError),
 }

--- a/crates/lib/vm-interpreter-pureset/src/lib.rs
+++ b/crates/lib/vm-interpreter-pureset/src/lib.rs
@@ -90,6 +90,32 @@ where
                 let list = make_list_result.map_err(Error::MakeList)?;
                 frame.regs.set(*dst, Promise::Resolved(list));
             }
+            waymark_vm_instructions_pureset::PureSet::MakeDict { dst, entries } => {
+                let mut resolved_entries = Vec::with_capacity(entries.len());
+
+                for (entry_pos, entry) in entries.iter().enumerate() {
+                    let key = frame.regs.get(entry.key).ok_or(Error::MissingDictKey {
+                        entry_pos,
+                        register: entry.key,
+                    })?;
+                    let key = key
+                        .require_resolved_ref()
+                        .map_err(|source| Error::UnresolvedDictKey { entry_pos, source })?;
+
+                    let value = frame.regs.get(entry.value).ok_or(Error::MissingDictValue {
+                        entry_pos,
+                        register: entry.value,
+                    })?;
+                    let value = value
+                        .require_resolved_ref()
+                        .map_err(|source| Error::UnresolvedDictValue { entry_pos, source })?;
+
+                    resolved_entries.push((key.clone(), value.clone()));
+                }
+
+                let dict = Value::make_dict(resolved_entries).map_err(Error::MakeDict)?;
+                frame.regs.set(*dst, Promise::Resolved(dict));
+            }
         }
 
         Ok(ExecutionOutcome::Continue(frame))

--- a/crates/lib/vm-interpreter-pureset/src/value.rs
+++ b/crates/lib/vm-interpreter-pureset/src/value.rs
@@ -57,6 +57,22 @@ pub enum MakeListError {
     ResultOutOfBounds,
 }
 
+/// An error from [`MakeDict::make_dict`].
+#[derive(Debug, thiserror::Error)]
+pub enum MakeDictError {
+    /// The value type does not support dictionary construction.
+    #[error("constructing dict values is not supported")]
+    NotDictable,
+
+    /// The value type does not support the provided key type.
+    #[error("dict keys of this type are not supported")]
+    UnsupportedKeyType,
+
+    /// The resulting dictionary could not be represented by the value type.
+    #[error("dict result is out of bounds")]
+    ResultOutOfBounds,
+}
+
 /// Apply binary scalar operations to resolved values.
 pub trait BinaryOps: Sized {
     /// Add two resolved values together.
@@ -215,7 +231,15 @@ pub trait MakeList: Sized {
         I: IntoIterator<Item = Self>;
 }
 
-/// A unifying trait for all value requirements.
-pub trait Value: BinaryOps + UnaryOps + MakeList {}
+/// Build a dictionary value from a sequence of resolved key-value pairs.
+pub trait MakeDict: Sized {
+    /// Construct a dictionary value preserving entry order.
+    fn make_dict<I>(entries: I) -> Result<Self, MakeDictError>
+    where
+        I: IntoIterator<Item = (Self, Self)>;
+}
 
-impl<T> Value for T where T: BinaryOps + UnaryOps + MakeList {}
+/// A unifying trait for all value requirements.
+pub trait Value: BinaryOps + UnaryOps + MakeList + MakeDict {}
+
+impl<T> Value for T where T: BinaryOps + UnaryOps + MakeList + MakeDict {}

--- a/crates/lib/vm-interpreter-pureset/tests/integration.rs
+++ b/crates/lib/vm-interpreter-pureset/tests/integration.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use waymark_vm_instructions_pureset::{BinaryOpKind, PureSet, UnaryOpKind};
 use waymark_vm_interpreter::ExecutionOutcome;
 use waymark_vm_interpreter_pureset::{BinaryOperandPosition, Error, PureSetInterpreter};
@@ -25,6 +27,7 @@ enum TestValue {
     Bool(bool),
     Text(&'static str),
     List(Vec<TestValue>),
+    Dict(BTreeMap<String, TestValue>),
 }
 
 impl From<TestConstValue> for TestValue {
@@ -42,6 +45,18 @@ fn is_truthy(value: &TestValue) -> bool {
         TestValue::Bool(value) => *value,
         TestValue::Text(value) => !value.is_empty(),
         TestValue::List(items) => !items.is_empty(),
+        TestValue::Dict(entries) => !entries.is_empty(),
+    }
+}
+
+fn dict_key(
+    value: &TestValue,
+) -> Result<String, waymark_vm_interpreter_pureset::value::MakeDictError> {
+    match value {
+        TestValue::Text(value) => Ok((*value).to_owned()),
+        TestValue::Int(_) | TestValue::Bool(_) | TestValue::List(_) | TestValue::Dict(_) => {
+            Err(waymark_vm_interpreter_pureset::value::MakeDictError::UnsupportedKeyType)
+        }
     }
 }
 
@@ -88,6 +103,23 @@ impl waymark_vm_interpreter_pureset::value::MakeList for TestValue {
         I: IntoIterator<Item = Self>,
     {
         Ok(Self::List(items.into_iter().collect()))
+    }
+}
+
+impl waymark_vm_interpreter_pureset::value::MakeDict for TestValue {
+    fn make_dict<I>(
+        entries: I,
+    ) -> Result<Self, waymark_vm_interpreter_pureset::value::MakeDictError>
+    where
+        I: IntoIterator<Item = (Self, Self)>,
+    {
+        let mut dict = BTreeMap::new();
+
+        for (key, value) in entries {
+            dict.insert(dict_key(&key)?, value);
+        }
+
+        Ok(Self::Dict(dict))
     }
 }
 
@@ -425,6 +457,89 @@ fn runtime_executes_make_list_to_a_terminal_effect() {
 }
 
 #[test]
+fn runtime_executes_make_dict_to_a_terminal_effect() {
+    let executable = executable(vec![function::<RuntimeInstruction>(
+        4,
+        vec![vec![
+            PureSet::LoadConst {
+                dst: RegisterId(0),
+                value: TestConstValue::Text("key"),
+            }
+            .into(),
+            PureSet::LoadConst {
+                dst: RegisterId(1),
+                value: TestConstValue::Text("hello"),
+            }
+            .into(),
+            PureSet::MakeDict {
+                dst: RegisterId(2),
+                entries: vec![waymark_vm_instructions_pureset::DictEntry {
+                    key: RegisterId(0),
+                    value: RegisterId(1),
+                }],
+            }
+            .into(),
+            RuntimeInstruction::EmitRegister(RegisterId(2)),
+        ]],
+    )]);
+
+    let mut runtime =
+        Runtime::with_conventional_entrypoint(RuntimeInterpreter::default(), executable)
+            .expect("function 0 should exist");
+
+    assert_eq!(
+        runtime
+            .run()
+            .expect("runtime should emit the constructed dict"),
+        TestValue::Dict(BTreeMap::from([(
+            "key".to_owned(),
+            TestValue::Text("hello"),
+        )]))
+    );
+}
+
+#[test]
+fn runtime_surfaces_make_dict_key_type_errors_from_the_pureset_interpreter() {
+    let executable = executable(vec![function::<RuntimeInstruction>(
+        4,
+        vec![vec![
+            PureSet::LoadConst {
+                dst: RegisterId(0),
+                value: TestConstValue::Int(2),
+            }
+            .into(),
+            PureSet::LoadConst {
+                dst: RegisterId(1),
+                value: TestConstValue::Text("hello"),
+            }
+            .into(),
+            PureSet::MakeDict {
+                dst: RegisterId(2),
+                entries: vec![waymark_vm_instructions_pureset::DictEntry {
+                    key: RegisterId(0),
+                    value: RegisterId(1),
+                }],
+            }
+            .into(),
+            RuntimeInstruction::EmitRegister(RegisterId(2)),
+        ]],
+    )]);
+
+    let mut runtime =
+        Runtime::with_conventional_entrypoint(RuntimeInterpreter::default(), executable)
+            .expect("function 0 should exist");
+
+    assert!(matches!(
+        runtime.run(),
+        Err(RunError::Step(waymark_vm_runtime::step::Error::Execution(
+            Error::MakeDict(
+                waymark_vm_interpreter_pureset::value::MakeDictError::UnsupportedKeyType
+            )
+        )))
+    ));
+}
+
+#[test]
 fn runtime_surfaces_unresolved_make_list_item_errors_from_the_pureset_interpreter() {
     let executable = executable(vec![function::<RuntimeInstruction>(
         2,
@@ -454,5 +569,46 @@ fn runtime_surfaces_unresolved_make_list_item_errors_from_the_pureset_interprete
                 source: waymark_vm_runtime_core::UnresolvedPromiseError { promise_state_id },
             }
         ))) if item_pos == 0 && promise_state_id == PromiseStateId(7)
+    ));
+}
+
+#[test]
+fn runtime_surfaces_unresolved_make_dict_key_errors_from_the_pureset_interpreter() {
+    let executable = executable(vec![function::<RuntimeInstruction>(
+        3,
+        vec![vec![
+            RuntimeInstruction::SetPending {
+                dst: RegisterId(0),
+                promise_state_id: PromiseStateId(7),
+            },
+            PureSet::LoadConst {
+                dst: RegisterId(1),
+                value: TestConstValue::Int(3),
+            }
+            .into(),
+            PureSet::MakeDict {
+                dst: RegisterId(2),
+                entries: vec![waymark_vm_instructions_pureset::DictEntry {
+                    key: RegisterId(0),
+                    value: RegisterId(1),
+                }],
+            }
+            .into(),
+            RuntimeInstruction::EmitRegister(RegisterId(2)),
+        ]],
+    )]);
+
+    let mut runtime =
+        Runtime::with_conventional_entrypoint(RuntimeInterpreter::default(), executable)
+            .expect("function 0 should exist");
+
+    assert!(matches!(
+        runtime.run(),
+        Err(RunError::Step(waymark_vm_runtime::step::Error::Execution(
+            Error::UnresolvedDictKey {
+                entry_pos,
+                source: waymark_vm_runtime_core::UnresolvedPromiseError { promise_state_id },
+            }
+        ))) if entry_pos == 0 && promise_state_id == PromiseStateId(7)
     ));
 }

--- a/crates/lib/vm-value/src/pureset.rs
+++ b/crates/lib/vm-value/src/pureset.rs
@@ -1,12 +1,27 @@
 //! [`waymark_vm_interpreter_pureset`] trait implementations for [`Value`].
 
+use indexmap::IndexMap;
 use typed_floats::NonNaNFinite;
 use waymark_vm_instructions_pureset::{
     BinaryOpKind as BinaryOperationKind, UnaryOpKind as UnaryOperationKind,
 };
-use waymark_vm_interpreter_pureset::value::{BinaryOperationError, UnaryOperationError};
+use waymark_vm_interpreter_pureset::value::{
+    BinaryOperationError, MakeDictError, UnaryOperationError,
+};
 
 use crate::{Value, pythonic};
+
+fn dict_key(value: &Value) -> Result<String, MakeDictError> {
+    match value {
+        Value::String(value) => Ok(value.clone()),
+        Value::Int(_)
+        | Value::Float(_)
+        | Value::Bool(_)
+        | Value::None
+        | Value::List(_)
+        | Value::Dict(_) => Err(MakeDictError::UnsupportedKeyType),
+    }
+}
 
 fn contains_bool(a: &Value, b: &Value) -> Result<bool, BinaryOperationError> {
     match (a, b) {
@@ -285,5 +300,20 @@ impl waymark_vm_interpreter_pureset::value::MakeList for Value {
         I: IntoIterator<Item = Self>,
     {
         Ok(Self::List(items.into_iter().collect()))
+    }
+}
+
+impl waymark_vm_interpreter_pureset::value::MakeDict for Value {
+    fn make_dict<I>(entries: I) -> Result<Self, MakeDictError>
+    where
+        I: IntoIterator<Item = (Self, Self)>,
+    {
+        let mut dict = IndexMap::new();
+
+        for (key, value) in entries {
+            dict.insert(dict_key(&key)?, value);
+        }
+
+        Ok(Self::Dict(dict))
     }
 }

--- a/crates/lib/vm-value/tests/integration.rs
+++ b/crates/lib/vm-value/tests/integration.rs
@@ -4,7 +4,8 @@ use waymark_vm_instructions_pureset::BinaryOpKind;
 use waymark_vm_interpreter_coreset::value::ShouldJump as _;
 use waymark_vm_interpreter_extcallset::value::SleepDuration as _;
 use waymark_vm_interpreter_pureset::value::{
-    BinaryOperationError, BinaryOps as _, MakeList as _, UnaryOps as _,
+    BinaryOperationError, BinaryOps as _, MakeDict as _, MakeDictError, MakeList as _,
+    UnaryOps as _,
 };
 use waymark_vm_value::{Value, extcallset};
 
@@ -233,6 +234,28 @@ fn logical_ops_lists_and_sleep_duration_use_runtime_semantics() {
         Value::make_list([Value::Int(2), Value::Bool(false)]).unwrap(),
         Value::List(vec![Value::Int(2), Value::Bool(false)])
     );
+    assert_eq!(
+        Value::make_dict([
+            (Value::String("name".to_owned()), Value::Int(2)),
+            (Value::String("na\"me".to_owned()), Value::Bool(false)),
+        ])
+        .unwrap(),
+        Value::Dict(IndexMap::from([
+            ("name".to_owned(), Value::Int(2)),
+            ("na\"me".to_owned(), Value::Bool(false)),
+        ]))
+    );
+    assert!(matches!(
+        Value::make_dict([(Value::Int(3), Value::Bool(false))]),
+        Err(MakeDictError::UnsupportedKeyType)
+    ));
+    assert!(matches!(
+        Value::make_dict([(
+            Value::List(vec![Value::String("nested".to_owned())]),
+            Value::None,
+        )]),
+        Err(MakeDictError::UnsupportedKeyType)
+    ));
     assert_eq!(
         Value::Int(5).to_sleep_duration().unwrap().get(),
         std::time::Duration::from_secs(5)


### PR DESCRIPTION
This PR adds support for
- dicts creation instruction and interpter,
- dict value variant, and
- dict and list creation at the compiler level.

There were quite a number of things missing that were needed to implement dict creation - but this PR takes care of all of them.

List indexing and dict key access will be both added later.