### PR TITLE
Add vm-compiler-for-ast-old-const-value

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5249,6 +5249,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "waymark-vm-compiler-for-ast-old-const-value"
+version = "0.1.0"
+dependencies = [
+ "thiserror",
+ "typed_floats",
+ "waymark-vm-ast-old",
+ "waymark-vm-value",
+]
+
+[[package]]
 name = "waymark-vm-compiler-for-ast-old-core"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5278,6 +5278,7 @@ version = "0.1.0"
 dependencies = [
  "waymark-vm-ast-old",
  "waymark-vm-bytecode-core",
+ "waymark-vm-compiler-for-ast-old-const-value",
  "waymark-vm-compiler-for-ast-old-core",
  "waymark-vm-instructions-coreset",
  "waymark-vm-instructions-extcallset",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ waymark-vm-ast-old-proto = { path = "crates/lib/vm-ast-old-proto" }
 waymark-vm-bytecode = { path = "crates/lib/vm-bytecode" }
 waymark-vm-bytecode-core = { path = "crates/lib/vm-bytecode-core" }
 waymark-vm-compiler-for-ast-old = { path = "crates/lib/vm-compiler-for-ast-old" }
+waymark-vm-compiler-for-ast-old-const-value = { path = "crates/lib/vm-compiler-for-ast-old-const-value" }
 waymark-vm-compiler-for-ast-old-core = { path = "crates/lib/vm-compiler-for-ast-old-core" }
 waymark-vm-compiler-for-ast-old-test-support = { path = "crates/lib/vm-compiler-for-ast-old-test-support" }
 waymark-vm-driver = { path = "crates/lib/vm-driver" }

--- a/crates/lib/vm-compiler-for-ast-old-const-value/Cargo.toml
+++ b/crates/lib/vm-compiler-for-ast-old-const-value/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "waymark-vm-compiler-for-ast-old-const-value"
+edition = "2024"
+version.workspace = true
+publish.workspace = true
+
+[dependencies]
+waymark-vm-ast-old = { workspace = true }
+waymark-vm-value = { workspace = true }
+
+thiserror = { workspace = true }
+typed_floats = { workspace = true }

--- a/crates/lib/vm-compiler-for-ast-old-const-value/src/lib.rs
+++ b/crates/lib/vm-compiler-for-ast-old-const-value/src/lib.rs
@@ -1,0 +1,78 @@
+//! Const value for [`waymark_vm_ast_old`].
+//!
+//! Provides lowering from the [`waymark_vm_ast_old::Literal`] and
+//! binding to [`waymark_vm_value::Value`].
+
+#![warn(missing_docs, clippy::missing_docs_in_private_items)]
+
+use typed_floats::NonNaNFinite;
+
+/// A subset of [`waymark_vm_value::Value`] that can be lowered from
+/// the [`waymark_vm_ast_old::Literal`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ConstValue {
+    /// Integer value.
+    Int(i64),
+
+    /// Non-NaN finite floating-point value.
+    Float(NonNaNFinite),
+
+    /// Boolean value.
+    Bool(bool),
+
+    /// String value.
+    String(String),
+
+    /// `None` value.
+    None,
+}
+
+impl From<ConstValue> for waymark_vm_value::Value {
+    fn from(value: ConstValue) -> Self {
+        match value {
+            ConstValue::Int(value) => Self::Int(value),
+            ConstValue::Float(value) => Self::Float(value),
+            ConstValue::Bool(value) => Self::Bool(value),
+            ConstValue::String(value) => Self::String(value),
+            ConstValue::None => Self::None,
+        }
+    }
+}
+
+/// Errors produced while lowering literals.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum LoweringError {
+    /// The float was an invalid value.
+    #[error("invalid float: {0}")]
+    InvalidFloat(#[source] typed_floats::InvalidNumber),
+}
+
+impl ConstValue {
+    /// Lowers one [`waymark_vm_ast_old::Literal`] into a [`ConstValue`].
+    pub fn lower(literal: &waymark_vm_ast_old::Literal) -> Result<Self, LoweringError> {
+        use waymark_vm_ast_old::Literal;
+        match literal {
+            Literal::Int(value) => Ok(ConstValue::Int(*value)),
+            Literal::Float(value) => {
+                let value = (*value).try_into().map_err(LoweringError::InvalidFloat)?;
+                Ok(ConstValue::Float(value))
+            }
+            Literal::String(value) => Ok(ConstValue::String(value.clone())),
+            Literal::Bool(value) => Ok(ConstValue::Bool(*value)),
+            Literal::None => Ok(ConstValue::None),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ConstValue, LoweringError};
+
+    #[test]
+    fn rejects_non_finite_float_literals() {
+        let error = ConstValue::lower(&waymark_vm_ast_old::Literal::Float(f64::NAN))
+            .expect_err("non-finite floats should fail");
+
+        assert!(matches!(error, LoweringError::InvalidFloat(_)));
+    }
+}

--- a/crates/lib/vm-compiler-for-ast-old-test-support/Cargo.toml
+++ b/crates/lib/vm-compiler-for-ast-old-test-support/Cargo.toml
@@ -7,6 +7,7 @@ publish.workspace = true
 [dependencies]
 waymark-vm-ast-old = { workspace = true }
 waymark-vm-bytecode-core = { workspace = true }
+waymark-vm-compiler-for-ast-old-const-value = { workspace = true }
 waymark-vm-compiler-for-ast-old-core = { workspace = true }
 waymark-vm-instructions-coreset = { workspace = true }
 waymark-vm-instructions-extcallset = { workspace = true }

--- a/crates/lib/vm-compiler-for-ast-old-test-support/src/lib.rs
+++ b/crates/lib/vm-compiler-for-ast-old-test-support/src/lib.rs
@@ -1,18 +1,21 @@
 //! Test support types for `vm-compiler-for-ast-old` crates.
 //!
-//! This crate provides a small VM spec plus lowering implementation used by
-//! compiler tests to assert on emitted bytecode without depending on a real
-//! production lowering.
+//! This crate provides a small VM spec used by compiler tests and wraps the
+//! shared const-value lowering in test-named types.
 
 #![warn(missing_docs, clippy::missing_docs_in_private_items)]
 
 use waymark_vm_ast_old::{ActionCall, Literal};
 
-/// Runtime VM values used by compiler tests.
+/// Test value type definition as an actual [`waymark_vm_value::Value`].
 pub use waymark_vm_value::Value as TestValue;
 
-/// Constant values used by the test VM spec.
-pub type TestConstValue = TestValue;
+/// Test const value type definition as
+/// an actual [`waymark_vm_compiler_for_ast_old_const_value::ConstValue`].
+pub use waymark_vm_compiler_for_ast_old_const_value::ConstValue as TestConstValue;
+
+/// Errors produced while lowering literals in tests.
+pub use waymark_vm_compiler_for_ast_old_const_value::LoweringError as TestLiteralLoweringError;
 
 /// Action reference used by the test VM spec.
 #[derive(Debug, Clone)]
@@ -20,13 +23,6 @@ pub struct TestActionRef(
     /// Action name captured from the AST call.
     pub String,
 );
-
-/// Errors produced while lowering literals in tests.
-#[derive(Debug, Clone)]
-pub enum TestLiteralError {
-    /// A floating-point literal could not be represented as a VM float.
-    InvalidFloat,
-}
 
 /// Errors produced while lowering actions in tests.
 #[derive(Debug, Clone)]
@@ -77,20 +73,9 @@ impl<Spec> waymark_vm_compiler_for_ast_old_core::lowering::PureSet<Spec> for Tes
 where
     Spec: waymark_vm_instructions_pureset::Spec<ConstValue = TestConstValue>,
 {
-    type LiteralError = TestLiteralError;
+    type LiteralError = TestLiteralLoweringError;
 
     fn lower_literal(literal: &Literal) -> Result<Spec::ConstValue, Self::LiteralError> {
-        match literal {
-            Literal::Int(value) => Ok(TestConstValue::Int(*value)),
-            Literal::Float(value) => {
-                let value = (*value)
-                    .try_into()
-                    .map_err(|_| TestLiteralError::InvalidFloat)?;
-                Ok(TestConstValue::Float(value))
-            }
-            Literal::String(value) => Ok(TestConstValue::String(value.clone())),
-            Literal::Bool(value) => Ok(TestConstValue::Bool(*value)),
-            Literal::None => Ok(TestConstValue::None),
-        }
+        TestConstValue::lower(literal)
     }
 }

--- a/crates/lib/vm-compiler-for-ast-old/src/tests.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/tests.rs
@@ -6,8 +6,7 @@ use waymark_vm_ast_old_helpers::{
 };
 use waymark_vm_compiler_for_ast_old_core::lowering;
 use waymark_vm_compiler_for_ast_old_test_support::{
-    TestActionRef, TestConstValue, TestLiteralError as TestLiteralLoweringError, TestLowering,
-    TestSpec,
+    TestActionRef, TestConstValue, TestLiteralLoweringError, TestLowering, TestSpec,
 };
 use waymark_vm_instructions_fullset::FullSet;
 use waymark_vm_instructions_pureset::PureSet;
@@ -137,7 +136,7 @@ fn rejects_non_finite_float_literals() {
     assert!(matches!(
         error,
         CompileError::FunctionCompiler(compiler::Error::LiteralLowering(
-            TestLiteralLoweringError::InvalidFloat
+            TestLiteralLoweringError::InvalidFloat(_)
         ))
     ));
 }


### PR DESCRIPTION
This PR goes in after #404

It addresses an issue brought up at #405 and #403, and reorganizes the code to provide more modular and elegant structure for binding the vm compiler to the vm value; this allows us to efficiently reuse lowering implementation code for literals and helps avoid code duplication.

Also, this placement fills in a spot that was intended by the trait design but wasn't filled-in beforehand. Now things connect together properly.