### PR TITLE
Implement length instruction / global function

### DIFF
--- a/crates/lib/vm-ast-old-helpers/src/lib.rs
+++ b/crates/lib/vm-ast-old-helpers/src/lib.rs
@@ -1,6 +1,7 @@
 use waymark_vm_ast_old::{
     ActionCall, BinaryOperator, Block, Call, ElifBranch, ElseBranch, Expr, FunctionCall,
-    FunctionDef, IfBranch, IoDecl, Kwarg, Literal, Program, Span, Spanned, Statement,
+    FunctionDef, GlobalFunction, IfBranch, IoDecl, Kwarg, Literal, Program, Span, Spanned,
+    Statement,
 };
 
 pub fn span() -> Span {
@@ -190,6 +191,34 @@ pub fn function_call(name: &str, args: Vec<Spanned<Expr>>) -> FunctionCall {
         kwargs: Vec::new(),
         global_function: None,
     }
+}
+
+pub fn builtin_function_call(
+    global_function: GlobalFunction,
+    args: Vec<Spanned<Expr>>,
+) -> FunctionCall {
+    let name = match global_function {
+        GlobalFunction::Range => "range",
+        GlobalFunction::Len => "len",
+        GlobalFunction::Enumerate => "enumerate",
+        GlobalFunction::IsException => "isexception",
+    };
+    let mut call = function_call(name, args);
+    call.global_function = Some(global_function);
+    call
+}
+
+pub fn builtin_function_expr(
+    global_function: GlobalFunction,
+    args: Vec<Spanned<Expr>>,
+) -> Spanned<Expr> {
+    spanned(Expr::FunctionCall {
+        call: builtin_function_call(global_function, args),
+    })
+}
+
+pub fn len_expr(arg: Spanned<Expr>) -> Spanned<Expr> {
+    builtin_function_expr(GlobalFunction::Len, vec![arg])
 }
 
 pub fn action_call(name: &str, kwargs: Vec<(&str, Spanned<Expr>)>) -> ActionCall {

--- a/crates/lib/vm-compiler-for-ast-old/src/function/compiler/bytecode/emitter.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/function/compiler/bytecode/emitter.rs
@@ -78,6 +78,11 @@ where
         self.emit(waymark_vm_instructions_pureset::PureSet::MakeDict { dst, entries }.into());
     }
 
+    /// Emits a container-length instruction.
+    pub fn emit_length(&mut self, dst: RegisterId, src: RegisterId) {
+        self.emit(waymark_vm_instructions_pureset::PureSet::Length { dst, src }.into());
+    }
+
     /// Emits a user-function call that writes a promise register.
     pub fn emit_call(
         &mut self,

--- a/crates/lib/vm-compiler-for-ast-old/src/function/compiler/lowering/value.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/function/compiler/lowering/value.rs
@@ -1,7 +1,8 @@
 //! Value lowering.
 
 use waymark_vm_ast_old::{
-    ActionCall, BinaryOperator, DictEntry, Expr, FunctionCall, Literal, Spanned, UnaryOperator,
+    ActionCall, BinaryOperator, DictEntry, Expr, FunctionCall, GlobalFunction, Literal, Spanned,
+    UnaryOperator,
 };
 use waymark_vm_runtime_core::RegisterId;
 
@@ -10,11 +11,12 @@ use crate::Marked;
 use super::CompilerContextRef;
 use super::env::RegisterHandle;
 use super::plan::call::{
-    ActionCallPlanFor, CallPlan, CallPlanFor, FunctionCallPlan, compile_expr_registers,
+    ActionCallPlanFor, CallPlan, CallPlanFor, FunctionCallPlan, UnsupportedFunctionCall,
+    compile_expr_registers,
 };
 use super::plan::expr::ExpressionPlan;
 use super::suspend::PromiseMarker;
-use super::{Error, ErrorFor};
+use super::{Error, ErrorFor, Unsupported};
 
 /// Lowers expressions and calls into bytecode values and control flow.
 pub struct ValueCompiler<'borrow, 'table, Spec, Lowering>
@@ -63,9 +65,10 @@ where
             }
             ExpressionPlan::List { elements } => self.compile_list_expr(elements, target),
             ExpressionPlan::Dict { entries } => self.compile_dict_expr(entries, target),
-            ExpressionPlan::FunctionCall { call } => {
-                self.compile_call(self.plan_function_call(call)?, target)
-            }
+            ExpressionPlan::FunctionCall { call } => match call.global_function {
+                Some(GlobalFunction::Len) => self.compile_length_call(call, target),
+                Some(_) | None => self.compile_call(self.plan_function_call(call)?, target),
+            },
             ExpressionPlan::ActionCall { call } => {
                 self.compile_call(self.plan_action_call(call)?, target)
             }
@@ -305,6 +308,36 @@ where
         Ok(dst)
     }
 
+    /// Compiles the built-in `len(...)` function into a dedicated pure opcode.
+    fn compile_length_call(
+        &mut self,
+        call: &FunctionCall,
+        target: ResultTarget,
+    ) -> Result<RegisterHandle, ErrorFor<Spec, Lowering>> {
+        if !call.kwargs.is_empty() {
+            return Err(Unsupported::FunctionCall {
+                name: call.name.clone(),
+                reason: UnsupportedFunctionCall::KeywordArguments,
+            }
+            .into());
+        }
+
+        if call.args.len() != 1 {
+            return Err(Error::FunctionArityMismatch {
+                function: call.name.clone(),
+                expected: 1,
+                actual: call.args.len(),
+            });
+        }
+
+        let src = self.compile_expr(&call.args[0], ResultTarget::Allocate)?;
+        let dst = self.allocate_result_register(target);
+        self.context
+            .emitter
+            .emit_length(dst.register(), src.register());
+        Ok(dst)
+    }
+
     /// Compiles a call and awaits its result.
     fn compile_call(
         &mut self,
@@ -439,7 +472,9 @@ mod tests {
 
     use index_type::IndexType;
     use waymark_vm_ast_old::{BinaryOperator, DictEntry, Expr};
-    use waymark_vm_ast_old_helpers::{action_call, binary_expr, function_call, int, spanned};
+    use waymark_vm_ast_old_helpers::{
+        action_call, binary_expr, function_call, int, len_expr, spanned,
+    };
     use waymark_vm_bytecode_core::{FunctionId, StateId};
     use waymark_vm_compiler_for_ast_old_test_support::{
         TestActionRef, TestConstValue, TestLowering, TestSpec,
@@ -1195,6 +1230,64 @@ mod tests {
                     && entries.len() == 1
                     && entries[0].key == RegisterId(0)
                     && entries[0].value == RegisterId(1)
+        ));
+        assert!(instructions.next().is_none());
+    }
+
+    #[test]
+    fn global_len_function_calls_emit_length_instruction() {
+        let function_table = build_function_table();
+        let mut emitter = FunctionEmitter::<TestSpec>::new();
+        let mut local_frame = LocalFrame::new();
+        let mut flow_state = FlowState::new();
+        let expr = len_expr(spanned(Expr::List {
+            elements: vec![int(1), int(2)],
+        }));
+
+        let dst = {
+            let mut values = ValueCompiler::<TestSpec, TestLowering>::new(
+                CompilerContextMut::new(
+                    &function_table,
+                    &mut emitter,
+                    &mut local_frame,
+                    &mut flow_state,
+                )
+                .into_ref(),
+            );
+
+            values
+                .compile_expr(&expr, ResultTarget::Allocate)
+                .expect("len expression should compile")
+        };
+
+        let result_register = dst.register();
+        let states = emitter.finish();
+        assert_eq!(local_frame.num_registers(), 3);
+
+        let mut instructions = states[StateId(0)].instructions.iter();
+        assert!(matches!(
+            instructions.next(),
+            Some(InstructionSet::PureSet(PureSet::LoadConst {
+                dst,
+                value: TestConstValue::Int(1),
+            })) if *dst == RegisterId(0)
+        ));
+        assert!(matches!(
+            instructions.next(),
+            Some(InstructionSet::PureSet(PureSet::LoadConst {
+                dst,
+                value: TestConstValue::Int(2),
+            })) if *dst == RegisterId(1)
+        ));
+        assert!(matches!(
+            instructions.next(),
+            Some(InstructionSet::PureSet(PureSet::MakeList { dst, items }))
+                if *dst == RegisterId(2) && items == &[RegisterId(0), RegisterId(1)]
+        ));
+        assert!(matches!(
+            instructions.next(),
+            Some(InstructionSet::PureSet(PureSet::Length { dst, src }))
+                if *dst == result_register && *src == RegisterId(2)
         ));
         assert!(instructions.next().is_none());
     }

--- a/crates/lib/vm-compiler-for-ast-old/tests/integration.rs
+++ b/crates/lib/vm-compiler-for-ast-old/tests/integration.rs
@@ -3,7 +3,9 @@ mod support;
 use support::{TestValue, compile_program, runtime, runtime_with_args};
 
 use waymark_nonzero_duration::NonZeroDuration;
-use waymark_vm_ast_old::{BinaryOperator, Call, Expr, Literal, Spanned, UnaryOperator};
+use waymark_vm_ast_old::{
+    BinaryOperator, Call, Expr, FunctionCall, GlobalFunction, Literal, Spanned, UnaryOperator,
+};
 use waymark_vm_ast_old_helpers::{
     action_call, action_expr, assignment, assignment_targets, binary_expr, break_stmt,
     conditional_stmt, continue_stmt, float, function, function_call, function_expr, int,
@@ -442,6 +444,37 @@ fn compiles_nested_dict_and_list_literals_to_completion() {
             .collect()
         )
     );
+}
+
+#[test]
+fn compiles_global_len_calls_to_completion() {
+    let program = program(vec![function(
+        "main",
+        &["items"],
+        vec![return_stmt(Some(spanned(Expr::FunctionCall {
+            call: FunctionCall {
+                name: "len".to_owned(),
+                args: vec![variable("items")],
+                kwargs: Vec::new(),
+                global_function: Some(GlobalFunction::Len),
+            },
+        })))],
+    )]);
+
+    let result = completed_int(
+        runtime_with_args(
+            compile_program(&program),
+            vec![TestValue::List(vec![
+                TestValue::Int(1),
+                TestValue::Int(2),
+                TestValue::Int(3),
+            ])],
+        )
+        .run()
+        .expect("program should complete"),
+    );
+
+    assert_eq!(result, 3);
 }
 
 #[test]

--- a/crates/lib/vm-instructions-pureset/src/lib.rs
+++ b/crates/lib/vm-instructions-pureset/src/lib.rs
@@ -153,6 +153,15 @@ pub enum PureSet<Spec: self::Spec> {
         op: UnaryOp<Spec::RegisterId>,
     },
 
+    /// Compute the length of a resolved container value.
+    Length {
+        /// The register to store the resulting length at.
+        dst: Spec::RegisterId,
+
+        /// The register that contains the value to measure.
+        src: Spec::RegisterId,
+    },
+
     /// Build a list value from resolved registers.
     MakeList {
         /// The register to store the resulting list at.

--- a/crates/lib/vm-interpreter-fullset/tests/integration.rs
+++ b/crates/lib/vm-interpreter-fullset/tests/integration.rs
@@ -131,6 +131,28 @@ impl waymark_vm_interpreter_pureset::value::MakeDict for TestValue {
     }
 }
 
+impl waymark_vm_interpreter_pureset::value::Length for TestValue {
+    type Length = usize;
+
+    fn length(&self) -> Result<usize, waymark_vm_interpreter_pureset::value::LengthError> {
+        match self {
+            Self::List(items) => Ok(items.len()),
+            Self::Int(_) | Self::Bool(_) => {
+                Err(waymark_vm_interpreter_pureset::value::LengthError::UnsupportedValue)
+            }
+        }
+    }
+
+    fn from_length(
+        length: usize,
+    ) -> Result<Self, waymark_vm_interpreter_pureset::value::FromLengthError> {
+        let value = i64::try_from(length).map_err(|_| {
+            waymark_vm_interpreter_pureset::value::FromLengthError::ResultOutOfBounds
+        })?;
+        Ok(Self::Int(value))
+    }
+}
+
 impl waymark_vm_interpreter_extcallset::value::SleepDuration for TestValue {
     type Error = TestSleepDurationError;
 

--- a/crates/lib/vm-interpreter-pureset/src/error.rs
+++ b/crates/lib/vm-interpreter-pureset/src/error.rs
@@ -81,6 +81,21 @@ pub enum Error {
         source: UnresolvedPromiseError,
     },
 
+    /// A `Length` instruction referenced an unset register.
+    #[error("length operand in register {register:?} is not initialized")]
+    MissingLengthOperand {
+        /// The register that was read.
+        register: RegisterId,
+    },
+
+    /// A `Length` instruction referenced an unresolved promise.
+    #[error("length operand is unresolved: {source}")]
+    UnresolvedLengthOperand {
+        /// The underlying unresolved promise error.
+        #[source]
+        source: UnresolvedPromiseError,
+    },
+
     /// A `MakeList` instruction referenced an unset register.
     #[error("list item {item_pos} in register {register:?} is not initialized")]
     MissingListItem {
@@ -165,6 +180,14 @@ pub enum Error {
         #[source]
         source: crate::value::UnaryOperationError,
     },
+
+    /// Evaluating a `Length` instruction failed.
+    #[error("length: {0}")]
+    Length(#[source] crate::value::LengthError),
+
+    /// Materializing the result of a `Length` instruction failed.
+    #[error("length result: {0}")]
+    FromLength(#[source] crate::value::FromLengthError),
 
     /// Evaluating a `MakeList` instruction failed.
     #[error("make_list: {0}")]

--- a/crates/lib/vm-interpreter-pureset/src/lib.rs
+++ b/crates/lib/vm-interpreter-pureset/src/lib.rs
@@ -70,6 +70,9 @@ where
             } => {
                 Self::execute_unary_operation(&mut frame, *dst, *src, *kind)?;
             }
+            waymark_vm_instructions_pureset::PureSet::Length { dst, src } => {
+                Self::execute_length(&mut frame, *dst, *src)?;
+            }
             waymark_vm_instructions_pureset::PureSet::MakeList { dst, items } => {
                 let make_list_result = with_register_values(
                     items.iter().copied(),
@@ -202,6 +205,26 @@ where
             UnaryOpKind::Not => Value::not(value),
         }
         .map_err(|source| Error::UnaryOperation { operation, source })?;
+
+        frame.regs.set(dst, Promise::Resolved(value));
+        Ok(())
+    }
+
+    fn execute_length(
+        frame: &mut Frame<FunctionId, StateId, Promise<Value>>,
+        dst: waymark_vm_runtime_core::RegisterId,
+        src: waymark_vm_runtime_core::RegisterId,
+    ) -> Result<(), Error> {
+        let value = frame
+            .regs
+            .get(src)
+            .ok_or(Error::MissingLengthOperand { register: src })?;
+        let value = value
+            .require_resolved_ref()
+            .map_err(|source| Error::UnresolvedLengthOperand { source })?;
+
+        let length = <Value as value::Length>::length(value).map_err(Error::Length)?;
+        let value = <Value as value::Length>::from_length(length).map_err(Error::FromLength)?;
 
         frame.regs.set(dst, Promise::Resolved(value));
         Ok(())

--- a/crates/lib/vm-interpreter-pureset/src/value.rs
+++ b/crates/lib/vm-interpreter-pureset/src/value.rs
@@ -73,6 +73,22 @@ pub enum MakeDictError {
     ResultOutOfBounds,
 }
 
+/// An error from [`Length::length`].
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum LengthError {
+    /// The value type does not support reporting a length for this value.
+    #[error("determining length is not supported for this value")]
+    UnsupportedValue,
+}
+
+/// An error from [`Length::from_length`].
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum FromLengthError {
+    /// The resulting length could not be represented by the value type.
+    #[error("length result is out of bounds")]
+    ResultOutOfBounds,
+}
+
 /// Apply binary scalar operations to resolved values.
 pub trait BinaryOps: Sized {
     /// Add two resolved values together.
@@ -239,7 +255,19 @@ pub trait MakeDict: Sized {
         I: IntoIterator<Item = (Self, Self)>;
 }
 
-/// A unifying trait for all value requirements.
-pub trait Value: BinaryOps + UnaryOps + MakeList + MakeDict {}
+/// Compute and materialize container lengths.
+pub trait Length: Sized {
+    /// The type for internal representation of a value length.
+    type Length;
 
-impl<T> Value for T where T: BinaryOps + UnaryOps + MakeList + MakeDict {}
+    /// Determine the length of the resolved value.
+    fn length(&self) -> Result<Self::Length, LengthError>;
+
+    /// Materialize a length result back into the VM value type.
+    fn from_length(length: Self::Length) -> Result<Self, FromLengthError>;
+}
+
+/// A unifying trait for all value requirements.
+pub trait Value: BinaryOps + UnaryOps + MakeList + MakeDict + Length {}
+
+impl<T> Value for T where T: BinaryOps + UnaryOps + MakeList + MakeDict + Length {}

--- a/crates/lib/vm-interpreter-pureset/tests/integration.rs
+++ b/crates/lib/vm-interpreter-pureset/tests/integration.rs
@@ -19,6 +19,7 @@ impl waymark_vm_instructions_pureset::Spec for TestSpec {
 enum TestConstValue {
     Int(i64),
     Text(&'static str),
+    OverflowLength,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -28,6 +29,7 @@ enum TestValue {
     Text(&'static str),
     List(Vec<TestValue>),
     Dict(BTreeMap<String, TestValue>),
+    OverflowLength,
 }
 
 impl From<TestConstValue> for TestValue {
@@ -35,6 +37,7 @@ impl From<TestConstValue> for TestValue {
         match value {
             TestConstValue::Int(value) => Self::Int(value),
             TestConstValue::Text(value) => Self::Text(value),
+            TestConstValue::OverflowLength => Self::OverflowLength,
         }
     }
 }
@@ -46,6 +49,7 @@ fn is_truthy(value: &TestValue) -> bool {
         TestValue::Text(value) => !value.is_empty(),
         TestValue::List(items) => !items.is_empty(),
         TestValue::Dict(entries) => !entries.is_empty(),
+        TestValue::OverflowLength => true,
     }
 }
 
@@ -54,7 +58,11 @@ fn dict_key(
 ) -> Result<String, waymark_vm_interpreter_pureset::value::MakeDictError> {
     match value {
         TestValue::Text(value) => Ok((*value).to_owned()),
-        TestValue::Int(_) | TestValue::Bool(_) | TestValue::List(_) | TestValue::Dict(_) => {
+        TestValue::Int(_)
+        | TestValue::Bool(_)
+        | TestValue::List(_)
+        | TestValue::Dict(_)
+        | TestValue::OverflowLength => {
             Err(waymark_vm_interpreter_pureset::value::MakeDictError::UnsupportedKeyType)
         }
     }
@@ -120,6 +128,50 @@ impl waymark_vm_interpreter_pureset::value::MakeDict for TestValue {
         }
 
         Ok(Self::Dict(dict))
+    }
+}
+
+enum TestLength {
+    Valid(i64),
+    Overflow,
+}
+
+impl waymark_vm_interpreter_pureset::value::Length for TestValue {
+    type Length = TestLength;
+
+    fn length(&self) -> Result<Self::Length, waymark_vm_interpreter_pureset::value::LengthError> {
+        match self {
+            Self::Text(value) => Ok(value
+                .len()
+                .try_into()
+                .map(TestLength::Valid)
+                .unwrap_or(TestLength::Overflow)),
+            Self::List(items) => Ok(items
+                .len()
+                .try_into()
+                .map(TestLength::Valid)
+                .unwrap_or(TestLength::Overflow)),
+            Self::Dict(entries) => Ok(entries
+                .len()
+                .try_into()
+                .map(TestLength::Valid)
+                .unwrap_or(TestLength::Overflow)),
+            Self::OverflowLength => Ok(TestLength::Overflow),
+            Self::Int(_) | Self::Bool(_) => {
+                Err(waymark_vm_interpreter_pureset::value::LengthError::UnsupportedValue)
+            }
+        }
+    }
+
+    fn from_length(
+        length: Self::Length,
+    ) -> Result<Self, waymark_vm_interpreter_pureset::value::FromLengthError> {
+        match length {
+            TestLength::Valid(value) => Ok(Self::Int(value)),
+            TestLength::Overflow => {
+                Err(waymark_vm_interpreter_pureset::value::FromLengthError::ResultOutOfBounds)
+            }
+        }
     }
 }
 
@@ -272,6 +324,109 @@ fn runtime_executes_copy_between_registers() {
 }
 
 #[test]
+fn runtime_executes_length_to_a_terminal_effect() {
+    let executable = executable(vec![function::<RuntimeInstruction>(
+        4,
+        vec![vec![
+            PureSet::LoadConst {
+                dst: RegisterId(0),
+                value: TestConstValue::Int(2),
+            }
+            .into(),
+            PureSet::LoadConst {
+                dst: RegisterId(1),
+                value: TestConstValue::Text("hello"),
+            }
+            .into(),
+            PureSet::MakeList {
+                dst: RegisterId(2),
+                items: vec![RegisterId(0), RegisterId(1)],
+            }
+            .into(),
+            PureSet::Length {
+                dst: RegisterId(3),
+                src: RegisterId(2),
+            }
+            .into(),
+            RuntimeInstruction::EmitRegister(RegisterId(3)),
+        ]],
+    )]);
+
+    let mut runtime =
+        Runtime::with_conventional_entrypoint(RuntimeInterpreter::default(), executable)
+            .expect("function 0 should exist");
+
+    assert_eq!(
+        runtime.run().expect("runtime should emit the list length"),
+        TestValue::Int(2)
+    );
+}
+
+#[test]
+fn runtime_surfaces_length_errors_from_the_pureset_interpreter() {
+    let executable = executable(vec![function::<RuntimeInstruction>(
+        2,
+        vec![vec![
+            PureSet::LoadConst {
+                dst: RegisterId(0),
+                value: TestConstValue::Int(9),
+            }
+            .into(),
+            PureSet::Length {
+                dst: RegisterId(1),
+                src: RegisterId(0),
+            }
+            .into(),
+            RuntimeInstruction::EmitRegister(RegisterId(1)),
+        ]],
+    )]);
+
+    let mut runtime =
+        Runtime::with_conventional_entrypoint(RuntimeInterpreter::default(), executable)
+            .expect("function 0 should exist");
+
+    assert!(matches!(
+        runtime.run(),
+        Err(RunError::Step(waymark_vm_runtime::step::Error::Execution(
+            Error::Length(waymark_vm_interpreter_pureset::value::LengthError::UnsupportedValue)
+        )))
+    ));
+}
+
+#[test]
+fn runtime_surfaces_from_length_errors_from_the_pureset_interpreter() {
+    let executable = executable(vec![function::<RuntimeInstruction>(
+        2,
+        vec![vec![
+            PureSet::LoadConst {
+                dst: RegisterId(0),
+                value: TestConstValue::OverflowLength,
+            }
+            .into(),
+            PureSet::Length {
+                dst: RegisterId(1),
+                src: RegisterId(0),
+            }
+            .into(),
+            RuntimeInstruction::EmitRegister(RegisterId(1)),
+        ]],
+    )]);
+
+    let mut runtime =
+        Runtime::with_conventional_entrypoint(RuntimeInterpreter::default(), executable)
+            .expect("function 0 should exist");
+
+    assert!(matches!(
+        runtime.run(),
+        Err(RunError::Step(waymark_vm_runtime::step::Error::Execution(
+            Error::FromLength(
+                waymark_vm_interpreter_pureset::value::FromLengthError::ResultOutOfBounds
+            )
+        )))
+    ));
+}
+
+#[test]
 fn runtime_surfaces_add_errors_from_the_pureset_interpreter() {
     let executable = executable(vec![function::<RuntimeInstruction>(
         2,
@@ -354,6 +509,38 @@ fn runtime_surfaces_unresolved_add_operand_errors_from_the_pureset_interpreter()
             Error::UnresolvedBinaryOperand {
                 operation: BinaryOpKind::Add,
                 operand_pos: BinaryOperandPosition::First,
+                source: waymark_vm_runtime_core::UnresolvedPromiseError { promise_state_id },
+            }
+        ))) if promise_state_id == PromiseStateId(7)
+    ));
+}
+
+#[test]
+fn runtime_surfaces_unresolved_length_operand_errors_from_the_pureset_interpreter() {
+    let executable = executable(vec![function::<RuntimeInstruction>(
+        2,
+        vec![vec![
+            RuntimeInstruction::SetPending {
+                dst: RegisterId(0),
+                promise_state_id: PromiseStateId(7),
+            },
+            PureSet::Length {
+                dst: RegisterId(1),
+                src: RegisterId(0),
+            }
+            .into(),
+            RuntimeInstruction::EmitRegister(RegisterId(1)),
+        ]],
+    )]);
+
+    let mut runtime =
+        Runtime::with_conventional_entrypoint(RuntimeInterpreter::default(), executable)
+            .expect("function 0 should exist");
+
+    assert!(matches!(
+        runtime.run(),
+        Err(RunError::Step(waymark_vm_runtime::step::Error::Execution(
+            Error::UnresolvedLengthOperand {
                 source: waymark_vm_runtime_core::UnresolvedPromiseError { promise_state_id },
             }
         ))) if promise_state_id == PromiseStateId(7)

--- a/crates/lib/vm-value/src/pureset.rs
+++ b/crates/lib/vm-value/src/pureset.rs
@@ -6,7 +6,7 @@ use waymark_vm_instructions_pureset::{
     BinaryOpKind as BinaryOperationKind, UnaryOpKind as UnaryOperationKind,
 };
 use waymark_vm_interpreter_pureset::value::{
-    BinaryOperationError, MakeDictError, UnaryOperationError,
+    BinaryOperationError, FromLengthError, LengthError, MakeDictError, UnaryOperationError,
 };
 
 use crate::{Value, pythonic};
@@ -315,5 +315,25 @@ impl waymark_vm_interpreter_pureset::value::MakeDict for Value {
         }
 
         Ok(Self::Dict(dict))
+    }
+}
+
+impl waymark_vm_interpreter_pureset::value::Length for Value {
+    type Length = usize;
+
+    fn length(&self) -> Result<Self::Length, LengthError> {
+        match self {
+            Self::String(value) => Ok(value.len()),
+            Self::List(items) => Ok(items.len()),
+            Self::Dict(entries) => Ok(entries.len()),
+            Self::Int(_) | Self::Float(_) | Self::Bool(_) | Self::None => {
+                Err(LengthError::UnsupportedValue)
+            }
+        }
+    }
+
+    fn from_length(length: Self::Length) -> Result<Self, FromLengthError> {
+        let value = i64::try_from(length).map_err(|_| FromLengthError::ResultOutOfBounds)?;
+        Ok(Self::Int(value))
     }
 }

--- a/crates/lib/vm-value/tests/integration.rs
+++ b/crates/lib/vm-value/tests/integration.rs
@@ -4,8 +4,8 @@ use waymark_vm_instructions_pureset::BinaryOpKind;
 use waymark_vm_interpreter_coreset::value::ShouldJump as _;
 use waymark_vm_interpreter_extcallset::value::SleepDuration as _;
 use waymark_vm_interpreter_pureset::value::{
-    BinaryOperationError, BinaryOps as _, MakeDict as _, MakeDictError, MakeList as _,
-    UnaryOps as _,
+    BinaryOperationError, BinaryOps as _, FromLengthError, Length as _, LengthError, MakeDict as _,
+    MakeDictError, MakeList as _, UnaryOps as _,
 };
 use waymark_vm_value::{Value, extcallset};
 
@@ -293,6 +293,36 @@ fn logical_ops_lists_and_sleep_duration_use_runtime_semantics() {
         Value::Bool(true).to_sleep_duration().unwrap_err(),
         extcallset::SleepDurationError::UnsupportedValue
     );
+}
+
+#[test]
+fn length_operations_follow_runtime_semantics() {
+    assert_eq!(
+        Value::List(vec![Value::Int(1), Value::Int(2)])
+            .length()
+            .unwrap(),
+        2
+    );
+    assert_eq!(Value::String("hello".to_owned()).length().unwrap(), 5);
+    assert_eq!(
+        Value::Dict(IndexMap::from([("key".to_owned(), Value::Int(1))]))
+            .length()
+            .unwrap(),
+        1
+    );
+    assert_eq!(Value::from_length(3).unwrap(), Value::Int(3));
+    assert!(matches!(
+        Value::Bool(false).length(),
+        Err(LengthError::UnsupportedValue)
+    ));
+
+    let too_large = usize::try_from(i64::MAX as u128 + 1).ok();
+    if let Some(too_large) = too_large {
+        assert!(matches!(
+            Value::from_length(too_large),
+            Err(FromLengthError::ResultOutOfBounds)
+        ));
+    }
 }
 
 #[test]


### PR DESCRIPTION
This PR adds support for the `len(...)` global fn at the AST via a new `Length` instruction in the pureset.

---

The file sizes are getting out of control, so we'll do a pass on splitting them up in the near future.