### PR TITLE
Implement index and dict dot ops

### DIFF
--- a/crates/lib/vm-compiler-for-ast-old/src/function/compiler/bytecode/emitter.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/function/compiler/bytecode/emitter.rs
@@ -78,6 +78,23 @@ where
         self.emit(waymark_vm_instructions_pureset::PureSet::MakeDict { dst, entries }.into());
     }
 
+    /// Emits an indexed-access instruction.
+    pub fn emit_index(&mut self, dst: RegisterId, object: RegisterId, index: RegisterId) {
+        self.emit(waymark_vm_instructions_pureset::PureSet::Index { dst, object, index }.into());
+    }
+
+    /// Emits an attribute-access instruction.
+    pub fn emit_dot(&mut self, dst: RegisterId, object: RegisterId, attribute: String) {
+        self.emit(
+            waymark_vm_instructions_pureset::PureSet::Dot {
+                dst,
+                object,
+                attribute,
+            }
+            .into(),
+        );
+    }
+
     /// Emits a container-length instruction.
     pub fn emit_length(&mut self, dst: RegisterId, src: RegisterId) {
         self.emit(waymark_vm_instructions_pureset::PureSet::Length { dst, src }.into());

--- a/crates/lib/vm-compiler-for-ast-old/src/function/compiler/lowering/value.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/function/compiler/lowering/value.rs
@@ -65,6 +65,12 @@ where
             }
             ExpressionPlan::List { elements } => self.compile_list_expr(elements, target),
             ExpressionPlan::Dict { entries } => self.compile_dict_expr(entries, target),
+            ExpressionPlan::Index { object, index } => {
+                self.compile_index_expr(object, index, target)
+            }
+            ExpressionPlan::Dot { object, attribute } => {
+                self.compile_dot_expr(object, attribute, target)
+            }
             ExpressionPlan::FunctionCall { call } => match call.global_function {
                 Some(GlobalFunction::Len) => self.compile_length_call(call, target),
                 Some(_) | None => self.compile_call(self.plan_function_call(call)?, target),
@@ -335,6 +341,46 @@ where
         self.context
             .emitter
             .emit_length(dst.register(), src.register());
+
+        Ok(dst)
+    }
+
+    /// Compiles an indexed-access expression from recursively evaluated operands.
+    fn compile_index_expr(
+        &mut self,
+        object: &Spanned<Expr>,
+        index: &Spanned<Expr>,
+        target: ResultTarget,
+    ) -> Result<RegisterHandle, ErrorFor<Spec, Lowering>> {
+        let object_register = self.compile_expr(object, ResultTarget::Allocate)?;
+        let index_register = self.compile_expr(index, ResultTarget::Allocate)?;
+        let dst = self.allocate_result_register(target);
+
+        self.context.emitter.emit_index(
+            dst.register(),
+            object_register.register(),
+            index_register.register(),
+        );
+
+        Ok(dst)
+    }
+
+    /// Compiles an attribute-access expression from a recursively evaluated object.
+    fn compile_dot_expr(
+        &mut self,
+        object: &Spanned<Expr>,
+        attribute: &str,
+        target: ResultTarget,
+    ) -> Result<RegisterHandle, ErrorFor<Spec, Lowering>> {
+        let object_register = self.compile_expr(object, ResultTarget::Allocate)?;
+        let dst = self.allocate_result_register(target);
+
+        self.context.emitter.emit_dot(
+            dst.register(),
+            object_register.register(),
+            attribute.to_owned(),
+        );
+
         Ok(dst)
     }
 
@@ -473,7 +519,7 @@ mod tests {
     use index_type::IndexType;
     use waymark_vm_ast_old::{BinaryOperator, DictEntry, Expr};
     use waymark_vm_ast_old_helpers::{
-        action_call, binary_expr, function_call, int, len_expr, spanned,
+        action_call, binary_expr, function_call, int, len_expr, spanned, string,
     };
     use waymark_vm_bytecode_core::{FunctionId, StateId};
     use waymark_vm_compiler_for_ast_old_test_support::{
@@ -1289,6 +1335,152 @@ mod tests {
             Some(InstructionSet::PureSet(PureSet::Length { dst, src }))
                 if *dst == result_register && *src == RegisterId(2)
         ));
+        assert!(instructions.next().is_none());
+    }
+
+    #[test]
+    fn index_expressions_emit_index() {
+        let function_table = build_function_table();
+        let mut emitter = FunctionEmitter::<TestSpec>::new();
+        let mut local_frame = LocalFrame::new();
+        let mut flow_state = FlowState::new();
+        let expr = spanned(Expr::Index {
+            object: Box::new(spanned(Expr::List {
+                elements: vec![int(3), int(4)],
+            })),
+            index: Box::new(int(1)),
+        });
+
+        let dst = {
+            let mut values = ValueCompiler::<TestSpec, TestLowering>::new(
+                CompilerContextMut::new(
+                    &function_table,
+                    &mut emitter,
+                    &mut local_frame,
+                    &mut flow_state,
+                )
+                .into_ref(),
+            );
+
+            values
+                .compile_expr(&expr, ResultTarget::Allocate)
+                .expect("index expression should compile")
+        };
+
+        let states = emitter.finish();
+
+        let mut instructions = states[StateId(0)].instructions.iter();
+        let first_item = match instructions.next() {
+            Some(InstructionSet::PureSet(PureSet::LoadConst {
+                dst,
+                value: TestConstValue::Int(3),
+            })) => *dst,
+            other => panic!("unexpected first instruction: {other:?}"),
+        };
+        let second_item = match instructions.next() {
+            Some(InstructionSet::PureSet(PureSet::LoadConst {
+                dst,
+                value: TestConstValue::Int(4),
+            })) => *dst,
+            other => panic!("unexpected second instruction: {other:?}"),
+        };
+        let list_register = match instructions.next() {
+            Some(InstructionSet::PureSet(PureSet::MakeList { dst, items }))
+                if items == &[first_item, second_item] =>
+            {
+                *dst
+            }
+            other => panic!("unexpected make-list instruction: {other:?}"),
+        };
+        let index_register = match instructions.next() {
+            Some(InstructionSet::PureSet(PureSet::LoadConst {
+                dst,
+                value: TestConstValue::Int(1),
+            })) => *dst,
+            other => panic!("unexpected index literal instruction: {other:?}"),
+        };
+        let result_register = match instructions.next() {
+            Some(InstructionSet::PureSet(PureSet::Index { dst, object, index }))
+                if *object == list_register && *index == index_register =>
+            {
+                *dst
+            }
+            other => panic!("unexpected index instruction: {other:?}"),
+        };
+
+        assert_eq!(dst.register(), result_register);
+        assert!(instructions.next().is_none());
+    }
+
+    #[test]
+    fn dot_expressions_emit_dot() {
+        let function_table = build_function_table();
+        let mut emitter = FunctionEmitter::<TestSpec>::new();
+        let mut local_frame = LocalFrame::new();
+        let mut flow_state = FlowState::new();
+        let expr = spanned(Expr::Dot {
+            object: Box::new(spanned(Expr::Dict {
+                entries: vec![DictEntry {
+                    key: string("field"),
+                    value: int(9),
+                }],
+            })),
+            attribute: "field".to_owned(),
+        });
+
+        let dst = {
+            let mut values = ValueCompiler::<TestSpec, TestLowering>::new(
+                CompilerContextMut::new(
+                    &function_table,
+                    &mut emitter,
+                    &mut local_frame,
+                    &mut flow_state,
+                )
+                .into_ref(),
+            );
+
+            values
+                .compile_expr(&expr, ResultTarget::Allocate)
+                .expect("dot expression should compile")
+        };
+
+        let states = emitter.finish();
+
+        let mut instructions = states[StateId(0)].instructions.iter();
+        let key_register = match instructions.next() {
+            Some(InstructionSet::PureSet(PureSet::LoadConst {
+                dst,
+                value: TestConstValue::String(value),
+            })) if value == "field" => *dst,
+            other => panic!("unexpected dict-key instruction: {other:?}"),
+        };
+        let value_register = match instructions.next() {
+            Some(InstructionSet::PureSet(PureSet::LoadConst {
+                dst,
+                value: TestConstValue::Int(9),
+            })) => *dst,
+            other => panic!("unexpected dict-value instruction: {other:?}"),
+        };
+        let object_register = match instructions.next() {
+            Some(InstructionSet::PureSet(PureSet::MakeDict { dst, entries }))
+                if entries.len() == 1
+                    && entries[0].key == key_register
+                    && entries[0].value == value_register =>
+            {
+                *dst
+            }
+            other => panic!("unexpected make-dict instruction: {other:?}"),
+        };
+        let result_register = match instructions.next() {
+            Some(InstructionSet::PureSet(PureSet::Dot {
+                dst,
+                object,
+                attribute,
+            })) if *object == object_register && attribute == "field" => *dst,
+            other => panic!("unexpected dot instruction: {other:?}"),
+        };
+
+        assert_eq!(dst.register(), result_register);
         assert!(instructions.next().is_none());
     }
 

--- a/crates/lib/vm-compiler-for-ast-old/src/function/compiler/plan/expr.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/function/compiler/plan/expr.rs
@@ -58,6 +58,24 @@ pub enum ExpressionPlan<'a> {
         entries: &'a [DictEntry],
     },
 
+    /// Indexed access such as `items[0]`.
+    Index {
+        /// Expression that produces the indexed object.
+        object: &'a Spanned<Expr>,
+
+        /// Expression that produces the index value.
+        index: &'a Spanned<Expr>,
+    },
+
+    /// Attribute access such as `record.field`.
+    Dot {
+        /// Expression that produces the accessed object.
+        object: &'a Spanned<Expr>,
+
+        /// Attribute name to look up.
+        attribute: &'a str,
+    },
+
     /// A call to another in-VM function.
     FunctionCall {
         /// Function-call payload from the AST.
@@ -74,12 +92,6 @@ pub enum ExpressionPlan<'a> {
 /// Expression variants that the generic value-lowering path rejects.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum UnsupportedExpressionKind {
-    /// Indexing expressions such as `items[0]`.
-    Index,
-
-    /// Attribute access such as `record.field`.
-    Dot,
-
     /// Spread expressions.
     SpreadExpr,
 }
@@ -107,12 +119,8 @@ impl<'a> ExpressionPlan<'a> {
             }),
             Expr::List { elements } => Ok(Self::List { elements }),
             Expr::Dict { entries } => Ok(Self::Dict { entries }),
-            Expr::Index { .. } => Err(Unsupported::Expression {
-                kind: UnsupportedExpressionKind::Index,
-            }),
-            Expr::Dot { .. } => Err(Unsupported::Expression {
-                kind: UnsupportedExpressionKind::Dot,
-            }),
+            Expr::Index { object, index } => Ok(Self::Index { object, index }),
+            Expr::Dot { object, attribute } => Ok(Self::Dot { object, attribute }),
             Expr::ParallelExpr { .. } => Err(Unsupported::ParallelExprOutsideAssignment),
             Expr::SpreadExpr { .. } => Err(Unsupported::Expression {
                 kind: UnsupportedExpressionKind::SpreadExpr,
@@ -124,8 +132,6 @@ impl<'a> ExpressionPlan<'a> {
 impl core::fmt::Display for UnsupportedExpressionKind {
     fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         formatter.write_str(match self {
-            Self::Index => "Index",
-            Self::Dot => "Dot",
             Self::SpreadExpr => "SpreadExpr",
         })
     }
@@ -194,7 +200,7 @@ mod tests {
     }
 
     #[test]
-    fn builds_variable_and_call_plans() {
+    fn builds_variable_call_collection_and_access_plans() {
         let variable_expr = variable("value");
         let function_expr = function_expr("child", vec![int(1)]);
         let action_expr = action_expr("fetch", vec![("value", int(2))]);
@@ -206,6 +212,14 @@ mod tests {
                 key: int(1),
                 value: int(2),
             }],
+        });
+        let index_expr = spanned(Expr::Index {
+            object: Box::new(variable("items")),
+            index: Box::new(int(0)),
+        });
+        let dot_expr = spanned(Expr::Dot {
+            object: Box::new(variable("record")),
+            attribute: "field".to_owned(),
         });
 
         assert!(matches!(
@@ -228,34 +242,26 @@ mod tests {
             ExpressionPlan::build(&dict_expr).expect("dicts should build"),
             ExpressionPlan::Dict { entries } if entries.len() == 1
         ));
+        assert!(matches!(
+            ExpressionPlan::build(&index_expr).expect("indexes should build"),
+            ExpressionPlan::Index { .. }
+        ));
+        assert!(matches!(
+            ExpressionPlan::build(&dot_expr).expect("dots should build"),
+            ExpressionPlan::Dot { attribute, .. } if attribute == "field"
+        ));
     }
 
     #[test]
-    fn rejects_unsupported_expression_variants() {
-        let unsupported = [
-            (
-                spanned(Expr::Index {
-                    object: Box::new(variable("items")),
-                    index: Box::new(int(0)),
-                }),
-                UnsupportedExpressionKind::Index,
-            ),
-            (
-                spanned(Expr::Dot {
-                    object: Box::new(variable("record")),
-                    attribute: "field".to_owned(),
-                }),
-                UnsupportedExpressionKind::Dot,
-            ),
-            (
-                spanned(Expr::SpreadExpr {
-                    collection: Box::new(variable("items")),
-                    loop_var: "item".to_owned(),
-                    action: action_call("notify", vec![("value", variable("item"))]),
-                }),
-                UnsupportedExpressionKind::SpreadExpr,
-            ),
-        ];
+    fn rejects_currently_unsupported_expression_variants() {
+        let unsupported = [(
+            spanned(Expr::SpreadExpr {
+                collection: Box::new(variable("items")),
+                loop_var: "item".to_owned(),
+                action: action_call("notify", vec![("value", variable("item"))]),
+            }),
+            UnsupportedExpressionKind::SpreadExpr,
+        )];
 
         for (expr, kind) in unsupported {
             let error =

--- a/crates/lib/vm-compiler-for-ast-old/tests/integration.rs
+++ b/crates/lib/vm-compiler-for-ast-old/tests/integration.rs
@@ -478,6 +478,105 @@ fn compiles_global_len_calls_to_completion() {
 }
 
 #[test]
+fn compiles_index_expressions_to_completion() {
+    struct IndexCase {
+        name: &'static str,
+        inputs: Vec<&'static str>,
+        expr: Spanned<Expr>,
+        args: Vec<TestValue>,
+        expected: TestValue,
+    }
+
+    let cases = vec![
+        IndexCase {
+            name: "list index",
+            inputs: vec!["items"],
+            expr: spanned(Expr::Index {
+                object: Box::new(variable("items")),
+                index: Box::new(int(1)),
+            }),
+            args: vec![TestValue::List(vec![TestValue::Int(3), TestValue::Int(8)])],
+            expected: TestValue::Int(8),
+        },
+        IndexCase {
+            name: "list negative index",
+            inputs: vec!["items"],
+            expr: spanned(Expr::Index {
+                object: Box::new(variable("items")),
+                index: Box::new(int(-1)),
+            }),
+            args: vec![TestValue::List(vec![TestValue::Int(3), TestValue::Int(8)])],
+            expected: TestValue::Int(8),
+        },
+        IndexCase {
+            name: "dict string key",
+            inputs: vec!["record"],
+            expr: spanned(Expr::Index {
+                object: Box::new(variable("record")),
+                index: Box::new(string("field")),
+            }),
+            args: vec![TestValue::Dict(
+                [("field".to_owned(), TestValue::Int(7))]
+                    .into_iter()
+                    .collect(),
+            )],
+            expected: TestValue::Int(7),
+        },
+        IndexCase {
+            name: "string index",
+            inputs: vec!["text"],
+            expr: spanned(Expr::Index {
+                object: Box::new(variable("text")),
+                index: Box::new(int(1)),
+            }),
+            args: vec![TestValue::String("hello".to_owned())],
+            expected: TestValue::String("e".to_owned()),
+        },
+    ];
+
+    for case in cases {
+        let program = program(vec![function(
+            "main",
+            case.inputs.as_slice(),
+            vec![return_stmt(Some(case.expr.clone()))],
+        )]);
+
+        let effect = runtime_with_args(compile_program(&program), case.args.clone())
+            .run()
+            .unwrap_or_else(|error| panic!("{} should complete: {error:?}", case.name));
+
+        assert_eq!(completed_value(effect), case.expected, "{}", case.name);
+    }
+}
+
+#[test]
+fn compiles_dot_expressions_to_completion() {
+    let program = program(vec![function(
+        "main",
+        &["record"],
+        vec![return_stmt(Some(spanned(Expr::Dot {
+            object: Box::new(variable("record")),
+            attribute: "field".to_owned(),
+        })))],
+    )]);
+
+    let executable = compile_program(&program);
+    let mut runtime = runtime_with_args(
+        executable,
+        vec![TestValue::Dict(
+            [("field".to_owned(), TestValue::Int(11))]
+                .into_iter()
+                .collect(),
+        )],
+    );
+
+    assert_eq!(
+        completed_value(runtime.run().expect("program should complete")),
+        TestValue::Int(11)
+    );
+}
+
+#[test]
 fn compiles_sleep_statements_into_resumable_sleep_effects() {
     let program = program(vec![function(
         "main",

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_control_flow__if_no_else_continue.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_control_flow__if_no_else_continue.py__bytecode.snap
@@ -2,12 +2,202 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_control_flow/if_no_else_continue.py
 ---
-Err(
-    FunctionCompiler(
-        Unsupported(
-            Expression {
-                kind: Dot,
+Ok(
+    Executable {
+        functions: [
+            Function {
+                states: [
+                    State {
+                        instructions: [
+                            ExtCallSet(
+                                ActionCall {
+                                    dst: RegisterId(
+                                        0,
+                                    ),
+                                    action_ref: TestActionRef(
+                                        "get_items",
+                                    ),
+                                    args: [],
+                                    resume: StateId(
+                                        1,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                Await {
+                                    dst: RegisterId(
+                                        0,
+                                    ),
+                                    src: RegisterId(
+                                        0,
+                                    ),
+                                    resume: StateId(
+                                        2,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            PureSet(
+                                LoadConst {
+                                    dst: RegisterId(
+                                        1,
+                                    ),
+                                    value: Int(
+                                        0,
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                Dot {
+                                    dst: RegisterId(
+                                        2,
+                                    ),
+                                    object: RegisterId(
+                                        0,
+                                    ),
+                                    attribute: "items",
+                                },
+                            ),
+                            CoreSet(
+                                JumpIf {
+                                    target_state: StateId(
+                                        4,
+                                    ),
+                                    cond: RegisterId(
+                                        2,
+                                    ),
+                                },
+                            ),
+                            CoreSet(
+                                Jump {
+                                    target_state: StateId(
+                                        3,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            ExtCallSet(
+                                ActionCall {
+                                    dst: RegisterId(
+                                        3,
+                                    ),
+                                    action_ref: TestActionRef(
+                                        "finalize",
+                                    ),
+                                    args: [
+                                        RegisterId(
+                                            1,
+                                        ),
+                                    ],
+                                    resume: StateId(
+                                        7,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            PureSet(
+                                Dot {
+                                    dst: RegisterId(
+                                        2,
+                                    ),
+                                    object: RegisterId(
+                                        0,
+                                    ),
+                                    attribute: "items",
+                                },
+                            ),
+                            ExtCallSet(
+                                ActionCall {
+                                    dst: RegisterId(
+                                        1,
+                                    ),
+                                    action_ref: TestActionRef(
+                                        "process_items",
+                                    ),
+                                    args: [
+                                        RegisterId(
+                                            2,
+                                        ),
+                                    ],
+                                    resume: StateId(
+                                        5,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                Await {
+                                    dst: RegisterId(
+                                        1,
+                                    ),
+                                    src: RegisterId(
+                                        1,
+                                    ),
+                                    resume: StateId(
+                                        6,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                Jump {
+                                    target_state: StateId(
+                                        3,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                Await {
+                                    dst: RegisterId(
+                                        3,
+                                    ),
+                                    src: RegisterId(
+                                        3,
+                                    ),
+                                    resume: StateId(
+                                        8,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                Return {
+                                    src: RegisterId(
+                                        3,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                ],
+                num_regs: 4,
             },
-        ),
-    ),
+        ],
+    },
 )

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_control_flow__if_with_accumulator.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_control_flow__if_with_accumulator.py__bytecode.snap
@@ -2,12 +2,329 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_control_flow/if_with_accumulator.py
 ---
-Err(
-    FunctionCompiler(
-        Unsupported(
-            Expression {
-                kind: Index,
+Ok(
+    Executable {
+        functions: [
+            Function {
+                states: [
+                    State {
+                        instructions: [
+                            PureSet(
+                                MakeList {
+                                    dst: RegisterId(
+                                        1,
+                                    ),
+                                    items: [],
+                                },
+                            ),
+                            PureSet(
+                                LoadConst {
+                                    dst: RegisterId(
+                                        2,
+                                    ),
+                                    value: Int(
+                                        50,
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                Binary {
+                                    kind: Gt,
+                                    op: BinaryOp {
+                                        dst: RegisterId(
+                                            3,
+                                        ),
+                                        a: RegisterId(
+                                            0,
+                                        ),
+                                        b: RegisterId(
+                                            2,
+                                        ),
+                                    },
+                                },
+                            ),
+                            CoreSet(
+                                JumpIf {
+                                    target_state: StateId(
+                                        2,
+                                    ),
+                                    cond: RegisterId(
+                                        3,
+                                    ),
+                                },
+                            ),
+                            ExtCallSet(
+                                ActionCall {
+                                    dst: RegisterId(
+                                        4,
+                                    ),
+                                    action_ref: TestActionRef(
+                                        "if_accum_process_low",
+                                    ),
+                                    args: [
+                                        RegisterId(
+                                            0,
+                                        ),
+                                    ],
+                                    resume: StateId(
+                                        3,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                JumpIf {
+                                    target_state: StateId(
+                                        10,
+                                    ),
+                                    cond: RegisterId(
+                                        1,
+                                    ),
+                                },
+                            ),
+                            CoreSet(
+                                Jump {
+                                    target_state: StateId(
+                                        9,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            ExtCallSet(
+                                ActionCall {
+                                    dst: RegisterId(
+                                        5,
+                                    ),
+                                    action_ref: TestActionRef(
+                                        "if_accum_process_high",
+                                    ),
+                                    args: [
+                                        RegisterId(
+                                            0,
+                                        ),
+                                    ],
+                                    resume: StateId(
+                                        5,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                Await {
+                                    dst: RegisterId(
+                                        4,
+                                    ),
+                                    src: RegisterId(
+                                        4,
+                                    ),
+                                    resume: StateId(
+                                        4,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            PureSet(
+                                MakeList {
+                                    dst: RegisterId(
+                                        3,
+                                    ),
+                                    items: [
+                                        RegisterId(
+                                            4,
+                                        ),
+                                    ],
+                                },
+                            ),
+                            PureSet(
+                                Binary {
+                                    kind: Add,
+                                    op: BinaryOp {
+                                        dst: RegisterId(
+                                            1,
+                                        ),
+                                        a: RegisterId(
+                                            1,
+                                        ),
+                                        b: RegisterId(
+                                            3,
+                                        ),
+                                    },
+                                },
+                            ),
+                            CoreSet(
+                                Jump {
+                                    target_state: StateId(
+                                        1,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                Await {
+                                    dst: RegisterId(
+                                        5,
+                                    ),
+                                    src: RegisterId(
+                                        5,
+                                    ),
+                                    resume: StateId(
+                                        6,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            ExtCallSet(
+                                ActionCall {
+                                    dst: RegisterId(
+                                        6,
+                                    ),
+                                    action_ref: TestActionRef(
+                                        "if_accum_finalize",
+                                    ),
+                                    args: [
+                                        RegisterId(
+                                            5,
+                                        ),
+                                    ],
+                                    resume: StateId(
+                                        7,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                Await {
+                                    dst: RegisterId(
+                                        6,
+                                    ),
+                                    src: RegisterId(
+                                        6,
+                                    ),
+                                    resume: StateId(
+                                        8,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            PureSet(
+                                MakeList {
+                                    dst: RegisterId(
+                                        3,
+                                    ),
+                                    items: [
+                                        RegisterId(
+                                            6,
+                                        ),
+                                    ],
+                                },
+                            ),
+                            PureSet(
+                                Binary {
+                                    kind: Add,
+                                    op: BinaryOp {
+                                        dst: RegisterId(
+                                            1,
+                                        ),
+                                        a: RegisterId(
+                                            1,
+                                        ),
+                                        b: RegisterId(
+                                            3,
+                                        ),
+                                    },
+                                },
+                            ),
+                            CoreSet(
+                                Jump {
+                                    target_state: StateId(
+                                        1,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            PureSet(
+                                LoadConst {
+                                    dst: RegisterId(
+                                        2,
+                                    ),
+                                    value: String(
+                                        "empty",
+                                    ),
+                                },
+                            ),
+                            CoreSet(
+                                Return {
+                                    src: RegisterId(
+                                        2,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            PureSet(
+                                LoadConst {
+                                    dst: RegisterId(
+                                        3,
+                                    ),
+                                    value: Int(
+                                        0,
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                Index {
+                                    dst: RegisterId(
+                                        2,
+                                    ),
+                                    object: RegisterId(
+                                        1,
+                                    ),
+                                    index: RegisterId(
+                                        3,
+                                    ),
+                                },
+                            ),
+                            CoreSet(
+                                Return {
+                                    src: RegisterId(
+                                        2,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                ],
+                num_regs: 7,
             },
-        ),
-    ),
+        ],
+    },
 )

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_models__dataclass_action_arg.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_models__dataclass_action_arg.py__bytecode.snap
@@ -2,12 +2,137 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_models/dataclass_action_arg.py
 ---
-Err(
-    FunctionCompiler(
-        Unsupported(
-            Expression {
-                kind: Dot,
+Ok(
+    Executable {
+        functions: [
+            Function {
+                states: [
+                    State {
+                        instructions: [
+                            ExtCallSet(
+                                ActionCall {
+                                    dst: RegisterId(
+                                        0,
+                                    ),
+                                    action_ref: TestActionRef(
+                                        "get_data_items",
+                                    ),
+                                    args: [],
+                                    resume: StateId(
+                                        1,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                Await {
+                                    dst: RegisterId(
+                                        0,
+                                    ),
+                                    src: RegisterId(
+                                        0,
+                                    ),
+                                    resume: StateId(
+                                        2,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            PureSet(
+                                LoadConst {
+                                    dst: RegisterId(
+                                        2,
+                                    ),
+                                    value: String(
+                                        "items",
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                MakeDict {
+                                    dst: RegisterId(
+                                        3,
+                                    ),
+                                    entries: [
+                                        DictEntry {
+                                            key: RegisterId(
+                                                2,
+                                            ),
+                                            value: RegisterId(
+                                                0,
+                                            ),
+                                        },
+                                    ],
+                                },
+                            ),
+                            ExtCallSet(
+                                ActionCall {
+                                    dst: RegisterId(
+                                        1,
+                                    ),
+                                    action_ref: TestActionRef(
+                                        "process_data",
+                                    ),
+                                    args: [
+                                        RegisterId(
+                                            3,
+                                        ),
+                                    ],
+                                    resume: StateId(
+                                        3,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                Await {
+                                    dst: RegisterId(
+                                        1,
+                                    ),
+                                    src: RegisterId(
+                                        1,
+                                    ),
+                                    resume: StateId(
+                                        4,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            PureSet(
+                                Dot {
+                                    dst: RegisterId(
+                                        3,
+                                    ),
+                                    object: RegisterId(
+                                        1,
+                                    ),
+                                    attribute: "count",
+                                },
+                            ),
+                            CoreSet(
+                                Return {
+                                    src: RegisterId(
+                                        3,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                ],
+                num_regs: 4,
             },
-        ),
-    ),
+        ],
+    },
 )

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_models__pydantic_action_arg.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_models__pydantic_action_arg.py__bytecode.snap
@@ -2,12 +2,137 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_models/pydantic_action_arg.py
 ---
-Err(
-    FunctionCompiler(
-        Unsupported(
-            Expression {
-                kind: Dot,
+Ok(
+    Executable {
+        functions: [
+            Function {
+                states: [
+                    State {
+                        instructions: [
+                            ExtCallSet(
+                                ActionCall {
+                                    dst: RegisterId(
+                                        0,
+                                    ),
+                                    action_ref: TestActionRef(
+                                        "get_items",
+                                    ),
+                                    args: [],
+                                    resume: StateId(
+                                        1,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                Await {
+                                    dst: RegisterId(
+                                        0,
+                                    ),
+                                    src: RegisterId(
+                                        0,
+                                    ),
+                                    resume: StateId(
+                                        2,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            PureSet(
+                                LoadConst {
+                                    dst: RegisterId(
+                                        2,
+                                    ),
+                                    value: String(
+                                        "items",
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                MakeDict {
+                                    dst: RegisterId(
+                                        3,
+                                    ),
+                                    entries: [
+                                        DictEntry {
+                                            key: RegisterId(
+                                                2,
+                                            ),
+                                            value: RegisterId(
+                                                0,
+                                            ),
+                                        },
+                                    ],
+                                },
+                            ),
+                            ExtCallSet(
+                                ActionCall {
+                                    dst: RegisterId(
+                                        1,
+                                    ),
+                                    action_ref: TestActionRef(
+                                        "process_request",
+                                    ),
+                                    args: [
+                                        RegisterId(
+                                            3,
+                                        ),
+                                    ],
+                                    resume: StateId(
+                                        3,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                Await {
+                                    dst: RegisterId(
+                                        1,
+                                    ),
+                                    src: RegisterId(
+                                        1,
+                                    ),
+                                    resume: StateId(
+                                        4,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            PureSet(
+                                Dot {
+                                    dst: RegisterId(
+                                        3,
+                                    ),
+                                    object: RegisterId(
+                                        1,
+                                    ),
+                                    attribute: "count",
+                                },
+                            ),
+                            CoreSet(
+                                Return {
+                                    src: RegisterId(
+                                        3,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                ],
+                num_regs: 4,
             },
-        ),
-    ),
+        ],
+    },
 )

--- a/crates/lib/vm-instructions-pureset/src/lib.rs
+++ b/crates/lib/vm-instructions-pureset/src/lib.rs
@@ -162,6 +162,30 @@ pub enum PureSet<Spec: self::Spec> {
         src: Spec::RegisterId,
     },
 
+    /// Resolve an indexed access from an object and index value.
+    Index {
+        /// The register to store the result at.
+        dst: Spec::RegisterId,
+
+        /// The register containing the indexed object.
+        object: Spec::RegisterId,
+
+        /// The register containing the index value.
+        index: Spec::RegisterId,
+    },
+
+    /// Resolve an attribute access from an object and attribute name.
+    Dot {
+        /// The register to store the result at.
+        dst: Spec::RegisterId,
+
+        /// The register containing the accessed object.
+        object: Spec::RegisterId,
+
+        /// The attribute name to read from the object.
+        attribute: String,
+    },
+
     /// Build a list value from resolved registers.
     MakeList {
         /// The register to store the resulting list at.

--- a/crates/lib/vm-interpreter-fullset/tests/integration.rs
+++ b/crates/lib/vm-interpreter-fullset/tests/integration.rs
@@ -153,6 +153,10 @@ impl waymark_vm_interpreter_pureset::value::Length for TestValue {
     }
 }
 
+impl waymark_vm_interpreter_pureset::value::IndexOp for TestValue {}
+
+impl waymark_vm_interpreter_pureset::value::DotOp for TestValue {}
+
 impl waymark_vm_interpreter_extcallset::value::SleepDuration for TestValue {
     type Error = TestSleepDurationError;
 

--- a/crates/lib/vm-interpreter-pureset/src/error.rs
+++ b/crates/lib/vm-interpreter-pureset/src/error.rs
@@ -159,6 +159,57 @@ pub enum Error {
         source: UnresolvedPromiseError,
     },
 
+    /// An `Index` instruction referenced an unset object register.
+    #[error("index object in register {register:?} is not initialized")]
+    MissingIndexObject {
+        /// The register that was read.
+        register: RegisterId,
+    },
+
+    /// An `Index` instruction referenced an unresolved object promise.
+    #[error("index object is unresolved: {source}")]
+    UnresolvedIndexObject {
+        /// The underlying unresolved promise error.
+        #[source]
+        source: UnresolvedPromiseError,
+    },
+
+    /// An `Index` instruction referenced an unset index register.
+    #[error("index operand in register {register:?} is not initialized")]
+    MissingIndexOperand {
+        /// The register that was read.
+        register: RegisterId,
+    },
+
+    /// An `Index` instruction referenced an unresolved index promise.
+    #[error("index operand is unresolved: {source}")]
+    UnresolvedIndexOperand {
+        /// The underlying unresolved promise error.
+        #[source]
+        source: UnresolvedPromiseError,
+    },
+
+    /// A `Dot` instruction referenced an unset object register.
+    #[error("dot object for attribute {attribute:?} in register {register:?} is not initialized")]
+    MissingDotObject {
+        /// The accessed attribute name.
+        attribute: String,
+
+        /// The register that was read.
+        register: RegisterId,
+    },
+
+    /// A `Dot` instruction referenced an unresolved object promise.
+    #[error("dot object for attribute {attribute:?} is unresolved: {source}")]
+    UnresolvedDotObject {
+        /// The accessed attribute name.
+        attribute: String,
+
+        /// The underlying unresolved promise error.
+        #[source]
+        source: UnresolvedPromiseError,
+    },
+
     /// Evaluating a binary scalar instruction failed.
     #[error("{operation}: {source}")]
     BinaryOperation {
@@ -196,4 +247,23 @@ pub enum Error {
     /// Evaluating a `MakeDict` instruction failed.
     #[error("make_dict: {0}")]
     MakeDict(#[source] crate::value::MakeDictError),
+
+    /// Evaluating an `Index` instruction failed.
+    #[error("index: {source}")]
+    IndexOperation {
+        /// The operation-specific failure.
+        #[source]
+        source: crate::value::IndexOperationError,
+    },
+
+    /// Evaluating a `Dot` instruction failed.
+    #[error("dot attribute {attribute:?}: {source}")]
+    DotOperation {
+        /// The accessed attribute name.
+        attribute: String,
+
+        /// The operation-specific failure.
+        #[source]
+        source: crate::value::DotOperationError,
+    },
 }

--- a/crates/lib/vm-interpreter-pureset/src/lib.rs
+++ b/crates/lib/vm-interpreter-pureset/src/lib.rs
@@ -73,6 +73,16 @@ where
             waymark_vm_instructions_pureset::PureSet::Length { dst, src } => {
                 Self::execute_length(&mut frame, *dst, *src)?;
             }
+            waymark_vm_instructions_pureset::PureSet::Index { dst, object, index } => {
+                Self::execute_index_operation(&mut frame, *dst, *object, *index)?;
+            }
+            waymark_vm_instructions_pureset::PureSet::Dot {
+                dst,
+                object,
+                attribute,
+            } => {
+                Self::execute_dot_operation(&mut frame, *dst, *object, attribute)?;
+            }
             waymark_vm_instructions_pureset::PureSet::MakeList { dst, items } => {
                 let make_list_result = with_register_values(
                     items.iter().copied(),
@@ -225,6 +235,65 @@ where
 
         let length = <Value as value::Length>::length(value).map_err(Error::Length)?;
         let value = <Value as value::Length>::from_length(length).map_err(Error::FromLength)?;
+
+        frame.regs.set(dst, Promise::Resolved(value));
+        Ok(())
+    }
+
+    fn execute_index_operation(
+        frame: &mut Frame<FunctionId, StateId, Promise<Value>>,
+        dst: waymark_vm_runtime_core::RegisterId,
+        object: waymark_vm_runtime_core::RegisterId,
+        index: waymark_vm_runtime_core::RegisterId,
+    ) -> Result<(), Error> {
+        let object_value = frame
+            .regs
+            .get(object)
+            .ok_or(Error::MissingIndexObject { register: object })?;
+        let object_value = object_value
+            .require_resolved_ref()
+            .map_err(|source| Error::UnresolvedIndexObject { source })?;
+
+        let index_value = frame
+            .regs
+            .get(index)
+            .ok_or(Error::MissingIndexOperand { register: index })?;
+        let index_value = index_value
+            .require_resolved_ref()
+            .map_err(|source| Error::UnresolvedIndexOperand { source })?;
+
+        let value = Value::index(object_value, index_value)
+            .map_err(|source| Error::IndexOperation { source })?;
+
+        frame.regs.set(dst, Promise::Resolved(value));
+        Ok(())
+    }
+
+    fn execute_dot_operation(
+        frame: &mut Frame<FunctionId, StateId, Promise<Value>>,
+        dst: waymark_vm_runtime_core::RegisterId,
+        object: waymark_vm_runtime_core::RegisterId,
+        attribute: &str,
+    ) -> Result<(), Error> {
+        let object_value = frame
+            .regs
+            .get(object)
+            .ok_or_else(|| Error::MissingDotObject {
+                attribute: attribute.to_owned(),
+                register: object,
+            })?;
+        let object_value =
+            object_value
+                .require_resolved_ref()
+                .map_err(|source| Error::UnresolvedDotObject {
+                    attribute: attribute.to_owned(),
+                    source,
+                })?;
+
+        let value = Value::dot(object_value, attribute).map_err(|source| Error::DotOperation {
+            attribute: attribute.to_owned(),
+            source,
+        })?;
 
         frame.regs.set(dst, Promise::Resolved(value));
         Ok(())

--- a/crates/lib/vm-interpreter-pureset/src/value.rs
+++ b/crates/lib/vm-interpreter-pureset/src/value.rs
@@ -89,6 +89,34 @@ pub enum FromLengthError {
     ResultOutOfBounds,
 }
 
+/// An error from [`IndexOp::index`].
+#[derive(Debug, thiserror::Error)]
+pub enum IndexOperationError {
+    /// The value type does not support indexed access for the operands.
+    #[error("indexed access is not supported for these operands")]
+    UnsupportedOperation,
+
+    /// The provided index falls outside the bounds of the target object.
+    #[error("index is out of bounds")]
+    IndexOutOfBounds,
+
+    /// The target dictionary does not contain the requested key.
+    #[error("key is missing")]
+    MissingKey,
+}
+
+/// An error from [`DotOp::dot`].
+#[derive(Debug, thiserror::Error)]
+pub enum DotOperationError {
+    /// The value type does not support attribute access for this object.
+    #[error("attribute access is not supported for this value")]
+    UnsupportedOperation,
+
+    /// The target object does not contain the requested attribute.
+    #[error("attribute is missing")]
+    MissingAttribute,
+}
+
 /// Apply binary scalar operations to resolved values.
 pub trait BinaryOps: Sized {
     /// Add two resolved values together.
@@ -267,7 +295,25 @@ pub trait Length: Sized {
     fn from_length(length: Self::Length) -> Result<Self, FromLengthError>;
 }
 
-/// A unifying trait for all value requirements.
-pub trait Value: BinaryOps + UnaryOps + MakeList + MakeDict + Length {}
+/// Resolve indexed access from a value and index operand.
+pub trait IndexOp: Sized {
+    /// Index into the resolved object using the resolved index value.
+    fn index(object: &Self, index: &Self) -> Result<Self, IndexOperationError> {
+        let _ = (object, index);
+        Err(IndexOperationError::UnsupportedOperation)
+    }
+}
 
-impl<T> Value for T where T: BinaryOps + UnaryOps + MakeList + MakeDict + Length {}
+/// Resolve attribute access from a value and attribute name.
+pub trait DotOp: Sized {
+    /// Read the named attribute from the resolved object.
+    fn dot(object: &Self, attribute: &str) -> Result<Self, DotOperationError> {
+        let _ = (object, attribute);
+        Err(DotOperationError::UnsupportedOperation)
+    }
+}
+
+/// A unifying trait for all value requirements.
+pub trait Value: BinaryOps + UnaryOps + MakeList + MakeDict + Length + IndexOp + DotOp {}
+
+impl<T> Value for T where T: BinaryOps + UnaryOps + MakeList + MakeDict + Length + IndexOp + DotOp {}

--- a/crates/lib/vm-interpreter-pureset/tests/integration.rs
+++ b/crates/lib/vm-interpreter-pureset/tests/integration.rs
@@ -68,6 +68,16 @@ fn dict_key(
     }
 }
 
+fn normalized_index(index: i64, len: usize) -> Option<usize> {
+    if index >= 0 {
+        let index = usize::try_from(index).ok()?;
+        return (index < len).then_some(index);
+    }
+
+    let distance_from_end = usize::try_from(index.unsigned_abs()).ok()?;
+    (distance_from_end <= len).then_some(len - distance_from_end)
+}
+
 impl waymark_vm_interpreter_pureset::value::BinaryOps for TestValue {
     fn add(
         a: &Self,
@@ -170,6 +180,47 @@ impl waymark_vm_interpreter_pureset::value::Length for TestValue {
             TestLength::Valid(value) => Ok(Self::Int(value)),
             TestLength::Overflow => {
                 Err(waymark_vm_interpreter_pureset::value::FromLengthError::ResultOutOfBounds)
+            }
+        }
+    }
+}
+
+impl waymark_vm_interpreter_pureset::value::IndexOp for TestValue {
+    fn index(
+        object: &Self,
+        index: &Self,
+    ) -> Result<Self, waymark_vm_interpreter_pureset::value::IndexOperationError> {
+        match (object, index) {
+            (Self::List(items), Self::Int(index)) => {
+                let index = normalized_index(*index, items.len()).ok_or(
+                    waymark_vm_interpreter_pureset::value::IndexOperationError::IndexOutOfBounds,
+                )?;
+
+                Ok(items[index].clone())
+            }
+            (Self::Dict(entries), Self::Text(key)) => entries
+                .get(*key)
+                .cloned()
+                .ok_or(waymark_vm_interpreter_pureset::value::IndexOperationError::MissingKey),
+            _ => Err(
+                waymark_vm_interpreter_pureset::value::IndexOperationError::UnsupportedOperation,
+            ),
+        }
+    }
+}
+
+impl waymark_vm_interpreter_pureset::value::DotOp for TestValue {
+    fn dot(
+        object: &Self,
+        attribute: &str,
+    ) -> Result<Self, waymark_vm_interpreter_pureset::value::DotOperationError> {
+        match object {
+            Self::Dict(entries) => entries
+                .get(attribute)
+                .cloned()
+                .ok_or(waymark_vm_interpreter_pureset::value::DotOperationError::MissingAttribute),
+            _ => {
+                Err(waymark_vm_interpreter_pureset::value::DotOperationError::UnsupportedOperation)
             }
         }
     }
@@ -686,6 +737,93 @@ fn runtime_executes_make_dict_to_a_terminal_effect() {
 }
 
 #[test]
+fn runtime_executes_index_to_a_terminal_effect() {
+    let executable = executable(vec![function::<RuntimeInstruction>(
+        4,
+        vec![vec![
+            PureSet::LoadConst {
+                dst: RegisterId(0),
+                value: TestConstValue::Int(2),
+            }
+            .into(),
+            PureSet::MakeList {
+                dst: RegisterId(1),
+                items: vec![RegisterId(0)],
+            }
+            .into(),
+            PureSet::LoadConst {
+                dst: RegisterId(2),
+                value: TestConstValue::Int(-1),
+            }
+            .into(),
+            PureSet::Index {
+                dst: RegisterId(3),
+                object: RegisterId(1),
+                index: RegisterId(2),
+            }
+            .into(),
+            RuntimeInstruction::EmitRegister(RegisterId(3)),
+        ]],
+    )]);
+
+    let mut runtime =
+        Runtime::with_conventional_entrypoint(RuntimeInterpreter::default(), executable)
+            .expect("function 0 should exist");
+
+    assert_eq!(
+        runtime
+            .run()
+            .expect("runtime should emit the indexed result"),
+        TestValue::Int(2)
+    );
+}
+
+#[test]
+fn runtime_executes_dot_to_a_terminal_effect() {
+    let executable = executable(vec![function::<RuntimeInstruction>(
+        4,
+        vec![vec![
+            PureSet::LoadConst {
+                dst: RegisterId(0),
+                value: TestConstValue::Text("field"),
+            }
+            .into(),
+            PureSet::LoadConst {
+                dst: RegisterId(1),
+                value: TestConstValue::Int(9),
+            }
+            .into(),
+            PureSet::MakeDict {
+                dst: RegisterId(2),
+                entries: vec![waymark_vm_instructions_pureset::DictEntry {
+                    key: RegisterId(0),
+                    value: RegisterId(1),
+                }],
+            }
+            .into(),
+            PureSet::Dot {
+                dst: RegisterId(3),
+                object: RegisterId(2),
+                attribute: "field".to_owned(),
+            }
+            .into(),
+            RuntimeInstruction::EmitRegister(RegisterId(3)),
+        ]],
+    )]);
+
+    let mut runtime =
+        Runtime::with_conventional_entrypoint(RuntimeInterpreter::default(), executable)
+            .expect("function 0 should exist");
+
+    assert_eq!(
+        runtime
+            .run()
+            .expect("runtime should emit the dotted result"),
+        TestValue::Int(9)
+    );
+}
+
+#[test]
 fn runtime_surfaces_make_dict_key_type_errors_from_the_pureset_interpreter() {
     let executable = executable(vec![function::<RuntimeInstruction>(
         4,
@@ -723,6 +861,98 @@ fn runtime_surfaces_make_dict_key_type_errors_from_the_pureset_interpreter() {
                 waymark_vm_interpreter_pureset::value::MakeDictError::UnsupportedKeyType
             )
         )))
+    ));
+}
+
+#[test]
+fn runtime_surfaces_unresolved_index_operand_errors_from_the_pureset_interpreter() {
+    let executable = executable(vec![function::<RuntimeInstruction>(
+        4,
+        vec![vec![
+            PureSet::LoadConst {
+                dst: RegisterId(0),
+                value: TestConstValue::Int(2),
+            }
+            .into(),
+            PureSet::MakeList {
+                dst: RegisterId(1),
+                items: vec![RegisterId(0)],
+            }
+            .into(),
+            RuntimeInstruction::SetPending {
+                dst: RegisterId(2),
+                promise_state_id: PromiseStateId(7),
+            },
+            PureSet::Index {
+                dst: RegisterId(3),
+                object: RegisterId(1),
+                index: RegisterId(2),
+            }
+            .into(),
+            RuntimeInstruction::EmitRegister(RegisterId(3)),
+        ]],
+    )]);
+
+    let mut runtime =
+        Runtime::with_conventional_entrypoint(RuntimeInterpreter::default(), executable)
+            .expect("function 0 should exist");
+
+    assert!(matches!(
+        runtime.run(),
+        Err(RunError::Step(waymark_vm_runtime::step::Error::Execution(
+            Error::UnresolvedIndexOperand {
+                source: waymark_vm_runtime_core::UnresolvedPromiseError { promise_state_id },
+            }
+        ))) if promise_state_id == PromiseStateId(7)
+    ));
+}
+
+#[test]
+fn runtime_surfaces_missing_dot_attribute_errors_from_the_pureset_interpreter() {
+    let executable = executable(vec![function::<RuntimeInstruction>(
+        4,
+        vec![vec![
+            PureSet::LoadConst {
+                dst: RegisterId(0),
+                value: TestConstValue::Text("present"),
+            }
+            .into(),
+            PureSet::LoadConst {
+                dst: RegisterId(1),
+                value: TestConstValue::Int(9),
+            }
+            .into(),
+            PureSet::MakeDict {
+                dst: RegisterId(2),
+                entries: vec![waymark_vm_instructions_pureset::DictEntry {
+                    key: RegisterId(0),
+                    value: RegisterId(1),
+                }],
+            }
+            .into(),
+            PureSet::Dot {
+                dst: RegisterId(3),
+                object: RegisterId(2),
+                attribute: "missing".to_owned(),
+            }
+            .into(),
+            RuntimeInstruction::EmitRegister(RegisterId(3)),
+        ]],
+    )]);
+
+    let mut runtime =
+        Runtime::with_conventional_entrypoint(RuntimeInterpreter::default(), executable)
+            .expect("function 0 should exist");
+
+    assert!(matches!(
+        runtime.run(),
+        Err(RunError::Step(waymark_vm_runtime::step::Error::Execution(
+            Error::DotOperation {
+                attribute,
+                source:
+                    waymark_vm_interpreter_pureset::value::DotOperationError::MissingAttribute,
+            }
+        ))) if attribute == "missing"
     ));
 }
 

--- a/crates/lib/vm-value/src/pureset.rs
+++ b/crates/lib/vm-value/src/pureset.rs
@@ -6,7 +6,8 @@ use waymark_vm_instructions_pureset::{
     BinaryOpKind as BinaryOperationKind, UnaryOpKind as UnaryOperationKind,
 };
 use waymark_vm_interpreter_pureset::value::{
-    BinaryOperationError, FromLengthError, LengthError, MakeDictError, UnaryOperationError,
+    BinaryOperationError, DotOperationError, FromLengthError, IndexOperationError, LengthError,
+    MakeDictError, UnaryOperationError,
 };
 
 use crate::{Value, pythonic};
@@ -45,6 +46,20 @@ where
     value
         .try_into()
         .map_err(|_| BinaryOperationError::ResultOutOfBounds { operation })
+}
+
+fn normalized_index(index: &Value, len: usize) -> Result<usize, IndexOperationError> {
+    match index {
+        Value::Int(index) => {
+            pythonic::normalized_index(*index, len).ok_or(IndexOperationError::IndexOutOfBounds)
+        }
+        Value::Float(_)
+        | Value::Bool(_)
+        | Value::String(_)
+        | Value::None
+        | Value::List(_)
+        | Value::Dict(_) => Err(IndexOperationError::UnsupportedOperation),
+    }
 }
 
 impl waymark_vm_interpreter_pureset::value::BinaryOps for Value {
@@ -335,5 +350,56 @@ impl waymark_vm_interpreter_pureset::value::Length for Value {
     fn from_length(length: Self::Length) -> Result<Self, FromLengthError> {
         let value = i64::try_from(length).map_err(|_| FromLengthError::ResultOutOfBounds)?;
         Ok(Self::Int(value))
+    }
+}
+
+impl waymark_vm_interpreter_pureset::value::IndexOp for Value {
+    fn index(object: &Self, index: &Self) -> Result<Self, IndexOperationError> {
+        match object {
+            Self::List(items) => {
+                let index = normalized_index(index, items.len())?;
+                Ok(items[index].clone())
+            }
+            Self::String(value) => {
+                let index = normalized_index(index, value.chars().count())?;
+                let character = value
+                    .chars()
+                    .nth(index)
+                    .expect("normalized string index should be in bounds");
+                Ok(Self::String(character.to_string()))
+            }
+            Self::Dict(entries) => match index {
+                Self::String(key) => entries
+                    .get(key)
+                    .cloned()
+                    .ok_or(IndexOperationError::MissingKey),
+                Self::Int(_)
+                | Self::Float(_)
+                | Self::Bool(_)
+                | Self::None
+                | Self::List(_)
+                | Self::Dict(_) => Err(IndexOperationError::UnsupportedOperation),
+            },
+            Self::Int(_) | Self::Float(_) | Self::Bool(_) | Self::None => {
+                Err(IndexOperationError::UnsupportedOperation)
+            }
+        }
+    }
+}
+
+impl waymark_vm_interpreter_pureset::value::DotOp for Value {
+    fn dot(object: &Self, attribute: &str) -> Result<Self, DotOperationError> {
+        match object {
+            Self::Dict(entries) => entries
+                .get(attribute)
+                .cloned()
+                .ok_or(DotOperationError::MissingAttribute),
+            Self::Int(_)
+            | Self::Float(_)
+            | Self::Bool(_)
+            | Self::String(_)
+            | Self::None
+            | Self::List(_) => Err(DotOperationError::UnsupportedOperation),
+        }
     }
 }

--- a/crates/lib/vm-value/src/pythonic.rs
+++ b/crates/lib/vm-value/src/pythonic.rs
@@ -49,3 +49,30 @@ pub(crate) fn checked_modulo_float(
 
     remainder.try_into().ok()
 }
+
+pub(crate) fn normalized_index(index: i64, len: usize) -> Option<usize> {
+    if index >= 0 {
+        let index = usize::try_from(index).ok()?;
+        return (index < len).then_some(index);
+    }
+
+    let distance_from_end = usize::try_from(index.unsigned_abs()).ok()?;
+    len.checked_sub(distance_from_end)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalized_index;
+
+    #[test]
+    fn normalized_index_matches_python_style_indexing() {
+        assert_eq!(normalized_index(0, 3), Some(0));
+        assert_eq!(normalized_index(2, 3), Some(2));
+        assert_eq!(normalized_index(3, 3), None);
+        assert_eq!(normalized_index(-1, 3), Some(2));
+        assert_eq!(normalized_index(-3, 3), Some(0));
+        assert_eq!(normalized_index(-4, 3), None);
+        assert_eq!(normalized_index(0, 0), None);
+        assert_eq!(normalized_index(i64::MIN, 3), None);
+    }
+}

--- a/crates/lib/vm-value/tests/integration.rs
+++ b/crates/lib/vm-value/tests/integration.rs
@@ -4,8 +4,9 @@ use waymark_vm_instructions_pureset::BinaryOpKind;
 use waymark_vm_interpreter_coreset::value::ShouldJump as _;
 use waymark_vm_interpreter_extcallset::value::SleepDuration as _;
 use waymark_vm_interpreter_pureset::value::{
-    BinaryOperationError, BinaryOps as _, FromLengthError, Length as _, LengthError, MakeDict as _,
-    MakeDictError, MakeList as _, UnaryOps as _,
+    BinaryOperationError, BinaryOps as _, DotOp as _, DotOperationError, FromLengthError,
+    IndexOp as _, IndexOperationError, Length as _, LengthError, MakeDict as _, MakeDictError,
+    MakeList as _, UnaryOps as _,
 };
 use waymark_vm_value::{Value, extcallset};
 
@@ -204,6 +205,64 @@ fn mixed_numeric_operations_do_not_silently_promote_ints_to_floats() {
         .unwrap(),
         Value::Bool(false)
     );
+}
+
+#[test]
+fn index_and_dot_operations_follow_runtime_semantics() {
+    assert_eq!(
+        Value::index(
+            &Value::List(vec![Value::Int(1), Value::Int(2)]),
+            &Value::Int(-1)
+        )
+        .unwrap(),
+        Value::Int(2)
+    );
+    assert_eq!(
+        Value::index(&Value::String("hello".to_owned()), &Value::Int(1)).unwrap(),
+        Value::String("e".to_owned())
+    );
+    assert_eq!(
+        Value::index(
+            &Value::Dict(IndexMap::from([("field".to_owned(), Value::Int(7))])),
+            &Value::String("field".to_owned())
+        )
+        .unwrap(),
+        Value::Int(7)
+    );
+    assert_eq!(
+        Value::dot(
+            &Value::Dict(IndexMap::from([("field".to_owned(), Value::Int(7))])),
+            "field"
+        )
+        .unwrap(),
+        Value::Int(7)
+    );
+}
+
+#[test]
+fn index_and_dot_operations_surface_expected_errors() {
+    assert!(matches!(
+        Value::index(&Value::List(vec![Value::Int(1)]), &Value::Int(1)),
+        Err(IndexOperationError::IndexOutOfBounds)
+    ));
+    assert!(matches!(
+        Value::index(
+            &Value::Dict(IndexMap::from([("field".to_owned(), Value::Int(7))])),
+            &Value::String("missing".to_owned())
+        ),
+        Err(IndexOperationError::MissingKey)
+    ));
+    assert!(matches!(
+        Value::dot(
+            &Value::Dict(IndexMap::from([("field".to_owned(), Value::Int(7))])),
+            "missing"
+        ),
+        Err(DotOperationError::MissingAttribute)
+    ));
+    assert!(matches!(
+        Value::dot(&Value::List(Vec::new()), "field"),
+        Err(DotOperationError::UnsupportedOperation)
+    ));
 }
 
 #[test]


### PR DESCRIPTION
This PR adds support for list index and dict dot ops.

Goes in after #408. But doesn't really use the length opcode machinery (turns out it's not necessary to wire things though it).