### PR TITLE
Implement for loops support at compiler

### DIFF
--- a/crates/lib/vm-ast-old-helpers/src/lib.rs
+++ b/crates/lib/vm-ast-old-helpers/src/lib.rs
@@ -217,8 +217,16 @@ pub fn builtin_function_expr(
     })
 }
 
+pub fn range_expr(args: Vec<Spanned<Expr>>) -> Spanned<Expr> {
+    builtin_function_expr(GlobalFunction::Range, args)
+}
+
 pub fn len_expr(arg: Spanned<Expr>) -> Spanned<Expr> {
     builtin_function_expr(GlobalFunction::Len, vec![arg])
+}
+
+pub fn enumerate_expr(iterable: Spanned<Expr>) -> Spanned<Expr> {
+    builtin_function_expr(GlobalFunction::Enumerate, vec![iterable])
 }
 
 pub fn action_call(name: &str, kwargs: Vec<(&str, Spanned<Expr>)>) -> ActionCall {

--- a/crates/lib/vm-compiler-for-ast-old/src/function/compiler.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/function/compiler.rs
@@ -34,11 +34,13 @@ mod lowering {
     use super::*;
 
     pub mod assignment;
+    pub mod for_loop;
     pub mod parallel;
     pub mod statement;
     pub mod value;
 
     pub use self::assignment::AssignmentCompiler;
+    pub use self::for_loop::ForLoopCompiler;
     pub use self::parallel::ParallelCompiler;
     pub use self::statement::StatementCompiler;
     pub use self::value::ValueCompiler;

--- a/crates/lib/vm-compiler-for-ast-old/src/function/compiler/lowering/for_loop.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/function/compiler/lowering/for_loop.rs
@@ -1,4 +1,32 @@
 //! For-loop lowering.
+//!
+//! `for` loops are lowered into a four-state bytecode skeleton modeled by
+//! [`ForLoopPlan`]: a `condition` state, a `body` state, a `continue` state
+//! (the target of `continue` statements and the natural fallthrough at the end
+//! of the body), and an `exit` state (the target of `break`). All variants
+//! share that shape and reach it through [`ForLoopCompiler::compile_loop_skeleton`],
+//! which lets each header shape contribute only the parts that actually
+//! differ:
+//!
+//! - **Header classification** ([`ResolvedForLoop`]) inspects the iterable
+//!   expression and decides between three lowering strategies: walking an
+//!   indexable value, a positive-step `range`, or a runtime-signed-step
+//!   `range`. `enumerate(...)` is unwrapped at this stage so the chosen
+//!   strategy is independent of whether the loop binds `(index, value)` pairs.
+//! - **Per-strategy lowering** ([`ForLoopCompiler::compile_indexed_loop`],
+//!   [`compile_positive_range_loop`](ForLoopCompiler::compile_positive_range_loop),
+//!   [`compile_stepped_range_loop`](ForLoopCompiler::compile_stepped_range_loop))
+//!   allocates the registers that must survive across iterations, then hands
+//!   the skeleton three closures that emit the loop condition, the
+//!   per-iteration body prep, and the continue-edge update.
+//! - **Variable binding** ([`compile_loop_bindings`](ForLoopCompiler::compile_loop_bindings))
+//!   normalizes the value/`enumerate` distinction and handles destructuring
+//!   into one, two, or N loop locals.
+//!
+//! Loop-control (`break`/`continue`) targets come from the shared
+//! [`LoopControlStack`]; the nested statement compiler used for the body
+//! pushes the current [`ForLoopPlan`]'s scope so inner statements jump to the
+//! correct states without knowing the lowering strategy.
 
 use waymark_vm_ast_old::{
     Block, Expr, FunctionCall, GlobalFunction, Kwarg, Literal, Span, Spanned,
@@ -242,7 +270,26 @@ where
         }
     }
 
-    /// Compiles a `for` loop that walks an indexable iterable.
+    /// Compiles a `for` loop that walks an arbitrary indexable iterable
+    /// (lists, tuples, strings, etc.) by stepping through `0..len(iterable)`.
+    ///
+    /// The lowering reserves three persistent registers up front:
+    ///
+    /// - `iterable_register` holds the evaluated source so we evaluate the
+    ///   iterable expression exactly once, even when the body mutates locals
+    ///   that the expression depends on.
+    /// - `index_register` is the loop counter, initialized to `0`. It doubles
+    ///   as the enumerate index when the binding is `Enumerate`, which is why
+    ///   no separate enumerate register is allocated and the continue update
+    ///   only increments `index_register`.
+    /// - `length_register` snapshots `len(iterable)` once via
+    ///   [`emit_length`](Self::context). Snapshotting matches Python's `for`
+    ///   semantics and avoids re-emitting the length probe per iteration.
+    ///
+    /// The body prep allocates a per-iteration temporary `item_register`,
+    /// emits `item = iterable[index]`, and routes both `item` and `index`
+    /// through [`compile_loop_bindings`](Self::compile_loop_bindings) so the
+    /// value/enumerate distinction is handled uniformly.
     fn compile_indexed_loop(
         &mut self,
         loop_vars: &[String],
@@ -357,7 +404,31 @@ where
         )
     }
 
-    /// Compiles `range(start, end, step)` loops with runtime sign checks.
+    /// Compiles `range(start, end, step)` loops where the step direction is
+    /// not known until run time.
+    ///
+    /// Python's `range` uses a strict comparison whose direction depends on
+    /// the sign of `step`: positive steps iterate while `current < end`,
+    /// negative steps while `current > end`, and a zero step raises
+    /// `ValueError` (which we model as an immediate `break`, leaving runtime
+    /// validation to the caller). Because `step` is a general expression, we
+    /// can't pick the comparison at compile time, so the condition fans out
+    /// across three bytecode states:
+    ///
+    /// 1. The loop's `condition_state` classifies `sign(step)`: it computes
+    ///    `step > 0` and `step < 0` against a `zero_register`, jumps to the
+    ///    matching bound-check state, and falls through to `break` when the
+    ///    step is zero. The two comparisons live in the same state as a
+    ///    fall-through chain to minimize jumps.
+    /// 2. `positive_condition_state` tests `current < end` and jumps to body
+    ///    or break.
+    /// 3. `negative_condition_state` tests `current > end` and jumps to body
+    ///    or break.
+    ///
+    /// `current_register`, `end_register`, and `step_register` are persistent
+    /// because they are read on every iteration; the continue update mutates
+    /// `current_register` in place via `current += step` (a true binary `Add`
+    /// rather than an immediate, since the step is a runtime value).
     fn compile_stepped_range_loop(
         &mut self,
         loop_vars: &[String],
@@ -505,6 +576,12 @@ where
     }
 
     /// Emits `if cmp(left, right) jump on_true else jump on_false`.
+    ///
+    /// Allocates a fresh temporary register for the boolean comparison result
+    /// rather than reusing one supplied by the caller, since the value is
+    /// consumed immediately by `emit_jump_if` and never read again. The
+    /// trailing unconditional `emit_jump(on_false)` closes the current state
+    /// so callers do not need to terminate it themselves.
     fn emit_compare_and_branch(
         &mut self,
         op: BinaryOpKind,
@@ -535,6 +612,13 @@ where
     }
 
     /// Compiles the loop body and routes fallthrough to the `continue` target.
+    ///
+    /// Pushes the loop's scope onto [`LoopControlStack`] before recursing into
+    /// the nested statement compiler so any `break`/`continue` inside the body
+    /// resolves to this loop's reserved states. After the body finishes, we
+    /// only emit the trailing jump to the continue target when the emitter is
+    /// still active (i.e. the body did not already terminate the current
+    /// state via `return`, an unconditional `break`, or similar).
     fn compile_loop_body<F>(
         &mut self,
         for_loop: &ForLoopPlan,
@@ -563,6 +647,16 @@ where
     }
 
     /// Compiles loop-variable bindings for one iteration.
+    ///
+    /// Dispatches on the binding mode, delegating to
+    /// [`compile_value_bindings`](Self::compile_value_bindings) for plain
+    /// iteration and to
+    /// [`compile_enumerate_bindings`](Self::compile_enumerate_bindings) for
+    /// `enumerate(...)` headers. The `enumerate` path requires an index
+    /// register; the caller is responsible for allocating it via
+    /// [`allocate_enumerate_index_register`](Self::allocate_enumerate_index_register)
+    /// (or, in the indexed-iteration case, reusing the loop counter) before
+    /// invoking this method.
     fn compile_loop_bindings(
         &mut self,
         loop_vars: &[String],
@@ -581,6 +675,16 @@ where
     }
 
     /// Compiles direct or destructured bindings from the current iteration value.
+    ///
+    /// Handles three shapes:
+    ///
+    /// - Zero loop variables (e.g. `for _ in xs` after lowering elides the
+    ///   binding): emit nothing.
+    /// - A single loop variable: bind the value register straight to the
+    ///   local via [`bind_register_to_local`](Self::bind_register_to_local),
+    ///   which elides the copy when the local already aliases the register.
+    /// - Multiple loop variables (tuple destructuring): index into the value
+    ///   register positionally, emitting one `emit_index` per loop local.
     fn compile_value_bindings(
         &mut self,
         loop_vars: &[String],
@@ -614,6 +718,19 @@ where
 
     /// Compiles `enumerate(...)` bindings as either a pair value or destructured
     /// index/value locals.
+    ///
+    /// Mirrors Python's `for x in enumerate(it)` vs `for i, v in enumerate(it)`
+    /// distinction:
+    ///
+    /// - One loop variable: materialize `[index, value]` as a list literal
+    ///   into the local so the user observes the same pair object Python
+    ///   would.
+    /// - Two loop variables: bind `index` and `value` directly, avoiding the
+    ///   list allocation.
+    /// - Three or more: build the pair list into a temporary and reuse
+    ///   [`compile_value_bindings`](Self::compile_value_bindings) to project
+    ///   it. This case is unreachable from well-formed Python but keeps the
+    ///   lowering total instead of panicking on malformed input.
     fn compile_enumerate_bindings(
         &mut self,
         loop_vars: &[String],
@@ -667,6 +784,12 @@ where
 
     /// Binds `source_register` into `name`, copying only when the target local
     /// uses a different register.
+    ///
+    /// The copy elision matters for hot loop variables: when the local was
+    /// freshly declared, the register allocator typically hands back the
+    /// source register itself, in which case the explicit `emit_copy` would
+    /// be a no-op store-then-load. The flow-state update still runs so
+    /// downstream passes see the local as initialized.
     fn bind_register_to_local(&mut self, name: &str, source_register: RegisterId) {
         let target = self
             .context
@@ -692,6 +815,12 @@ where
     }
 
     /// Compiles an expression into the exact target register.
+    ///
+    /// Hints the value compiler with [`ResultTarget::Existing`] so it can emit
+    /// directly into `target_register` when possible, and falls back to a
+    /// trailing `emit_copy` when the compiler had to materialize the value in
+    /// a different register (for example, because the expression evaluated to
+    /// an existing local that the loop must not overwrite).
     fn compile_expr_into_register(
         &mut self,
         expr: &Spanned<Expr>,
@@ -729,6 +858,12 @@ where
     }
 
     /// Emits `target_register = target_register + immediate`.
+    ///
+    /// Used for the constant `+1` step of indexed and positive-range loops,
+    /// as well as the enumerate-index update. The immediate is materialized
+    /// through [`compile_temporary_int_literal`](Self::compile_temporary_int_literal)
+    /// so it goes through the same literal-folding path as any other integer
+    /// literal in the program.
     fn emit_add_assign_immediate(
         &mut self,
         target_register: RegisterId,

--- a/crates/lib/vm-compiler-for-ast-old/src/function/compiler/lowering/for_loop.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/function/compiler/lowering/for_loop.rs
@@ -293,6 +293,24 @@ where
 
     /// Compiles `range(stop)` and `range(start, stop)` loops with implicit
     /// positive step `1`.
+    ///
+    /// This is kept separate from [`Self::compile_stepped_range_loop`] rather
+    /// than dispatched through it with a synthetic `step = 1` because the step
+    /// sign is statically known here. That lets us:
+    ///
+    /// - Skip the runtime sign-classification chain in the condition state
+    ///   (two extra comparisons, two `jump_if`s, the step-zero break edge),
+    ///   plus the two auxiliary `positive_condition_state` /
+    ///   `negative_condition_state` bytecode states they require.
+    /// - Avoid materializing a `step` register and the zero literal used to
+    ///   classify it.
+    /// - Fold the continue-edge update into `emit_add_assign_immediate`, which
+    ///   emits a constant `+1` via a temporary instead of an `Add` against a
+    ///   persistent step register.
+    ///
+    /// The stepped variant could produce equivalent semantics, but only after
+    /// the bytecode pass eliminated the dead negative branch, and we would
+    /// still pay for the extra reserved states.
     fn compile_positive_range_loop(
         &mut self,
         loop_vars: &[String],
@@ -441,12 +459,12 @@ where
     /// Emits the common scaffold shared by every `for` loop lowering.
     ///
     /// The caller supplies three closures:
-    /// * `emit_condition` runs starting in the condition state and must end
+    /// - `emit_condition` runs starting in the condition state and must end
     ///   with control transferred to either the body state or the loop's break
     ///   target via [`emit_compare_and_branch`].
-    /// * `prepare_body` runs at the top of the body state to materialize loop
+    /// - `prepare_body` runs at the top of the body state to materialize loop
     ///   variable bindings before the body block compiles.
-    /// * `emit_continue_update` runs in the continue state and must advance the
+    /// - `emit_continue_update` runs in the continue state and must advance the
     ///   loop state before the skeleton jumps back to the condition.
     fn compile_loop_skeleton<C, B, U>(
         &mut self,

--- a/crates/lib/vm-compiler-for-ast-old/src/function/compiler/lowering/for_loop.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/function/compiler/lowering/for_loop.rs
@@ -1,0 +1,765 @@
+//! For-loop lowering.
+
+use waymark_vm_ast_old::{
+    Block, Expr, FunctionCall, GlobalFunction, Kwarg, Literal, Span, Spanned,
+};
+use waymark_vm_bytecode_core::StateId;
+use waymark_vm_instructions_pureset::BinaryOpKind;
+use waymark_vm_runtime_core::RegisterId;
+
+use super::CompilerContextMut;
+use super::ErrorFor;
+use super::StatementCompiler;
+use super::Unsupported;
+use super::ValueCompiler;
+use super::env::{FlowState, RegisterHandle};
+use super::r#loop::LoopControlStack;
+use super::plan::call::UnsupportedFunctionCall;
+use super::plan::r#loop::ForLoopPlan;
+use super::{Error, LoopControlKind};
+
+/// Lowers `for` loops into bytecode states and register updates.
+pub struct ForLoopCompiler<'borrow, 'table, Spec, Lowering>
+where
+    Spec: waymark_vm_compiler_for_ast_old_core::SpecRequirements,
+    Lowering: waymark_vm_compiler_for_ast_old_core::lowering::FullSet<Spec>,
+{
+    /// Mutable compiler context for for-loop lowering.
+    context: CompilerContextMut<'borrow, 'table, Spec, Lowering>,
+
+    /// Active loop scopes visible to nested statements.
+    loop_control: LoopControlStack,
+}
+
+/// How a `for` loop binds values into its loop variables.
+#[derive(Clone, Copy)]
+enum LoopBinding {
+    /// Bind the current iteration value directly.
+    Value,
+
+    /// Bind an `enumerate(...)` pair of `[index, value]`.
+    Enumerate,
+}
+
+/// Validated loop-source shapes that the lowering path knows how to execute.
+enum ResolvedForLoop<'expr> {
+    /// Iterate an indexable iterable with an optional enumerate binding.
+    Indexed {
+        /// Source iterable expression.
+        iterable: &'expr Spanned<Expr>,
+
+        /// How iteration values bind to loop variables.
+        binding: LoopBinding,
+    },
+
+    /// Iterate a validated `range(...)` header.
+    Range {
+        /// Parsed `range(...)` header.
+        range: RangeLoop<'expr>,
+
+        /// How iteration values bind to loop variables.
+        binding: LoopBinding,
+    },
+}
+
+/// Validated `range(...)` header shapes supported by the compiler.
+enum RangeLoop<'expr> {
+    /// `range(stop)` or `range(start, stop)`.
+    Positive {
+        /// Optional starting value. When omitted the loop starts at `0`.
+        start: Option<&'expr Spanned<Expr>>,
+
+        /// Exclusive loop bound.
+        end: &'expr Spanned<Expr>,
+    },
+
+    /// `range(start, stop, step)`.
+    Stepped {
+        /// Starting value.
+        start: &'expr Spanned<Expr>,
+
+        /// Exclusive loop bound.
+        end: &'expr Spanned<Expr>,
+
+        /// Per-iteration increment or decrement.
+        step: &'expr Spanned<Expr>,
+    },
+}
+
+impl<'expr> ResolvedForLoop<'expr> {
+    /// Classifies the `for` loop header into one lowering strategy.
+    fn build<Spec, Lowering>(
+        iterable: &'expr Spanned<Expr>,
+    ) -> Result<Self, ErrorFor<Spec, Lowering>>
+    where
+        Spec: waymark_vm_compiler_for_ast_old_core::SpecRequirements,
+        Lowering: waymark_vm_compiler_for_ast_old_core::lowering::FullSet<Spec>,
+    {
+        match &iterable.value {
+            Expr::FunctionCall { call } if call.global_function == Some(GlobalFunction::Range) => {
+                Self::range::<Spec, Lowering>(call, LoopBinding::Value)
+            }
+            Expr::FunctionCall { call }
+                if call.global_function == Some(GlobalFunction::Enumerate) =>
+            {
+                Self::enumerate::<Spec, Lowering>(call)
+            }
+            _ => Ok(Self::Indexed {
+                iterable,
+                binding: LoopBinding::Value,
+            }),
+        }
+    }
+
+    /// Validates and classifies a `range(...)` call.
+    fn range<Spec, Lowering>(
+        call: &'expr FunctionCall,
+        binding: LoopBinding,
+    ) -> Result<Self, ErrorFor<Spec, Lowering>>
+    where
+        Spec: waymark_vm_compiler_for_ast_old_core::SpecRequirements,
+        Lowering: waymark_vm_compiler_for_ast_old_core::lowering::FullSet<Spec>,
+    {
+        let function = builtin_call_name(call, "range");
+
+        if !call.kwargs.is_empty() {
+            return Err(Unsupported::FunctionCall {
+                name: function,
+                reason: UnsupportedFunctionCall::KeywordArguments,
+            }
+            .into());
+        }
+
+        let range = match call.args.as_slice() {
+            [] => {
+                return Err(Error::FunctionArityMismatch {
+                    function,
+                    expected: 1,
+                    actual: 0,
+                });
+            }
+            [end] => RangeLoop::Positive { start: None, end },
+            [start, end] => RangeLoop::Positive {
+                start: Some(start),
+                end,
+            },
+            [start, end, step] => RangeLoop::Stepped { start, end, step },
+            _ => {
+                return Err(Error::FunctionArityMismatch {
+                    function,
+                    expected: 3,
+                    actual: call.args.len(),
+                });
+            }
+        };
+
+        Ok(Self::Range { range, binding })
+    }
+
+    /// Validates and classifies an `enumerate(...)` call.
+    fn enumerate<Spec, Lowering>(
+        call: &'expr FunctionCall,
+    ) -> Result<Self, ErrorFor<Spec, Lowering>>
+    where
+        Spec: waymark_vm_compiler_for_ast_old_core::SpecRequirements,
+        Lowering: waymark_vm_compiler_for_ast_old_core::lowering::FullSet<Spec>,
+    {
+        let function = builtin_call_name(call, "enumerate");
+
+        match (call.args.as_slice(), call.kwargs.as_slice()) {
+            ([iterable], []) => {
+                Self::bind_iterable::<Spec, Lowering>(iterable, LoopBinding::Enumerate)
+            }
+            ([], [Kwarg { name, value }]) if name == "items" => {
+                Self::bind_iterable::<Spec, Lowering>(value, LoopBinding::Enumerate)
+            }
+            (args, []) => Err(Error::FunctionArityMismatch {
+                function,
+                expected: 1,
+                actual: args.len(),
+            }),
+            _ => Err(Unsupported::FunctionCall {
+                name: function,
+                reason: UnsupportedFunctionCall::KeywordArguments,
+            }
+            .into()),
+        }
+    }
+
+    /// Reclassifies the wrapped iterable for `enumerate(...)` loop lowering.
+    fn bind_iterable<Spec, Lowering>(
+        iterable: &'expr Spanned<Expr>,
+        binding: LoopBinding,
+    ) -> Result<Self, ErrorFor<Spec, Lowering>>
+    where
+        Spec: waymark_vm_compiler_for_ast_old_core::SpecRequirements,
+        Lowering: waymark_vm_compiler_for_ast_old_core::lowering::FullSet<Spec>,
+    {
+        match &iterable.value {
+            Expr::FunctionCall { call } if call.global_function == Some(GlobalFunction::Range) => {
+                Self::range::<Spec, Lowering>(call, binding)
+            }
+            _ => Ok(Self::Indexed { iterable, binding }),
+        }
+    }
+}
+
+impl<'borrow, 'table, Spec, Lowering> ForLoopCompiler<'borrow, 'table, Spec, Lowering>
+where
+    Spec: waymark_vm_compiler_for_ast_old_core::SpecRequirements,
+    Lowering: waymark_vm_compiler_for_ast_old_core::lowering::FullSet<Spec>,
+{
+    /// Creates a for-loop compiler over the provided context and loop scope.
+    pub fn new(
+        context: CompilerContextMut<'borrow, 'table, Spec, Lowering>,
+        loop_control: LoopControlStack,
+    ) -> Self {
+        Self {
+            context,
+            loop_control,
+        }
+    }
+
+    /// Compiles a `for` loop using the appropriate validated header shape.
+    pub fn compile(
+        &mut self,
+        loop_vars: &[String],
+        iterable: &Spanned<Expr>,
+        body: &Spanned<Block>,
+    ) -> Result<(), ErrorFor<Spec, Lowering>> {
+        match ResolvedForLoop::build::<Spec, Lowering>(iterable)? {
+            ResolvedForLoop::Indexed { iterable, binding } => {
+                self.compile_indexed_loop(loop_vars, iterable, body, binding)
+            }
+            ResolvedForLoop::Range {
+                range: RangeLoop::Positive { start, end },
+                binding,
+            } => self.compile_positive_range_loop(loop_vars, start, end, body, binding),
+            ResolvedForLoop::Range {
+                range: RangeLoop::Stepped { start, end, step },
+                binding,
+            } => self.compile_stepped_range_loop(loop_vars, start, end, step, body, binding),
+        }
+    }
+
+    /// Compiles a `for` loop that walks an indexable iterable.
+    fn compile_indexed_loop(
+        &mut self,
+        loop_vars: &[String],
+        iterable: &Spanned<Expr>,
+        body: &Spanned<Block>,
+        binding: LoopBinding,
+    ) -> Result<(), ErrorFor<Spec, Lowering>> {
+        let iterable_register = self.context.local_frame.allocate_register();
+        self.compile_expr_into_register(iterable, iterable_register)?;
+
+        let index_register = self.context.local_frame.allocate_register();
+        self.emit_int_literal_into_register(index_register, 0)?;
+
+        let length_register = self.context.local_frame.allocate_register();
+        self.context
+            .emitter
+            .emit_length(length_register, iterable_register);
+
+        let incoming_flow = self.context.flow_state.clone();
+        let for_loop = ForLoopPlan::new(
+            &incoming_flow,
+            self.new_state(),
+            self.new_state(),
+            self.new_state(),
+            self.new_state(),
+        );
+        let body_loop_scope = for_loop.loop_scope();
+
+        self.context.emitter.emit_jump(for_loop.condition_state());
+
+        self.switch_to_with_flow(for_loop.condition_state(), for_loop.condition_flow());
+        {
+            let condition_register = self.context.local_frame.allocate_temporary_register();
+            self.context.emitter.emit_binary(
+                BinaryOpKind::Lt,
+                condition_register.register(),
+                index_register,
+                length_register,
+            );
+            self.context
+                .emitter
+                .emit_jump_if(for_loop.body_state(), condition_register.register());
+        }
+        self.context
+            .emitter
+            .emit_jump(body_loop_scope.target(LoopControlKind::Break));
+
+        self.compile_loop_body(&for_loop, body, |compiler| {
+            let item_register = compiler.context.local_frame.allocate_temporary_register();
+            compiler.context.emitter.emit_index(
+                item_register.register(),
+                iterable_register,
+                index_register,
+            );
+            compiler.compile_loop_bindings(
+                loop_vars,
+                binding,
+                item_register.register(),
+                Some(index_register),
+            )
+        })?;
+
+        self.switch_to_with_flow(for_loop.continue_state(), for_loop.continue_flow());
+        self.emit_add_assign_immediate(index_register, 1)?;
+        self.context.emitter.emit_jump(for_loop.condition_state());
+
+        let (exit_state, exit_flow) = for_loop.finish();
+        self.switch_to_with_flow(exit_state, exit_flow);
+
+        Ok(())
+    }
+
+    /// Compiles `range(stop)` and `range(start, stop)` loops with implicit
+    /// positive step `1`.
+    fn compile_positive_range_loop(
+        &mut self,
+        loop_vars: &[String],
+        start: Option<&Spanned<Expr>>,
+        end: &Spanned<Expr>,
+        body: &Spanned<Block>,
+        binding: LoopBinding,
+    ) -> Result<(), ErrorFor<Spec, Lowering>> {
+        let current_register = self.context.local_frame.allocate_register();
+        match start {
+            Some(start) => self.compile_expr_into_register(start, current_register)?,
+            None => self.emit_int_literal_into_register(current_register, 0)?,
+        }
+
+        let end_register = self.context.local_frame.allocate_register();
+        self.compile_expr_into_register(end, end_register)?;
+
+        let enumerate_index_register = self.allocate_enumerate_index_register(binding)?;
+
+        let incoming_flow = self.context.flow_state.clone();
+        let for_loop = ForLoopPlan::new(
+            &incoming_flow,
+            self.new_state(),
+            self.new_state(),
+            self.new_state(),
+            self.new_state(),
+        );
+        let body_loop_scope = for_loop.loop_scope();
+
+        self.context.emitter.emit_jump(for_loop.condition_state());
+
+        self.switch_to_with_flow(for_loop.condition_state(), for_loop.condition_flow());
+        {
+            let condition_register = self.context.local_frame.allocate_temporary_register();
+            self.context.emitter.emit_binary(
+                BinaryOpKind::Lt,
+                condition_register.register(),
+                current_register,
+                end_register,
+            );
+            self.context
+                .emitter
+                .emit_jump_if(for_loop.body_state(), condition_register.register());
+        }
+        self.context
+            .emitter
+            .emit_jump(body_loop_scope.target(LoopControlKind::Break));
+
+        self.compile_loop_body(&for_loop, body, |compiler| {
+            compiler.compile_loop_bindings(
+                loop_vars,
+                binding,
+                current_register,
+                enumerate_index_register,
+            )
+        })?;
+
+        self.switch_to_with_flow(for_loop.continue_state(), for_loop.continue_flow());
+        self.emit_add_assign_immediate(current_register, 1)?;
+        if let Some(enumerate_index_register) = enumerate_index_register {
+            self.emit_add_assign_immediate(enumerate_index_register, 1)?;
+        }
+        self.context.emitter.emit_jump(for_loop.condition_state());
+
+        let (exit_state, exit_flow) = for_loop.finish();
+        self.switch_to_with_flow(exit_state, exit_flow);
+
+        Ok(())
+    }
+
+    /// Compiles `range(start, end, step)` loops with runtime sign checks.
+    fn compile_stepped_range_loop(
+        &mut self,
+        loop_vars: &[String],
+        start: &Spanned<Expr>,
+        end: &Spanned<Expr>,
+        step: &Spanned<Expr>,
+        body: &Spanned<Block>,
+        binding: LoopBinding,
+    ) -> Result<(), ErrorFor<Spec, Lowering>> {
+        let current_register = self.context.local_frame.allocate_register();
+        self.compile_expr_into_register(start, current_register)?;
+
+        let end_register = self.context.local_frame.allocate_register();
+        self.compile_expr_into_register(end, end_register)?;
+
+        let step_register = self.context.local_frame.allocate_register();
+        self.compile_expr_into_register(step, step_register)?;
+
+        let enumerate_index_register = self.allocate_enumerate_index_register(binding)?;
+
+        let incoming_flow = self.context.flow_state.clone();
+        let condition_state = self.new_state();
+        let positive_condition_state = self.new_state();
+        let negative_condition_state = self.new_state();
+        let body_state = self.new_state();
+        let continue_state = self.new_state();
+        let exit_state = self.new_state();
+        let for_loop = ForLoopPlan::new(
+            &incoming_flow,
+            condition_state,
+            body_state,
+            continue_state,
+            exit_state,
+        );
+        let body_loop_scope = for_loop.loop_scope();
+
+        self.context.emitter.emit_jump(for_loop.condition_state());
+
+        self.switch_to_with_flow(for_loop.condition_state(), for_loop.condition_flow());
+        {
+            let zero_register = self.compile_temporary_int_literal(0)?;
+            let positive_register = self.context.local_frame.allocate_temporary_register();
+            self.context.emitter.emit_binary(
+                BinaryOpKind::Gt,
+                positive_register.register(),
+                step_register,
+                zero_register.register(),
+            );
+            self.context
+                .emitter
+                .emit_jump_if(positive_condition_state, positive_register.register());
+
+            let negative_register = self.context.local_frame.allocate_temporary_register();
+            self.context.emitter.emit_binary(
+                BinaryOpKind::Lt,
+                negative_register.register(),
+                step_register,
+                zero_register.register(),
+            );
+            self.context
+                .emitter
+                .emit_jump_if(negative_condition_state, negative_register.register());
+        }
+        self.context
+            .emitter
+            .emit_jump(body_loop_scope.target(LoopControlKind::Break));
+
+        self.switch_to_with_flow(positive_condition_state, incoming_flow.clone());
+        {
+            let condition_register = self.context.local_frame.allocate_temporary_register();
+            self.context.emitter.emit_binary(
+                BinaryOpKind::Lt,
+                condition_register.register(),
+                current_register,
+                end_register,
+            );
+            self.context
+                .emitter
+                .emit_jump_if(for_loop.body_state(), condition_register.register());
+        }
+        self.context
+            .emitter
+            .emit_jump(body_loop_scope.target(LoopControlKind::Break));
+
+        self.switch_to_with_flow(negative_condition_state, incoming_flow.clone());
+        {
+            let condition_register = self.context.local_frame.allocate_temporary_register();
+            self.context.emitter.emit_binary(
+                BinaryOpKind::Gt,
+                condition_register.register(),
+                current_register,
+                end_register,
+            );
+            self.context
+                .emitter
+                .emit_jump_if(for_loop.body_state(), condition_register.register());
+        }
+        self.context
+            .emitter
+            .emit_jump(body_loop_scope.target(LoopControlKind::Break));
+
+        self.compile_loop_body(&for_loop, body, |compiler| {
+            compiler.compile_loop_bindings(
+                loop_vars,
+                binding,
+                current_register,
+                enumerate_index_register,
+            )
+        })?;
+
+        self.switch_to_with_flow(for_loop.continue_state(), for_loop.continue_flow());
+        self.context.emitter.emit_binary(
+            BinaryOpKind::Add,
+            current_register,
+            current_register,
+            step_register,
+        );
+        if let Some(enumerate_index_register) = enumerate_index_register {
+            self.emit_add_assign_immediate(enumerate_index_register, 1)?;
+        }
+        self.context.emitter.emit_jump(for_loop.condition_state());
+
+        let (exit_state, exit_flow) = for_loop.finish();
+        self.switch_to_with_flow(exit_state, exit_flow);
+
+        Ok(())
+    }
+
+    /// Compiles the loop body and routes fallthrough to the `continue` target.
+    fn compile_loop_body<F>(
+        &mut self,
+        for_loop: &ForLoopPlan,
+        body: &Spanned<Block>,
+        prepare_body: F,
+    ) -> Result<(), ErrorFor<Spec, Lowering>>
+    where
+        F: FnOnce(&mut Self) -> Result<(), ErrorFor<Spec, Lowering>>,
+    {
+        let body_loop_scope = for_loop.loop_scope();
+        let body_loop_control = self.loop_control.with_loop(body_loop_scope);
+
+        self.switch_to_with_flow(for_loop.body_state(), for_loop.body_flow());
+        prepare_body(self)?;
+
+        let mut body_compiler = self.nested_statement_compiler(body_loop_control);
+        body_compiler.compile_block(body)?;
+
+        if self.context.emitter.is_active() {
+            self.context
+                .emitter
+                .emit_jump(body_loop_scope.target(LoopControlKind::Continue));
+        }
+
+        Ok(())
+    }
+
+    /// Compiles loop-variable bindings for one iteration.
+    fn compile_loop_bindings(
+        &mut self,
+        loop_vars: &[String],
+        binding: LoopBinding,
+        value_register: RegisterId,
+        enumerate_index_register: Option<RegisterId>,
+    ) -> Result<(), ErrorFor<Spec, Lowering>> {
+        match binding {
+            LoopBinding::Value => self.compile_value_bindings(loop_vars, value_register),
+            LoopBinding::Enumerate => self.compile_enumerate_bindings(
+                loop_vars,
+                enumerate_index_register.expect("enumerate loops require an index register"),
+                value_register,
+            ),
+        }
+    }
+
+    /// Compiles direct or destructured bindings from the current iteration value.
+    fn compile_value_bindings(
+        &mut self,
+        loop_vars: &[String],
+        value_register: RegisterId,
+    ) -> Result<(), ErrorFor<Spec, Lowering>> {
+        if loop_vars.is_empty() {
+            return Ok(());
+        }
+
+        if loop_vars.len() == 1 {
+            self.bind_register_to_local(&loop_vars[0], value_register);
+            return Ok(());
+        }
+
+        for (index, loop_var) in loop_vars.iter().enumerate() {
+            let index_register = self.compile_temporary_int_literal(index as i64)?;
+            let target = self
+                .context
+                .local_frame
+                .get_or_declare_local(loop_var, self.context.flow_state);
+            self.context.emitter.emit_index(
+                target.register(),
+                value_register,
+                index_register.register(),
+            );
+            self.context.flow_state.mark_initialized(target);
+        }
+
+        Ok(())
+    }
+
+    /// Compiles `enumerate(...)` bindings as either a pair value or destructured
+    /// index/value locals.
+    fn compile_enumerate_bindings(
+        &mut self,
+        loop_vars: &[String],
+        index_register: RegisterId,
+        value_register: RegisterId,
+    ) -> Result<(), ErrorFor<Spec, Lowering>> {
+        if loop_vars.is_empty() {
+            return Ok(());
+        }
+
+        if loop_vars.len() == 1 {
+            let target = self
+                .context
+                .local_frame
+                .get_or_declare_local(&loop_vars[0], self.context.flow_state);
+            self.context
+                .emitter
+                .emit_make_list(target.register(), vec![index_register, value_register]);
+            self.context.flow_state.mark_initialized(target);
+            return Ok(());
+        }
+
+        if loop_vars.len() == 2 {
+            self.bind_register_to_local(&loop_vars[0], index_register);
+            self.bind_register_to_local(&loop_vars[1], value_register);
+            return Ok(());
+        }
+
+        let pair_register = self.context.local_frame.allocate_temporary_register();
+        self.context.emitter.emit_make_list(
+            pair_register.register(),
+            vec![index_register, value_register],
+        );
+        self.compile_value_bindings(loop_vars, pair_register.register())
+    }
+
+    /// Allocates and initializes the enumerate index register when needed.
+    fn allocate_enumerate_index_register(
+        &mut self,
+        binding: LoopBinding,
+    ) -> Result<Option<RegisterId>, ErrorFor<Spec, Lowering>> {
+        match binding {
+            LoopBinding::Value => Ok(None),
+            LoopBinding::Enumerate => {
+                let register = self.context.local_frame.allocate_register();
+                self.emit_int_literal_into_register(register, 0)?;
+                Ok(Some(register))
+            }
+        }
+    }
+
+    /// Binds `source_register` into `name`, copying only when the target local
+    /// uses a different register.
+    fn bind_register_to_local(&mut self, name: &str, source_register: RegisterId) {
+        let target = self
+            .context
+            .local_frame
+            .get_or_declare_local(name, self.context.flow_state);
+        if target.register() != source_register {
+            self.context
+                .emitter
+                .emit_copy(target.register(), source_register);
+        }
+        self.context.flow_state.mark_initialized(target);
+    }
+
+    /// Switches the emitter and flow state to a reserved state id.
+    fn switch_to_with_flow(&mut self, state_id: StateId, flow_state: FlowState) {
+        self.context.emitter.switch_to(state_id);
+        *self.context.flow_state = flow_state;
+    }
+
+    /// Reserves a new bytecode state id.
+    fn new_state(&mut self) -> StateId {
+        self.context.emitter.reserve_state()
+    }
+
+    /// Compiles an expression into the exact target register.
+    fn compile_expr_into_register(
+        &mut self,
+        expr: &Spanned<Expr>,
+        target_register: RegisterId,
+    ) -> Result<(), ErrorFor<Spec, Lowering>> {
+        let value_register = self
+            .value_compiler()
+            .compile_expr(expr, super::value::ResultTarget::Existing(target_register))?;
+        if value_register.register() != target_register {
+            self.context
+                .emitter
+                .emit_copy(target_register, value_register.register());
+        }
+        Ok(())
+    }
+
+    /// Emits an integer literal into the provided persistent register.
+    fn emit_int_literal_into_register(
+        &mut self,
+        target_register: RegisterId,
+        value: i64,
+    ) -> Result<(), ErrorFor<Spec, Lowering>> {
+        self.compile_expr_into_register(&synthetic_int_expr(value), target_register)
+    }
+
+    /// Compiles an integer literal into a temporary register.
+    fn compile_temporary_int_literal(
+        &mut self,
+        value: i64,
+    ) -> Result<RegisterHandle, ErrorFor<Spec, Lowering>> {
+        self.value_compiler().compile_expr(
+            &synthetic_int_expr(value),
+            super::value::ResultTarget::Allocate,
+        )
+    }
+
+    /// Emits `target_register = target_register + immediate`.
+    fn emit_add_assign_immediate(
+        &mut self,
+        target_register: RegisterId,
+        immediate: i64,
+    ) -> Result<(), ErrorFor<Spec, Lowering>> {
+        let immediate_register = self.compile_temporary_int_literal(immediate)?;
+        self.context.emitter.emit_binary(
+            BinaryOpKind::Add,
+            target_register,
+            target_register,
+            immediate_register.register(),
+        );
+        Ok(())
+    }
+
+    /// Creates a value compiler borrowing the current context.
+    fn value_compiler(&mut self) -> ValueCompiler<'_, 'table, Spec, Lowering> {
+        ValueCompiler::new(self.context.reborrow_ref())
+    }
+
+    /// Creates a nested statement compiler with derived loop-control scope.
+    fn nested_statement_compiler(
+        &mut self,
+        loop_control: LoopControlStack,
+    ) -> StatementCompiler<'_, 'table, Spec, Lowering> {
+        StatementCompiler::new(self.context.reborrow_mut(), loop_control)
+    }
+}
+
+/// Returns a stable function name for built-ins parsed without a textual name.
+fn builtin_call_name(call: &FunctionCall, fallback: &str) -> String {
+    if call.name.is_empty() {
+        return fallback.to_owned();
+    }
+
+    call.name.clone()
+}
+
+/// Creates a synthetic integer literal expression for compiler-internal lowering.
+fn synthetic_int_expr(value: i64) -> Spanned<Expr> {
+    Spanned {
+        value: Expr::Literal {
+            value: Literal::Int(value),
+        },
+        span: Span {
+            start_line: 0,
+            start_col: 0,
+            end_line: 0,
+            end_col: 0,
+        },
+    }
+}

--- a/crates/lib/vm-compiler-for-ast-old/src/function/compiler/lowering/for_loop.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/function/compiler/lowering/for_loop.rs
@@ -261,58 +261,34 @@ where
             .emitter
             .emit_length(length_register, iterable_register);
 
-        let incoming_flow = self.context.flow_state.clone();
-        let for_loop = ForLoopPlan::new(
-            &incoming_flow,
-            self.new_state(),
-            self.new_state(),
-            self.new_state(),
-            self.new_state(),
-        );
-        let body_loop_scope = for_loop.loop_scope();
-
-        self.context.emitter.emit_jump(for_loop.condition_state());
-
-        self.switch_to_with_flow(for_loop.condition_state(), for_loop.condition_flow());
-        {
-            let condition_register = self.context.local_frame.allocate_temporary_register();
-            self.context.emitter.emit_binary(
-                BinaryOpKind::Lt,
-                condition_register.register(),
-                index_register,
-                length_register,
-            );
-            self.context
-                .emitter
-                .emit_jump_if(for_loop.body_state(), condition_register.register());
-        }
-        self.context
-            .emitter
-            .emit_jump(body_loop_scope.target(LoopControlKind::Break));
-
-        self.compile_loop_body(&for_loop, body, |compiler| {
-            let item_register = compiler.context.local_frame.allocate_temporary_register();
-            compiler.context.emitter.emit_index(
-                item_register.register(),
-                iterable_register,
-                index_register,
-            );
-            compiler.compile_loop_bindings(
-                loop_vars,
-                binding,
-                item_register.register(),
-                Some(index_register),
-            )
-        })?;
-
-        self.switch_to_with_flow(for_loop.continue_state(), for_loop.continue_flow());
-        self.emit_add_assign_immediate(index_register, 1)?;
-        self.context.emitter.emit_jump(for_loop.condition_state());
-
-        let (exit_state, exit_flow) = for_loop.finish();
-        self.switch_to_with_flow(exit_state, exit_flow);
-
-        Ok(())
+        self.compile_loop_skeleton(
+            body,
+            |compiler, for_loop| {
+                compiler.emit_compare_and_branch(
+                    BinaryOpKind::Lt,
+                    index_register,
+                    length_register,
+                    for_loop.body_state(),
+                    for_loop.loop_scope().target(LoopControlKind::Break),
+                );
+                Ok(())
+            },
+            |compiler| {
+                let item_register = compiler.context.local_frame.allocate_temporary_register();
+                compiler.context.emitter.emit_index(
+                    item_register.register(),
+                    iterable_register,
+                    index_register,
+                );
+                compiler.compile_loop_bindings(
+                    loop_vars,
+                    binding,
+                    item_register.register(),
+                    Some(index_register),
+                )
+            },
+            |compiler| compiler.emit_add_assign_immediate(index_register, 1),
+        )
     }
 
     /// Compiles `range(stop)` and `range(start, stop)` loops with implicit
@@ -336,55 +312,31 @@ where
 
         let enumerate_index_register = self.allocate_enumerate_index_register(binding)?;
 
-        let incoming_flow = self.context.flow_state.clone();
-        let for_loop = ForLoopPlan::new(
-            &incoming_flow,
-            self.new_state(),
-            self.new_state(),
-            self.new_state(),
-            self.new_state(),
-        );
-        let body_loop_scope = for_loop.loop_scope();
-
-        self.context.emitter.emit_jump(for_loop.condition_state());
-
-        self.switch_to_with_flow(for_loop.condition_state(), for_loop.condition_flow());
-        {
-            let condition_register = self.context.local_frame.allocate_temporary_register();
-            self.context.emitter.emit_binary(
-                BinaryOpKind::Lt,
-                condition_register.register(),
-                current_register,
-                end_register,
-            );
-            self.context
-                .emitter
-                .emit_jump_if(for_loop.body_state(), condition_register.register());
-        }
-        self.context
-            .emitter
-            .emit_jump(body_loop_scope.target(LoopControlKind::Break));
-
-        self.compile_loop_body(&for_loop, body, |compiler| {
-            compiler.compile_loop_bindings(
-                loop_vars,
-                binding,
-                current_register,
-                enumerate_index_register,
-            )
-        })?;
-
-        self.switch_to_with_flow(for_loop.continue_state(), for_loop.continue_flow());
-        self.emit_add_assign_immediate(current_register, 1)?;
-        if let Some(enumerate_index_register) = enumerate_index_register {
-            self.emit_add_assign_immediate(enumerate_index_register, 1)?;
-        }
-        self.context.emitter.emit_jump(for_loop.condition_state());
-
-        let (exit_state, exit_flow) = for_loop.finish();
-        self.switch_to_with_flow(exit_state, exit_flow);
-
-        Ok(())
+        self.compile_loop_skeleton(
+            body,
+            |compiler, for_loop| {
+                compiler.emit_compare_and_branch(
+                    BinaryOpKind::Lt,
+                    current_register,
+                    end_register,
+                    for_loop.body_state(),
+                    for_loop.loop_scope().target(LoopControlKind::Break),
+                );
+                Ok(())
+            },
+            |compiler| {
+                compiler.compile_loop_bindings(
+                    loop_vars,
+                    binding,
+                    current_register,
+                    enumerate_index_register,
+                )
+            },
+            |compiler| {
+                compiler.emit_add_assign_immediate(current_register, 1)?;
+                compiler.emit_enumerate_increment(enumerate_index_register)
+            },
+        )
     }
 
     /// Compiles `range(start, end, step)` loops with runtime sign checks.
@@ -408,111 +360,159 @@ where
 
         let enumerate_index_register = self.allocate_enumerate_index_register(binding)?;
 
-        let incoming_flow = self.context.flow_state.clone();
-        let condition_state = self.new_state();
         let positive_condition_state = self.new_state();
         let negative_condition_state = self.new_state();
-        let body_state = self.new_state();
-        let continue_state = self.new_state();
-        let exit_state = self.new_state();
+
+        self.compile_loop_skeleton(
+            body,
+            |compiler, for_loop| {
+                let break_target = for_loop.loop_scope().target(LoopControlKind::Break);
+                let incoming_flow = for_loop.condition_flow();
+
+                // In the condition state, classify the step sign as a
+                // fall-through chain so we route to the matching bound check
+                // (or to break when the step is zero) in a single state.
+                let zero_register = compiler.compile_temporary_int_literal(0)?;
+                let positive_register = compiler.context.local_frame.allocate_temporary_register();
+                compiler.context.emitter.emit_binary(
+                    BinaryOpKind::Gt,
+                    positive_register.register(),
+                    step_register,
+                    zero_register.register(),
+                );
+                compiler
+                    .context
+                    .emitter
+                    .emit_jump_if(positive_condition_state, positive_register.register());
+
+                let negative_register = compiler.context.local_frame.allocate_temporary_register();
+                compiler.context.emitter.emit_binary(
+                    BinaryOpKind::Lt,
+                    negative_register.register(),
+                    step_register,
+                    zero_register.register(),
+                );
+                compiler
+                    .context
+                    .emitter
+                    .emit_jump_if(negative_condition_state, negative_register.register());
+                compiler.context.emitter.emit_jump(break_target);
+
+                compiler.switch_to_with_flow(positive_condition_state, incoming_flow.clone());
+                compiler.emit_compare_and_branch(
+                    BinaryOpKind::Lt,
+                    current_register,
+                    end_register,
+                    for_loop.body_state(),
+                    break_target,
+                );
+
+                compiler.switch_to_with_flow(negative_condition_state, incoming_flow);
+                compiler.emit_compare_and_branch(
+                    BinaryOpKind::Gt,
+                    current_register,
+                    end_register,
+                    for_loop.body_state(),
+                    break_target,
+                );
+
+                Ok(())
+            },
+            |compiler| {
+                compiler.compile_loop_bindings(
+                    loop_vars,
+                    binding,
+                    current_register,
+                    enumerate_index_register,
+                )
+            },
+            |compiler| {
+                compiler.context.emitter.emit_binary(
+                    BinaryOpKind::Add,
+                    current_register,
+                    current_register,
+                    step_register,
+                );
+                compiler.emit_enumerate_increment(enumerate_index_register)
+            },
+        )
+    }
+
+    /// Emits the common scaffold shared by every `for` loop lowering.
+    ///
+    /// The caller supplies three closures:
+    /// * `emit_condition` runs starting in the condition state and must end
+    ///   with control transferred to either the body state or the loop's break
+    ///   target via [`emit_compare_and_branch`].
+    /// * `prepare_body` runs at the top of the body state to materialize loop
+    ///   variable bindings before the body block compiles.
+    /// * `emit_continue_update` runs in the continue state and must advance the
+    ///   loop state before the skeleton jumps back to the condition.
+    fn compile_loop_skeleton<C, B, U>(
+        &mut self,
+        body: &Spanned<Block>,
+        emit_condition: C,
+        prepare_body: B,
+        emit_continue_update: U,
+    ) -> Result<(), ErrorFor<Spec, Lowering>>
+    where
+        C: FnOnce(&mut Self, &ForLoopPlan) -> Result<(), ErrorFor<Spec, Lowering>>,
+        B: FnOnce(&mut Self) -> Result<(), ErrorFor<Spec, Lowering>>,
+        U: FnOnce(&mut Self) -> Result<(), ErrorFor<Spec, Lowering>>,
+    {
+        let incoming_flow = self.context.flow_state.clone();
         let for_loop = ForLoopPlan::new(
             &incoming_flow,
-            condition_state,
-            body_state,
-            continue_state,
-            exit_state,
+            self.new_state(),
+            self.new_state(),
+            self.new_state(),
+            self.new_state(),
         );
-        let body_loop_scope = for_loop.loop_scope();
 
         self.context.emitter.emit_jump(for_loop.condition_state());
 
         self.switch_to_with_flow(for_loop.condition_state(), for_loop.condition_flow());
-        {
-            let zero_register = self.compile_temporary_int_literal(0)?;
-            let positive_register = self.context.local_frame.allocate_temporary_register();
-            self.context.emitter.emit_binary(
-                BinaryOpKind::Gt,
-                positive_register.register(),
-                step_register,
-                zero_register.register(),
-            );
-            self.context
-                .emitter
-                .emit_jump_if(positive_condition_state, positive_register.register());
+        emit_condition(self, &for_loop)?;
 
-            let negative_register = self.context.local_frame.allocate_temporary_register();
-            self.context.emitter.emit_binary(
-                BinaryOpKind::Lt,
-                negative_register.register(),
-                step_register,
-                zero_register.register(),
-            );
-            self.context
-                .emitter
-                .emit_jump_if(negative_condition_state, negative_register.register());
-        }
-        self.context
-            .emitter
-            .emit_jump(body_loop_scope.target(LoopControlKind::Break));
-
-        self.switch_to_with_flow(positive_condition_state, incoming_flow.clone());
-        {
-            let condition_register = self.context.local_frame.allocate_temporary_register();
-            self.context.emitter.emit_binary(
-                BinaryOpKind::Lt,
-                condition_register.register(),
-                current_register,
-                end_register,
-            );
-            self.context
-                .emitter
-                .emit_jump_if(for_loop.body_state(), condition_register.register());
-        }
-        self.context
-            .emitter
-            .emit_jump(body_loop_scope.target(LoopControlKind::Break));
-
-        self.switch_to_with_flow(negative_condition_state, incoming_flow.clone());
-        {
-            let condition_register = self.context.local_frame.allocate_temporary_register();
-            self.context.emitter.emit_binary(
-                BinaryOpKind::Gt,
-                condition_register.register(),
-                current_register,
-                end_register,
-            );
-            self.context
-                .emitter
-                .emit_jump_if(for_loop.body_state(), condition_register.register());
-        }
-        self.context
-            .emitter
-            .emit_jump(body_loop_scope.target(LoopControlKind::Break));
-
-        self.compile_loop_body(&for_loop, body, |compiler| {
-            compiler.compile_loop_bindings(
-                loop_vars,
-                binding,
-                current_register,
-                enumerate_index_register,
-            )
-        })?;
+        self.compile_loop_body(&for_loop, body, prepare_body)?;
 
         self.switch_to_with_flow(for_loop.continue_state(), for_loop.continue_flow());
-        self.context.emitter.emit_binary(
-            BinaryOpKind::Add,
-            current_register,
-            current_register,
-            step_register,
-        );
-        if let Some(enumerate_index_register) = enumerate_index_register {
-            self.emit_add_assign_immediate(enumerate_index_register, 1)?;
-        }
+        emit_continue_update(self)?;
         self.context.emitter.emit_jump(for_loop.condition_state());
 
         let (exit_state, exit_flow) = for_loop.finish();
         self.switch_to_with_flow(exit_state, exit_flow);
 
+        Ok(())
+    }
+
+    /// Emits `if cmp(left, right) jump on_true else jump on_false`.
+    fn emit_compare_and_branch(
+        &mut self,
+        op: BinaryOpKind,
+        left: RegisterId,
+        right: RegisterId,
+        on_true: StateId,
+        on_false: StateId,
+    ) {
+        let condition_register = self.context.local_frame.allocate_temporary_register();
+        self.context
+            .emitter
+            .emit_binary(op, condition_register.register(), left, right);
+        self.context
+            .emitter
+            .emit_jump_if(on_true, condition_register.register());
+        self.context.emitter.emit_jump(on_false);
+    }
+
+    /// Increments the enumerate-index register by one if enumeration is in use.
+    fn emit_enumerate_increment(
+        &mut self,
+        enumerate_index_register: Option<RegisterId>,
+    ) -> Result<(), ErrorFor<Spec, Lowering>> {
+        if let Some(register) = enumerate_index_register {
+            self.emit_add_assign_immediate(register, 1)?;
+        }
         Ok(())
     }
 

--- a/crates/lib/vm-compiler-for-ast-old/src/function/compiler/lowering/for_loop.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/function/compiler/lowering/for_loop.rs
@@ -1,32 +1,22 @@
 //! For-loop lowering.
 //!
-//! `for` loops are lowered into a four-state bytecode skeleton modeled by
-//! [`ForLoopPlan`]: a `condition` state, a `body` state, a `continue` state
-//! (the target of `continue` statements and the natural fallthrough at the end
-//! of the body), and an `exit` state (the target of `break`). All variants
-//! share that shape and reach it through [`ForLoopCompiler::compile_loop_skeleton`],
-//! which lets each header shape contribute only the parts that actually
-//! differ:
+//! # Shared skeleton
 //!
-//! - **Header classification** ([`ResolvedForLoop`]) inspects the iterable
-//!   expression and decides between three lowering strategies: walking an
-//!   indexable value, a positive-step `range`, or a runtime-signed-step
-//!   `range`. `enumerate(...)` is unwrapped at this stage so the chosen
-//!   strategy is independent of whether the loop binds `(index, value)` pairs.
-//! - **Per-strategy lowering** ([`ForLoopCompiler::compile_indexed_loop`],
-//!   [`compile_positive_range_loop`](ForLoopCompiler::compile_positive_range_loop),
-//!   [`compile_stepped_range_loop`](ForLoopCompiler::compile_stepped_range_loop))
-//!   allocates the registers that must survive across iterations, then hands
-//!   the skeleton three closures that emit the loop condition, the
-//!   per-iteration body prep, and the continue-edge update.
-//! - **Variable binding** ([`compile_loop_bindings`](ForLoopCompiler::compile_loop_bindings))
-//!   normalizes the value/`enumerate` distinction and handles destructuring
-//!   into one, two, or N loop locals.
+//! All `for` loops share one four-state skeleton (condition, body, continue,
+//! exit) so that `break`/`continue` resolution and flow-state plumbing stay
+//! in one place.
 //!
-//! Loop-control (`break`/`continue`) targets come from the shared
-//! [`LoopControlStack`]; the nested statement compiler used for the body
-//! pushes the current [`ForLoopPlan`]'s scope so inner statements jump to the
-//! correct states without knowing the lowering strategy.
+//! # Header variants
+//!
+//! Header variants exist only where they let cheaper cases skip machinery
+//! the expensive ones need. In particular, a runtime-signed `range` step is
+//! the only thing that forces extra condition states, so statically-known
+//! steps get their own path.
+//!
+//! # Enumerate
+//!
+//! `enumerate(...)` is unwrapped during header classification to keep
+//! iteration mechanics independent of variable-binding shape.
 
 use waymark_vm_ast_old::{
     Block, Expr, FunctionCall, GlobalFunction, Kwarg, Literal, Span, Spanned,

--- a/crates/lib/vm-compiler-for-ast-old/src/function/compiler/lowering/statement.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/function/compiler/lowering/statement.rs
@@ -4,6 +4,7 @@ use waymark_vm_ast_old::{Block, ElifBranch, ElseBranch, Expr, IfBranch, Spanned,
 
 use super::AssignmentCompiler;
 use super::CompilerContextMut;
+use super::ForLoopCompiler;
 use super::ParallelCompiler;
 use super::ValueCompiler;
 use super::conditional::{ConditionalJoin, ConditionalJoinFinish};
@@ -102,6 +103,13 @@ where
             }
             StatementPlan::WhileLoop { condition, body } => {
                 self.compile_while_loop(condition, body)?;
+            }
+            StatementPlan::ForLoop {
+                loop_vars,
+                iterable,
+                body,
+            } => {
+                self.compile_for_loop(loop_vars, iterable, body)?;
             }
             StatementPlan::Conditional {
                 if_branch,
@@ -255,6 +263,17 @@ where
         Ok(())
     }
 
+    /// Compiles a `for` loop over a generic iterable, `range(...)`, or
+    /// `enumerate(...)`.
+    fn compile_for_loop(
+        &mut self,
+        loop_vars: &[String],
+        iterable: &Spanned<Expr>,
+        body: &Spanned<Block>,
+    ) -> Result<(), ErrorFor<Spec, Lowering>> {
+        self.for_loop_compiler().compile(loop_vars, iterable, body)
+    }
+
     /// Compiles a `break` statement.
     fn compile_break(&mut self) -> Result<(), ErrorFor<Spec, Lowering>> {
         self.compile_loop_control(LoopControlKind::Break)
@@ -307,6 +326,11 @@ where
     /// Creates a value compiler borrowing the current context.
     fn value_compiler(&mut self) -> ValueCompiler<'_, 'table, Spec, Lowering> {
         ValueCompiler::new(self.context.reborrow_ref())
+    }
+
+    /// Creates a for-loop compiler borrowing the current context mutably.
+    fn for_loop_compiler(&mut self) -> ForLoopCompiler<'_, 'table, Spec, Lowering> {
+        ForLoopCompiler::new(self.context.reborrow_mut(), self.loop_control.clone())
     }
 
     /// Creates an assignment compiler borrowing the current context mutably.

--- a/crates/lib/vm-compiler-for-ast-old/src/function/compiler/plan/loop.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/function/compiler/plan/loop.rs
@@ -19,6 +19,24 @@ pub struct WhileLoopPlan {
     exit_state: StateId,
 }
 
+/// Reserved state ids and flow data for lowering one `for` loop.
+pub struct ForLoopPlan {
+    /// Flow state entering the loop.
+    incoming_flow: FlowState,
+
+    /// State where the loop condition is evaluated.
+    condition_state: StateId,
+
+    /// State where the loop body begins.
+    body_state: StateId,
+
+    /// State reached by `continue` before re-checking the loop condition.
+    continue_state: StateId,
+
+    /// State reached when the loop exits.
+    exit_state: StateId,
+}
+
 impl WhileLoopPlan {
     /// Creates a loop plan from the reserved condition, body, and exit states.
     pub fn new(
@@ -66,6 +84,66 @@ impl WhileLoopPlan {
     }
 }
 
+impl ForLoopPlan {
+    /// Creates a loop plan from the reserved condition, body, continue, and
+    /// exit states.
+    pub fn new(
+        incoming_flow: &FlowState,
+        condition_state: StateId,
+        body_state: StateId,
+        continue_state: StateId,
+        exit_state: StateId,
+    ) -> Self {
+        Self {
+            incoming_flow: incoming_flow.clone(),
+            condition_state,
+            body_state,
+            continue_state,
+            exit_state,
+        }
+    }
+
+    /// Returns the condition-state id.
+    pub fn condition_state(&self) -> StateId {
+        self.condition_state
+    }
+
+    /// Returns the body-state id.
+    pub fn body_state(&self) -> StateId {
+        self.body_state
+    }
+
+    /// Returns the continue-state id.
+    pub fn continue_state(&self) -> StateId {
+        self.continue_state
+    }
+
+    /// Returns the loop-control scope used for `break` and `continue`.
+    pub fn loop_scope(&self) -> crate::function::compiler::r#loop::LoopScope {
+        crate::function::compiler::r#loop::LoopScope::new(self.exit_state, self.continue_state)
+    }
+
+    /// Returns the flow state to use when evaluating the condition.
+    pub fn condition_flow(&self) -> FlowState {
+        self.incoming_flow.clone()
+    }
+
+    /// Returns the flow state to use when entering the body.
+    pub fn body_flow(&self) -> FlowState {
+        self.incoming_flow.clone()
+    }
+
+    /// Returns the flow state to use when executing the continue target.
+    pub fn continue_flow(&self) -> FlowState {
+        self.incoming_flow.clone()
+    }
+
+    /// Returns the exit state and restored incoming flow for loop exit.
+    pub fn finish(self) -> (StateId, FlowState) {
+        (self.exit_state, self.incoming_flow)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -100,6 +178,39 @@ mod tests {
 
         let (exit_state, exit_flow) = while_loop.finish();
         assert_eq!(exit_state, StateId(6));
+        assert!(exit_flow.is_initialized(shared));
+    }
+
+    #[test]
+    fn for_loop_plan_restores_incoming_flow_at_exit() {
+        let mut locals = Locals::new();
+        let shared = locals
+            .declare("shared".to_owned(), RegisterId(0))
+            .expect("shared local should declare");
+
+        let mut incoming_flow = FlowState::new();
+        incoming_flow.mark_initialized(shared);
+
+        let for_loop = ForLoopPlan::new(
+            &incoming_flow,
+            StateId(4),
+            StateId(5),
+            StateId(6),
+            StateId(7),
+        );
+        let loop_scope = for_loop.loop_scope();
+
+        assert_eq!(for_loop.condition_state(), StateId(4));
+        assert_eq!(for_loop.body_state(), StateId(5));
+        assert_eq!(for_loop.continue_state(), StateId(6));
+        assert_eq!(loop_scope.target(LoopControlKind::Break), StateId(7));
+        assert_eq!(loop_scope.target(LoopControlKind::Continue), StateId(6));
+        assert!(for_loop.condition_flow().is_initialized(shared));
+        assert!(for_loop.body_flow().is_initialized(shared));
+        assert!(for_loop.continue_flow().is_initialized(shared));
+
+        let (exit_state, exit_flow) = for_loop.finish();
+        assert_eq!(exit_state, StateId(7));
         assert!(exit_flow.is_initialized(shared));
     }
 }

--- a/crates/lib/vm-compiler-for-ast-old/src/function/compiler/plan/statement.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/function/compiler/plan/statement.rs
@@ -64,6 +64,18 @@ where
         body: &'a Spanned<Block>,
     },
 
+    /// A `for` loop.
+    ForLoop {
+        /// Loop variables bound on each iteration.
+        loop_vars: &'a [String],
+
+        /// Iterable expression evaluated by the loop.
+        iterable: &'a Spanned<Expr>,
+
+        /// Loop body.
+        body: &'a Spanned<Block>,
+    },
+
     /// An `if`/`elif`/`else` chain.
     Conditional {
         /// Primary `if` branch.
@@ -88,9 +100,6 @@ where
 pub enum UnsupportedStatementKind {
     /// Spread-action statements.
     SpreadAction,
-
-    /// `for` loops.
-    ForLoop,
 
     /// `try`/`except` blocks.
     TryExcept,
@@ -120,6 +129,15 @@ where
                 calls: build_parallel_call_plans::<Spec, Lowering>(calls, function_table)?,
             }),
             Statement::WhileLoop { condition, body } => Ok(Self::WhileLoop { condition, body }),
+            Statement::ForLoop {
+                loop_vars,
+                iterable,
+                body,
+            } => Ok(Self::ForLoop {
+                loop_vars,
+                iterable,
+                body,
+            }),
             Statement::Conditional {
                 if_branch,
                 elif_branches,
@@ -135,10 +153,6 @@ where
                 kind: UnsupportedStatementKind::SpreadAction,
             }
             .into()),
-            Statement::ForLoop { .. } => Err(Unsupported::Statement {
-                kind: UnsupportedStatementKind::ForLoop,
-            }
-            .into()),
             Statement::TryExcept { .. } => Err(Unsupported::Statement {
                 kind: UnsupportedStatementKind::TryExcept,
             }
@@ -151,7 +165,6 @@ impl core::fmt::Display for UnsupportedStatementKind {
     fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         formatter.write_str(match self {
             Self::SpreadAction => "SpreadAction",
-            Self::ForLoop => "ForLoop",
             Self::TryExcept => "TryExcept",
         })
     }
@@ -164,7 +177,7 @@ mod tests {
     use waymark_vm_ast_old::{Spanned, Statement};
     use waymark_vm_ast_old_helpers::{
         action_call, action_stmt, assignment, block, break_stmt, conditional_stmt, continue_stmt,
-        int, parallel_stmt, return_stmt, sleep_stmt, spanned, variable, while_stmt,
+        for_stmt, int, parallel_stmt, return_stmt, sleep_stmt, spanned, variable, while_stmt,
     };
     use waymark_vm_compiler_for_ast_old_test_support::{TestLowering, TestSpec};
 
@@ -212,6 +225,7 @@ mod tests {
     fn builds_control_flow_statement_plans() {
         let function_table = build_function_table();
         let conditional = conditional_stmt(int(1), vec![return_stmt(None)], Vec::new(), None);
+        let for_loop = for_stmt(&["item"], variable("items"), vec![continue_stmt()]);
         let while_loop = while_stmt(variable("flag"), vec![continue_stmt()]);
         let parallel = parallel_stmt(vec![waymark_vm_ast_old::Call::Action(action_call(
             "notify",
@@ -227,6 +241,11 @@ mod tests {
             StatementPlan::<TestSpec>::build::<TestLowering>(&while_loop.value, &function_table)
                 .expect("while loops should build"),
             StatementPlan::WhileLoop { .. }
+        ));
+        assert!(matches!(
+            StatementPlan::<TestSpec>::build::<TestLowering>(&for_loop.value, &function_table)
+                .expect("for loops should build"),
+            StatementPlan::ForLoop { loop_vars, .. } if loop_vars == ["item".to_owned()]
         ));
         assert!(matches!(
             StatementPlan::<TestSpec>::build::<TestLowering>(&parallel.value, &function_table)
@@ -259,10 +278,6 @@ mod tests {
                     action: action_call("notify", Vec::new()),
                 }),
                 UnsupportedStatementKind::SpreadAction,
-            ),
-            (
-                waymark_vm_ast_old_helpers::for_stmt(&["item"], variable("items"), Vec::new()),
-                UnsupportedStatementKind::ForLoop,
             ),
             (
                 spanned(Statement::TryExcept {

--- a/crates/lib/vm-compiler-for-ast-old/src/lib.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/lib.rs
@@ -8,8 +8,9 @@
 //!
 //! The current compiler intentionally implements only the subset that can be
 //! represented by the existing VM instruction set: literals, variables,
-//! scalar binary and unary operations, simple assignments, conditionals, while loops,
-//! `break`/`continue`, returns, user function calls, and action calls.
+//! scalar binary and unary operations, simple assignments, conditionals, `while`
+//! and `for` loops, `break`/`continue`, returns, user function calls, and
+//! action calls.
 //!
 //! Unsupported statements and expressions are rejected with [`CompileError`]
 //! instead of being lowered to incorrect or lossy bytecode.

--- a/crates/lib/vm-compiler-for-ast-old/src/tests.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/tests.rs
@@ -1,6 +1,6 @@
 use waymark_vm_ast_old::{ActionCall, BinaryOperator, Call, Expr, GlobalFunction, Kwarg, Literal};
 use waymark_vm_ast_old_helpers::{
-    action_call, action_stmt, assignment, assignment_targets, binary_expr, break_stmt,
+    action_call, action_expr, action_stmt, assignment, assignment_targets, binary_expr, break_stmt,
     builtin_function_call, conditional_stmt, continue_stmt, enumerate_expr, float, for_stmt,
     function, int, parallel_expr, program, range_expr, return_stmt, spanned, variable, while_stmt,
 };
@@ -410,6 +410,324 @@ fn compiles_for_loops_over_lists() {
     )]);
 
     compile::<TestSpec, TestLowering>(&program).expect("list for loops should compile");
+}
+
+#[test]
+fn whole_program_async_indexed_for_loops_match_the_documented_lowering_shape() {
+    // Raw code:
+    //
+    //   results = []
+    //   for item in items:
+    //       processed = await process_value(item)
+    //       results.append(processed)
+    //   return results
+    //
+    // VM registers:
+    //
+    //   r0 = input items
+    //   r1 = results
+    //   r2 = iterable snapshot
+    //   r3 = loop index
+    //   r4 = length
+    //   r5 = temp reused for cond/item/+1
+    //   r6 = item local
+    //   r7 = processed promise/value
+    //
+    // VM compilation:
+    //
+    //   S0: results=[], r2=r0, r3=0, r4=len(r2), jump S1
+    //   S1: r5=(r3<r4), if r5 jump S2 else S4
+    //   S2: r5=r2[r3], r6=r5, ActionCall -> resume S5
+    //   S5: Await r7 -> resume S6
+    //   S6: results += [r7], jump S3
+    //   S3: r3=r3+1, jump S1
+    //   S4: return r1
+    //
+    // The old AST does not expose method-call syntax, so the body models
+    // `results.append(processed)` as `results = results + [processed]`.
+    let program = program(vec![function(
+        "main",
+        &["items"],
+        vec![
+            assignment(
+                "results",
+                spanned(Expr::List {
+                    elements: Vec::new(),
+                }),
+            ),
+            for_stmt(
+                &["item"],
+                variable("items"),
+                vec![
+                    assignment(
+                        "processed",
+                        action_expr("process_value", vec![("item", variable("item"))]),
+                    ),
+                    assignment(
+                        "results",
+                        binary_expr(
+                            variable("results"),
+                            BinaryOperator::Add,
+                            spanned(Expr::List {
+                                elements: vec![variable("processed")],
+                            }),
+                        ),
+                    ),
+                ],
+            ),
+            return_stmt(Some(variable("results"))),
+        ],
+    )]);
+
+    let executable = compile::<TestSpec, TestLowering>(&program)
+        .expect("documented async for loop should compile");
+
+    insta::assert_debug_snapshot!(executable, @r###"
+    Executable {
+        functions: [
+            Function {
+                states: [
+                    State {
+                        instructions: [
+                            PureSet(
+                                MakeList {
+                                    dst: RegisterId(
+                                        1,
+                                    ),
+                                    items: [],
+                                },
+                            ),
+                            PureSet(
+                                Copy {
+                                    dst: RegisterId(
+                                        2,
+                                    ),
+                                    src: RegisterId(
+                                        0,
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                LoadConst {
+                                    dst: RegisterId(
+                                        3,
+                                    ),
+                                    value: Int(
+                                        0,
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                Length {
+                                    dst: RegisterId(
+                                        4,
+                                    ),
+                                    src: RegisterId(
+                                        2,
+                                    ),
+                                },
+                            ),
+                            CoreSet(
+                                Jump {
+                                    target_state: StateId(
+                                        1,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            PureSet(
+                                Binary {
+                                    kind: Lt,
+                                    op: BinaryOp {
+                                        dst: RegisterId(
+                                            5,
+                                        ),
+                                        a: RegisterId(
+                                            3,
+                                        ),
+                                        b: RegisterId(
+                                            4,
+                                        ),
+                                    },
+                                },
+                            ),
+                            CoreSet(
+                                JumpIf {
+                                    target_state: StateId(
+                                        2,
+                                    ),
+                                    cond: RegisterId(
+                                        5,
+                                    ),
+                                },
+                            ),
+                            CoreSet(
+                                Jump {
+                                    target_state: StateId(
+                                        4,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            PureSet(
+                                Index {
+                                    dst: RegisterId(
+                                        5,
+                                    ),
+                                    object: RegisterId(
+                                        2,
+                                    ),
+                                    index: RegisterId(
+                                        3,
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                Copy {
+                                    dst: RegisterId(
+                                        6,
+                                    ),
+                                    src: RegisterId(
+                                        5,
+                                    ),
+                                },
+                            ),
+                            ExtCallSet(
+                                ActionCall {
+                                    dst: RegisterId(
+                                        7,
+                                    ),
+                                    action_ref: TestActionRef(
+                                        "process_value",
+                                    ),
+                                    args: [
+                                        RegisterId(
+                                            6,
+                                        ),
+                                    ],
+                                    resume: StateId(
+                                        5,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            PureSet(
+                                LoadConst {
+                                    dst: RegisterId(
+                                        5,
+                                    ),
+                                    value: Int(
+                                        1,
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                Binary {
+                                    kind: Add,
+                                    op: BinaryOp {
+                                        dst: RegisterId(
+                                            3,
+                                        ),
+                                        a: RegisterId(
+                                            3,
+                                        ),
+                                        b: RegisterId(
+                                            5,
+                                        ),
+                                    },
+                                },
+                            ),
+                            CoreSet(
+                                Jump {
+                                    target_state: StateId(
+                                        1,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                Return {
+                                    src: RegisterId(
+                                        1,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                Await {
+                                    dst: RegisterId(
+                                        7,
+                                    ),
+                                    src: RegisterId(
+                                        7,
+                                    ),
+                                    resume: StateId(
+                                        6,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            PureSet(
+                                MakeList {
+                                    dst: RegisterId(
+                                        5,
+                                    ),
+                                    items: [
+                                        RegisterId(
+                                            7,
+                                        ),
+                                    ],
+                                },
+                            ),
+                            PureSet(
+                                Binary {
+                                    kind: Add,
+                                    op: BinaryOp {
+                                        dst: RegisterId(
+                                            1,
+                                        ),
+                                        a: RegisterId(
+                                            1,
+                                        ),
+                                        b: RegisterId(
+                                            5,
+                                        ),
+                                    },
+                                },
+                            ),
+                            CoreSet(
+                                Jump {
+                                    target_state: StateId(
+                                        3,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                ],
+                num_regs: 8,
+            },
+        ],
+    }
+    "###);
 }
 
 #[test]

--- a/crates/lib/vm-compiler-for-ast-old/src/tests.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/tests.rs
@@ -611,6 +611,156 @@ fn rejects_for_loops_over_enumerate_with_mixed_positional_and_keyword_args() {
 }
 
 #[test]
+fn compiles_for_loops_over_single_arg_range() {
+    let program = program(vec![function(
+        "main",
+        &[],
+        vec![
+            assignment("total", int(0)),
+            for_stmt(
+                &["item"],
+                range_expr(vec![int(4)]),
+                vec![assignment(
+                    "total",
+                    binary_expr(variable("total"), BinaryOperator::Add, variable("item")),
+                )],
+            ),
+            return_stmt(Some(variable("total"))),
+        ],
+    )]);
+
+    compile::<TestSpec, TestLowering>(&program).expect("range(stop) for loops should compile");
+}
+
+#[test]
+fn compiles_for_loops_over_stepped_range() {
+    let program = program(vec![function(
+        "main",
+        &[],
+        vec![
+            assignment("total", int(0)),
+            for_stmt(
+                &["item"],
+                range_expr(vec![int(0), int(10), int(2)]),
+                vec![assignment(
+                    "total",
+                    binary_expr(variable("total"), BinaryOperator::Add, variable("item")),
+                )],
+            ),
+            return_stmt(Some(variable("total"))),
+        ],
+    )]);
+
+    compile::<TestSpec, TestLowering>(&program)
+        .expect("range(start, stop, step) for loops should compile");
+}
+
+#[test]
+fn compiles_enumerate_over_stepped_range_for_loops() {
+    let program = program(vec![function(
+        "main",
+        &[],
+        vec![
+            assignment("total", int(0)),
+            for_stmt(
+                &["idx", "item"],
+                enumerate_expr(range_expr(vec![int(10), int(0), int(-2)])),
+                vec![assignment(
+                    "total",
+                    binary_expr(
+                        variable("total"),
+                        BinaryOperator::Add,
+                        binary_expr(variable("idx"), BinaryOperator::Add, variable("item")),
+                    ),
+                )],
+            ),
+            return_stmt(Some(variable("total"))),
+        ],
+    )]);
+
+    compile::<TestSpec, TestLowering>(&program)
+        .expect("enumerated stepped range for loops should compile");
+}
+
+#[test]
+fn compiles_for_loops_binding_enumerate_as_single_pair() {
+    let program = program(vec![function(
+        "main",
+        &["items"],
+        vec![
+            assignment("count", int(0)),
+            for_stmt(
+                &["pair"],
+                enumerate_expr(variable("items")),
+                vec![assignment(
+                    "count",
+                    binary_expr(variable("count"), BinaryOperator::Add, variable("pair")),
+                )],
+            ),
+            return_stmt(Some(variable("count"))),
+        ],
+    )]);
+
+    compile::<TestSpec, TestLowering>(&program)
+        .expect("single-variable enumerate for loops should compile");
+}
+
+#[test]
+fn rejects_for_loops_over_range_with_no_args() {
+    let program = program(vec![function(
+        "main",
+        &[],
+        vec![for_stmt(&["item"], range_expr(Vec::new()), Vec::new())],
+    )]);
+
+    let error = match compile::<TestSpec, TestLowering>(&program) {
+        Ok(_) => panic!("range with no args should fail"),
+        Err(error) => error,
+    };
+
+    assert!(matches!(
+        error,
+        CompileError::FunctionCompiler(compiler::Error::FunctionArityMismatch {
+            function,
+            expected,
+            actual,
+        }) if function == "range" && expected == 1 && actual == 0
+    ));
+}
+
+#[test]
+fn rejects_for_loops_over_range_with_keyword_args() {
+    let mut call = builtin_function_call(GlobalFunction::Range, vec![int(4)]);
+    call.kwargs.push(Kwarg {
+        name: "stop".to_owned(),
+        value: int(10),
+    });
+
+    let program = program(vec![function(
+        "main",
+        &[],
+        vec![for_stmt(
+            &["item"],
+            spanned(Expr::FunctionCall { call }),
+            Vec::new(),
+        )],
+    )]);
+
+    let error = match compile::<TestSpec, TestLowering>(&program) {
+        Ok(_) => panic!("range with keyword args should fail"),
+        Err(error) => error,
+    };
+
+    assert!(matches!(
+        error,
+        CompileError::FunctionCompiler(compiler::Error::Unsupported(
+            compiler::Unsupported::FunctionCall { name, reason }
+        )) if name == "range"
+            && reason == compiler::UnsupportedFunctionCall::KeywordArguments
+    ));
+}
+
+#[test]
 fn rejects_loop_variables_initialized_only_inside_for_loops() {
     let program = program(vec![function(
         "main",

--- a/crates/lib/vm-compiler-for-ast-old/src/tests.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/tests.rs
@@ -1,8 +1,8 @@
-use waymark_vm_ast_old::{ActionCall, Call, Literal};
+use waymark_vm_ast_old::{ActionCall, BinaryOperator, Call, Expr, GlobalFunction, Kwarg, Literal};
 use waymark_vm_ast_old_helpers::{
-    action_call, action_stmt, assignment, assignment_targets, break_stmt, conditional_stmt,
-    continue_stmt, float, for_stmt, function, int, parallel_expr, program, return_stmt, variable,
-    while_stmt,
+    action_call, action_stmt, assignment, assignment_targets, binary_expr, break_stmt,
+    builtin_function_call, conditional_stmt, continue_stmt, enumerate_expr, float, for_stmt,
+    function, int, parallel_expr, program, range_expr, return_stmt, spanned, variable, while_stmt,
 };
 use waymark_vm_compiler_for_ast_old_core::lowering;
 use waymark_vm_compiler_for_ast_old_test_support::{
@@ -391,25 +391,245 @@ fn rejects_variables_initialized_only_inside_while_loops() {
 }
 
 #[test]
-fn rejects_unsupported_for_loops() {
+fn compiles_for_loops_over_lists() {
+    let program = program(vec![function(
+        "main",
+        &["items"],
+        vec![
+            assignment("total", int(0)),
+            for_stmt(
+                &["item"],
+                variable("items"),
+                vec![assignment(
+                    "total",
+                    binary_expr(variable("total"), BinaryOperator::Add, variable("item")),
+                )],
+            ),
+            return_stmt(Some(variable("total"))),
+        ],
+    )]);
+
+    compile::<TestSpec, TestLowering>(&program).expect("list for loops should compile");
+}
+
+#[test]
+fn compiles_for_loops_over_range() {
     let program = program(vec![function(
         "main",
         &[],
-        vec![for_stmt(&["item"], int(1), vec![])],
+        vec![
+            assignment("total", int(0)),
+            for_stmt(
+                &["item"],
+                range_expr(vec![int(1), int(4)]),
+                vec![assignment(
+                    "total",
+                    binary_expr(variable("total"), BinaryOperator::Add, variable("item")),
+                )],
+            ),
+            return_stmt(Some(variable("total"))),
+        ],
+    )]);
+
+    compile::<TestSpec, TestLowering>(&program).expect("range for loops should compile");
+}
+
+#[test]
+fn compiles_for_loops_over_enumerate() {
+    let program = program(vec![function(
+        "main",
+        &["items"],
+        vec![
+            assignment("total", int(0)),
+            for_stmt(
+                &["idx", "item"],
+                enumerate_expr(variable("items")),
+                vec![assignment(
+                    "total",
+                    binary_expr(
+                        variable("total"),
+                        BinaryOperator::Add,
+                        binary_expr(variable("idx"), BinaryOperator::Add, variable("item")),
+                    ),
+                )],
+            ),
+            return_stmt(Some(variable("total"))),
+        ],
+    )]);
+
+    compile::<TestSpec, TestLowering>(&program).expect("enumerate for loops should compile");
+}
+
+#[test]
+fn compiles_enumerate_over_range_for_loops() {
+    let program = program(vec![function(
+        "main",
+        &[],
+        vec![
+            assignment("total", int(0)),
+            for_stmt(
+                &["idx", "item"],
+                enumerate_expr(range_expr(vec![int(2), int(5)])),
+                vec![assignment(
+                    "total",
+                    binary_expr(
+                        variable("total"),
+                        BinaryOperator::Add,
+                        binary_expr(variable("idx"), BinaryOperator::Add, variable("item")),
+                    ),
+                )],
+            ),
+            return_stmt(Some(variable("total"))),
+        ],
+    )]);
+
+    compile::<TestSpec, TestLowering>(&program).expect("enumerated range for loops should compile");
+}
+
+#[test]
+fn compiles_for_loops_over_enumerate_items_kwarg() {
+    let mut call = builtin_function_call(GlobalFunction::Enumerate, Vec::new());
+    call.kwargs.push(Kwarg {
+        name: "items".to_owned(),
+        value: variable("items"),
+    });
+
+    let program = program(vec![function(
+        "main",
+        &["items"],
+        vec![
+            assignment("total", int(0)),
+            for_stmt(
+                &["idx", "item"],
+                spanned(Expr::FunctionCall { call }),
+                vec![assignment(
+                    "total",
+                    binary_expr(
+                        variable("total"),
+                        BinaryOperator::Add,
+                        binary_expr(variable("idx"), BinaryOperator::Add, variable("item")),
+                    ),
+                )],
+            ),
+            return_stmt(Some(variable("total"))),
+        ],
+    )]);
+
+    compile::<TestSpec, TestLowering>(&program)
+        .expect("enumerate(items=...) for loops should compile");
+}
+
+#[test]
+fn rejects_for_loops_over_range_with_too_many_args() {
+    let program = program(vec![function(
+        "main",
+        &[],
+        vec![for_stmt(
+            &["item"],
+            range_expr(vec![int(0), int(4), int(1), int(2)]),
+            Vec::new(),
+        )],
     )]);
 
     let error = match compile::<TestSpec, TestLowering>(&program) {
-        Ok(_) => panic!("for loops should stay unsupported"),
+        Ok(_) => panic!("range with too many args should fail"),
+        Err(error) => error,
+    };
+
+    assert!(matches!(
+        error,
+        CompileError::FunctionCompiler(compiler::Error::FunctionArityMismatch {
+            function,
+            expected,
+            actual,
+        }) if function == "range" && expected == 3 && actual == 4
+    ));
+}
+
+#[test]
+fn rejects_for_loops_over_enumerate_with_too_many_args() {
+    let program = program(vec![function(
+        "main",
+        &["items", "other"],
+        vec![for_stmt(
+            &["idx", "item"],
+            spanned(Expr::FunctionCall {
+                call: builtin_function_call(
+                    GlobalFunction::Enumerate,
+                    vec![variable("items"), variable("other")],
+                ),
+            }),
+            Vec::new(),
+        )],
+    )]);
+
+    let error = match compile::<TestSpec, TestLowering>(&program) {
+        Ok(_) => panic!("enumerate with too many args should fail"),
+        Err(error) => error,
+    };
+
+    assert!(matches!(
+        error,
+        CompileError::FunctionCompiler(compiler::Error::FunctionArityMismatch {
+            function,
+            expected,
+            actual,
+        }) if function == "enumerate" && expected == 1 && actual == 2
+    ));
+}
+
+#[test]
+fn rejects_for_loops_over_enumerate_with_mixed_positional_and_keyword_args() {
+    let mut call = builtin_function_call(GlobalFunction::Enumerate, vec![variable("items")]);
+    call.kwargs.push(Kwarg {
+        name: "items".to_owned(),
+        value: variable("other"),
+    });
+
+    let program = program(vec![function(
+        "main",
+        &["items", "other"],
+        vec![for_stmt(
+            &["idx", "item"],
+            spanned(Expr::FunctionCall { call }),
+            Vec::new(),
+        )],
+    )]);
+
+    let error = match compile::<TestSpec, TestLowering>(&program) {
+        Ok(_) => panic!("enumerate with mixed args should fail"),
         Err(error) => error,
     };
 
     assert!(matches!(
         error,
         CompileError::FunctionCompiler(compiler::Error::Unsupported(
-            compiler::Unsupported::Statement {
-                kind: compiler::UnsupportedStatementKind::ForLoop
-            }
-        ))
+            compiler::Unsupported::FunctionCall { name, reason }
+        )) if name == "enumerate"
+            && reason == compiler::UnsupportedFunctionCall::KeywordArguments
+    ));
+}
+
+#[test]
+fn rejects_loop_variables_initialized_only_inside_for_loops() {
+    let program = program(vec![function(
+        "main",
+        &["items"],
+        vec![
+            for_stmt(&["item"], variable("items"), vec![continue_stmt()]),
+            return_stmt(Some(variable("item"))),
+        ],
+    )]);
+
+    let error = match compile::<TestSpec, TestLowering>(&program) {
+        Ok(_) => panic!("loop-only bindings should fail outside the for loop"),
+        Err(error) => error,
+    };
+
+    assert!(matches!(
+        error,
+        CompileError::FunctionCompiler(compiler::Error::UnknownVariable { name })
+            if name == "item"
     ));
 }
 

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_comprehension__dict_comprehension_assignment.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_comprehension__dict_comprehension_assignment.py__bytecode.snap
@@ -2,12 +2,236 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_comprehension/dict_comprehension_assignment.py
 ---
-Err(
-    FunctionCompiler(
-        Unsupported(
-            Statement {
-                kind: ForLoop,
+Ok(
+    Executable {
+        functions: [
+            Function {
+                states: [
+                    State {
+                        instructions: [
+                            PureSet(
+                                MakeDict {
+                                    dst: RegisterId(
+                                        1,
+                                    ),
+                                    entries: [],
+                                },
+                            ),
+                            PureSet(
+                                Copy {
+                                    dst: RegisterId(
+                                        2,
+                                    ),
+                                    src: RegisterId(
+                                        0,
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                LoadConst {
+                                    dst: RegisterId(
+                                        3,
+                                    ),
+                                    value: Int(
+                                        0,
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                Length {
+                                    dst: RegisterId(
+                                        4,
+                                    ),
+                                    src: RegisterId(
+                                        2,
+                                    ),
+                                },
+                            ),
+                            CoreSet(
+                                Jump {
+                                    target_state: StateId(
+                                        1,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            PureSet(
+                                Binary {
+                                    kind: Lt,
+                                    op: BinaryOp {
+                                        dst: RegisterId(
+                                            5,
+                                        ),
+                                        a: RegisterId(
+                                            3,
+                                        ),
+                                        b: RegisterId(
+                                            4,
+                                        ),
+                                    },
+                                },
+                            ),
+                            CoreSet(
+                                JumpIf {
+                                    target_state: StateId(
+                                        2,
+                                    ),
+                                    cond: RegisterId(
+                                        5,
+                                    ),
+                                },
+                            ),
+                            CoreSet(
+                                Jump {
+                                    target_state: StateId(
+                                        4,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            PureSet(
+                                Index {
+                                    dst: RegisterId(
+                                        5,
+                                    ),
+                                    object: RegisterId(
+                                        2,
+                                    ),
+                                    index: RegisterId(
+                                        3,
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                Copy {
+                                    dst: RegisterId(
+                                        6,
+                                    ),
+                                    src: RegisterId(
+                                        5,
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                Dot {
+                                    dst: RegisterId(
+                                        5,
+                                    ),
+                                    object: RegisterId(
+                                        6,
+                                    ),
+                                    attribute: "active",
+                                },
+                            ),
+                            CoreSet(
+                                JumpIf {
+                                    target_state: StateId(
+                                        6,
+                                    ),
+                                    cond: RegisterId(
+                                        5,
+                                    ),
+                                },
+                            ),
+                            CoreSet(
+                                Jump {
+                                    target_state: StateId(
+                                        5,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            PureSet(
+                                LoadConst {
+                                    dst: RegisterId(
+                                        5,
+                                    ),
+                                    value: Int(
+                                        1,
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                Binary {
+                                    kind: Add,
+                                    op: BinaryOp {
+                                        dst: RegisterId(
+                                            3,
+                                        ),
+                                        a: RegisterId(
+                                            3,
+                                        ),
+                                        b: RegisterId(
+                                            5,
+                                        ),
+                                    },
+                                },
+                            ),
+                            CoreSet(
+                                Jump {
+                                    target_state: StateId(
+                                        1,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                Return {
+                                    src: RegisterId(
+                                        1,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                Jump {
+                                    target_state: StateId(
+                                        3,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            PureSet(
+                                Dot {
+                                    dst: RegisterId(
+                                        7,
+                                    ),
+                                    object: RegisterId(
+                                        6,
+                                    ),
+                                    attribute: "name",
+                                },
+                            ),
+                            CoreSet(
+                                Jump {
+                                    target_state: StateId(
+                                        5,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                ],
+                num_regs: 8,
             },
-        ),
-    ),
+        ],
+    },
 )

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_comprehension__dict_comprehension_tuple.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_comprehension__dict_comprehension_tuple.py__bytecode.snap
@@ -2,12 +2,228 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_comprehension/dict_comprehension_tuple.py
 ---
-Err(
-    FunctionCompiler(
-        Unsupported(
-            Statement {
-                kind: ForLoop,
+Ok(
+    Executable {
+        functions: [
+            Function {
+                states: [
+                    State {
+                        instructions: [
+                            PureSet(
+                                MakeDict {
+                                    dst: RegisterId(
+                                        1,
+                                    ),
+                                    entries: [],
+                                },
+                            ),
+                            PureSet(
+                                Copy {
+                                    dst: RegisterId(
+                                        2,
+                                    ),
+                                    src: RegisterId(
+                                        0,
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                LoadConst {
+                                    dst: RegisterId(
+                                        3,
+                                    ),
+                                    value: Int(
+                                        0,
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                Length {
+                                    dst: RegisterId(
+                                        4,
+                                    ),
+                                    src: RegisterId(
+                                        2,
+                                    ),
+                                },
+                            ),
+                            CoreSet(
+                                Jump {
+                                    target_state: StateId(
+                                        1,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            PureSet(
+                                Binary {
+                                    kind: Lt,
+                                    op: BinaryOp {
+                                        dst: RegisterId(
+                                            5,
+                                        ),
+                                        a: RegisterId(
+                                            3,
+                                        ),
+                                        b: RegisterId(
+                                            4,
+                                        ),
+                                    },
+                                },
+                            ),
+                            CoreSet(
+                                JumpIf {
+                                    target_state: StateId(
+                                        2,
+                                    ),
+                                    cond: RegisterId(
+                                        5,
+                                    ),
+                                },
+                            ),
+                            CoreSet(
+                                Jump {
+                                    target_state: StateId(
+                                        4,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            PureSet(
+                                Index {
+                                    dst: RegisterId(
+                                        5,
+                                    ),
+                                    object: RegisterId(
+                                        2,
+                                    ),
+                                    index: RegisterId(
+                                        3,
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                LoadConst {
+                                    dst: RegisterId(
+                                        6,
+                                    ),
+                                    value: Int(
+                                        0,
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                Index {
+                                    dst: RegisterId(
+                                        7,
+                                    ),
+                                    object: RegisterId(
+                                        5,
+                                    ),
+                                    index: RegisterId(
+                                        6,
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                LoadConst {
+                                    dst: RegisterId(
+                                        6,
+                                    ),
+                                    value: Int(
+                                        1,
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                Index {
+                                    dst: RegisterId(
+                                        8,
+                                    ),
+                                    object: RegisterId(
+                                        5,
+                                    ),
+                                    index: RegisterId(
+                                        6,
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                Copy {
+                                    dst: RegisterId(
+                                        9,
+                                    ),
+                                    src: RegisterId(
+                                        8,
+                                    ),
+                                },
+                            ),
+                            CoreSet(
+                                Jump {
+                                    target_state: StateId(
+                                        3,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            PureSet(
+                                LoadConst {
+                                    dst: RegisterId(
+                                        5,
+                                    ),
+                                    value: Int(
+                                        1,
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                Binary {
+                                    kind: Add,
+                                    op: BinaryOp {
+                                        dst: RegisterId(
+                                            3,
+                                        ),
+                                        a: RegisterId(
+                                            3,
+                                        ),
+                                        b: RegisterId(
+                                            5,
+                                        ),
+                                    },
+                                },
+                            ),
+                            CoreSet(
+                                Jump {
+                                    target_state: StateId(
+                                        1,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                Return {
+                                    src: RegisterId(
+                                        1,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                ],
+                num_regs: 10,
             },
-        ),
-    ),
+        ],
+    },
 )

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_comprehension__list_comprehension_assignment.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_comprehension__list_comprehension_assignment.py__bytecode.snap
@@ -2,12 +2,253 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_comprehension/list_comprehension_assignment.py
 ---
-Err(
-    FunctionCompiler(
-        Unsupported(
-            Statement {
-                kind: ForLoop,
+Ok(
+    Executable {
+        functions: [
+            Function {
+                states: [
+                    State {
+                        instructions: [
+                            PureSet(
+                                MakeList {
+                                    dst: RegisterId(
+                                        1,
+                                    ),
+                                    items: [],
+                                },
+                            ),
+                            PureSet(
+                                Copy {
+                                    dst: RegisterId(
+                                        2,
+                                    ),
+                                    src: RegisterId(
+                                        0,
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                LoadConst {
+                                    dst: RegisterId(
+                                        3,
+                                    ),
+                                    value: Int(
+                                        0,
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                Length {
+                                    dst: RegisterId(
+                                        4,
+                                    ),
+                                    src: RegisterId(
+                                        2,
+                                    ),
+                                },
+                            ),
+                            CoreSet(
+                                Jump {
+                                    target_state: StateId(
+                                        1,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            PureSet(
+                                Binary {
+                                    kind: Lt,
+                                    op: BinaryOp {
+                                        dst: RegisterId(
+                                            5,
+                                        ),
+                                        a: RegisterId(
+                                            3,
+                                        ),
+                                        b: RegisterId(
+                                            4,
+                                        ),
+                                    },
+                                },
+                            ),
+                            CoreSet(
+                                JumpIf {
+                                    target_state: StateId(
+                                        2,
+                                    ),
+                                    cond: RegisterId(
+                                        5,
+                                    ),
+                                },
+                            ),
+                            CoreSet(
+                                Jump {
+                                    target_state: StateId(
+                                        4,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            PureSet(
+                                Index {
+                                    dst: RegisterId(
+                                        5,
+                                    ),
+                                    object: RegisterId(
+                                        2,
+                                    ),
+                                    index: RegisterId(
+                                        3,
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                Copy {
+                                    dst: RegisterId(
+                                        6,
+                                    ),
+                                    src: RegisterId(
+                                        5,
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                Dot {
+                                    dst: RegisterId(
+                                        5,
+                                    ),
+                                    object: RegisterId(
+                                        6,
+                                    ),
+                                    attribute: "active",
+                                },
+                            ),
+                            CoreSet(
+                                JumpIf {
+                                    target_state: StateId(
+                                        6,
+                                    ),
+                                    cond: RegisterId(
+                                        5,
+                                    ),
+                                },
+                            ),
+                            CoreSet(
+                                Jump {
+                                    target_state: StateId(
+                                        5,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            PureSet(
+                                LoadConst {
+                                    dst: RegisterId(
+                                        5,
+                                    ),
+                                    value: Int(
+                                        1,
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                Binary {
+                                    kind: Add,
+                                    op: BinaryOp {
+                                        dst: RegisterId(
+                                            3,
+                                        ),
+                                        a: RegisterId(
+                                            3,
+                                        ),
+                                        b: RegisterId(
+                                            5,
+                                        ),
+                                    },
+                                },
+                            ),
+                            CoreSet(
+                                Jump {
+                                    target_state: StateId(
+                                        1,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                Return {
+                                    src: RegisterId(
+                                        1,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                Jump {
+                                    target_state: StateId(
+                                        3,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            PureSet(
+                                MakeList {
+                                    dst: RegisterId(
+                                        5,
+                                    ),
+                                    items: [
+                                        RegisterId(
+                                            6,
+                                        ),
+                                    ],
+                                },
+                            ),
+                            PureSet(
+                                Binary {
+                                    kind: Add,
+                                    op: BinaryOp {
+                                        dst: RegisterId(
+                                            1,
+                                        ),
+                                        a: RegisterId(
+                                            1,
+                                        ),
+                                        b: RegisterId(
+                                            5,
+                                        ),
+                                    },
+                                },
+                            ),
+                            CoreSet(
+                                Jump {
+                                    target_state: StateId(
+                                        5,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                ],
+                num_regs: 7,
             },
-        ),
-    ),
+        ],
+    },
 )

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_comprehension__list_comprehension_ifexp.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_comprehension__list_comprehension_ifexp.py__bytecode.snap
@@ -2,12 +2,302 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_comprehension/list_comprehension_ifexp.py
 ---
-Err(
-    FunctionCompiler(
-        Unsupported(
-            Statement {
-                kind: ForLoop,
+Ok(
+    Executable {
+        functions: [
+            Function {
+                states: [
+                    State {
+                        instructions: [
+                            PureSet(
+                                MakeList {
+                                    dst: RegisterId(
+                                        1,
+                                    ),
+                                    items: [],
+                                },
+                            ),
+                            PureSet(
+                                Copy {
+                                    dst: RegisterId(
+                                        2,
+                                    ),
+                                    src: RegisterId(
+                                        0,
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                LoadConst {
+                                    dst: RegisterId(
+                                        3,
+                                    ),
+                                    value: Int(
+                                        0,
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                Length {
+                                    dst: RegisterId(
+                                        4,
+                                    ),
+                                    src: RegisterId(
+                                        2,
+                                    ),
+                                },
+                            ),
+                            CoreSet(
+                                Jump {
+                                    target_state: StateId(
+                                        1,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            PureSet(
+                                Binary {
+                                    kind: Lt,
+                                    op: BinaryOp {
+                                        dst: RegisterId(
+                                            5,
+                                        ),
+                                        a: RegisterId(
+                                            3,
+                                        ),
+                                        b: RegisterId(
+                                            4,
+                                        ),
+                                    },
+                                },
+                            ),
+                            CoreSet(
+                                JumpIf {
+                                    target_state: StateId(
+                                        2,
+                                    ),
+                                    cond: RegisterId(
+                                        5,
+                                    ),
+                                },
+                            ),
+                            CoreSet(
+                                Jump {
+                                    target_state: StateId(
+                                        4,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            PureSet(
+                                Index {
+                                    dst: RegisterId(
+                                        5,
+                                    ),
+                                    object: RegisterId(
+                                        2,
+                                    ),
+                                    index: RegisterId(
+                                        3,
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                Copy {
+                                    dst: RegisterId(
+                                        6,
+                                    ),
+                                    src: RegisterId(
+                                        5,
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                Dot {
+                                    dst: RegisterId(
+                                        5,
+                                    ),
+                                    object: RegisterId(
+                                        6,
+                                    ),
+                                    attribute: "active",
+                                },
+                            ),
+                            CoreSet(
+                                JumpIf {
+                                    target_state: StateId(
+                                        6,
+                                    ),
+                                    cond: RegisterId(
+                                        5,
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                LoadConst {
+                                    dst: RegisterId(
+                                        5,
+                                    ),
+                                    value: String(
+                                        "inactive",
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                MakeList {
+                                    dst: RegisterId(
+                                        7,
+                                    ),
+                                    items: [
+                                        RegisterId(
+                                            5,
+                                        ),
+                                    ],
+                                },
+                            ),
+                            PureSet(
+                                Binary {
+                                    kind: Add,
+                                    op: BinaryOp {
+                                        dst: RegisterId(
+                                            1,
+                                        ),
+                                        a: RegisterId(
+                                            1,
+                                        ),
+                                        b: RegisterId(
+                                            7,
+                                        ),
+                                    },
+                                },
+                            ),
+                            CoreSet(
+                                Jump {
+                                    target_state: StateId(
+                                        5,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            PureSet(
+                                LoadConst {
+                                    dst: RegisterId(
+                                        5,
+                                    ),
+                                    value: Int(
+                                        1,
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                Binary {
+                                    kind: Add,
+                                    op: BinaryOp {
+                                        dst: RegisterId(
+                                            3,
+                                        ),
+                                        a: RegisterId(
+                                            3,
+                                        ),
+                                        b: RegisterId(
+                                            5,
+                                        ),
+                                    },
+                                },
+                            ),
+                            CoreSet(
+                                Jump {
+                                    target_state: StateId(
+                                        1,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                Return {
+                                    src: RegisterId(
+                                        1,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                Jump {
+                                    target_state: StateId(
+                                        3,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            PureSet(
+                                Dot {
+                                    dst: RegisterId(
+                                        7,
+                                    ),
+                                    object: RegisterId(
+                                        6,
+                                    ),
+                                    attribute: "name",
+                                },
+                            ),
+                            PureSet(
+                                MakeList {
+                                    dst: RegisterId(
+                                        5,
+                                    ),
+                                    items: [
+                                        RegisterId(
+                                            7,
+                                        ),
+                                    ],
+                                },
+                            ),
+                            PureSet(
+                                Binary {
+                                    kind: Add,
+                                    op: BinaryOp {
+                                        dst: RegisterId(
+                                            1,
+                                        ),
+                                        a: RegisterId(
+                                            1,
+                                        ),
+                                        b: RegisterId(
+                                            5,
+                                        ),
+                                    },
+                                },
+                            ),
+                            CoreSet(
+                                Jump {
+                                    target_state: StateId(
+                                        5,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                ],
+                num_regs: 8,
             },
-        ),
-    ),
+        ],
+    },
 )

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_control_flow__for_multi_action.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_control_flow__for_multi_action.py__bytecode.snap
@@ -2,12 +2,336 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_control_flow/for_multi_action.py
 ---
-Err(
-    FunctionCompiler(
-        Unsupported(
-            Statement {
-                kind: ForLoop,
+Ok(
+    Executable {
+        functions: [
+            Function {
+                states: [
+                    State {
+                        instructions: [
+                            PureSet(
+                                LoadConst {
+                                    dst: RegisterId(
+                                        1,
+                                    ),
+                                    value: Int(
+                                        1,
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                LoadConst {
+                                    dst: RegisterId(
+                                        2,
+                                    ),
+                                    value: Int(
+                                        2,
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                LoadConst {
+                                    dst: RegisterId(
+                                        3,
+                                    ),
+                                    value: Int(
+                                        3,
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                MakeList {
+                                    dst: RegisterId(
+                                        0,
+                                    ),
+                                    items: [
+                                        RegisterId(
+                                            1,
+                                        ),
+                                        RegisterId(
+                                            2,
+                                        ),
+                                        RegisterId(
+                                            3,
+                                        ),
+                                    ],
+                                },
+                            ),
+                            PureSet(
+                                MakeList {
+                                    dst: RegisterId(
+                                        4,
+                                    ),
+                                    items: [],
+                                },
+                            ),
+                            PureSet(
+                                Copy {
+                                    dst: RegisterId(
+                                        5,
+                                    ),
+                                    src: RegisterId(
+                                        0,
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                LoadConst {
+                                    dst: RegisterId(
+                                        6,
+                                    ),
+                                    value: Int(
+                                        0,
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                Length {
+                                    dst: RegisterId(
+                                        7,
+                                    ),
+                                    src: RegisterId(
+                                        5,
+                                    ),
+                                },
+                            ),
+                            CoreSet(
+                                Jump {
+                                    target_state: StateId(
+                                        1,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            PureSet(
+                                Binary {
+                                    kind: Lt,
+                                    op: BinaryOp {
+                                        dst: RegisterId(
+                                            3,
+                                        ),
+                                        a: RegisterId(
+                                            6,
+                                        ),
+                                        b: RegisterId(
+                                            7,
+                                        ),
+                                    },
+                                },
+                            ),
+                            CoreSet(
+                                JumpIf {
+                                    target_state: StateId(
+                                        2,
+                                    ),
+                                    cond: RegisterId(
+                                        3,
+                                    ),
+                                },
+                            ),
+                            CoreSet(
+                                Jump {
+                                    target_state: StateId(
+                                        4,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            PureSet(
+                                Index {
+                                    dst: RegisterId(
+                                        3,
+                                    ),
+                                    object: RegisterId(
+                                        5,
+                                    ),
+                                    index: RegisterId(
+                                        6,
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                Copy {
+                                    dst: RegisterId(
+                                        8,
+                                    ),
+                                    src: RegisterId(
+                                        3,
+                                    ),
+                                },
+                            ),
+                            ExtCallSet(
+                                ActionCall {
+                                    dst: RegisterId(
+                                        9,
+                                    ),
+                                    action_ref: TestActionRef(
+                                        "step_one_for",
+                                    ),
+                                    args: [
+                                        RegisterId(
+                                            8,
+                                        ),
+                                    ],
+                                    resume: StateId(
+                                        5,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            PureSet(
+                                LoadConst {
+                                    dst: RegisterId(
+                                        3,
+                                    ),
+                                    value: Int(
+                                        1,
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                Binary {
+                                    kind: Add,
+                                    op: BinaryOp {
+                                        dst: RegisterId(
+                                            6,
+                                        ),
+                                        a: RegisterId(
+                                            6,
+                                        ),
+                                        b: RegisterId(
+                                            3,
+                                        ),
+                                    },
+                                },
+                            ),
+                            CoreSet(
+                                Jump {
+                                    target_state: StateId(
+                                        1,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                Return {
+                                    src: RegisterId(
+                                        4,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                Await {
+                                    dst: RegisterId(
+                                        9,
+                                    ),
+                                    src: RegisterId(
+                                        9,
+                                    ),
+                                    resume: StateId(
+                                        6,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            ExtCallSet(
+                                ActionCall {
+                                    dst: RegisterId(
+                                        10,
+                                    ),
+                                    action_ref: TestActionRef(
+                                        "step_two_for",
+                                    ),
+                                    args: [
+                                        RegisterId(
+                                            9,
+                                        ),
+                                    ],
+                                    resume: StateId(
+                                        7,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                Await {
+                                    dst: RegisterId(
+                                        10,
+                                    ),
+                                    src: RegisterId(
+                                        10,
+                                    ),
+                                    resume: StateId(
+                                        8,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            PureSet(
+                                MakeList {
+                                    dst: RegisterId(
+                                        3,
+                                    ),
+                                    items: [
+                                        RegisterId(
+                                            10,
+                                        ),
+                                    ],
+                                },
+                            ),
+                            PureSet(
+                                Binary {
+                                    kind: Add,
+                                    op: BinaryOp {
+                                        dst: RegisterId(
+                                            4,
+                                        ),
+                                        a: RegisterId(
+                                            4,
+                                        ),
+                                        b: RegisterId(
+                                            3,
+                                        ),
+                                    },
+                                },
+                            ),
+                            CoreSet(
+                                Jump {
+                                    target_state: StateId(
+                                        3,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                ],
+                num_regs: 11,
             },
-        ),
-    ),
+        ],
+    },
 )

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_control_flow__for_simple.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_control_flow__for_simple.py__bytecode.snap
@@ -2,12 +2,297 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_control_flow/for_simple.py
 ---
-Err(
-    FunctionCompiler(
-        Unsupported(
-            Statement {
-                kind: ForLoop,
+Ok(
+    Executable {
+        functions: [
+            Function {
+                states: [
+                    State {
+                        instructions: [
+                            PureSet(
+                                LoadConst {
+                                    dst: RegisterId(
+                                        1,
+                                    ),
+                                    value: String(
+                                        "a",
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                LoadConst {
+                                    dst: RegisterId(
+                                        2,
+                                    ),
+                                    value: String(
+                                        "b",
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                LoadConst {
+                                    dst: RegisterId(
+                                        3,
+                                    ),
+                                    value: String(
+                                        "c",
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                MakeList {
+                                    dst: RegisterId(
+                                        0,
+                                    ),
+                                    items: [
+                                        RegisterId(
+                                            1,
+                                        ),
+                                        RegisterId(
+                                            2,
+                                        ),
+                                        RegisterId(
+                                            3,
+                                        ),
+                                    ],
+                                },
+                            ),
+                            PureSet(
+                                MakeList {
+                                    dst: RegisterId(
+                                        4,
+                                    ),
+                                    items: [],
+                                },
+                            ),
+                            PureSet(
+                                Copy {
+                                    dst: RegisterId(
+                                        5,
+                                    ),
+                                    src: RegisterId(
+                                        0,
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                LoadConst {
+                                    dst: RegisterId(
+                                        6,
+                                    ),
+                                    value: Int(
+                                        0,
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                Length {
+                                    dst: RegisterId(
+                                        7,
+                                    ),
+                                    src: RegisterId(
+                                        5,
+                                    ),
+                                },
+                            ),
+                            CoreSet(
+                                Jump {
+                                    target_state: StateId(
+                                        1,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            PureSet(
+                                Binary {
+                                    kind: Lt,
+                                    op: BinaryOp {
+                                        dst: RegisterId(
+                                            3,
+                                        ),
+                                        a: RegisterId(
+                                            6,
+                                        ),
+                                        b: RegisterId(
+                                            7,
+                                        ),
+                                    },
+                                },
+                            ),
+                            CoreSet(
+                                JumpIf {
+                                    target_state: StateId(
+                                        2,
+                                    ),
+                                    cond: RegisterId(
+                                        3,
+                                    ),
+                                },
+                            ),
+                            CoreSet(
+                                Jump {
+                                    target_state: StateId(
+                                        4,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            PureSet(
+                                Index {
+                                    dst: RegisterId(
+                                        3,
+                                    ),
+                                    object: RegisterId(
+                                        5,
+                                    ),
+                                    index: RegisterId(
+                                        6,
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                Copy {
+                                    dst: RegisterId(
+                                        8,
+                                    ),
+                                    src: RegisterId(
+                                        3,
+                                    ),
+                                },
+                            ),
+                            ExtCallSet(
+                                ActionCall {
+                                    dst: RegisterId(
+                                        9,
+                                    ),
+                                    action_ref: TestActionRef(
+                                        "process_item_simple",
+                                    ),
+                                    args: [
+                                        RegisterId(
+                                            8,
+                                        ),
+                                    ],
+                                    resume: StateId(
+                                        5,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            PureSet(
+                                LoadConst {
+                                    dst: RegisterId(
+                                        3,
+                                    ),
+                                    value: Int(
+                                        1,
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                Binary {
+                                    kind: Add,
+                                    op: BinaryOp {
+                                        dst: RegisterId(
+                                            6,
+                                        ),
+                                        a: RegisterId(
+                                            6,
+                                        ),
+                                        b: RegisterId(
+                                            3,
+                                        ),
+                                    },
+                                },
+                            ),
+                            CoreSet(
+                                Jump {
+                                    target_state: StateId(
+                                        1,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                Return {
+                                    src: RegisterId(
+                                        4,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                Await {
+                                    dst: RegisterId(
+                                        9,
+                                    ),
+                                    src: RegisterId(
+                                        9,
+                                    ),
+                                    resume: StateId(
+                                        6,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            PureSet(
+                                MakeList {
+                                    dst: RegisterId(
+                                        3,
+                                    ),
+                                    items: [
+                                        RegisterId(
+                                            9,
+                                        ),
+                                    ],
+                                },
+                            ),
+                            PureSet(
+                                Binary {
+                                    kind: Add,
+                                    op: BinaryOp {
+                                        dst: RegisterId(
+                                            4,
+                                        ),
+                                        a: RegisterId(
+                                            4,
+                                        ),
+                                        b: RegisterId(
+                                            3,
+                                        ),
+                                    },
+                                },
+                            ),
+                            CoreSet(
+                                Jump {
+                                    target_state: StateId(
+                                        3,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                ],
+                num_regs: 10,
             },
-        ),
-    ),
+        ],
+    },
 )

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_for_loop__for_break.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_for_loop__for_break.py__bytecode.snap
@@ -2,12 +2,294 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_for_loop/for_break.py
 ---
-Err(
-    FunctionCompiler(
-        Unsupported(
-            Statement {
-                kind: ForLoop,
+Ok(
+    Executable {
+        functions: [
+            Function {
+                states: [
+                    State {
+                        instructions: [
+                            PureSet(
+                                LoadConst {
+                                    dst: RegisterId(
+                                        1,
+                                    ),
+                                    value: String(
+                                        "not found",
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                Copy {
+                                    dst: RegisterId(
+                                        2,
+                                    ),
+                                    src: RegisterId(
+                                        0,
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                LoadConst {
+                                    dst: RegisterId(
+                                        3,
+                                    ),
+                                    value: Int(
+                                        0,
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                Length {
+                                    dst: RegisterId(
+                                        4,
+                                    ),
+                                    src: RegisterId(
+                                        2,
+                                    ),
+                                },
+                            ),
+                            CoreSet(
+                                Jump {
+                                    target_state: StateId(
+                                        1,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            PureSet(
+                                Binary {
+                                    kind: Lt,
+                                    op: BinaryOp {
+                                        dst: RegisterId(
+                                            5,
+                                        ),
+                                        a: RegisterId(
+                                            3,
+                                        ),
+                                        b: RegisterId(
+                                            4,
+                                        ),
+                                    },
+                                },
+                            ),
+                            CoreSet(
+                                JumpIf {
+                                    target_state: StateId(
+                                        2,
+                                    ),
+                                    cond: RegisterId(
+                                        5,
+                                    ),
+                                },
+                            ),
+                            CoreSet(
+                                Jump {
+                                    target_state: StateId(
+                                        4,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            PureSet(
+                                Index {
+                                    dst: RegisterId(
+                                        5,
+                                    ),
+                                    object: RegisterId(
+                                        2,
+                                    ),
+                                    index: RegisterId(
+                                        3,
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                Copy {
+                                    dst: RegisterId(
+                                        6,
+                                    ),
+                                    src: RegisterId(
+                                        5,
+                                    ),
+                                },
+                            ),
+                            ExtCallSet(
+                                ActionCall {
+                                    dst: RegisterId(
+                                        7,
+                                    ),
+                                    action_ref: TestActionRef(
+                                        "check_item",
+                                    ),
+                                    args: [
+                                        RegisterId(
+                                            6,
+                                        ),
+                                    ],
+                                    resume: StateId(
+                                        5,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            PureSet(
+                                LoadConst {
+                                    dst: RegisterId(
+                                        5,
+                                    ),
+                                    value: Int(
+                                        1,
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                Binary {
+                                    kind: Add,
+                                    op: BinaryOp {
+                                        dst: RegisterId(
+                                            3,
+                                        ),
+                                        a: RegisterId(
+                                            3,
+                                        ),
+                                        b: RegisterId(
+                                            5,
+                                        ),
+                                    },
+                                },
+                            ),
+                            CoreSet(
+                                Jump {
+                                    target_state: StateId(
+                                        1,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                Return {
+                                    src: RegisterId(
+                                        1,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                Await {
+                                    dst: RegisterId(
+                                        7,
+                                    ),
+                                    src: RegisterId(
+                                        7,
+                                    ),
+                                    resume: StateId(
+                                        6,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                JumpIf {
+                                    target_state: StateId(
+                                        8,
+                                    ),
+                                    cond: RegisterId(
+                                        7,
+                                    ),
+                                },
+                            ),
+                            CoreSet(
+                                Jump {
+                                    target_state: StateId(
+                                        7,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                Jump {
+                                    target_state: StateId(
+                                        3,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            ExtCallSet(
+                                ActionCall {
+                                    dst: RegisterId(
+                                        1,
+                                    ),
+                                    action_ref: TestActionRef(
+                                        "process_found",
+                                    ),
+                                    args: [
+                                        RegisterId(
+                                            6,
+                                        ),
+                                    ],
+                                    resume: StateId(
+                                        9,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                Await {
+                                    dst: RegisterId(
+                                        1,
+                                    ),
+                                    src: RegisterId(
+                                        1,
+                                    ),
+                                    resume: StateId(
+                                        10,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                Jump {
+                                    target_state: StateId(
+                                        4,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                ],
+                num_regs: 8,
             },
-        ),
-    ),
+        ],
+    },
 )

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_for_loop__for_concat_accumulator.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_for_loop__for_concat_accumulator.py__bytecode.snap
@@ -2,12 +2,249 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_for_loop/for_concat_accumulator.py
 ---
-Err(
-    FunctionCompiler(
-        Unsupported(
-            Statement {
-                kind: ForLoop,
+Ok(
+    Executable {
+        functions: [
+            Function {
+                states: [
+                    State {
+                        instructions: [
+                            PureSet(
+                                MakeList {
+                                    dst: RegisterId(
+                                        1,
+                                    ),
+                                    items: [],
+                                },
+                            ),
+                            PureSet(
+                                Copy {
+                                    dst: RegisterId(
+                                        2,
+                                    ),
+                                    src: RegisterId(
+                                        0,
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                LoadConst {
+                                    dst: RegisterId(
+                                        3,
+                                    ),
+                                    value: Int(
+                                        0,
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                Length {
+                                    dst: RegisterId(
+                                        4,
+                                    ),
+                                    src: RegisterId(
+                                        2,
+                                    ),
+                                },
+                            ),
+                            CoreSet(
+                                Jump {
+                                    target_state: StateId(
+                                        1,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            PureSet(
+                                Binary {
+                                    kind: Lt,
+                                    op: BinaryOp {
+                                        dst: RegisterId(
+                                            5,
+                                        ),
+                                        a: RegisterId(
+                                            3,
+                                        ),
+                                        b: RegisterId(
+                                            4,
+                                        ),
+                                    },
+                                },
+                            ),
+                            CoreSet(
+                                JumpIf {
+                                    target_state: StateId(
+                                        2,
+                                    ),
+                                    cond: RegisterId(
+                                        5,
+                                    ),
+                                },
+                            ),
+                            CoreSet(
+                                Jump {
+                                    target_state: StateId(
+                                        4,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            PureSet(
+                                Index {
+                                    dst: RegisterId(
+                                        5,
+                                    ),
+                                    object: RegisterId(
+                                        2,
+                                    ),
+                                    index: RegisterId(
+                                        3,
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                Copy {
+                                    dst: RegisterId(
+                                        6,
+                                    ),
+                                    src: RegisterId(
+                                        5,
+                                    ),
+                                },
+                            ),
+                            ExtCallSet(
+                                ActionCall {
+                                    dst: RegisterId(
+                                        7,
+                                    ),
+                                    action_ref: TestActionRef(
+                                        "concat_accum_process_value",
+                                    ),
+                                    args: [
+                                        RegisterId(
+                                            6,
+                                        ),
+                                    ],
+                                    resume: StateId(
+                                        5,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            PureSet(
+                                LoadConst {
+                                    dst: RegisterId(
+                                        5,
+                                    ),
+                                    value: Int(
+                                        1,
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                Binary {
+                                    kind: Add,
+                                    op: BinaryOp {
+                                        dst: RegisterId(
+                                            3,
+                                        ),
+                                        a: RegisterId(
+                                            3,
+                                        ),
+                                        b: RegisterId(
+                                            5,
+                                        ),
+                                    },
+                                },
+                            ),
+                            CoreSet(
+                                Jump {
+                                    target_state: StateId(
+                                        1,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                Return {
+                                    src: RegisterId(
+                                        1,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                Await {
+                                    dst: RegisterId(
+                                        7,
+                                    ),
+                                    src: RegisterId(
+                                        7,
+                                    ),
+                                    resume: StateId(
+                                        6,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            PureSet(
+                                MakeList {
+                                    dst: RegisterId(
+                                        5,
+                                    ),
+                                    items: [
+                                        RegisterId(
+                                            7,
+                                        ),
+                                    ],
+                                },
+                            ),
+                            PureSet(
+                                Binary {
+                                    kind: Add,
+                                    op: BinaryOp {
+                                        dst: RegisterId(
+                                            1,
+                                        ),
+                                        a: RegisterId(
+                                            1,
+                                        ),
+                                        b: RegisterId(
+                                            5,
+                                        ),
+                                    },
+                                },
+                            ),
+                            CoreSet(
+                                Jump {
+                                    target_state: StateId(
+                                        3,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                ],
+                num_regs: 8,
             },
-        ),
-    ),
+        ],
+    },
 )

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_for_loop__for_continue.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_for_loop__for_continue.py__bytecode.snap
@@ -2,12 +2,310 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_for_loop/for_continue.py
 ---
-Err(
-    FunctionCompiler(
-        Unsupported(
-            Statement {
-                kind: ForLoop,
+Ok(
+    Executable {
+        functions: [
+            Function {
+                states: [
+                    State {
+                        instructions: [
+                            PureSet(
+                                LoadConst {
+                                    dst: RegisterId(
+                                        1,
+                                    ),
+                                    value: Int(
+                                        0,
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                Copy {
+                                    dst: RegisterId(
+                                        2,
+                                    ),
+                                    src: RegisterId(
+                                        0,
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                LoadConst {
+                                    dst: RegisterId(
+                                        3,
+                                    ),
+                                    value: Int(
+                                        0,
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                Length {
+                                    dst: RegisterId(
+                                        4,
+                                    ),
+                                    src: RegisterId(
+                                        2,
+                                    ),
+                                },
+                            ),
+                            CoreSet(
+                                Jump {
+                                    target_state: StateId(
+                                        1,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            PureSet(
+                                Binary {
+                                    kind: Lt,
+                                    op: BinaryOp {
+                                        dst: RegisterId(
+                                            5,
+                                        ),
+                                        a: RegisterId(
+                                            3,
+                                        ),
+                                        b: RegisterId(
+                                            4,
+                                        ),
+                                    },
+                                },
+                            ),
+                            CoreSet(
+                                JumpIf {
+                                    target_state: StateId(
+                                        2,
+                                    ),
+                                    cond: RegisterId(
+                                        5,
+                                    ),
+                                },
+                            ),
+                            CoreSet(
+                                Jump {
+                                    target_state: StateId(
+                                        4,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            PureSet(
+                                Index {
+                                    dst: RegisterId(
+                                        5,
+                                    ),
+                                    object: RegisterId(
+                                        2,
+                                    ),
+                                    index: RegisterId(
+                                        3,
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                Copy {
+                                    dst: RegisterId(
+                                        6,
+                                    ),
+                                    src: RegisterId(
+                                        5,
+                                    ),
+                                },
+                            ),
+                            ExtCallSet(
+                                ActionCall {
+                                    dst: RegisterId(
+                                        7,
+                                    ),
+                                    action_ref: TestActionRef(
+                                        "should_skip",
+                                    ),
+                                    args: [
+                                        RegisterId(
+                                            6,
+                                        ),
+                                    ],
+                                    resume: StateId(
+                                        5,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            PureSet(
+                                LoadConst {
+                                    dst: RegisterId(
+                                        5,
+                                    ),
+                                    value: Int(
+                                        1,
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                Binary {
+                                    kind: Add,
+                                    op: BinaryOp {
+                                        dst: RegisterId(
+                                            3,
+                                        ),
+                                        a: RegisterId(
+                                            3,
+                                        ),
+                                        b: RegisterId(
+                                            5,
+                                        ),
+                                    },
+                                },
+                            ),
+                            CoreSet(
+                                Jump {
+                                    target_state: StateId(
+                                        1,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                Return {
+                                    src: RegisterId(
+                                        1,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                Await {
+                                    dst: RegisterId(
+                                        7,
+                                    ),
+                                    src: RegisterId(
+                                        7,
+                                    ),
+                                    resume: StateId(
+                                        6,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                JumpIf {
+                                    target_state: StateId(
+                                        8,
+                                    ),
+                                    cond: RegisterId(
+                                        7,
+                                    ),
+                                },
+                            ),
+                            CoreSet(
+                                Jump {
+                                    target_state: StateId(
+                                        7,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            ExtCallSet(
+                                ActionCall {
+                                    dst: RegisterId(
+                                        8,
+                                    ),
+                                    action_ref: TestActionRef(
+                                        "process_item",
+                                    ),
+                                    args: [
+                                        RegisterId(
+                                            6,
+                                        ),
+                                    ],
+                                    resume: StateId(
+                                        9,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                Jump {
+                                    target_state: StateId(
+                                        3,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                Await {
+                                    dst: RegisterId(
+                                        8,
+                                    ),
+                                    src: RegisterId(
+                                        8,
+                                    ),
+                                    resume: StateId(
+                                        10,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            PureSet(
+                                Binary {
+                                    kind: Add,
+                                    op: BinaryOp {
+                                        dst: RegisterId(
+                                            1,
+                                        ),
+                                        a: RegisterId(
+                                            1,
+                                        ),
+                                        b: RegisterId(
+                                            8,
+                                        ),
+                                    },
+                                },
+                            ),
+                            CoreSet(
+                                Jump {
+                                    target_state: StateId(
+                                        3,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                ],
+                num_regs: 9,
             },
-        ),
-    ),
+        ],
+    },
 )

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_for_loop__for_counter_accumulator.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_for_loop__for_counter_accumulator.py__bytecode.snap
@@ -2,12 +2,281 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_for_loop/for_counter_accumulator.py
 ---
-Err(
-    FunctionCompiler(
-        Unsupported(
-            Statement {
-                kind: ForLoop,
+Ok(
+    Executable {
+        functions: [
+            Function {
+                states: [
+                    State {
+                        instructions: [
+                            PureSet(
+                                LoadConst {
+                                    dst: RegisterId(
+                                        1,
+                                    ),
+                                    value: Int(
+                                        0,
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                Copy {
+                                    dst: RegisterId(
+                                        2,
+                                    ),
+                                    src: RegisterId(
+                                        0,
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                LoadConst {
+                                    dst: RegisterId(
+                                        3,
+                                    ),
+                                    value: Int(
+                                        0,
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                Length {
+                                    dst: RegisterId(
+                                        4,
+                                    ),
+                                    src: RegisterId(
+                                        2,
+                                    ),
+                                },
+                            ),
+                            CoreSet(
+                                Jump {
+                                    target_state: StateId(
+                                        1,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            PureSet(
+                                Binary {
+                                    kind: Lt,
+                                    op: BinaryOp {
+                                        dst: RegisterId(
+                                            5,
+                                        ),
+                                        a: RegisterId(
+                                            3,
+                                        ),
+                                        b: RegisterId(
+                                            4,
+                                        ),
+                                    },
+                                },
+                            ),
+                            CoreSet(
+                                JumpIf {
+                                    target_state: StateId(
+                                        2,
+                                    ),
+                                    cond: RegisterId(
+                                        5,
+                                    ),
+                                },
+                            ),
+                            CoreSet(
+                                Jump {
+                                    target_state: StateId(
+                                        4,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            PureSet(
+                                Index {
+                                    dst: RegisterId(
+                                        5,
+                                    ),
+                                    object: RegisterId(
+                                        2,
+                                    ),
+                                    index: RegisterId(
+                                        3,
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                Copy {
+                                    dst: RegisterId(
+                                        6,
+                                    ),
+                                    src: RegisterId(
+                                        5,
+                                    ),
+                                },
+                            ),
+                            ExtCallSet(
+                                ActionCall {
+                                    dst: RegisterId(
+                                        7,
+                                    ),
+                                    action_ref: TestActionRef(
+                                        "counter_accum_check_valid",
+                                    ),
+                                    args: [
+                                        RegisterId(
+                                            6,
+                                        ),
+                                    ],
+                                    resume: StateId(
+                                        5,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            PureSet(
+                                LoadConst {
+                                    dst: RegisterId(
+                                        5,
+                                    ),
+                                    value: Int(
+                                        1,
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                Binary {
+                                    kind: Add,
+                                    op: BinaryOp {
+                                        dst: RegisterId(
+                                            3,
+                                        ),
+                                        a: RegisterId(
+                                            3,
+                                        ),
+                                        b: RegisterId(
+                                            5,
+                                        ),
+                                    },
+                                },
+                            ),
+                            CoreSet(
+                                Jump {
+                                    target_state: StateId(
+                                        1,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                Return {
+                                    src: RegisterId(
+                                        1,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                Await {
+                                    dst: RegisterId(
+                                        7,
+                                    ),
+                                    src: RegisterId(
+                                        7,
+                                    ),
+                                    resume: StateId(
+                                        6,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                JumpIf {
+                                    target_state: StateId(
+                                        8,
+                                    ),
+                                    cond: RegisterId(
+                                        7,
+                                    ),
+                                },
+                            ),
+                            CoreSet(
+                                Jump {
+                                    target_state: StateId(
+                                        7,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                Jump {
+                                    target_state: StateId(
+                                        3,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            PureSet(
+                                LoadConst {
+                                    dst: RegisterId(
+                                        5,
+                                    ),
+                                    value: Int(
+                                        1,
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                Binary {
+                                    kind: Add,
+                                    op: BinaryOp {
+                                        dst: RegisterId(
+                                            1,
+                                        ),
+                                        a: RegisterId(
+                                            1,
+                                        ),
+                                        b: RegisterId(
+                                            5,
+                                        ),
+                                    },
+                                },
+                            ),
+                            CoreSet(
+                                Jump {
+                                    target_state: StateId(
+                                        7,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                ],
+                num_regs: 8,
             },
-        ),
-    ),
+        ],
+    },
 )

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_for_loop__for_dict_accumulator.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_for_loop__for_dict_accumulator.py__bytecode.snap
@@ -5,8 +5,8 @@ expression: bytecode for python/tests/fixtures_for_loop/for_dict_accumulator.py
 Err(
     FunctionCompiler(
         Unsupported(
-            Statement {
-                kind: ForLoop,
+            AssignmentTargetCount {
+                count: 2,
             },
         ),
     ),

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_for_loop__for_multi_accumulator.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_for_loop__for_multi_accumulator.py__bytecode.snap
@@ -5,8 +5,8 @@ expression: bytecode for python/tests/fixtures_for_loop/for_multi_accumulator.py
 Err(
     FunctionCompiler(
         Unsupported(
-            Statement {
-                kind: ForLoop,
+            AssignmentTargetCount {
+                count: 2,
             },
         ),
     ),

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_for_loop__for_multiple_calls.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_for_loop__for_multiple_calls.py__bytecode.snap
@@ -2,12 +2,288 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_for_loop/for_multiple_calls.py
 ---
-Err(
-    FunctionCompiler(
-        Unsupported(
-            Statement {
-                kind: ForLoop,
+Ok(
+    Executable {
+        functions: [
+            Function {
+                states: [
+                    State {
+                        instructions: [
+                            PureSet(
+                                MakeList {
+                                    dst: RegisterId(
+                                        1,
+                                    ),
+                                    items: [],
+                                },
+                            ),
+                            PureSet(
+                                Copy {
+                                    dst: RegisterId(
+                                        2,
+                                    ),
+                                    src: RegisterId(
+                                        0,
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                LoadConst {
+                                    dst: RegisterId(
+                                        3,
+                                    ),
+                                    value: Int(
+                                        0,
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                Length {
+                                    dst: RegisterId(
+                                        4,
+                                    ),
+                                    src: RegisterId(
+                                        2,
+                                    ),
+                                },
+                            ),
+                            CoreSet(
+                                Jump {
+                                    target_state: StateId(
+                                        1,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            PureSet(
+                                Binary {
+                                    kind: Lt,
+                                    op: BinaryOp {
+                                        dst: RegisterId(
+                                            5,
+                                        ),
+                                        a: RegisterId(
+                                            3,
+                                        ),
+                                        b: RegisterId(
+                                            4,
+                                        ),
+                                    },
+                                },
+                            ),
+                            CoreSet(
+                                JumpIf {
+                                    target_state: StateId(
+                                        2,
+                                    ),
+                                    cond: RegisterId(
+                                        5,
+                                    ),
+                                },
+                            ),
+                            CoreSet(
+                                Jump {
+                                    target_state: StateId(
+                                        4,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            PureSet(
+                                Index {
+                                    dst: RegisterId(
+                                        5,
+                                    ),
+                                    object: RegisterId(
+                                        2,
+                                    ),
+                                    index: RegisterId(
+                                        3,
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                Copy {
+                                    dst: RegisterId(
+                                        6,
+                                    ),
+                                    src: RegisterId(
+                                        5,
+                                    ),
+                                },
+                            ),
+                            ExtCallSet(
+                                ActionCall {
+                                    dst: RegisterId(
+                                        7,
+                                    ),
+                                    action_ref: TestActionRef(
+                                        "for_step_one",
+                                    ),
+                                    args: [
+                                        RegisterId(
+                                            6,
+                                        ),
+                                    ],
+                                    resume: StateId(
+                                        5,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            PureSet(
+                                LoadConst {
+                                    dst: RegisterId(
+                                        5,
+                                    ),
+                                    value: Int(
+                                        1,
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                Binary {
+                                    kind: Add,
+                                    op: BinaryOp {
+                                        dst: RegisterId(
+                                            3,
+                                        ),
+                                        a: RegisterId(
+                                            3,
+                                        ),
+                                        b: RegisterId(
+                                            5,
+                                        ),
+                                    },
+                                },
+                            ),
+                            CoreSet(
+                                Jump {
+                                    target_state: StateId(
+                                        1,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                Return {
+                                    src: RegisterId(
+                                        1,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                Await {
+                                    dst: RegisterId(
+                                        7,
+                                    ),
+                                    src: RegisterId(
+                                        7,
+                                    ),
+                                    resume: StateId(
+                                        6,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            ExtCallSet(
+                                ActionCall {
+                                    dst: RegisterId(
+                                        8,
+                                    ),
+                                    action_ref: TestActionRef(
+                                        "for_step_two",
+                                    ),
+                                    args: [
+                                        RegisterId(
+                                            7,
+                                        ),
+                                    ],
+                                    resume: StateId(
+                                        7,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                Await {
+                                    dst: RegisterId(
+                                        8,
+                                    ),
+                                    src: RegisterId(
+                                        8,
+                                    ),
+                                    resume: StateId(
+                                        8,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            PureSet(
+                                MakeList {
+                                    dst: RegisterId(
+                                        5,
+                                    ),
+                                    items: [
+                                        RegisterId(
+                                            8,
+                                        ),
+                                    ],
+                                },
+                            ),
+                            PureSet(
+                                Binary {
+                                    kind: Add,
+                                    op: BinaryOp {
+                                        dst: RegisterId(
+                                            1,
+                                        ),
+                                        a: RegisterId(
+                                            1,
+                                        ),
+                                        b: RegisterId(
+                                            5,
+                                        ),
+                                    },
+                                },
+                            ),
+                            CoreSet(
+                                Jump {
+                                    target_state: StateId(
+                                        3,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                ],
+                num_regs: 9,
             },
-        ),
-    ),
+        ],
+    },
 )

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_for_loop__for_single_accumulator.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_for_loop__for_single_accumulator.py__bytecode.snap
@@ -2,12 +2,249 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_for_loop/for_single_accumulator.py
 ---
-Err(
-    FunctionCompiler(
-        Unsupported(
-            Statement {
-                kind: ForLoop,
+Ok(
+    Executable {
+        functions: [
+            Function {
+                states: [
+                    State {
+                        instructions: [
+                            PureSet(
+                                MakeList {
+                                    dst: RegisterId(
+                                        1,
+                                    ),
+                                    items: [],
+                                },
+                            ),
+                            PureSet(
+                                Copy {
+                                    dst: RegisterId(
+                                        2,
+                                    ),
+                                    src: RegisterId(
+                                        0,
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                LoadConst {
+                                    dst: RegisterId(
+                                        3,
+                                    ),
+                                    value: Int(
+                                        0,
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                Length {
+                                    dst: RegisterId(
+                                        4,
+                                    ),
+                                    src: RegisterId(
+                                        2,
+                                    ),
+                                },
+                            ),
+                            CoreSet(
+                                Jump {
+                                    target_state: StateId(
+                                        1,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            PureSet(
+                                Binary {
+                                    kind: Lt,
+                                    op: BinaryOp {
+                                        dst: RegisterId(
+                                            5,
+                                        ),
+                                        a: RegisterId(
+                                            3,
+                                        ),
+                                        b: RegisterId(
+                                            4,
+                                        ),
+                                    },
+                                },
+                            ),
+                            CoreSet(
+                                JumpIf {
+                                    target_state: StateId(
+                                        2,
+                                    ),
+                                    cond: RegisterId(
+                                        5,
+                                    ),
+                                },
+                            ),
+                            CoreSet(
+                                Jump {
+                                    target_state: StateId(
+                                        4,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            PureSet(
+                                Index {
+                                    dst: RegisterId(
+                                        5,
+                                    ),
+                                    object: RegisterId(
+                                        2,
+                                    ),
+                                    index: RegisterId(
+                                        3,
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                Copy {
+                                    dst: RegisterId(
+                                        6,
+                                    ),
+                                    src: RegisterId(
+                                        5,
+                                    ),
+                                },
+                            ),
+                            ExtCallSet(
+                                ActionCall {
+                                    dst: RegisterId(
+                                        7,
+                                    ),
+                                    action_ref: TestActionRef(
+                                        "single_accum_process_value",
+                                    ),
+                                    args: [
+                                        RegisterId(
+                                            6,
+                                        ),
+                                    ],
+                                    resume: StateId(
+                                        5,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            PureSet(
+                                LoadConst {
+                                    dst: RegisterId(
+                                        5,
+                                    ),
+                                    value: Int(
+                                        1,
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                Binary {
+                                    kind: Add,
+                                    op: BinaryOp {
+                                        dst: RegisterId(
+                                            3,
+                                        ),
+                                        a: RegisterId(
+                                            3,
+                                        ),
+                                        b: RegisterId(
+                                            5,
+                                        ),
+                                    },
+                                },
+                            ),
+                            CoreSet(
+                                Jump {
+                                    target_state: StateId(
+                                        1,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                Return {
+                                    src: RegisterId(
+                                        1,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                Await {
+                                    dst: RegisterId(
+                                        7,
+                                    ),
+                                    src: RegisterId(
+                                        7,
+                                    ),
+                                    resume: StateId(
+                                        6,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            PureSet(
+                                MakeList {
+                                    dst: RegisterId(
+                                        5,
+                                    ),
+                                    items: [
+                                        RegisterId(
+                                            7,
+                                        ),
+                                    ],
+                                },
+                            ),
+                            PureSet(
+                                Binary {
+                                    kind: Add,
+                                    op: BinaryOp {
+                                        dst: RegisterId(
+                                            1,
+                                        ),
+                                        a: RegisterId(
+                                            1,
+                                        ),
+                                        b: RegisterId(
+                                            5,
+                                        ),
+                                    },
+                                },
+                            ),
+                            CoreSet(
+                                Jump {
+                                    target_state: StateId(
+                                        3,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                ],
+                num_regs: 8,
             },
-        ),
-    ),
+        ],
+    },
 )

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_for_loop__for_with_append.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_for_loop__for_with_append.py__bytecode.snap
@@ -2,12 +2,249 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_for_loop/for_with_append.py
 ---
-Err(
-    FunctionCompiler(
-        Unsupported(
-            Statement {
-                kind: ForLoop,
+Ok(
+    Executable {
+        functions: [
+            Function {
+                states: [
+                    State {
+                        instructions: [
+                            PureSet(
+                                MakeList {
+                                    dst: RegisterId(
+                                        1,
+                                    ),
+                                    items: [],
+                                },
+                            ),
+                            PureSet(
+                                Copy {
+                                    dst: RegisterId(
+                                        2,
+                                    ),
+                                    src: RegisterId(
+                                        0,
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                LoadConst {
+                                    dst: RegisterId(
+                                        3,
+                                    ),
+                                    value: Int(
+                                        0,
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                Length {
+                                    dst: RegisterId(
+                                        4,
+                                    ),
+                                    src: RegisterId(
+                                        2,
+                                    ),
+                                },
+                            ),
+                            CoreSet(
+                                Jump {
+                                    target_state: StateId(
+                                        1,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            PureSet(
+                                Binary {
+                                    kind: Lt,
+                                    op: BinaryOp {
+                                        dst: RegisterId(
+                                            5,
+                                        ),
+                                        a: RegisterId(
+                                            3,
+                                        ),
+                                        b: RegisterId(
+                                            4,
+                                        ),
+                                    },
+                                },
+                            ),
+                            CoreSet(
+                                JumpIf {
+                                    target_state: StateId(
+                                        2,
+                                    ),
+                                    cond: RegisterId(
+                                        5,
+                                    ),
+                                },
+                            ),
+                            CoreSet(
+                                Jump {
+                                    target_state: StateId(
+                                        4,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            PureSet(
+                                Index {
+                                    dst: RegisterId(
+                                        5,
+                                    ),
+                                    object: RegisterId(
+                                        2,
+                                    ),
+                                    index: RegisterId(
+                                        3,
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                Copy {
+                                    dst: RegisterId(
+                                        6,
+                                    ),
+                                    src: RegisterId(
+                                        5,
+                                    ),
+                                },
+                            ),
+                            ExtCallSet(
+                                ActionCall {
+                                    dst: RegisterId(
+                                        7,
+                                    ),
+                                    action_ref: TestActionRef(
+                                        "process_value",
+                                    ),
+                                    args: [
+                                        RegisterId(
+                                            6,
+                                        ),
+                                    ],
+                                    resume: StateId(
+                                        5,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            PureSet(
+                                LoadConst {
+                                    dst: RegisterId(
+                                        5,
+                                    ),
+                                    value: Int(
+                                        1,
+                                    ),
+                                },
+                            ),
+                            PureSet(
+                                Binary {
+                                    kind: Add,
+                                    op: BinaryOp {
+                                        dst: RegisterId(
+                                            3,
+                                        ),
+                                        a: RegisterId(
+                                            3,
+                                        ),
+                                        b: RegisterId(
+                                            5,
+                                        ),
+                                    },
+                                },
+                            ),
+                            CoreSet(
+                                Jump {
+                                    target_state: StateId(
+                                        1,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                Return {
+                                    src: RegisterId(
+                                        1,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            CoreSet(
+                                Await {
+                                    dst: RegisterId(
+                                        7,
+                                    ),
+                                    src: RegisterId(
+                                        7,
+                                    ),
+                                    resume: StateId(
+                                        6,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                    State {
+                        instructions: [
+                            PureSet(
+                                MakeList {
+                                    dst: RegisterId(
+                                        5,
+                                    ),
+                                    items: [
+                                        RegisterId(
+                                            7,
+                                        ),
+                                    ],
+                                },
+                            ),
+                            PureSet(
+                                Binary {
+                                    kind: Add,
+                                    op: BinaryOp {
+                                        dst: RegisterId(
+                                            1,
+                                        ),
+                                        a: RegisterId(
+                                            1,
+                                        ),
+                                        b: RegisterId(
+                                            5,
+                                        ),
+                                    },
+                                },
+                            ),
+                            CoreSet(
+                                Jump {
+                                    target_state: StateId(
+                                        3,
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                ],
+                num_regs: 8,
             },
-        ),
-    ),
+        ],
+    },
 )

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_generator_filter.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_generator_filter.py__bytecode.snap
@@ -5,8 +5,8 @@ expression: bytecode for python/tests/fixtures_gather/gather_generator_filter.py
 Err(
     FunctionCompiler(
         Unsupported(
-            Statement {
-                kind: ForLoop,
+            Expression {
+                kind: SpreadExpr,
             },
         ),
     ),

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_listcomp_filter.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_listcomp_filter.py__bytecode.snap
@@ -5,8 +5,8 @@ expression: bytecode for python/tests/fixtures_gather/gather_listcomp_filter.py
 Err(
     FunctionCompiler(
         Unsupported(
-            Statement {
-                kind: ForLoop,
+            Expression {
+                kind: SpreadExpr,
             },
         ),
     ),


### PR DESCRIPTION
This PR implements for loops support by lowering them into simple jumps at the compiler size.

The following modes are supported:
- iteration over lists (`for item in items`)
- iteration over ranges (`for index in range(...)`)
- iteration over enumerates over lists as positional (`for index, item in enumerate(items)`)
- iteration over enumerates over lists as kwarg (`for index, item in enumerate(items = items)`)
- iteration over enumerates over ranges as positional (`for index, item in enumerate(range(...))`)
- iteration over enumerates over ranges as kwarg (`for index, item in enumerate(items = range(...))`)

The last two don't make much sense at first glance, but if used with a stepped range could be useful for some cases.

Iterating over dicts is not supported currently.

For ranges, the supported variants are:
- `range(stop)`
- `range(start, stop)`
- `range(start, stop, step)`

Internally we support two modes of iteration:
- range-based
- index-based (with indexes traversing from 0 to the length of the list, exclusive)

---

This is what I had in mind for the initial MVP release of the compiler. I've looked into how we can add support for something more advanced, and it seems like it's going to be quite a bit of work. Not too much, but enough to postpone to later. especially since we don't seem to support anything more advanced just yet with the current DAG implementation.

---

With the for-loops out of the way, there is very little surface to cover left:
- spreads - looked into them deeper, and realized they're not as trivial as I thought; will probably work on them next
- exceptions - supporting exceptions as first-class values is easy, but providing bubbling and try-catch support can actually be a quite complex task, so I'll be doing some research in the background before tackling it; I mean, it could be done simply - but I wonder if there's a more elegant way
- minor corrections - like tuple unpacking in assignments and etc

---

Overall, the for-loops came to be quite clean; I imagined it would be more messy, but the encapsulate quite well.