### PR TITLE
Add bytecode formatting facilities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5245,6 +5245,7 @@ dependencies = [
  "waymark-vm-ast-old-helpers",
  "waymark-vm-bytecode",
  "waymark-vm-bytecode-core",
+ "waymark-vm-bytecode-fmt",
  "waymark-vm-compiler-for-ast-old-core",
  "waymark-vm-compiler-for-ast-old-test-support",
  "waymark-vm-instructions-coreset",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5190,6 +5190,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "waymark-vm-bytecode-fmt"
+version = "0.1.0"
+dependencies = [
+ "index_type",
+ "insta",
+ "waymark-vm-bytecode",
+ "waymark-vm-bytecode-core",
+]
+
+[[package]]
 name = "waymark-vm-cli"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,7 @@ waymark-vm-ast-old-helpers = { path = "crates/lib/vm-ast-old-helpers" }
 waymark-vm-ast-old-proto = { path = "crates/lib/vm-ast-old-proto" }
 waymark-vm-bytecode = { path = "crates/lib/vm-bytecode" }
 waymark-vm-bytecode-core = { path = "crates/lib/vm-bytecode-core" }
+waymark-vm-bytecode-fmt = { path = "crates/lib/vm-bytecode-fmt" }
 waymark-vm-compiler-for-ast-old = { path = "crates/lib/vm-compiler-for-ast-old" }
 waymark-vm-compiler-for-ast-old-const-value = { path = "crates/lib/vm-compiler-for-ast-old-const-value" }
 waymark-vm-compiler-for-ast-old-core = { path = "crates/lib/vm-compiler-for-ast-old-core" }

--- a/crates/lib/vm-bytecode-core/src/lib.rs
+++ b/crates/lib/vm-bytecode-core/src/lib.rs
@@ -5,17 +5,17 @@
 use index_type::{IndexTooBigError, IndexType};
 
 /// Identifies a function within a VM executable.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, IndexType, Default)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, IndexType, Default)]
 #[index_type(error = FunctionIdTooBigError)]
 pub struct FunctionId(pub usize);
 
 /// Identifies a state-machine state within a function.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, IndexType, Default)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, IndexType, Default)]
 #[index_type(error = StateIdTooBigError)]
 pub struct StateId(pub usize);
 
 /// Identifies an instruction within a state.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, IndexType, Default)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, IndexType, Default)]
 #[index_type(error = InstructionIdTooBigError)]
 pub struct InstructionId(pub usize);
 
@@ -33,3 +33,21 @@ pub struct StateIdTooBigError;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, IndexTooBigError)]
 #[index_too_big_error(msg = "instruction id")]
 pub struct InstructionIdTooBigError;
+
+impl core::fmt::Debug for FunctionId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "f{}", self.0)
+    }
+}
+
+impl core::fmt::Debug for StateId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "s{}", self.0)
+    }
+}
+
+impl core::fmt::Debug for InstructionId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "x{}", self.0)
+    }
+}

--- a/crates/lib/vm-bytecode-fmt/Cargo.toml
+++ b/crates/lib/vm-bytecode-fmt/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "waymark-vm-bytecode-fmt"
+edition = "2024"
+version.workspace = true
+publish.workspace = true
+
+[dependencies]
+waymark-vm-bytecode = { workspace = true }
+waymark-vm-bytecode-core = { workspace = true }
+
+index_type = { workspace = true }
+
+[dev-dependencies]
+insta = { workspace = true }

--- a/crates/lib/vm-bytecode-fmt/src/display.rs
+++ b/crates/lib/vm-bytecode-fmt/src/display.rs
@@ -1,0 +1,28 @@
+use crate::Fmt;
+
+impl<'a, Instruction> core::fmt::Display for Fmt<'a, waymark_vm_bytecode::Executable<Instruction>>
+where
+    Instruction: core::fmt::Debug,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> core::fmt::Result {
+        self.padded_fmt(f, 0)
+    }
+}
+
+impl<'a, Instruction> core::fmt::Display for Fmt<'a, waymark_vm_bytecode::Function<Instruction>>
+where
+    Instruction: core::fmt::Debug,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> core::fmt::Result {
+        self.padded_fmt(f, 0)
+    }
+}
+
+impl<'a, Instruction> core::fmt::Display for Fmt<'a, waymark_vm_bytecode::State<Instruction>>
+where
+    Instruction: core::fmt::Debug,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> core::fmt::Result {
+        self.padded_fmt(f, 0)
+    }
+}

--- a/crates/lib/vm-bytecode-fmt/src/impl.rs
+++ b/crates/lib/vm-bytecode-fmt/src/impl.rs
@@ -3,15 +3,21 @@ use waymark_vm_bytecode_core::{FunctionId, InstructionId, StateId};
 
 use crate::Fmt;
 
+fn write_padding(f: &mut std::fmt::Formatter<'_>, level: usize) -> core::fmt::Result {
+    for _ in 0..level {
+        f.write_str("  ")?;
+    }
+    Ok(())
+}
+
 impl<'a, Instruction> Fmt<'a, TypedVec<InstructionId, Instruction>>
 where
     Instruction: core::fmt::Debug,
 {
     pub fn padded_fmt(&self, f: &mut std::fmt::Formatter<'_>, padding: usize) -> core::fmt::Result {
-        let pad = " ".repeat(padding);
-
         for instruction in self.0.iter() {
-            writeln!(f, "{pad}{:?}", instruction)?;
+            write_padding(f, padding)?;
+            writeln!(f, "{:?}", instruction)?;
         }
 
         Ok(())
@@ -32,11 +38,10 @@ where
     Instruction: core::fmt::Debug,
 {
     pub fn padded_fmt(&self, f: &mut std::fmt::Formatter<'_>, padding: usize) -> core::fmt::Result {
-        let pad = " ".repeat(padding);
-
         for (index, state) in self.0.iter_enumerated() {
-            writeln!(f, "{pad}{:?}:", index)?;
-            Fmt(state).padded_fmt(f, padding + 2)?;
+            write_padding(f, padding)?;
+            writeln!(f, "{:?}:", index)?;
+            Fmt(state).padded_fmt(f, padding + 1)?;
         }
 
         Ok(())
@@ -57,11 +62,10 @@ where
     Instruction: core::fmt::Debug,
 {
     pub fn padded_fmt(&self, f: &mut std::fmt::Formatter<'_>, padding: usize) -> core::fmt::Result {
-        let pad = " ".repeat(padding);
-
         for (index, function) in self.0.iter_enumerated() {
-            writeln!(f, "{pad}{:?}: [{} registers]", index, function.num_regs)?;
-            Fmt(&function.states).padded_fmt(f, padding + 2)?;
+            write_padding(f, padding)?;
+            writeln!(f, "{:?}: [{} registers]", index, function.num_regs)?;
+            Fmt(&function.states).padded_fmt(f, padding + 1)?;
         }
 
         Ok(())

--- a/crates/lib/vm-bytecode-fmt/src/impl.rs
+++ b/crates/lib/vm-bytecode-fmt/src/impl.rs
@@ -1,0 +1,78 @@
+use index_type::typed_vec::TypedVec;
+use waymark_vm_bytecode_core::{FunctionId, InstructionId, StateId};
+
+use crate::Fmt;
+
+impl<'a, Instruction> Fmt<'a, TypedVec<InstructionId, Instruction>>
+where
+    Instruction: core::fmt::Debug,
+{
+    pub fn padded_fmt(&self, f: &mut std::fmt::Formatter<'_>, padding: usize) -> core::fmt::Result {
+        let pad = " ".repeat(padding);
+
+        for instruction in self.0.iter() {
+            writeln!(f, "{pad}{:?}", instruction)?;
+        }
+
+        Ok(())
+    }
+}
+
+impl<'a, Instruction> Fmt<'a, waymark_vm_bytecode::State<Instruction>>
+where
+    Instruction: core::fmt::Debug,
+{
+    pub fn padded_fmt(&self, f: &mut std::fmt::Formatter<'_>, padding: usize) -> core::fmt::Result {
+        Fmt(&self.0.instructions).padded_fmt(f, padding)
+    }
+}
+
+impl<'a, Instruction> Fmt<'a, TypedVec<StateId, waymark_vm_bytecode::State<Instruction>>>
+where
+    Instruction: core::fmt::Debug,
+{
+    pub fn padded_fmt(&self, f: &mut std::fmt::Formatter<'_>, padding: usize) -> core::fmt::Result {
+        let pad = " ".repeat(padding);
+
+        for (index, state) in self.0.iter_enumerated() {
+            writeln!(f, "{pad}{:?}:", index)?;
+            Fmt(state).padded_fmt(f, padding + 2)?;
+        }
+
+        Ok(())
+    }
+}
+
+impl<'a, Instruction> Fmt<'a, waymark_vm_bytecode::Function<Instruction>>
+where
+    Instruction: core::fmt::Debug,
+{
+    pub fn padded_fmt(&self, f: &mut std::fmt::Formatter<'_>, padding: usize) -> core::fmt::Result {
+        Fmt(&self.0.states).padded_fmt(f, padding)
+    }
+}
+
+impl<'a, Instruction> Fmt<'a, TypedVec<FunctionId, waymark_vm_bytecode::Function<Instruction>>>
+where
+    Instruction: core::fmt::Debug,
+{
+    pub fn padded_fmt(&self, f: &mut std::fmt::Formatter<'_>, padding: usize) -> core::fmt::Result {
+        let pad = " ".repeat(padding);
+
+        for (index, function) in self.0.iter_enumerated() {
+            writeln!(f, "{pad}{:?}: [{} registers]", index, function.num_regs)?;
+            Fmt(&function.states).padded_fmt(f, padding + 2)?;
+        }
+
+        Ok(())
+    }
+}
+
+impl<'a, Instruction> Fmt<'a, waymark_vm_bytecode::Executable<Instruction>>
+where
+    Instruction: core::fmt::Debug,
+{
+    pub fn padded_fmt(&self, f: &mut std::fmt::Formatter<'_>, padding: usize) -> core::fmt::Result {
+        Fmt(&self.0.functions).padded_fmt(f, padding)
+    }
+}

--- a/crates/lib/vm-bytecode-fmt/src/lib.rs
+++ b/crates/lib/vm-bytecode-fmt/src/lib.rs
@@ -1,0 +1,11 @@
+mod display;
+mod r#impl;
+
+pub struct Fmt<'a, T>(pub &'a T);
+
+pub fn display<'a, T>(value: &'a T) -> Fmt<'a, T>
+where
+    Fmt<'a, T>: core::fmt::Display,
+{
+    Fmt(value)
+}

--- a/crates/lib/vm-bytecode-fmt/tests/snapshots/visual__fmt_display_prints_dummy_instruction_set.snap
+++ b/crates/lib/vm-bytecode-fmt/tests/snapshots/visual__fmt_display_prints_dummy_instruction_set.snap
@@ -1,0 +1,10 @@
+---
+source: crates/lib/vm-bytecode-fmt/tests/visual.rs
+expression: Fmt(&executable)
+---
+f0: [123 registers]
+  s0:
+    LoadConst7
+    Jump { target: s1 }
+  s1:
+    Return

--- a/crates/lib/vm-bytecode-fmt/tests/visual.rs
+++ b/crates/lib/vm-bytecode-fmt/tests/visual.rs
@@ -1,0 +1,33 @@
+use index_type::typed_vec;
+use waymark_vm_bytecode::{Executable, Function, State};
+use waymark_vm_bytecode_core::StateId;
+
+#[allow(dead_code)]
+#[derive(Debug)]
+enum DummyInstruction {
+    LoadConst7,
+    Jump { target: StateId },
+    Return,
+}
+
+#[test]
+fn fmt_display_prints_dummy_instruction_set() {
+    let executable = Executable {
+        functions: typed_vec![Function {
+            states: typed_vec![
+                State {
+                    instructions: typed_vec![
+                        DummyInstruction::LoadConst7,
+                        DummyInstruction::Jump { target: StateId(1) },
+                    ],
+                },
+                State {
+                    instructions: typed_vec![DummyInstruction::Return,],
+                }
+            ],
+            num_regs: 123,
+        }],
+    };
+
+    insta::assert_snapshot!(waymark_vm_bytecode_fmt::display(&executable));
+}

--- a/crates/lib/vm-compiler-for-ast-old/Cargo.toml
+++ b/crates/lib/vm-compiler-for-ast-old/Cargo.toml
@@ -23,6 +23,7 @@ thiserror = { workspace = true }
 waymark-nonzero-duration = { workspace = true }
 waymark-support-test-python = { workspace = true }
 waymark-vm-ast-old-helpers = { workspace = true }
+waymark-vm-bytecode-fmt = { workspace = true }
 waymark-vm-compiler-for-ast-old-test-support = { workspace = true }
 waymark-vm-interpreter-coreset = { workspace = true }
 waymark-vm-interpreter-extcallset = { workspace = true }

--- a/crates/lib/vm-compiler-for-ast-old/src/tests/for_loops.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/tests/for_loops.rs
@@ -102,252 +102,35 @@ fn whole_program_async_indexed_for_loops_match_the_documented_lowering_shape() {
     let executable = compile::<TestSpec, TestLowering>(&program)
         .expect("documented async for loop should compile");
 
-    insta::assert_debug_snapshot!(executable, @r###"
-    Executable {
-        functions: [
-            Function {
-                states: [
-                    State {
-                        instructions: [
-                            PureSet(
-                                MakeList {
-                                    dst: RegisterId(
-                                        1,
-                                    ),
-                                    items: [],
-                                },
-                            ),
-                            PureSet(
-                                Copy {
-                                    dst: RegisterId(
-                                        2,
-                                    ),
-                                    src: RegisterId(
-                                        0,
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        3,
-                                    ),
-                                    value: Int(
-                                        0,
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                Length {
-                                    dst: RegisterId(
-                                        4,
-                                    ),
-                                    src: RegisterId(
-                                        2,
-                                    ),
-                                },
-                            ),
-                            CoreSet(
-                                Jump {
-                                    target_state: StateId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            PureSet(
-                                Binary {
-                                    kind: Lt,
-                                    op: BinaryOp {
-                                        dst: RegisterId(
-                                            5,
-                                        ),
-                                        a: RegisterId(
-                                            3,
-                                        ),
-                                        b: RegisterId(
-                                            4,
-                                        ),
-                                    },
-                                },
-                            ),
-                            CoreSet(
-                                JumpIf {
-                                    target_state: StateId(
-                                        2,
-                                    ),
-                                    cond: RegisterId(
-                                        5,
-                                    ),
-                                },
-                            ),
-                            CoreSet(
-                                Jump {
-                                    target_state: StateId(
-                                        4,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            PureSet(
-                                Index {
-                                    dst: RegisterId(
-                                        5,
-                                    ),
-                                    object: RegisterId(
-                                        2,
-                                    ),
-                                    index: RegisterId(
-                                        3,
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                Copy {
-                                    dst: RegisterId(
-                                        6,
-                                    ),
-                                    src: RegisterId(
-                                        5,
-                                    ),
-                                },
-                            ),
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        7,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "process_value",
-                                    ),
-                                    args: [
-                                        RegisterId(
-                                            6,
-                                        ),
-                                    ],
-                                    resume: StateId(
-                                        5,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        5,
-                                    ),
-                                    value: Int(
-                                        1,
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                Binary {
-                                    kind: Add,
-                                    op: BinaryOp {
-                                        dst: RegisterId(
-                                            3,
-                                        ),
-                                        a: RegisterId(
-                                            3,
-                                        ),
-                                        b: RegisterId(
-                                            5,
-                                        ),
-                                    },
-                                },
-                            ),
-                            CoreSet(
-                                Jump {
-                                    target_state: StateId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Return {
-                                    src: RegisterId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        7,
-                                    ),
-                                    src: RegisterId(
-                                        7,
-                                    ),
-                                    resume: StateId(
-                                        6,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            PureSet(
-                                MakeList {
-                                    dst: RegisterId(
-                                        5,
-                                    ),
-                                    items: [
-                                        RegisterId(
-                                            7,
-                                        ),
-                                    ],
-                                },
-                            ),
-                            PureSet(
-                                Binary {
-                                    kind: Add,
-                                    op: BinaryOp {
-                                        dst: RegisterId(
-                                            1,
-                                        ),
-                                        a: RegisterId(
-                                            1,
-                                        ),
-                                        b: RegisterId(
-                                            5,
-                                        ),
-                                    },
-                                },
-                            ),
-                            CoreSet(
-                                Jump {
-                                    target_state: StateId(
-                                        3,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                ],
-                num_regs: 8,
-            },
-        ],
-    }
-    "###);
+    insta::assert_snapshot!(waymark_vm_bytecode_fmt::display(&executable), @r#"
+    f0: [8 registers]
+      s0:
+        PureSet(MakeList { dst: r1, items: [] })
+        PureSet(Copy { dst: r2, src: r0 })
+        PureSet(LoadConst { dst: r3, value: Int(0) })
+        PureSet(Length { dst: r4, src: r2 })
+        CoreSet(Jump { target_state: s1 })
+      s1:
+        PureSet(Binary { kind: Lt, op: BinaryOp { dst: r5, a: r3, b: r4 } })
+        CoreSet(JumpIf { target_state: s2, cond: r5 })
+        CoreSet(Jump { target_state: s4 })
+      s2:
+        PureSet(Index { dst: r5, object: r2, index: r3 })
+        PureSet(Copy { dst: r6, src: r5 })
+        ExtCallSet(ActionCall { dst: r7, action_ref: TestActionRef("process_value"), args: [r6], resume: s5 })
+      s3:
+        PureSet(LoadConst { dst: r5, value: Int(1) })
+        PureSet(Binary { kind: Add, op: BinaryOp { dst: r3, a: r3, b: r5 } })
+        CoreSet(Jump { target_state: s1 })
+      s4:
+        CoreSet(Return { src: r1 })
+      s5:
+        CoreSet(Await { dst: r7, src: r7, resume: s6 })
+      s6:
+        PureSet(MakeList { dst: r5, items: [r7] })
+        PureSet(Binary { kind: Add, op: BinaryOp { dst: r1, a: r1, b: r5 } })
+        CoreSet(Jump { target_state: s3 })
+    "#);
 }
 
 #[test]

--- a/crates/lib/vm-compiler-for-ast-old/tests/python.rs
+++ b/crates/lib/vm-compiler-for-ast-old/tests/python.rs
@@ -94,7 +94,23 @@ async fn compile_python_tests() {
             waymark_vm_compiler_for_ast_old::compile::<TestSpec, TestLowering>(&program);
 
         let snapshot = format!("{}/bytecode", python_test_file.display());
-        let details = format!("bytecode for python/tests/{}", python_test_file.display());
-        insta::assert_debug_snapshot!(snapshot, bytecode_result, &details);
+
+        match bytecode_result {
+            Ok(bytecode) => {
+                let details = format!("bytecode for python/tests/{}", python_test_file.display());
+                insta::assert_snapshot!(
+                    snapshot,
+                    waymark_vm_bytecode_fmt::display(&bytecode),
+                    &details
+                );
+            }
+            Err(error) => {
+                let details = format!(
+                    "bytecode for python/tests/{} [compilation error]",
+                    python_test_file.display()
+                );
+                insta::assert_debug_snapshot!(snapshot, error, &details)
+            }
+        }
     }
 }

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_actions__action_kwargs.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_actions__action_kwargs.py__bytecode.snap
@@ -2,87 +2,12 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_actions/action_kwargs.py
 ---
-Ok(
-    Executable {
-        functions: [
-            Function {
-                states: [
-                    State {
-                        instructions: [
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        1,
-                                    ),
-                                    value: String(
-                                        "World",
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        2,
-                                    ),
-                                    value: String(
-                                        "Hi",
-                                    ),
-                                },
-                            ),
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        0,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "greet_person",
-                                    ),
-                                    args: [
-                                        RegisterId(
-                                            1,
-                                        ),
-                                        RegisterId(
-                                            2,
-                                        ),
-                                    ],
-                                    resume: StateId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        0,
-                                    ),
-                                    src: RegisterId(
-                                        0,
-                                    ),
-                                    resume: StateId(
-                                        2,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Return {
-                                    src: RegisterId(
-                                        0,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                ],
-                num_regs: 3,
-            },
-        ],
-    },
-)
+f0: [3 registers]
+  s0:
+    PureSet(LoadConst { dst: r1, value: String("World") })
+    PureSet(LoadConst { dst: r2, value: String("Hi") })
+    ExtCallSet(ActionCall { dst: r0, action_ref: TestActionRef("greet_person"), args: [r1, r2], resume: s1 })
+  s1:
+    CoreSet(Await { dst: r0, src: r0, resume: s2 })
+  s2:
+    CoreSet(Return { src: r0 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_actions__action_mixed_args.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_actions__action_mixed_args.py__bytecode.snap
@@ -2,100 +2,13 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_actions/action_mixed_args.py
 ---
-Ok(
-    Executable {
-        functions: [
-            Function {
-                states: [
-                    State {
-                        instructions: [
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        1,
-                                    ),
-                                    value: Int(
-                                        5,
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        2,
-                                    ),
-                                    value: Int(
-                                        10,
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        3,
-                                    ),
-                                    value: Int(
-                                        2,
-                                    ),
-                                },
-                            ),
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        0,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "compute_value",
-                                    ),
-                                    args: [
-                                        RegisterId(
-                                            1,
-                                        ),
-                                        RegisterId(
-                                            2,
-                                        ),
-                                        RegisterId(
-                                            3,
-                                        ),
-                                    ],
-                                    resume: StateId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        0,
-                                    ),
-                                    src: RegisterId(
-                                        0,
-                                    ),
-                                    resume: StateId(
-                                        2,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Return {
-                                    src: RegisterId(
-                                        0,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                ],
-                num_regs: 4,
-            },
-        ],
-    },
-)
+f0: [4 registers]
+  s0:
+    PureSet(LoadConst { dst: r1, value: Int(5) })
+    PureSet(LoadConst { dst: r2, value: Int(10) })
+    PureSet(LoadConst { dst: r3, value: Int(2) })
+    ExtCallSet(ActionCall { dst: r0, action_ref: TestActionRef("compute_value"), args: [r1, r2, r3], resume: s1 })
+  s1:
+    CoreSet(Await { dst: r0, src: r0, resume: s2 })
+  s2:
+    CoreSet(Return { src: r0 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_actions__action_no_assignment.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_actions__action_no_assignment.py__bytecode.snap
@@ -2,158 +2,20 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_actions/action_no_assignment.py
 ---
-Ok(
-    Executable {
-        functions: [
-            Function {
-                states: [
-                    State {
-                        instructions: [
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        1,
-                                    ),
-                                    value: String(
-                                        "starting",
-                                    ),
-                                },
-                            ),
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        0,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "log_event",
-                                    ),
-                                    args: [
-                                        RegisterId(
-                                            1,
-                                        ),
-                                    ],
-                                    resume: StateId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        0,
-                                    ),
-                                    src: RegisterId(
-                                        0,
-                                    ),
-                                    resume: StateId(
-                                        2,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        2,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "get_final_value",
-                                    ),
-                                    args: [],
-                                    resume: StateId(
-                                        3,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        2,
-                                    ),
-                                    src: RegisterId(
-                                        2,
-                                    ),
-                                    resume: StateId(
-                                        4,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        1,
-                                    ),
-                                    value: String(
-                                        "finished",
-                                    ),
-                                },
-                            ),
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        0,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "log_event",
-                                    ),
-                                    args: [
-                                        RegisterId(
-                                            1,
-                                        ),
-                                    ],
-                                    resume: StateId(
-                                        5,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        0,
-                                    ),
-                                    src: RegisterId(
-                                        0,
-                                    ),
-                                    resume: StateId(
-                                        6,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Return {
-                                    src: RegisterId(
-                                        2,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                ],
-                num_regs: 3,
-            },
-        ],
-    },
-)
+f0: [3 registers]
+  s0:
+    PureSet(LoadConst { dst: r1, value: String("starting") })
+    ExtCallSet(ActionCall { dst: r0, action_ref: TestActionRef("log_event"), args: [r1], resume: s1 })
+  s1:
+    CoreSet(Await { dst: r0, src: r0, resume: s2 })
+  s2:
+    ExtCallSet(ActionCall { dst: r2, action_ref: TestActionRef("get_final_value"), args: [], resume: s3 })
+  s3:
+    CoreSet(Await { dst: r2, src: r2, resume: s4 })
+  s4:
+    PureSet(LoadConst { dst: r1, value: String("finished") })
+    ExtCallSet(ActionCall { dst: r0, action_ref: TestActionRef("log_event"), args: [r1], resume: s5 })
+  s5:
+    CoreSet(Await { dst: r0, src: r0, resume: s6 })
+  s6:
+    CoreSet(Return { src: r2 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_actions__action_positional_args.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_actions__action_positional_args.py__bytecode.snap
@@ -2,87 +2,12 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_actions/action_positional_args.py
 ---
-Ok(
-    Executable {
-        functions: [
-            Function {
-                states: [
-                    State {
-                        instructions: [
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        1,
-                                    ),
-                                    value: Int(
-                                        10,
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        2,
-                                    ),
-                                    value: Int(
-                                        20,
-                                    ),
-                                },
-                            ),
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        0,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "add_numbers",
-                                    ),
-                                    args: [
-                                        RegisterId(
-                                            1,
-                                        ),
-                                        RegisterId(
-                                            2,
-                                        ),
-                                    ],
-                                    resume: StateId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        0,
-                                    ),
-                                    src: RegisterId(
-                                        0,
-                                    ),
-                                    resume: StateId(
-                                        2,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Return {
-                                    src: RegisterId(
-                                        0,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                ],
-                num_regs: 3,
-            },
-        ],
-    },
-)
+f0: [3 registers]
+  s0:
+    PureSet(LoadConst { dst: r1, value: Int(10) })
+    PureSet(LoadConst { dst: r2, value: Int(20) })
+    ExtCallSet(ActionCall { dst: r0, action_ref: TestActionRef("add_numbers"), args: [r1, r2], resume: s1 })
+  s1:
+    CoreSet(Await { dst: r0, src: r0, resume: s2 })
+  s2:
+    CoreSet(Return { src: r0 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_actions__action_return.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_actions__action_return.py__bytecode.snap
@@ -2,64 +2,10 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_actions/action_return.py
 ---
-Ok(
-    Executable {
-        functions: [
-            Function {
-                states: [
-                    State {
-                        instructions: [
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        1,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "compute_result",
-                                    ),
-                                    args: [
-                                        RegisterId(
-                                            0,
-                                        ),
-                                    ],
-                                    resume: StateId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        1,
-                                    ),
-                                    src: RegisterId(
-                                        1,
-                                    ),
-                                    resume: StateId(
-                                        2,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Return {
-                                    src: RegisterId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                ],
-                num_regs: 2,
-            },
-        ],
-    },
-)
+f0: [2 registers]
+  s0:
+    ExtCallSet(ActionCall { dst: r1, action_ref: TestActionRef("compute_result"), args: [r0], resume: s1 })
+  s1:
+    CoreSet(Await { dst: r1, src: r1, resume: s2 })
+  s2:
+    CoreSet(Return { src: r1 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_actions__action_variable_args.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_actions__action_variable_args.py__bytecode.snap
@@ -2,102 +2,14 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_actions/action_variable_args.py
 ---
-Ok(
-    Executable {
-        functions: [
-            Function {
-                states: [
-                    State {
-                        instructions: [
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        1,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "get_base_value",
-                                    ),
-                                    args: [],
-                                    resume: StateId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        1,
-                                    ),
-                                    src: RegisterId(
-                                        1,
-                                    ),
-                                    resume: StateId(
-                                        2,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        2,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "multiply_by",
-                                    ),
-                                    args: [
-                                        RegisterId(
-                                            1,
-                                        ),
-                                        RegisterId(
-                                            0,
-                                        ),
-                                    ],
-                                    resume: StateId(
-                                        3,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        2,
-                                    ),
-                                    src: RegisterId(
-                                        2,
-                                    ),
-                                    resume: StateId(
-                                        4,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Return {
-                                    src: RegisterId(
-                                        2,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                ],
-                num_regs: 3,
-            },
-        ],
-    },
-)
+f0: [3 registers]
+  s0:
+    ExtCallSet(ActionCall { dst: r1, action_ref: TestActionRef("get_base_value"), args: [], resume: s1 })
+  s1:
+    CoreSet(Await { dst: r1, src: r1, resume: s2 })
+  s2:
+    ExtCallSet(ActionCall { dst: r2, action_ref: TestActionRef("multiply_by"), args: [r1, r0], resume: s3 })
+  s3:
+    CoreSet(Await { dst: r2, src: r2, resume: s4 })
+  s4:
+    CoreSet(Return { src: r2 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_actions__literal_return.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_actions__literal_return.py__bytecode.snap
@@ -2,70 +2,11 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_actions/literal_return.py
 ---
-Ok(
-    Executable {
-        functions: [
-            Function {
-                states: [
-                    State {
-                        instructions: [
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        0,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "do_something",
-                                    ),
-                                    args: [],
-                                    resume: StateId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        0,
-                                    ),
-                                    src: RegisterId(
-                                        0,
-                                    ),
-                                    resume: StateId(
-                                        2,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        0,
-                                    ),
-                                    value: Int(
-                                        42,
-                                    ),
-                                },
-                            ),
-                            CoreSet(
-                                Return {
-                                    src: RegisterId(
-                                        0,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                ],
-                num_regs: 1,
-            },
-        ],
-    },
-)
+f0: [1 registers]
+  s0:
+    ExtCallSet(ActionCall { dst: r0, action_ref: TestActionRef("do_something"), args: [], resume: s1 })
+  s1:
+    CoreSet(Await { dst: r0, src: r0, resume: s2 })
+  s2:
+    PureSet(LoadConst { dst: r0, value: Int(42) })
+    CoreSet(Return { src: r0 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_actions__simple_action.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_actions__simple_action.py__bytecode.snap
@@ -2,64 +2,10 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_actions/simple_action.py
 ---
-Ok(
-    Executable {
-        functions: [
-            Function {
-                states: [
-                    State {
-                        instructions: [
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        1,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "process",
-                                    ),
-                                    args: [
-                                        RegisterId(
-                                            0,
-                                        ),
-                                    ],
-                                    resume: StateId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        1,
-                                    ),
-                                    src: RegisterId(
-                                        1,
-                                    ),
-                                    resume: StateId(
-                                        2,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Return {
-                                    src: RegisterId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                ],
-                num_regs: 2,
-            },
-        ],
-    },
-)
+f0: [2 registers]
+  s0:
+    ExtCallSet(ActionCall { dst: r1, action_ref: TestActionRef("process"), args: [r0], resume: s1 })
+  s1:
+    CoreSet(Await { dst: r1, src: r1, resume: s2 })
+  s2:
+    CoreSet(Return { src: r1 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_actions__variable_return.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_actions__variable_return.py__bytecode.snap
@@ -2,64 +2,10 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_actions/variable_return.py
 ---
-Ok(
-    Executable {
-        functions: [
-            Function {
-                states: [
-                    State {
-                        instructions: [
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        1,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "compute_result_for_variable_return",
-                                    ),
-                                    args: [
-                                        RegisterId(
-                                            0,
-                                        ),
-                                    ],
-                                    resume: StateId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        1,
-                                    ),
-                                    src: RegisterId(
-                                        1,
-                                    ),
-                                    resume: StateId(
-                                        2,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Return {
-                                    src: RegisterId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                ],
-                num_regs: 2,
-            },
-        ],
-    },
-)
+f0: [2 registers]
+  s0:
+    ExtCallSet(ActionCall { dst: r1, action_ref: TestActionRef("compute_result_for_variable_return"), args: [r0], resume: s1 })
+  s1:
+    CoreSet(Await { dst: r1, src: r1, resume: s2 })
+  s2:
+    CoreSet(Return { src: r1 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_comprehension__dict_comprehension_assignment.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_comprehension__dict_comprehension_assignment.py__bytecode.snap
@@ -2,236 +2,31 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_comprehension/dict_comprehension_assignment.py
 ---
-Ok(
-    Executable {
-        functions: [
-            Function {
-                states: [
-                    State {
-                        instructions: [
-                            PureSet(
-                                MakeDict {
-                                    dst: RegisterId(
-                                        1,
-                                    ),
-                                    entries: [],
-                                },
-                            ),
-                            PureSet(
-                                Copy {
-                                    dst: RegisterId(
-                                        2,
-                                    ),
-                                    src: RegisterId(
-                                        0,
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        3,
-                                    ),
-                                    value: Int(
-                                        0,
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                Length {
-                                    dst: RegisterId(
-                                        4,
-                                    ),
-                                    src: RegisterId(
-                                        2,
-                                    ),
-                                },
-                            ),
-                            CoreSet(
-                                Jump {
-                                    target_state: StateId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            PureSet(
-                                Binary {
-                                    kind: Lt,
-                                    op: BinaryOp {
-                                        dst: RegisterId(
-                                            5,
-                                        ),
-                                        a: RegisterId(
-                                            3,
-                                        ),
-                                        b: RegisterId(
-                                            4,
-                                        ),
-                                    },
-                                },
-                            ),
-                            CoreSet(
-                                JumpIf {
-                                    target_state: StateId(
-                                        2,
-                                    ),
-                                    cond: RegisterId(
-                                        5,
-                                    ),
-                                },
-                            ),
-                            CoreSet(
-                                Jump {
-                                    target_state: StateId(
-                                        4,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            PureSet(
-                                Index {
-                                    dst: RegisterId(
-                                        5,
-                                    ),
-                                    object: RegisterId(
-                                        2,
-                                    ),
-                                    index: RegisterId(
-                                        3,
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                Copy {
-                                    dst: RegisterId(
-                                        6,
-                                    ),
-                                    src: RegisterId(
-                                        5,
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                Dot {
-                                    dst: RegisterId(
-                                        5,
-                                    ),
-                                    object: RegisterId(
-                                        6,
-                                    ),
-                                    attribute: "active",
-                                },
-                            ),
-                            CoreSet(
-                                JumpIf {
-                                    target_state: StateId(
-                                        6,
-                                    ),
-                                    cond: RegisterId(
-                                        5,
-                                    ),
-                                },
-                            ),
-                            CoreSet(
-                                Jump {
-                                    target_state: StateId(
-                                        5,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        5,
-                                    ),
-                                    value: Int(
-                                        1,
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                Binary {
-                                    kind: Add,
-                                    op: BinaryOp {
-                                        dst: RegisterId(
-                                            3,
-                                        ),
-                                        a: RegisterId(
-                                            3,
-                                        ),
-                                        b: RegisterId(
-                                            5,
-                                        ),
-                                    },
-                                },
-                            ),
-                            CoreSet(
-                                Jump {
-                                    target_state: StateId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Return {
-                                    src: RegisterId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Jump {
-                                    target_state: StateId(
-                                        3,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            PureSet(
-                                Dot {
-                                    dst: RegisterId(
-                                        7,
-                                    ),
-                                    object: RegisterId(
-                                        6,
-                                    ),
-                                    attribute: "name",
-                                },
-                            ),
-                            CoreSet(
-                                Jump {
-                                    target_state: StateId(
-                                        5,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                ],
-                num_regs: 8,
-            },
-        ],
-    },
-)
+f0: [8 registers]
+  s0:
+    PureSet(MakeDict { dst: r1, entries: [] })
+    PureSet(Copy { dst: r2, src: r0 })
+    PureSet(LoadConst { dst: r3, value: Int(0) })
+    PureSet(Length { dst: r4, src: r2 })
+    CoreSet(Jump { target_state: s1 })
+  s1:
+    PureSet(Binary { kind: Lt, op: BinaryOp { dst: r5, a: r3, b: r4 } })
+    CoreSet(JumpIf { target_state: s2, cond: r5 })
+    CoreSet(Jump { target_state: s4 })
+  s2:
+    PureSet(Index { dst: r5, object: r2, index: r3 })
+    PureSet(Copy { dst: r6, src: r5 })
+    PureSet(Dot { dst: r5, object: r6, attribute: "active" })
+    CoreSet(JumpIf { target_state: s6, cond: r5 })
+    CoreSet(Jump { target_state: s5 })
+  s3:
+    PureSet(LoadConst { dst: r5, value: Int(1) })
+    PureSet(Binary { kind: Add, op: BinaryOp { dst: r3, a: r3, b: r5 } })
+    CoreSet(Jump { target_state: s1 })
+  s4:
+    CoreSet(Return { src: r1 })
+  s5:
+    CoreSet(Jump { target_state: s3 })
+  s6:
+    PureSet(Dot { dst: r7, object: r6, attribute: "name" })
+    CoreSet(Jump { target_state: s5 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_comprehension__dict_comprehension_tuple.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_comprehension__dict_comprehension_tuple.py__bytecode.snap
@@ -2,228 +2,28 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_comprehension/dict_comprehension_tuple.py
 ---
-Ok(
-    Executable {
-        functions: [
-            Function {
-                states: [
-                    State {
-                        instructions: [
-                            PureSet(
-                                MakeDict {
-                                    dst: RegisterId(
-                                        1,
-                                    ),
-                                    entries: [],
-                                },
-                            ),
-                            PureSet(
-                                Copy {
-                                    dst: RegisterId(
-                                        2,
-                                    ),
-                                    src: RegisterId(
-                                        0,
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        3,
-                                    ),
-                                    value: Int(
-                                        0,
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                Length {
-                                    dst: RegisterId(
-                                        4,
-                                    ),
-                                    src: RegisterId(
-                                        2,
-                                    ),
-                                },
-                            ),
-                            CoreSet(
-                                Jump {
-                                    target_state: StateId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            PureSet(
-                                Binary {
-                                    kind: Lt,
-                                    op: BinaryOp {
-                                        dst: RegisterId(
-                                            5,
-                                        ),
-                                        a: RegisterId(
-                                            3,
-                                        ),
-                                        b: RegisterId(
-                                            4,
-                                        ),
-                                    },
-                                },
-                            ),
-                            CoreSet(
-                                JumpIf {
-                                    target_state: StateId(
-                                        2,
-                                    ),
-                                    cond: RegisterId(
-                                        5,
-                                    ),
-                                },
-                            ),
-                            CoreSet(
-                                Jump {
-                                    target_state: StateId(
-                                        4,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            PureSet(
-                                Index {
-                                    dst: RegisterId(
-                                        5,
-                                    ),
-                                    object: RegisterId(
-                                        2,
-                                    ),
-                                    index: RegisterId(
-                                        3,
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        6,
-                                    ),
-                                    value: Int(
-                                        0,
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                Index {
-                                    dst: RegisterId(
-                                        7,
-                                    ),
-                                    object: RegisterId(
-                                        5,
-                                    ),
-                                    index: RegisterId(
-                                        6,
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        6,
-                                    ),
-                                    value: Int(
-                                        1,
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                Index {
-                                    dst: RegisterId(
-                                        8,
-                                    ),
-                                    object: RegisterId(
-                                        5,
-                                    ),
-                                    index: RegisterId(
-                                        6,
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                Copy {
-                                    dst: RegisterId(
-                                        9,
-                                    ),
-                                    src: RegisterId(
-                                        8,
-                                    ),
-                                },
-                            ),
-                            CoreSet(
-                                Jump {
-                                    target_state: StateId(
-                                        3,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        5,
-                                    ),
-                                    value: Int(
-                                        1,
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                Binary {
-                                    kind: Add,
-                                    op: BinaryOp {
-                                        dst: RegisterId(
-                                            3,
-                                        ),
-                                        a: RegisterId(
-                                            3,
-                                        ),
-                                        b: RegisterId(
-                                            5,
-                                        ),
-                                    },
-                                },
-                            ),
-                            CoreSet(
-                                Jump {
-                                    target_state: StateId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Return {
-                                    src: RegisterId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                ],
-                num_regs: 10,
-            },
-        ],
-    },
-)
+f0: [10 registers]
+  s0:
+    PureSet(MakeDict { dst: r1, entries: [] })
+    PureSet(Copy { dst: r2, src: r0 })
+    PureSet(LoadConst { dst: r3, value: Int(0) })
+    PureSet(Length { dst: r4, src: r2 })
+    CoreSet(Jump { target_state: s1 })
+  s1:
+    PureSet(Binary { kind: Lt, op: BinaryOp { dst: r5, a: r3, b: r4 } })
+    CoreSet(JumpIf { target_state: s2, cond: r5 })
+    CoreSet(Jump { target_state: s4 })
+  s2:
+    PureSet(Index { dst: r5, object: r2, index: r3 })
+    PureSet(LoadConst { dst: r6, value: Int(0) })
+    PureSet(Index { dst: r7, object: r5, index: r6 })
+    PureSet(LoadConst { dst: r6, value: Int(1) })
+    PureSet(Index { dst: r8, object: r5, index: r6 })
+    PureSet(Copy { dst: r9, src: r8 })
+    CoreSet(Jump { target_state: s3 })
+  s3:
+    PureSet(LoadConst { dst: r5, value: Int(1) })
+    PureSet(Binary { kind: Add, op: BinaryOp { dst: r3, a: r3, b: r5 } })
+    CoreSet(Jump { target_state: s1 })
+  s4:
+    CoreSet(Return { src: r1 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_comprehension__list_comprehension_assignment.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_comprehension__list_comprehension_assignment.py__bytecode.snap
@@ -2,253 +2,32 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_comprehension/list_comprehension_assignment.py
 ---
-Ok(
-    Executable {
-        functions: [
-            Function {
-                states: [
-                    State {
-                        instructions: [
-                            PureSet(
-                                MakeList {
-                                    dst: RegisterId(
-                                        1,
-                                    ),
-                                    items: [],
-                                },
-                            ),
-                            PureSet(
-                                Copy {
-                                    dst: RegisterId(
-                                        2,
-                                    ),
-                                    src: RegisterId(
-                                        0,
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        3,
-                                    ),
-                                    value: Int(
-                                        0,
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                Length {
-                                    dst: RegisterId(
-                                        4,
-                                    ),
-                                    src: RegisterId(
-                                        2,
-                                    ),
-                                },
-                            ),
-                            CoreSet(
-                                Jump {
-                                    target_state: StateId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            PureSet(
-                                Binary {
-                                    kind: Lt,
-                                    op: BinaryOp {
-                                        dst: RegisterId(
-                                            5,
-                                        ),
-                                        a: RegisterId(
-                                            3,
-                                        ),
-                                        b: RegisterId(
-                                            4,
-                                        ),
-                                    },
-                                },
-                            ),
-                            CoreSet(
-                                JumpIf {
-                                    target_state: StateId(
-                                        2,
-                                    ),
-                                    cond: RegisterId(
-                                        5,
-                                    ),
-                                },
-                            ),
-                            CoreSet(
-                                Jump {
-                                    target_state: StateId(
-                                        4,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            PureSet(
-                                Index {
-                                    dst: RegisterId(
-                                        5,
-                                    ),
-                                    object: RegisterId(
-                                        2,
-                                    ),
-                                    index: RegisterId(
-                                        3,
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                Copy {
-                                    dst: RegisterId(
-                                        6,
-                                    ),
-                                    src: RegisterId(
-                                        5,
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                Dot {
-                                    dst: RegisterId(
-                                        5,
-                                    ),
-                                    object: RegisterId(
-                                        6,
-                                    ),
-                                    attribute: "active",
-                                },
-                            ),
-                            CoreSet(
-                                JumpIf {
-                                    target_state: StateId(
-                                        6,
-                                    ),
-                                    cond: RegisterId(
-                                        5,
-                                    ),
-                                },
-                            ),
-                            CoreSet(
-                                Jump {
-                                    target_state: StateId(
-                                        5,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        5,
-                                    ),
-                                    value: Int(
-                                        1,
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                Binary {
-                                    kind: Add,
-                                    op: BinaryOp {
-                                        dst: RegisterId(
-                                            3,
-                                        ),
-                                        a: RegisterId(
-                                            3,
-                                        ),
-                                        b: RegisterId(
-                                            5,
-                                        ),
-                                    },
-                                },
-                            ),
-                            CoreSet(
-                                Jump {
-                                    target_state: StateId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Return {
-                                    src: RegisterId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Jump {
-                                    target_state: StateId(
-                                        3,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            PureSet(
-                                MakeList {
-                                    dst: RegisterId(
-                                        5,
-                                    ),
-                                    items: [
-                                        RegisterId(
-                                            6,
-                                        ),
-                                    ],
-                                },
-                            ),
-                            PureSet(
-                                Binary {
-                                    kind: Add,
-                                    op: BinaryOp {
-                                        dst: RegisterId(
-                                            1,
-                                        ),
-                                        a: RegisterId(
-                                            1,
-                                        ),
-                                        b: RegisterId(
-                                            5,
-                                        ),
-                                    },
-                                },
-                            ),
-                            CoreSet(
-                                Jump {
-                                    target_state: StateId(
-                                        5,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                ],
-                num_regs: 7,
-            },
-        ],
-    },
-)
+f0: [7 registers]
+  s0:
+    PureSet(MakeList { dst: r1, items: [] })
+    PureSet(Copy { dst: r2, src: r0 })
+    PureSet(LoadConst { dst: r3, value: Int(0) })
+    PureSet(Length { dst: r4, src: r2 })
+    CoreSet(Jump { target_state: s1 })
+  s1:
+    PureSet(Binary { kind: Lt, op: BinaryOp { dst: r5, a: r3, b: r4 } })
+    CoreSet(JumpIf { target_state: s2, cond: r5 })
+    CoreSet(Jump { target_state: s4 })
+  s2:
+    PureSet(Index { dst: r5, object: r2, index: r3 })
+    PureSet(Copy { dst: r6, src: r5 })
+    PureSet(Dot { dst: r5, object: r6, attribute: "active" })
+    CoreSet(JumpIf { target_state: s6, cond: r5 })
+    CoreSet(Jump { target_state: s5 })
+  s3:
+    PureSet(LoadConst { dst: r5, value: Int(1) })
+    PureSet(Binary { kind: Add, op: BinaryOp { dst: r3, a: r3, b: r5 } })
+    CoreSet(Jump { target_state: s1 })
+  s4:
+    CoreSet(Return { src: r1 })
+  s5:
+    CoreSet(Jump { target_state: s3 })
+  s6:
+    PureSet(MakeList { dst: r5, items: [r6] })
+    PureSet(Binary { kind: Add, op: BinaryOp { dst: r1, a: r1, b: r5 } })
+    CoreSet(Jump { target_state: s5 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_comprehension__list_comprehension_ifexp.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_comprehension__list_comprehension_ifexp.py__bytecode.snap
@@ -2,302 +2,36 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_comprehension/list_comprehension_ifexp.py
 ---
-Ok(
-    Executable {
-        functions: [
-            Function {
-                states: [
-                    State {
-                        instructions: [
-                            PureSet(
-                                MakeList {
-                                    dst: RegisterId(
-                                        1,
-                                    ),
-                                    items: [],
-                                },
-                            ),
-                            PureSet(
-                                Copy {
-                                    dst: RegisterId(
-                                        2,
-                                    ),
-                                    src: RegisterId(
-                                        0,
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        3,
-                                    ),
-                                    value: Int(
-                                        0,
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                Length {
-                                    dst: RegisterId(
-                                        4,
-                                    ),
-                                    src: RegisterId(
-                                        2,
-                                    ),
-                                },
-                            ),
-                            CoreSet(
-                                Jump {
-                                    target_state: StateId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            PureSet(
-                                Binary {
-                                    kind: Lt,
-                                    op: BinaryOp {
-                                        dst: RegisterId(
-                                            5,
-                                        ),
-                                        a: RegisterId(
-                                            3,
-                                        ),
-                                        b: RegisterId(
-                                            4,
-                                        ),
-                                    },
-                                },
-                            ),
-                            CoreSet(
-                                JumpIf {
-                                    target_state: StateId(
-                                        2,
-                                    ),
-                                    cond: RegisterId(
-                                        5,
-                                    ),
-                                },
-                            ),
-                            CoreSet(
-                                Jump {
-                                    target_state: StateId(
-                                        4,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            PureSet(
-                                Index {
-                                    dst: RegisterId(
-                                        5,
-                                    ),
-                                    object: RegisterId(
-                                        2,
-                                    ),
-                                    index: RegisterId(
-                                        3,
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                Copy {
-                                    dst: RegisterId(
-                                        6,
-                                    ),
-                                    src: RegisterId(
-                                        5,
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                Dot {
-                                    dst: RegisterId(
-                                        5,
-                                    ),
-                                    object: RegisterId(
-                                        6,
-                                    ),
-                                    attribute: "active",
-                                },
-                            ),
-                            CoreSet(
-                                JumpIf {
-                                    target_state: StateId(
-                                        6,
-                                    ),
-                                    cond: RegisterId(
-                                        5,
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        5,
-                                    ),
-                                    value: String(
-                                        "inactive",
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                MakeList {
-                                    dst: RegisterId(
-                                        7,
-                                    ),
-                                    items: [
-                                        RegisterId(
-                                            5,
-                                        ),
-                                    ],
-                                },
-                            ),
-                            PureSet(
-                                Binary {
-                                    kind: Add,
-                                    op: BinaryOp {
-                                        dst: RegisterId(
-                                            1,
-                                        ),
-                                        a: RegisterId(
-                                            1,
-                                        ),
-                                        b: RegisterId(
-                                            7,
-                                        ),
-                                    },
-                                },
-                            ),
-                            CoreSet(
-                                Jump {
-                                    target_state: StateId(
-                                        5,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        5,
-                                    ),
-                                    value: Int(
-                                        1,
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                Binary {
-                                    kind: Add,
-                                    op: BinaryOp {
-                                        dst: RegisterId(
-                                            3,
-                                        ),
-                                        a: RegisterId(
-                                            3,
-                                        ),
-                                        b: RegisterId(
-                                            5,
-                                        ),
-                                    },
-                                },
-                            ),
-                            CoreSet(
-                                Jump {
-                                    target_state: StateId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Return {
-                                    src: RegisterId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Jump {
-                                    target_state: StateId(
-                                        3,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            PureSet(
-                                Dot {
-                                    dst: RegisterId(
-                                        7,
-                                    ),
-                                    object: RegisterId(
-                                        6,
-                                    ),
-                                    attribute: "name",
-                                },
-                            ),
-                            PureSet(
-                                MakeList {
-                                    dst: RegisterId(
-                                        5,
-                                    ),
-                                    items: [
-                                        RegisterId(
-                                            7,
-                                        ),
-                                    ],
-                                },
-                            ),
-                            PureSet(
-                                Binary {
-                                    kind: Add,
-                                    op: BinaryOp {
-                                        dst: RegisterId(
-                                            1,
-                                        ),
-                                        a: RegisterId(
-                                            1,
-                                        ),
-                                        b: RegisterId(
-                                            5,
-                                        ),
-                                    },
-                                },
-                            ),
-                            CoreSet(
-                                Jump {
-                                    target_state: StateId(
-                                        5,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                ],
-                num_regs: 8,
-            },
-        ],
-    },
-)
+f0: [8 registers]
+  s0:
+    PureSet(MakeList { dst: r1, items: [] })
+    PureSet(Copy { dst: r2, src: r0 })
+    PureSet(LoadConst { dst: r3, value: Int(0) })
+    PureSet(Length { dst: r4, src: r2 })
+    CoreSet(Jump { target_state: s1 })
+  s1:
+    PureSet(Binary { kind: Lt, op: BinaryOp { dst: r5, a: r3, b: r4 } })
+    CoreSet(JumpIf { target_state: s2, cond: r5 })
+    CoreSet(Jump { target_state: s4 })
+  s2:
+    PureSet(Index { dst: r5, object: r2, index: r3 })
+    PureSet(Copy { dst: r6, src: r5 })
+    PureSet(Dot { dst: r5, object: r6, attribute: "active" })
+    CoreSet(JumpIf { target_state: s6, cond: r5 })
+    PureSet(LoadConst { dst: r5, value: String("inactive") })
+    PureSet(MakeList { dst: r7, items: [r5] })
+    PureSet(Binary { kind: Add, op: BinaryOp { dst: r1, a: r1, b: r7 } })
+    CoreSet(Jump { target_state: s5 })
+  s3:
+    PureSet(LoadConst { dst: r5, value: Int(1) })
+    PureSet(Binary { kind: Add, op: BinaryOp { dst: r3, a: r3, b: r5 } })
+    CoreSet(Jump { target_state: s1 })
+  s4:
+    CoreSet(Return { src: r1 })
+  s5:
+    CoreSet(Jump { target_state: s3 })
+  s6:
+    PureSet(Dot { dst: r7, object: r6, attribute: "name" })
+    PureSet(MakeList { dst: r5, items: [r7] })
+    PureSet(Binary { kind: Add, op: BinaryOp { dst: r1, a: r1, b: r5 } })
+    CoreSet(Jump { target_state: s5 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_conditional__if_await_action_condition.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_conditional__if_await_action_condition.py__bytecode.snap
@@ -2,116 +2,17 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_conditional/if_await_action_condition.py
 ---
-Ok(
-    Executable {
-        functions: [
-            Function {
-                states: [
-                    State {
-                        instructions: [
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        1,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "is_even",
-                                    ),
-                                    args: [
-                                        RegisterId(
-                                            0,
-                                        ),
-                                    ],
-                                    resume: StateId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        1,
-                                    ),
-                                    src: RegisterId(
-                                        1,
-                                    ),
-                                    resume: StateId(
-                                        2,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                JumpIf {
-                                    target_state: StateId(
-                                        4,
-                                    ),
-                                    cond: RegisterId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                            CoreSet(
-                                Jump {
-                                    target_state: StateId(
-                                        3,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        2,
-                                    ),
-                                    value: Int(
-                                        0,
-                                    ),
-                                },
-                            ),
-                            CoreSet(
-                                Return {
-                                    src: RegisterId(
-                                        2,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        2,
-                                    ),
-                                    value: Int(
-                                        1,
-                                    ),
-                                },
-                            ),
-                            CoreSet(
-                                Return {
-                                    src: RegisterId(
-                                        2,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                ],
-                num_regs: 3,
-            },
-        ],
-    },
-)
+f0: [3 registers]
+  s0:
+    ExtCallSet(ActionCall { dst: r1, action_ref: TestActionRef("is_even"), args: [r0], resume: s1 })
+  s1:
+    CoreSet(Await { dst: r1, src: r1, resume: s2 })
+  s2:
+    CoreSet(JumpIf { target_state: s4, cond: r1 })
+    CoreSet(Jump { target_state: s3 })
+  s3:
+    PureSet(LoadConst { dst: r2, value: Int(0) })
+    CoreSet(Return { src: r2 })
+  s4:
+    PureSet(LoadConst { dst: r2, value: Int(1) })
+    CoreSet(Return { src: r2 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_conditional__if_multiple_calls.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_conditional__if_multiple_calls.py__bytecode.snap
@@ -2,163 +2,21 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_conditional/if_multiple_calls.py
 ---
-Ok(
-    Executable {
-        functions: [
-            Function {
-                states: [
-                    State {
-                        instructions: [
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        1,
-                                    ),
-                                    value: Int(
-                                        0,
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                Binary {
-                                    kind: Gt,
-                                    op: BinaryOp {
-                                        dst: RegisterId(
-                                            2,
-                                        ),
-                                        a: RegisterId(
-                                            0,
-                                        ),
-                                        b: RegisterId(
-                                            1,
-                                        ),
-                                    },
-                                },
-                            ),
-                            CoreSet(
-                                JumpIf {
-                                    target_state: StateId(
-                                        2,
-                                    ),
-                                    cond: RegisterId(
-                                        2,
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        2,
-                                    ),
-                                    value: Int(
-                                        0,
-                                    ),
-                                },
-                            ),
-                            CoreSet(
-                                Return {
-                                    src: RegisterId(
-                                        2,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [],
-                    },
-                    State {
-                        instructions: [
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        3,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "if_step_one",
-                                    ),
-                                    args: [
-                                        RegisterId(
-                                            0,
-                                        ),
-                                    ],
-                                    resume: StateId(
-                                        3,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        3,
-                                    ),
-                                    src: RegisterId(
-                                        3,
-                                    ),
-                                    resume: StateId(
-                                        4,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        4,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "if_step_two",
-                                    ),
-                                    args: [
-                                        RegisterId(
-                                            3,
-                                        ),
-                                    ],
-                                    resume: StateId(
-                                        5,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        4,
-                                    ),
-                                    src: RegisterId(
-                                        4,
-                                    ),
-                                    resume: StateId(
-                                        6,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Return {
-                                    src: RegisterId(
-                                        4,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                ],
-                num_regs: 5,
-            },
-        ],
-    },
-)
+f0: [5 registers]
+  s0:
+    PureSet(LoadConst { dst: r1, value: Int(0) })
+    PureSet(Binary { kind: Gt, op: BinaryOp { dst: r2, a: r0, b: r1 } })
+    CoreSet(JumpIf { target_state: s2, cond: r2 })
+    PureSet(LoadConst { dst: r2, value: Int(0) })
+    CoreSet(Return { src: r2 })
+  s1:
+  s2:
+    ExtCallSet(ActionCall { dst: r3, action_ref: TestActionRef("if_step_one"), args: [r0], resume: s3 })
+  s3:
+    CoreSet(Await { dst: r3, src: r3, resume: s4 })
+  s4:
+    ExtCallSet(ActionCall { dst: r4, action_ref: TestActionRef("if_step_two"), args: [r3], resume: s5 })
+  s5:
+    CoreSet(Await { dst: r4, src: r4, resume: s6 })
+  s6:
+    CoreSet(Return { src: r4 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_control_flow__for_multi_action.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_control_flow__for_multi_action.py__bytecode.snap
@@ -2,336 +2,38 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_control_flow/for_multi_action.py
 ---
-Ok(
-    Executable {
-        functions: [
-            Function {
-                states: [
-                    State {
-                        instructions: [
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        1,
-                                    ),
-                                    value: Int(
-                                        1,
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        2,
-                                    ),
-                                    value: Int(
-                                        2,
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        3,
-                                    ),
-                                    value: Int(
-                                        3,
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                MakeList {
-                                    dst: RegisterId(
-                                        0,
-                                    ),
-                                    items: [
-                                        RegisterId(
-                                            1,
-                                        ),
-                                        RegisterId(
-                                            2,
-                                        ),
-                                        RegisterId(
-                                            3,
-                                        ),
-                                    ],
-                                },
-                            ),
-                            PureSet(
-                                MakeList {
-                                    dst: RegisterId(
-                                        4,
-                                    ),
-                                    items: [],
-                                },
-                            ),
-                            PureSet(
-                                Copy {
-                                    dst: RegisterId(
-                                        5,
-                                    ),
-                                    src: RegisterId(
-                                        0,
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        6,
-                                    ),
-                                    value: Int(
-                                        0,
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                Length {
-                                    dst: RegisterId(
-                                        7,
-                                    ),
-                                    src: RegisterId(
-                                        5,
-                                    ),
-                                },
-                            ),
-                            CoreSet(
-                                Jump {
-                                    target_state: StateId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            PureSet(
-                                Binary {
-                                    kind: Lt,
-                                    op: BinaryOp {
-                                        dst: RegisterId(
-                                            3,
-                                        ),
-                                        a: RegisterId(
-                                            6,
-                                        ),
-                                        b: RegisterId(
-                                            7,
-                                        ),
-                                    },
-                                },
-                            ),
-                            CoreSet(
-                                JumpIf {
-                                    target_state: StateId(
-                                        2,
-                                    ),
-                                    cond: RegisterId(
-                                        3,
-                                    ),
-                                },
-                            ),
-                            CoreSet(
-                                Jump {
-                                    target_state: StateId(
-                                        4,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            PureSet(
-                                Index {
-                                    dst: RegisterId(
-                                        3,
-                                    ),
-                                    object: RegisterId(
-                                        5,
-                                    ),
-                                    index: RegisterId(
-                                        6,
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                Copy {
-                                    dst: RegisterId(
-                                        8,
-                                    ),
-                                    src: RegisterId(
-                                        3,
-                                    ),
-                                },
-                            ),
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        9,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "step_one_for",
-                                    ),
-                                    args: [
-                                        RegisterId(
-                                            8,
-                                        ),
-                                    ],
-                                    resume: StateId(
-                                        5,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        3,
-                                    ),
-                                    value: Int(
-                                        1,
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                Binary {
-                                    kind: Add,
-                                    op: BinaryOp {
-                                        dst: RegisterId(
-                                            6,
-                                        ),
-                                        a: RegisterId(
-                                            6,
-                                        ),
-                                        b: RegisterId(
-                                            3,
-                                        ),
-                                    },
-                                },
-                            ),
-                            CoreSet(
-                                Jump {
-                                    target_state: StateId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Return {
-                                    src: RegisterId(
-                                        4,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        9,
-                                    ),
-                                    src: RegisterId(
-                                        9,
-                                    ),
-                                    resume: StateId(
-                                        6,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        10,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "step_two_for",
-                                    ),
-                                    args: [
-                                        RegisterId(
-                                            9,
-                                        ),
-                                    ],
-                                    resume: StateId(
-                                        7,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        10,
-                                    ),
-                                    src: RegisterId(
-                                        10,
-                                    ),
-                                    resume: StateId(
-                                        8,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            PureSet(
-                                MakeList {
-                                    dst: RegisterId(
-                                        3,
-                                    ),
-                                    items: [
-                                        RegisterId(
-                                            10,
-                                        ),
-                                    ],
-                                },
-                            ),
-                            PureSet(
-                                Binary {
-                                    kind: Add,
-                                    op: BinaryOp {
-                                        dst: RegisterId(
-                                            4,
-                                        ),
-                                        a: RegisterId(
-                                            4,
-                                        ),
-                                        b: RegisterId(
-                                            3,
-                                        ),
-                                    },
-                                },
-                            ),
-                            CoreSet(
-                                Jump {
-                                    target_state: StateId(
-                                        3,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                ],
-                num_regs: 11,
-            },
-        ],
-    },
-)
+f0: [11 registers]
+  s0:
+    PureSet(LoadConst { dst: r1, value: Int(1) })
+    PureSet(LoadConst { dst: r2, value: Int(2) })
+    PureSet(LoadConst { dst: r3, value: Int(3) })
+    PureSet(MakeList { dst: r0, items: [r1, r2, r3] })
+    PureSet(MakeList { dst: r4, items: [] })
+    PureSet(Copy { dst: r5, src: r0 })
+    PureSet(LoadConst { dst: r6, value: Int(0) })
+    PureSet(Length { dst: r7, src: r5 })
+    CoreSet(Jump { target_state: s1 })
+  s1:
+    PureSet(Binary { kind: Lt, op: BinaryOp { dst: r3, a: r6, b: r7 } })
+    CoreSet(JumpIf { target_state: s2, cond: r3 })
+    CoreSet(Jump { target_state: s4 })
+  s2:
+    PureSet(Index { dst: r3, object: r5, index: r6 })
+    PureSet(Copy { dst: r8, src: r3 })
+    ExtCallSet(ActionCall { dst: r9, action_ref: TestActionRef("step_one_for"), args: [r8], resume: s5 })
+  s3:
+    PureSet(LoadConst { dst: r3, value: Int(1) })
+    PureSet(Binary { kind: Add, op: BinaryOp { dst: r6, a: r6, b: r3 } })
+    CoreSet(Jump { target_state: s1 })
+  s4:
+    CoreSet(Return { src: r4 })
+  s5:
+    CoreSet(Await { dst: r9, src: r9, resume: s6 })
+  s6:
+    ExtCallSet(ActionCall { dst: r10, action_ref: TestActionRef("step_two_for"), args: [r9], resume: s7 })
+  s7:
+    CoreSet(Await { dst: r10, src: r10, resume: s8 })
+  s8:
+    PureSet(MakeList { dst: r3, items: [r10] })
+    PureSet(Binary { kind: Add, op: BinaryOp { dst: r4, a: r4, b: r3 } })
+    CoreSet(Jump { target_state: s3 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_control_flow__for_simple.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_control_flow__for_simple.py__bytecode.snap
@@ -2,297 +2,34 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_control_flow/for_simple.py
 ---
-Ok(
-    Executable {
-        functions: [
-            Function {
-                states: [
-                    State {
-                        instructions: [
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        1,
-                                    ),
-                                    value: String(
-                                        "a",
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        2,
-                                    ),
-                                    value: String(
-                                        "b",
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        3,
-                                    ),
-                                    value: String(
-                                        "c",
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                MakeList {
-                                    dst: RegisterId(
-                                        0,
-                                    ),
-                                    items: [
-                                        RegisterId(
-                                            1,
-                                        ),
-                                        RegisterId(
-                                            2,
-                                        ),
-                                        RegisterId(
-                                            3,
-                                        ),
-                                    ],
-                                },
-                            ),
-                            PureSet(
-                                MakeList {
-                                    dst: RegisterId(
-                                        4,
-                                    ),
-                                    items: [],
-                                },
-                            ),
-                            PureSet(
-                                Copy {
-                                    dst: RegisterId(
-                                        5,
-                                    ),
-                                    src: RegisterId(
-                                        0,
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        6,
-                                    ),
-                                    value: Int(
-                                        0,
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                Length {
-                                    dst: RegisterId(
-                                        7,
-                                    ),
-                                    src: RegisterId(
-                                        5,
-                                    ),
-                                },
-                            ),
-                            CoreSet(
-                                Jump {
-                                    target_state: StateId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            PureSet(
-                                Binary {
-                                    kind: Lt,
-                                    op: BinaryOp {
-                                        dst: RegisterId(
-                                            3,
-                                        ),
-                                        a: RegisterId(
-                                            6,
-                                        ),
-                                        b: RegisterId(
-                                            7,
-                                        ),
-                                    },
-                                },
-                            ),
-                            CoreSet(
-                                JumpIf {
-                                    target_state: StateId(
-                                        2,
-                                    ),
-                                    cond: RegisterId(
-                                        3,
-                                    ),
-                                },
-                            ),
-                            CoreSet(
-                                Jump {
-                                    target_state: StateId(
-                                        4,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            PureSet(
-                                Index {
-                                    dst: RegisterId(
-                                        3,
-                                    ),
-                                    object: RegisterId(
-                                        5,
-                                    ),
-                                    index: RegisterId(
-                                        6,
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                Copy {
-                                    dst: RegisterId(
-                                        8,
-                                    ),
-                                    src: RegisterId(
-                                        3,
-                                    ),
-                                },
-                            ),
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        9,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "process_item_simple",
-                                    ),
-                                    args: [
-                                        RegisterId(
-                                            8,
-                                        ),
-                                    ],
-                                    resume: StateId(
-                                        5,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        3,
-                                    ),
-                                    value: Int(
-                                        1,
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                Binary {
-                                    kind: Add,
-                                    op: BinaryOp {
-                                        dst: RegisterId(
-                                            6,
-                                        ),
-                                        a: RegisterId(
-                                            6,
-                                        ),
-                                        b: RegisterId(
-                                            3,
-                                        ),
-                                    },
-                                },
-                            ),
-                            CoreSet(
-                                Jump {
-                                    target_state: StateId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Return {
-                                    src: RegisterId(
-                                        4,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        9,
-                                    ),
-                                    src: RegisterId(
-                                        9,
-                                    ),
-                                    resume: StateId(
-                                        6,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            PureSet(
-                                MakeList {
-                                    dst: RegisterId(
-                                        3,
-                                    ),
-                                    items: [
-                                        RegisterId(
-                                            9,
-                                        ),
-                                    ],
-                                },
-                            ),
-                            PureSet(
-                                Binary {
-                                    kind: Add,
-                                    op: BinaryOp {
-                                        dst: RegisterId(
-                                            4,
-                                        ),
-                                        a: RegisterId(
-                                            4,
-                                        ),
-                                        b: RegisterId(
-                                            3,
-                                        ),
-                                    },
-                                },
-                            ),
-                            CoreSet(
-                                Jump {
-                                    target_state: StateId(
-                                        3,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                ],
-                num_regs: 10,
-            },
-        ],
-    },
-)
+f0: [10 registers]
+  s0:
+    PureSet(LoadConst { dst: r1, value: String("a") })
+    PureSet(LoadConst { dst: r2, value: String("b") })
+    PureSet(LoadConst { dst: r3, value: String("c") })
+    PureSet(MakeList { dst: r0, items: [r1, r2, r3] })
+    PureSet(MakeList { dst: r4, items: [] })
+    PureSet(Copy { dst: r5, src: r0 })
+    PureSet(LoadConst { dst: r6, value: Int(0) })
+    PureSet(Length { dst: r7, src: r5 })
+    CoreSet(Jump { target_state: s1 })
+  s1:
+    PureSet(Binary { kind: Lt, op: BinaryOp { dst: r3, a: r6, b: r7 } })
+    CoreSet(JumpIf { target_state: s2, cond: r3 })
+    CoreSet(Jump { target_state: s4 })
+  s2:
+    PureSet(Index { dst: r3, object: r5, index: r6 })
+    PureSet(Copy { dst: r8, src: r3 })
+    ExtCallSet(ActionCall { dst: r9, action_ref: TestActionRef("process_item_simple"), args: [r8], resume: s5 })
+  s3:
+    PureSet(LoadConst { dst: r3, value: Int(1) })
+    PureSet(Binary { kind: Add, op: BinaryOp { dst: r6, a: r6, b: r3 } })
+    CoreSet(Jump { target_state: s1 })
+  s4:
+    CoreSet(Return { src: r4 })
+  s5:
+    CoreSet(Await { dst: r9, src: r9, resume: s6 })
+  s6:
+    PureSet(MakeList { dst: r3, items: [r9] })
+    PureSet(Binary { kind: Add, op: BinaryOp { dst: r4, a: r4, b: r3 } })
+    CoreSet(Jump { target_state: s3 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_control_flow__if_elif_else.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_control_flow__if_elif_else.py__bytecode.snap
@@ -2,317 +2,39 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_control_flow/if_elif_else.py
 ---
-Ok(
-    Executable {
-        functions: [
-            Function {
-                states: [
-                    State {
-                        instructions: [
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        1,
-                                    ),
-                                    value: Int(
-                                        1,
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                Binary {
-                                    kind: Eq,
-                                    op: BinaryOp {
-                                        dst: RegisterId(
-                                            2,
-                                        ),
-                                        a: RegisterId(
-                                            0,
-                                        ),
-                                        b: RegisterId(
-                                            1,
-                                        ),
-                                    },
-                                },
-                            ),
-                            CoreSet(
-                                JumpIf {
-                                    target_state: StateId(
-                                        2,
-                                    ),
-                                    cond: RegisterId(
-                                        2,
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        2,
-                                    ),
-                                    value: Int(
-                                        2,
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                Binary {
-                                    kind: Eq,
-                                    op: BinaryOp {
-                                        dst: RegisterId(
-                                            1,
-                                        ),
-                                        a: RegisterId(
-                                            0,
-                                        ),
-                                        b: RegisterId(
-                                            2,
-                                        ),
-                                    },
-                                },
-                            ),
-                            CoreSet(
-                                JumpIf {
-                                    target_state: StateId(
-                                        3,
-                                    ),
-                                    cond: RegisterId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        1,
-                                    ),
-                                    value: Int(
-                                        3,
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                Binary {
-                                    kind: Eq,
-                                    op: BinaryOp {
-                                        dst: RegisterId(
-                                            2,
-                                        ),
-                                        a: RegisterId(
-                                            0,
-                                        ),
-                                        b: RegisterId(
-                                            1,
-                                        ),
-                                    },
-                                },
-                            ),
-                            CoreSet(
-                                JumpIf {
-                                    target_state: StateId(
-                                        4,
-                                    ),
-                                    cond: RegisterId(
-                                        2,
-                                    ),
-                                },
-                            ),
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        3,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "handle_default",
-                                    ),
-                                    args: [],
-                                    resume: StateId(
-                                        5,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Return {
-                                    src: RegisterId(
-                                        3,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        3,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "handle_case_a",
-                                    ),
-                                    args: [],
-                                    resume: StateId(
-                                        7,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        3,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "handle_case_b",
-                                    ),
-                                    args: [],
-                                    resume: StateId(
-                                        9,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        3,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "handle_case_c",
-                                    ),
-                                    args: [],
-                                    resume: StateId(
-                                        11,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        3,
-                                    ),
-                                    src: RegisterId(
-                                        3,
-                                    ),
-                                    resume: StateId(
-                                        6,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Jump {
-                                    target_state: StateId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        3,
-                                    ),
-                                    src: RegisterId(
-                                        3,
-                                    ),
-                                    resume: StateId(
-                                        8,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Jump {
-                                    target_state: StateId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        3,
-                                    ),
-                                    src: RegisterId(
-                                        3,
-                                    ),
-                                    resume: StateId(
-                                        10,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Jump {
-                                    target_state: StateId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        3,
-                                    ),
-                                    src: RegisterId(
-                                        3,
-                                    ),
-                                    resume: StateId(
-                                        12,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Jump {
-                                    target_state: StateId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                ],
-                num_regs: 4,
-            },
-        ],
-    },
-)
+f0: [4 registers]
+  s0:
+    PureSet(LoadConst { dst: r1, value: Int(1) })
+    PureSet(Binary { kind: Eq, op: BinaryOp { dst: r2, a: r0, b: r1 } })
+    CoreSet(JumpIf { target_state: s2, cond: r2 })
+    PureSet(LoadConst { dst: r2, value: Int(2) })
+    PureSet(Binary { kind: Eq, op: BinaryOp { dst: r1, a: r0, b: r2 } })
+    CoreSet(JumpIf { target_state: s3, cond: r1 })
+    PureSet(LoadConst { dst: r1, value: Int(3) })
+    PureSet(Binary { kind: Eq, op: BinaryOp { dst: r2, a: r0, b: r1 } })
+    CoreSet(JumpIf { target_state: s4, cond: r2 })
+    ExtCallSet(ActionCall { dst: r3, action_ref: TestActionRef("handle_default"), args: [], resume: s5 })
+  s1:
+    CoreSet(Return { src: r3 })
+  s2:
+    ExtCallSet(ActionCall { dst: r3, action_ref: TestActionRef("handle_case_a"), args: [], resume: s7 })
+  s3:
+    ExtCallSet(ActionCall { dst: r3, action_ref: TestActionRef("handle_case_b"), args: [], resume: s9 })
+  s4:
+    ExtCallSet(ActionCall { dst: r3, action_ref: TestActionRef("handle_case_c"), args: [], resume: s11 })
+  s5:
+    CoreSet(Await { dst: r3, src: r3, resume: s6 })
+  s6:
+    CoreSet(Jump { target_state: s1 })
+  s7:
+    CoreSet(Await { dst: r3, src: r3, resume: s8 })
+  s8:
+    CoreSet(Jump { target_state: s1 })
+  s9:
+    CoreSet(Await { dst: r3, src: r3, resume: s10 })
+  s10:
+    CoreSet(Jump { target_state: s1 })
+  s11:
+    CoreSet(Await { dst: r3, src: r3, resume: s12 })
+  s12:
+    CoreSet(Jump { target_state: s1 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_control_flow__if_multi_action.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_control_flow__if_multi_action.py__bytecode.snap
@@ -2,225 +2,29 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_control_flow/if_multi_action.py
 ---
-Ok(
-    Executable {
-        functions: [
-            Function {
-                states: [
-                    State {
-                        instructions: [
-                            CoreSet(
-                                JumpIf {
-                                    target_state: StateId(
-                                        2,
-                                    ),
-                                    cond: RegisterId(
-                                        0,
-                                    ),
-                                },
-                            ),
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        1,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "action_else_1",
-                                    ),
-                                    args: [],
-                                    resume: StateId(
-                                        3,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Return {
-                                    src: RegisterId(
-                                        3,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        4,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "action_if_1",
-                                    ),
-                                    args: [],
-                                    resume: StateId(
-                                        7,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        1,
-                                    ),
-                                    src: RegisterId(
-                                        1,
-                                    ),
-                                    resume: StateId(
-                                        4,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        2,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "action_else_2",
-                                    ),
-                                    args: [
-                                        RegisterId(
-                                            1,
-                                        ),
-                                    ],
-                                    resume: StateId(
-                                        5,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        2,
-                                    ),
-                                    src: RegisterId(
-                                        2,
-                                    ),
-                                    resume: StateId(
-                                        6,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            PureSet(
-                                Copy {
-                                    dst: RegisterId(
-                                        3,
-                                    ),
-                                    src: RegisterId(
-                                        2,
-                                    ),
-                                },
-                            ),
-                            CoreSet(
-                                Jump {
-                                    target_state: StateId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        4,
-                                    ),
-                                    src: RegisterId(
-                                        4,
-                                    ),
-                                    resume: StateId(
-                                        8,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        5,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "action_if_2",
-                                    ),
-                                    args: [
-                                        RegisterId(
-                                            4,
-                                        ),
-                                    ],
-                                    resume: StateId(
-                                        9,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        5,
-                                    ),
-                                    src: RegisterId(
-                                        5,
-                                    ),
-                                    resume: StateId(
-                                        10,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            PureSet(
-                                Copy {
-                                    dst: RegisterId(
-                                        3,
-                                    ),
-                                    src: RegisterId(
-                                        5,
-                                    ),
-                                },
-                            ),
-                            CoreSet(
-                                Jump {
-                                    target_state: StateId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                ],
-                num_regs: 6,
-            },
-        ],
-    },
-)
+f0: [6 registers]
+  s0:
+    CoreSet(JumpIf { target_state: s2, cond: r0 })
+    ExtCallSet(ActionCall { dst: r1, action_ref: TestActionRef("action_else_1"), args: [], resume: s3 })
+  s1:
+    CoreSet(Return { src: r3 })
+  s2:
+    ExtCallSet(ActionCall { dst: r4, action_ref: TestActionRef("action_if_1"), args: [], resume: s7 })
+  s3:
+    CoreSet(Await { dst: r1, src: r1, resume: s4 })
+  s4:
+    ExtCallSet(ActionCall { dst: r2, action_ref: TestActionRef("action_else_2"), args: [r1], resume: s5 })
+  s5:
+    CoreSet(Await { dst: r2, src: r2, resume: s6 })
+  s6:
+    PureSet(Copy { dst: r3, src: r2 })
+    CoreSet(Jump { target_state: s1 })
+  s7:
+    CoreSet(Await { dst: r4, src: r4, resume: s8 })
+  s8:
+    ExtCallSet(ActionCall { dst: r5, action_ref: TestActionRef("action_if_2"), args: [r4], resume: s9 })
+  s9:
+    CoreSet(Await { dst: r5, src: r5, resume: s10 })
+  s10:
+    PureSet(Copy { dst: r3, src: r5 })
+    CoreSet(Jump { target_state: s1 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_control_flow__if_no_else_continue.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_control_flow__if_no_else_continue.py__bytecode.snap
@@ -2,202 +2,26 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_control_flow/if_no_else_continue.py
 ---
-Ok(
-    Executable {
-        functions: [
-            Function {
-                states: [
-                    State {
-                        instructions: [
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        0,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "get_items",
-                                    ),
-                                    args: [],
-                                    resume: StateId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        0,
-                                    ),
-                                    src: RegisterId(
-                                        0,
-                                    ),
-                                    resume: StateId(
-                                        2,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        1,
-                                    ),
-                                    value: Int(
-                                        0,
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                Dot {
-                                    dst: RegisterId(
-                                        2,
-                                    ),
-                                    object: RegisterId(
-                                        0,
-                                    ),
-                                    attribute: "items",
-                                },
-                            ),
-                            CoreSet(
-                                JumpIf {
-                                    target_state: StateId(
-                                        4,
-                                    ),
-                                    cond: RegisterId(
-                                        2,
-                                    ),
-                                },
-                            ),
-                            CoreSet(
-                                Jump {
-                                    target_state: StateId(
-                                        3,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        3,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "finalize",
-                                    ),
-                                    args: [
-                                        RegisterId(
-                                            1,
-                                        ),
-                                    ],
-                                    resume: StateId(
-                                        7,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            PureSet(
-                                Dot {
-                                    dst: RegisterId(
-                                        2,
-                                    ),
-                                    object: RegisterId(
-                                        0,
-                                    ),
-                                    attribute: "items",
-                                },
-                            ),
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        1,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "process_items",
-                                    ),
-                                    args: [
-                                        RegisterId(
-                                            2,
-                                        ),
-                                    ],
-                                    resume: StateId(
-                                        5,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        1,
-                                    ),
-                                    src: RegisterId(
-                                        1,
-                                    ),
-                                    resume: StateId(
-                                        6,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Jump {
-                                    target_state: StateId(
-                                        3,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        3,
-                                    ),
-                                    src: RegisterId(
-                                        3,
-                                    ),
-                                    resume: StateId(
-                                        8,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Return {
-                                    src: RegisterId(
-                                        3,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                ],
-                num_regs: 4,
-            },
-        ],
-    },
-)
+f0: [4 registers]
+  s0:
+    ExtCallSet(ActionCall { dst: r0, action_ref: TestActionRef("get_items"), args: [], resume: s1 })
+  s1:
+    CoreSet(Await { dst: r0, src: r0, resume: s2 })
+  s2:
+    PureSet(LoadConst { dst: r1, value: Int(0) })
+    PureSet(Dot { dst: r2, object: r0, attribute: "items" })
+    CoreSet(JumpIf { target_state: s4, cond: r2 })
+    CoreSet(Jump { target_state: s3 })
+  s3:
+    ExtCallSet(ActionCall { dst: r3, action_ref: TestActionRef("finalize"), args: [r1], resume: s7 })
+  s4:
+    PureSet(Dot { dst: r2, object: r0, attribute: "items" })
+    ExtCallSet(ActionCall { dst: r1, action_ref: TestActionRef("process_items"), args: [r2], resume: s5 })
+  s5:
+    CoreSet(Await { dst: r1, src: r1, resume: s6 })
+  s6:
+    CoreSet(Jump { target_state: s3 })
+  s7:
+    CoreSet(Await { dst: r3, src: r3, resume: s8 })
+  s8:
+    CoreSet(Return { src: r3 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_control_flow__if_simple.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_control_flow__if_simple.py__bytecode.snap
@@ -2,127 +2,19 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_control_flow/if_simple.py
 ---
-Ok(
-    Executable {
-        functions: [
-            Function {
-                states: [
-                    State {
-                        instructions: [
-                            CoreSet(
-                                JumpIf {
-                                    target_state: StateId(
-                                        2,
-                                    ),
-                                    cond: RegisterId(
-                                        0,
-                                    ),
-                                },
-                            ),
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        1,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "handle_false_case",
-                                    ),
-                                    args: [],
-                                    resume: StateId(
-                                        3,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Return {
-                                    src: RegisterId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        1,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "handle_true_case",
-                                    ),
-                                    args: [],
-                                    resume: StateId(
-                                        5,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        1,
-                                    ),
-                                    src: RegisterId(
-                                        1,
-                                    ),
-                                    resume: StateId(
-                                        4,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Jump {
-                                    target_state: StateId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        1,
-                                    ),
-                                    src: RegisterId(
-                                        1,
-                                    ),
-                                    resume: StateId(
-                                        6,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Jump {
-                                    target_state: StateId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                ],
-                num_regs: 2,
-            },
-        ],
-    },
-)
+f0: [2 registers]
+  s0:
+    CoreSet(JumpIf { target_state: s2, cond: r0 })
+    ExtCallSet(ActionCall { dst: r1, action_ref: TestActionRef("handle_false_case"), args: [], resume: s3 })
+  s1:
+    CoreSet(Return { src: r1 })
+  s2:
+    ExtCallSet(ActionCall { dst: r1, action_ref: TestActionRef("handle_true_case"), args: [], resume: s5 })
+  s3:
+    CoreSet(Await { dst: r1, src: r1, resume: s4 })
+  s4:
+    CoreSet(Jump { target_state: s1 })
+  s5:
+    CoreSet(Await { dst: r1, src: r1, resume: s6 })
+  s6:
+    CoreSet(Jump { target_state: s1 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_control_flow__if_with_accumulator.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_control_flow__if_with_accumulator.py__bytecode.snap
@@ -2,329 +2,38 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_control_flow/if_with_accumulator.py
 ---
-Ok(
-    Executable {
-        functions: [
-            Function {
-                states: [
-                    State {
-                        instructions: [
-                            PureSet(
-                                MakeList {
-                                    dst: RegisterId(
-                                        1,
-                                    ),
-                                    items: [],
-                                },
-                            ),
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        2,
-                                    ),
-                                    value: Int(
-                                        50,
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                Binary {
-                                    kind: Gt,
-                                    op: BinaryOp {
-                                        dst: RegisterId(
-                                            3,
-                                        ),
-                                        a: RegisterId(
-                                            0,
-                                        ),
-                                        b: RegisterId(
-                                            2,
-                                        ),
-                                    },
-                                },
-                            ),
-                            CoreSet(
-                                JumpIf {
-                                    target_state: StateId(
-                                        2,
-                                    ),
-                                    cond: RegisterId(
-                                        3,
-                                    ),
-                                },
-                            ),
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        4,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "if_accum_process_low",
-                                    ),
-                                    args: [
-                                        RegisterId(
-                                            0,
-                                        ),
-                                    ],
-                                    resume: StateId(
-                                        3,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                JumpIf {
-                                    target_state: StateId(
-                                        10,
-                                    ),
-                                    cond: RegisterId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                            CoreSet(
-                                Jump {
-                                    target_state: StateId(
-                                        9,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        5,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "if_accum_process_high",
-                                    ),
-                                    args: [
-                                        RegisterId(
-                                            0,
-                                        ),
-                                    ],
-                                    resume: StateId(
-                                        5,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        4,
-                                    ),
-                                    src: RegisterId(
-                                        4,
-                                    ),
-                                    resume: StateId(
-                                        4,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            PureSet(
-                                MakeList {
-                                    dst: RegisterId(
-                                        3,
-                                    ),
-                                    items: [
-                                        RegisterId(
-                                            4,
-                                        ),
-                                    ],
-                                },
-                            ),
-                            PureSet(
-                                Binary {
-                                    kind: Add,
-                                    op: BinaryOp {
-                                        dst: RegisterId(
-                                            1,
-                                        ),
-                                        a: RegisterId(
-                                            1,
-                                        ),
-                                        b: RegisterId(
-                                            3,
-                                        ),
-                                    },
-                                },
-                            ),
-                            CoreSet(
-                                Jump {
-                                    target_state: StateId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        5,
-                                    ),
-                                    src: RegisterId(
-                                        5,
-                                    ),
-                                    resume: StateId(
-                                        6,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        6,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "if_accum_finalize",
-                                    ),
-                                    args: [
-                                        RegisterId(
-                                            5,
-                                        ),
-                                    ],
-                                    resume: StateId(
-                                        7,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        6,
-                                    ),
-                                    src: RegisterId(
-                                        6,
-                                    ),
-                                    resume: StateId(
-                                        8,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            PureSet(
-                                MakeList {
-                                    dst: RegisterId(
-                                        3,
-                                    ),
-                                    items: [
-                                        RegisterId(
-                                            6,
-                                        ),
-                                    ],
-                                },
-                            ),
-                            PureSet(
-                                Binary {
-                                    kind: Add,
-                                    op: BinaryOp {
-                                        dst: RegisterId(
-                                            1,
-                                        ),
-                                        a: RegisterId(
-                                            1,
-                                        ),
-                                        b: RegisterId(
-                                            3,
-                                        ),
-                                    },
-                                },
-                            ),
-                            CoreSet(
-                                Jump {
-                                    target_state: StateId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        2,
-                                    ),
-                                    value: String(
-                                        "empty",
-                                    ),
-                                },
-                            ),
-                            CoreSet(
-                                Return {
-                                    src: RegisterId(
-                                        2,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        3,
-                                    ),
-                                    value: Int(
-                                        0,
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                Index {
-                                    dst: RegisterId(
-                                        2,
-                                    ),
-                                    object: RegisterId(
-                                        1,
-                                    ),
-                                    index: RegisterId(
-                                        3,
-                                    ),
-                                },
-                            ),
-                            CoreSet(
-                                Return {
-                                    src: RegisterId(
-                                        2,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                ],
-                num_regs: 7,
-            },
-        ],
-    },
-)
+f0: [7 registers]
+  s0:
+    PureSet(MakeList { dst: r1, items: [] })
+    PureSet(LoadConst { dst: r2, value: Int(50) })
+    PureSet(Binary { kind: Gt, op: BinaryOp { dst: r3, a: r0, b: r2 } })
+    CoreSet(JumpIf { target_state: s2, cond: r3 })
+    ExtCallSet(ActionCall { dst: r4, action_ref: TestActionRef("if_accum_process_low"), args: [r0], resume: s3 })
+  s1:
+    CoreSet(JumpIf { target_state: s10, cond: r1 })
+    CoreSet(Jump { target_state: s9 })
+  s2:
+    ExtCallSet(ActionCall { dst: r5, action_ref: TestActionRef("if_accum_process_high"), args: [r0], resume: s5 })
+  s3:
+    CoreSet(Await { dst: r4, src: r4, resume: s4 })
+  s4:
+    PureSet(MakeList { dst: r3, items: [r4] })
+    PureSet(Binary { kind: Add, op: BinaryOp { dst: r1, a: r1, b: r3 } })
+    CoreSet(Jump { target_state: s1 })
+  s5:
+    CoreSet(Await { dst: r5, src: r5, resume: s6 })
+  s6:
+    ExtCallSet(ActionCall { dst: r6, action_ref: TestActionRef("if_accum_finalize"), args: [r5], resume: s7 })
+  s7:
+    CoreSet(Await { dst: r6, src: r6, resume: s8 })
+  s8:
+    PureSet(MakeList { dst: r3, items: [r6] })
+    PureSet(Binary { kind: Add, op: BinaryOp { dst: r1, a: r1, b: r3 } })
+    CoreSet(Jump { target_state: s1 })
+  s9:
+    PureSet(LoadConst { dst: r2, value: String("empty") })
+    CoreSet(Return { src: r2 })
+  s10:
+    PureSet(LoadConst { dst: r3, value: Int(0) })
+    PureSet(Index { dst: r2, object: r1, index: r3 })
+    CoreSet(Return { src: r2 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_control_flow__try_except_capture.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_control_flow__try_except_capture.py__bytecode.snap
@@ -1,13 +1,11 @@
 ---
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
-expression: bytecode for python/tests/fixtures_control_flow/try_except_capture.py
+expression: "bytecode for python/tests/fixtures_control_flow/try_except_capture.py [compilation error]"
 ---
-Err(
-    FunctionCompiler(
-        Unsupported(
-            Statement {
-                kind: TryExcept,
-            },
-        ),
+FunctionCompiler(
+    Unsupported(
+        Statement {
+            kind: TryExcept,
+        },
     ),
 )

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_control_flow__try_multi_action.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_control_flow__try_multi_action.py__bytecode.snap
@@ -1,13 +1,11 @@
 ---
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
-expression: bytecode for python/tests/fixtures_control_flow/try_multi_action.py
+expression: "bytecode for python/tests/fixtures_control_flow/try_multi_action.py [compilation error]"
 ---
-Err(
-    FunctionCompiler(
-        Unsupported(
-            Statement {
-                kind: TryExcept,
-            },
-        ),
+FunctionCompiler(
+    Unsupported(
+        Statement {
+            kind: TryExcept,
+        },
     ),
 )

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_control_flow__try_multi_except.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_control_flow__try_multi_except.py__bytecode.snap
@@ -1,13 +1,11 @@
 ---
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
-expression: bytecode for python/tests/fixtures_control_flow/try_multi_except.py
+expression: "bytecode for python/tests/fixtures_control_flow/try_multi_except.py [compilation error]"
 ---
-Err(
-    FunctionCompiler(
-        Unsupported(
-            Statement {
-                kind: TryExcept,
-            },
-        ),
+FunctionCompiler(
+    Unsupported(
+        Statement {
+            kind: TryExcept,
+        },
     ),
 )

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_control_flow__try_simple.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_control_flow__try_simple.py__bytecode.snap
@@ -1,13 +1,11 @@
 ---
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
-expression: bytecode for python/tests/fixtures_control_flow/try_simple.py
+expression: "bytecode for python/tests/fixtures_control_flow/try_simple.py [compilation error]"
 ---
-Err(
-    FunctionCompiler(
-        Unsupported(
-            Statement {
-                kind: TryExcept,
-            },
-        ),
+FunctionCompiler(
+    Unsupported(
+        Statement {
+            kind: TryExcept,
+        },
     ),
 )

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_control_flow__while_simple.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_control_flow__while_simple.py__bytecode.snap
@@ -2,133 +2,19 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_control_flow/while_simple.py
 ---
-Ok(
-    Executable {
-        functions: [
-            Function {
-                states: [
-                    State {
-                        instructions: [
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        1,
-                                    ),
-                                    value: Int(
-                                        0,
-                                    ),
-                                },
-                            ),
-                            CoreSet(
-                                Jump {
-                                    target_state: StateId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            PureSet(
-                                Binary {
-                                    kind: Lt,
-                                    op: BinaryOp {
-                                        dst: RegisterId(
-                                            2,
-                                        ),
-                                        a: RegisterId(
-                                            1,
-                                        ),
-                                        b: RegisterId(
-                                            0,
-                                        ),
-                                    },
-                                },
-                            ),
-                            CoreSet(
-                                JumpIf {
-                                    target_state: StateId(
-                                        2,
-                                    ),
-                                    cond: RegisterId(
-                                        2,
-                                    ),
-                                },
-                            ),
-                            CoreSet(
-                                Jump {
-                                    target_state: StateId(
-                                        3,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        1,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "increment",
-                                    ),
-                                    args: [
-                                        RegisterId(
-                                            1,
-                                        ),
-                                    ],
-                                    resume: StateId(
-                                        4,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Return {
-                                    src: RegisterId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        1,
-                                    ),
-                                    src: RegisterId(
-                                        1,
-                                    ),
-                                    resume: StateId(
-                                        5,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Jump {
-                                    target_state: StateId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                ],
-                num_regs: 3,
-            },
-        ],
-    },
-)
+f0: [3 registers]
+  s0:
+    PureSet(LoadConst { dst: r1, value: Int(0) })
+    CoreSet(Jump { target_state: s1 })
+  s1:
+    PureSet(Binary { kind: Lt, op: BinaryOp { dst: r2, a: r1, b: r0 } })
+    CoreSet(JumpIf { target_state: s2, cond: r2 })
+    CoreSet(Jump { target_state: s3 })
+  s2:
+    ExtCallSet(ActionCall { dst: r1, action_ref: TestActionRef("increment"), args: [r1], resume: s4 })
+  s3:
+    CoreSet(Return { src: r1 })
+  s4:
+    CoreSet(Await { dst: r1, src: r1, resume: s5 })
+  s5:
+    CoreSet(Jump { target_state: s1 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_for_loop__for_break.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_for_loop__for_break.py__bytecode.snap
@@ -2,294 +2,37 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_for_loop/for_break.py
 ---
-Ok(
-    Executable {
-        functions: [
-            Function {
-                states: [
-                    State {
-                        instructions: [
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        1,
-                                    ),
-                                    value: String(
-                                        "not found",
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                Copy {
-                                    dst: RegisterId(
-                                        2,
-                                    ),
-                                    src: RegisterId(
-                                        0,
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        3,
-                                    ),
-                                    value: Int(
-                                        0,
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                Length {
-                                    dst: RegisterId(
-                                        4,
-                                    ),
-                                    src: RegisterId(
-                                        2,
-                                    ),
-                                },
-                            ),
-                            CoreSet(
-                                Jump {
-                                    target_state: StateId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            PureSet(
-                                Binary {
-                                    kind: Lt,
-                                    op: BinaryOp {
-                                        dst: RegisterId(
-                                            5,
-                                        ),
-                                        a: RegisterId(
-                                            3,
-                                        ),
-                                        b: RegisterId(
-                                            4,
-                                        ),
-                                    },
-                                },
-                            ),
-                            CoreSet(
-                                JumpIf {
-                                    target_state: StateId(
-                                        2,
-                                    ),
-                                    cond: RegisterId(
-                                        5,
-                                    ),
-                                },
-                            ),
-                            CoreSet(
-                                Jump {
-                                    target_state: StateId(
-                                        4,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            PureSet(
-                                Index {
-                                    dst: RegisterId(
-                                        5,
-                                    ),
-                                    object: RegisterId(
-                                        2,
-                                    ),
-                                    index: RegisterId(
-                                        3,
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                Copy {
-                                    dst: RegisterId(
-                                        6,
-                                    ),
-                                    src: RegisterId(
-                                        5,
-                                    ),
-                                },
-                            ),
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        7,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "check_item",
-                                    ),
-                                    args: [
-                                        RegisterId(
-                                            6,
-                                        ),
-                                    ],
-                                    resume: StateId(
-                                        5,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        5,
-                                    ),
-                                    value: Int(
-                                        1,
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                Binary {
-                                    kind: Add,
-                                    op: BinaryOp {
-                                        dst: RegisterId(
-                                            3,
-                                        ),
-                                        a: RegisterId(
-                                            3,
-                                        ),
-                                        b: RegisterId(
-                                            5,
-                                        ),
-                                    },
-                                },
-                            ),
-                            CoreSet(
-                                Jump {
-                                    target_state: StateId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Return {
-                                    src: RegisterId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        7,
-                                    ),
-                                    src: RegisterId(
-                                        7,
-                                    ),
-                                    resume: StateId(
-                                        6,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                JumpIf {
-                                    target_state: StateId(
-                                        8,
-                                    ),
-                                    cond: RegisterId(
-                                        7,
-                                    ),
-                                },
-                            ),
-                            CoreSet(
-                                Jump {
-                                    target_state: StateId(
-                                        7,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Jump {
-                                    target_state: StateId(
-                                        3,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        1,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "process_found",
-                                    ),
-                                    args: [
-                                        RegisterId(
-                                            6,
-                                        ),
-                                    ],
-                                    resume: StateId(
-                                        9,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        1,
-                                    ),
-                                    src: RegisterId(
-                                        1,
-                                    ),
-                                    resume: StateId(
-                                        10,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Jump {
-                                    target_state: StateId(
-                                        4,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                ],
-                num_regs: 8,
-            },
-        ],
-    },
-)
+f0: [8 registers]
+  s0:
+    PureSet(LoadConst { dst: r1, value: String("not found") })
+    PureSet(Copy { dst: r2, src: r0 })
+    PureSet(LoadConst { dst: r3, value: Int(0) })
+    PureSet(Length { dst: r4, src: r2 })
+    CoreSet(Jump { target_state: s1 })
+  s1:
+    PureSet(Binary { kind: Lt, op: BinaryOp { dst: r5, a: r3, b: r4 } })
+    CoreSet(JumpIf { target_state: s2, cond: r5 })
+    CoreSet(Jump { target_state: s4 })
+  s2:
+    PureSet(Index { dst: r5, object: r2, index: r3 })
+    PureSet(Copy { dst: r6, src: r5 })
+    ExtCallSet(ActionCall { dst: r7, action_ref: TestActionRef("check_item"), args: [r6], resume: s5 })
+  s3:
+    PureSet(LoadConst { dst: r5, value: Int(1) })
+    PureSet(Binary { kind: Add, op: BinaryOp { dst: r3, a: r3, b: r5 } })
+    CoreSet(Jump { target_state: s1 })
+  s4:
+    CoreSet(Return { src: r1 })
+  s5:
+    CoreSet(Await { dst: r7, src: r7, resume: s6 })
+  s6:
+    CoreSet(JumpIf { target_state: s8, cond: r7 })
+    CoreSet(Jump { target_state: s7 })
+  s7:
+    CoreSet(Jump { target_state: s3 })
+  s8:
+    ExtCallSet(ActionCall { dst: r1, action_ref: TestActionRef("process_found"), args: [r6], resume: s9 })
+  s9:
+    CoreSet(Await { dst: r1, src: r1, resume: s10 })
+  s10:
+    CoreSet(Jump { target_state: s4 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_for_loop__for_concat_accumulator.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_for_loop__for_concat_accumulator.py__bytecode.snap
@@ -2,249 +2,30 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_for_loop/for_concat_accumulator.py
 ---
-Ok(
-    Executable {
-        functions: [
-            Function {
-                states: [
-                    State {
-                        instructions: [
-                            PureSet(
-                                MakeList {
-                                    dst: RegisterId(
-                                        1,
-                                    ),
-                                    items: [],
-                                },
-                            ),
-                            PureSet(
-                                Copy {
-                                    dst: RegisterId(
-                                        2,
-                                    ),
-                                    src: RegisterId(
-                                        0,
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        3,
-                                    ),
-                                    value: Int(
-                                        0,
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                Length {
-                                    dst: RegisterId(
-                                        4,
-                                    ),
-                                    src: RegisterId(
-                                        2,
-                                    ),
-                                },
-                            ),
-                            CoreSet(
-                                Jump {
-                                    target_state: StateId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            PureSet(
-                                Binary {
-                                    kind: Lt,
-                                    op: BinaryOp {
-                                        dst: RegisterId(
-                                            5,
-                                        ),
-                                        a: RegisterId(
-                                            3,
-                                        ),
-                                        b: RegisterId(
-                                            4,
-                                        ),
-                                    },
-                                },
-                            ),
-                            CoreSet(
-                                JumpIf {
-                                    target_state: StateId(
-                                        2,
-                                    ),
-                                    cond: RegisterId(
-                                        5,
-                                    ),
-                                },
-                            ),
-                            CoreSet(
-                                Jump {
-                                    target_state: StateId(
-                                        4,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            PureSet(
-                                Index {
-                                    dst: RegisterId(
-                                        5,
-                                    ),
-                                    object: RegisterId(
-                                        2,
-                                    ),
-                                    index: RegisterId(
-                                        3,
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                Copy {
-                                    dst: RegisterId(
-                                        6,
-                                    ),
-                                    src: RegisterId(
-                                        5,
-                                    ),
-                                },
-                            ),
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        7,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "concat_accum_process_value",
-                                    ),
-                                    args: [
-                                        RegisterId(
-                                            6,
-                                        ),
-                                    ],
-                                    resume: StateId(
-                                        5,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        5,
-                                    ),
-                                    value: Int(
-                                        1,
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                Binary {
-                                    kind: Add,
-                                    op: BinaryOp {
-                                        dst: RegisterId(
-                                            3,
-                                        ),
-                                        a: RegisterId(
-                                            3,
-                                        ),
-                                        b: RegisterId(
-                                            5,
-                                        ),
-                                    },
-                                },
-                            ),
-                            CoreSet(
-                                Jump {
-                                    target_state: StateId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Return {
-                                    src: RegisterId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        7,
-                                    ),
-                                    src: RegisterId(
-                                        7,
-                                    ),
-                                    resume: StateId(
-                                        6,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            PureSet(
-                                MakeList {
-                                    dst: RegisterId(
-                                        5,
-                                    ),
-                                    items: [
-                                        RegisterId(
-                                            7,
-                                        ),
-                                    ],
-                                },
-                            ),
-                            PureSet(
-                                Binary {
-                                    kind: Add,
-                                    op: BinaryOp {
-                                        dst: RegisterId(
-                                            1,
-                                        ),
-                                        a: RegisterId(
-                                            1,
-                                        ),
-                                        b: RegisterId(
-                                            5,
-                                        ),
-                                    },
-                                },
-                            ),
-                            CoreSet(
-                                Jump {
-                                    target_state: StateId(
-                                        3,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                ],
-                num_regs: 8,
-            },
-        ],
-    },
-)
+f0: [8 registers]
+  s0:
+    PureSet(MakeList { dst: r1, items: [] })
+    PureSet(Copy { dst: r2, src: r0 })
+    PureSet(LoadConst { dst: r3, value: Int(0) })
+    PureSet(Length { dst: r4, src: r2 })
+    CoreSet(Jump { target_state: s1 })
+  s1:
+    PureSet(Binary { kind: Lt, op: BinaryOp { dst: r5, a: r3, b: r4 } })
+    CoreSet(JumpIf { target_state: s2, cond: r5 })
+    CoreSet(Jump { target_state: s4 })
+  s2:
+    PureSet(Index { dst: r5, object: r2, index: r3 })
+    PureSet(Copy { dst: r6, src: r5 })
+    ExtCallSet(ActionCall { dst: r7, action_ref: TestActionRef("concat_accum_process_value"), args: [r6], resume: s5 })
+  s3:
+    PureSet(LoadConst { dst: r5, value: Int(1) })
+    PureSet(Binary { kind: Add, op: BinaryOp { dst: r3, a: r3, b: r5 } })
+    CoreSet(Jump { target_state: s1 })
+  s4:
+    CoreSet(Return { src: r1 })
+  s5:
+    CoreSet(Await { dst: r7, src: r7, resume: s6 })
+  s6:
+    PureSet(MakeList { dst: r5, items: [r7] })
+    PureSet(Binary { kind: Add, op: BinaryOp { dst: r1, a: r1, b: r5 } })
+    CoreSet(Jump { target_state: s3 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_for_loop__for_continue.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_for_loop__for_continue.py__bytecode.snap
@@ -2,310 +2,38 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_for_loop/for_continue.py
 ---
-Ok(
-    Executable {
-        functions: [
-            Function {
-                states: [
-                    State {
-                        instructions: [
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        1,
-                                    ),
-                                    value: Int(
-                                        0,
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                Copy {
-                                    dst: RegisterId(
-                                        2,
-                                    ),
-                                    src: RegisterId(
-                                        0,
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        3,
-                                    ),
-                                    value: Int(
-                                        0,
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                Length {
-                                    dst: RegisterId(
-                                        4,
-                                    ),
-                                    src: RegisterId(
-                                        2,
-                                    ),
-                                },
-                            ),
-                            CoreSet(
-                                Jump {
-                                    target_state: StateId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            PureSet(
-                                Binary {
-                                    kind: Lt,
-                                    op: BinaryOp {
-                                        dst: RegisterId(
-                                            5,
-                                        ),
-                                        a: RegisterId(
-                                            3,
-                                        ),
-                                        b: RegisterId(
-                                            4,
-                                        ),
-                                    },
-                                },
-                            ),
-                            CoreSet(
-                                JumpIf {
-                                    target_state: StateId(
-                                        2,
-                                    ),
-                                    cond: RegisterId(
-                                        5,
-                                    ),
-                                },
-                            ),
-                            CoreSet(
-                                Jump {
-                                    target_state: StateId(
-                                        4,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            PureSet(
-                                Index {
-                                    dst: RegisterId(
-                                        5,
-                                    ),
-                                    object: RegisterId(
-                                        2,
-                                    ),
-                                    index: RegisterId(
-                                        3,
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                Copy {
-                                    dst: RegisterId(
-                                        6,
-                                    ),
-                                    src: RegisterId(
-                                        5,
-                                    ),
-                                },
-                            ),
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        7,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "should_skip",
-                                    ),
-                                    args: [
-                                        RegisterId(
-                                            6,
-                                        ),
-                                    ],
-                                    resume: StateId(
-                                        5,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        5,
-                                    ),
-                                    value: Int(
-                                        1,
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                Binary {
-                                    kind: Add,
-                                    op: BinaryOp {
-                                        dst: RegisterId(
-                                            3,
-                                        ),
-                                        a: RegisterId(
-                                            3,
-                                        ),
-                                        b: RegisterId(
-                                            5,
-                                        ),
-                                    },
-                                },
-                            ),
-                            CoreSet(
-                                Jump {
-                                    target_state: StateId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Return {
-                                    src: RegisterId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        7,
-                                    ),
-                                    src: RegisterId(
-                                        7,
-                                    ),
-                                    resume: StateId(
-                                        6,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                JumpIf {
-                                    target_state: StateId(
-                                        8,
-                                    ),
-                                    cond: RegisterId(
-                                        7,
-                                    ),
-                                },
-                            ),
-                            CoreSet(
-                                Jump {
-                                    target_state: StateId(
-                                        7,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        8,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "process_item",
-                                    ),
-                                    args: [
-                                        RegisterId(
-                                            6,
-                                        ),
-                                    ],
-                                    resume: StateId(
-                                        9,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Jump {
-                                    target_state: StateId(
-                                        3,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        8,
-                                    ),
-                                    src: RegisterId(
-                                        8,
-                                    ),
-                                    resume: StateId(
-                                        10,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            PureSet(
-                                Binary {
-                                    kind: Add,
-                                    op: BinaryOp {
-                                        dst: RegisterId(
-                                            1,
-                                        ),
-                                        a: RegisterId(
-                                            1,
-                                        ),
-                                        b: RegisterId(
-                                            8,
-                                        ),
-                                    },
-                                },
-                            ),
-                            CoreSet(
-                                Jump {
-                                    target_state: StateId(
-                                        3,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                ],
-                num_regs: 9,
-            },
-        ],
-    },
-)
+f0: [9 registers]
+  s0:
+    PureSet(LoadConst { dst: r1, value: Int(0) })
+    PureSet(Copy { dst: r2, src: r0 })
+    PureSet(LoadConst { dst: r3, value: Int(0) })
+    PureSet(Length { dst: r4, src: r2 })
+    CoreSet(Jump { target_state: s1 })
+  s1:
+    PureSet(Binary { kind: Lt, op: BinaryOp { dst: r5, a: r3, b: r4 } })
+    CoreSet(JumpIf { target_state: s2, cond: r5 })
+    CoreSet(Jump { target_state: s4 })
+  s2:
+    PureSet(Index { dst: r5, object: r2, index: r3 })
+    PureSet(Copy { dst: r6, src: r5 })
+    ExtCallSet(ActionCall { dst: r7, action_ref: TestActionRef("should_skip"), args: [r6], resume: s5 })
+  s3:
+    PureSet(LoadConst { dst: r5, value: Int(1) })
+    PureSet(Binary { kind: Add, op: BinaryOp { dst: r3, a: r3, b: r5 } })
+    CoreSet(Jump { target_state: s1 })
+  s4:
+    CoreSet(Return { src: r1 })
+  s5:
+    CoreSet(Await { dst: r7, src: r7, resume: s6 })
+  s6:
+    CoreSet(JumpIf { target_state: s8, cond: r7 })
+    CoreSet(Jump { target_state: s7 })
+  s7:
+    ExtCallSet(ActionCall { dst: r8, action_ref: TestActionRef("process_item"), args: [r6], resume: s9 })
+  s8:
+    CoreSet(Jump { target_state: s3 })
+  s9:
+    CoreSet(Await { dst: r8, src: r8, resume: s10 })
+  s10:
+    PureSet(Binary { kind: Add, op: BinaryOp { dst: r1, a: r1, b: r8 } })
+    CoreSet(Jump { target_state: s3 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_for_loop__for_counter_accumulator.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_for_loop__for_counter_accumulator.py__bytecode.snap
@@ -2,281 +2,35 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_for_loop/for_counter_accumulator.py
 ---
-Ok(
-    Executable {
-        functions: [
-            Function {
-                states: [
-                    State {
-                        instructions: [
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        1,
-                                    ),
-                                    value: Int(
-                                        0,
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                Copy {
-                                    dst: RegisterId(
-                                        2,
-                                    ),
-                                    src: RegisterId(
-                                        0,
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        3,
-                                    ),
-                                    value: Int(
-                                        0,
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                Length {
-                                    dst: RegisterId(
-                                        4,
-                                    ),
-                                    src: RegisterId(
-                                        2,
-                                    ),
-                                },
-                            ),
-                            CoreSet(
-                                Jump {
-                                    target_state: StateId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            PureSet(
-                                Binary {
-                                    kind: Lt,
-                                    op: BinaryOp {
-                                        dst: RegisterId(
-                                            5,
-                                        ),
-                                        a: RegisterId(
-                                            3,
-                                        ),
-                                        b: RegisterId(
-                                            4,
-                                        ),
-                                    },
-                                },
-                            ),
-                            CoreSet(
-                                JumpIf {
-                                    target_state: StateId(
-                                        2,
-                                    ),
-                                    cond: RegisterId(
-                                        5,
-                                    ),
-                                },
-                            ),
-                            CoreSet(
-                                Jump {
-                                    target_state: StateId(
-                                        4,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            PureSet(
-                                Index {
-                                    dst: RegisterId(
-                                        5,
-                                    ),
-                                    object: RegisterId(
-                                        2,
-                                    ),
-                                    index: RegisterId(
-                                        3,
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                Copy {
-                                    dst: RegisterId(
-                                        6,
-                                    ),
-                                    src: RegisterId(
-                                        5,
-                                    ),
-                                },
-                            ),
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        7,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "counter_accum_check_valid",
-                                    ),
-                                    args: [
-                                        RegisterId(
-                                            6,
-                                        ),
-                                    ],
-                                    resume: StateId(
-                                        5,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        5,
-                                    ),
-                                    value: Int(
-                                        1,
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                Binary {
-                                    kind: Add,
-                                    op: BinaryOp {
-                                        dst: RegisterId(
-                                            3,
-                                        ),
-                                        a: RegisterId(
-                                            3,
-                                        ),
-                                        b: RegisterId(
-                                            5,
-                                        ),
-                                    },
-                                },
-                            ),
-                            CoreSet(
-                                Jump {
-                                    target_state: StateId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Return {
-                                    src: RegisterId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        7,
-                                    ),
-                                    src: RegisterId(
-                                        7,
-                                    ),
-                                    resume: StateId(
-                                        6,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                JumpIf {
-                                    target_state: StateId(
-                                        8,
-                                    ),
-                                    cond: RegisterId(
-                                        7,
-                                    ),
-                                },
-                            ),
-                            CoreSet(
-                                Jump {
-                                    target_state: StateId(
-                                        7,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Jump {
-                                    target_state: StateId(
-                                        3,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        5,
-                                    ),
-                                    value: Int(
-                                        1,
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                Binary {
-                                    kind: Add,
-                                    op: BinaryOp {
-                                        dst: RegisterId(
-                                            1,
-                                        ),
-                                        a: RegisterId(
-                                            1,
-                                        ),
-                                        b: RegisterId(
-                                            5,
-                                        ),
-                                    },
-                                },
-                            ),
-                            CoreSet(
-                                Jump {
-                                    target_state: StateId(
-                                        7,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                ],
-                num_regs: 8,
-            },
-        ],
-    },
-)
+f0: [8 registers]
+  s0:
+    PureSet(LoadConst { dst: r1, value: Int(0) })
+    PureSet(Copy { dst: r2, src: r0 })
+    PureSet(LoadConst { dst: r3, value: Int(0) })
+    PureSet(Length { dst: r4, src: r2 })
+    CoreSet(Jump { target_state: s1 })
+  s1:
+    PureSet(Binary { kind: Lt, op: BinaryOp { dst: r5, a: r3, b: r4 } })
+    CoreSet(JumpIf { target_state: s2, cond: r5 })
+    CoreSet(Jump { target_state: s4 })
+  s2:
+    PureSet(Index { dst: r5, object: r2, index: r3 })
+    PureSet(Copy { dst: r6, src: r5 })
+    ExtCallSet(ActionCall { dst: r7, action_ref: TestActionRef("counter_accum_check_valid"), args: [r6], resume: s5 })
+  s3:
+    PureSet(LoadConst { dst: r5, value: Int(1) })
+    PureSet(Binary { kind: Add, op: BinaryOp { dst: r3, a: r3, b: r5 } })
+    CoreSet(Jump { target_state: s1 })
+  s4:
+    CoreSet(Return { src: r1 })
+  s5:
+    CoreSet(Await { dst: r7, src: r7, resume: s6 })
+  s6:
+    CoreSet(JumpIf { target_state: s8, cond: r7 })
+    CoreSet(Jump { target_state: s7 })
+  s7:
+    CoreSet(Jump { target_state: s3 })
+  s8:
+    PureSet(LoadConst { dst: r5, value: Int(1) })
+    PureSet(Binary { kind: Add, op: BinaryOp { dst: r1, a: r1, b: r5 } })
+    CoreSet(Jump { target_state: s7 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_for_loop__for_dict_accumulator.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_for_loop__for_dict_accumulator.py__bytecode.snap
@@ -1,13 +1,11 @@
 ---
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
-expression: bytecode for python/tests/fixtures_for_loop/for_dict_accumulator.py
+expression: "bytecode for python/tests/fixtures_for_loop/for_dict_accumulator.py [compilation error]"
 ---
-Err(
-    FunctionCompiler(
-        Unsupported(
-            AssignmentTargetCount {
-                count: 2,
-            },
-        ),
+FunctionCompiler(
+    Unsupported(
+        AssignmentTargetCount {
+            count: 2,
+        },
     ),
 )

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_for_loop__for_multi_accumulator.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_for_loop__for_multi_accumulator.py__bytecode.snap
@@ -1,13 +1,11 @@
 ---
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
-expression: bytecode for python/tests/fixtures_for_loop/for_multi_accumulator.py
+expression: "bytecode for python/tests/fixtures_for_loop/for_multi_accumulator.py [compilation error]"
 ---
-Err(
-    FunctionCompiler(
-        Unsupported(
-            AssignmentTargetCount {
-                count: 2,
-            },
-        ),
+FunctionCompiler(
+    Unsupported(
+        AssignmentTargetCount {
+            count: 2,
+        },
     ),
 )

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_for_loop__for_multiple_calls.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_for_loop__for_multiple_calls.py__bytecode.snap
@@ -2,288 +2,34 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_for_loop/for_multiple_calls.py
 ---
-Ok(
-    Executable {
-        functions: [
-            Function {
-                states: [
-                    State {
-                        instructions: [
-                            PureSet(
-                                MakeList {
-                                    dst: RegisterId(
-                                        1,
-                                    ),
-                                    items: [],
-                                },
-                            ),
-                            PureSet(
-                                Copy {
-                                    dst: RegisterId(
-                                        2,
-                                    ),
-                                    src: RegisterId(
-                                        0,
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        3,
-                                    ),
-                                    value: Int(
-                                        0,
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                Length {
-                                    dst: RegisterId(
-                                        4,
-                                    ),
-                                    src: RegisterId(
-                                        2,
-                                    ),
-                                },
-                            ),
-                            CoreSet(
-                                Jump {
-                                    target_state: StateId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            PureSet(
-                                Binary {
-                                    kind: Lt,
-                                    op: BinaryOp {
-                                        dst: RegisterId(
-                                            5,
-                                        ),
-                                        a: RegisterId(
-                                            3,
-                                        ),
-                                        b: RegisterId(
-                                            4,
-                                        ),
-                                    },
-                                },
-                            ),
-                            CoreSet(
-                                JumpIf {
-                                    target_state: StateId(
-                                        2,
-                                    ),
-                                    cond: RegisterId(
-                                        5,
-                                    ),
-                                },
-                            ),
-                            CoreSet(
-                                Jump {
-                                    target_state: StateId(
-                                        4,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            PureSet(
-                                Index {
-                                    dst: RegisterId(
-                                        5,
-                                    ),
-                                    object: RegisterId(
-                                        2,
-                                    ),
-                                    index: RegisterId(
-                                        3,
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                Copy {
-                                    dst: RegisterId(
-                                        6,
-                                    ),
-                                    src: RegisterId(
-                                        5,
-                                    ),
-                                },
-                            ),
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        7,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "for_step_one",
-                                    ),
-                                    args: [
-                                        RegisterId(
-                                            6,
-                                        ),
-                                    ],
-                                    resume: StateId(
-                                        5,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        5,
-                                    ),
-                                    value: Int(
-                                        1,
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                Binary {
-                                    kind: Add,
-                                    op: BinaryOp {
-                                        dst: RegisterId(
-                                            3,
-                                        ),
-                                        a: RegisterId(
-                                            3,
-                                        ),
-                                        b: RegisterId(
-                                            5,
-                                        ),
-                                    },
-                                },
-                            ),
-                            CoreSet(
-                                Jump {
-                                    target_state: StateId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Return {
-                                    src: RegisterId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        7,
-                                    ),
-                                    src: RegisterId(
-                                        7,
-                                    ),
-                                    resume: StateId(
-                                        6,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        8,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "for_step_two",
-                                    ),
-                                    args: [
-                                        RegisterId(
-                                            7,
-                                        ),
-                                    ],
-                                    resume: StateId(
-                                        7,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        8,
-                                    ),
-                                    src: RegisterId(
-                                        8,
-                                    ),
-                                    resume: StateId(
-                                        8,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            PureSet(
-                                MakeList {
-                                    dst: RegisterId(
-                                        5,
-                                    ),
-                                    items: [
-                                        RegisterId(
-                                            8,
-                                        ),
-                                    ],
-                                },
-                            ),
-                            PureSet(
-                                Binary {
-                                    kind: Add,
-                                    op: BinaryOp {
-                                        dst: RegisterId(
-                                            1,
-                                        ),
-                                        a: RegisterId(
-                                            1,
-                                        ),
-                                        b: RegisterId(
-                                            5,
-                                        ),
-                                    },
-                                },
-                            ),
-                            CoreSet(
-                                Jump {
-                                    target_state: StateId(
-                                        3,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                ],
-                num_regs: 9,
-            },
-        ],
-    },
-)
+f0: [9 registers]
+  s0:
+    PureSet(MakeList { dst: r1, items: [] })
+    PureSet(Copy { dst: r2, src: r0 })
+    PureSet(LoadConst { dst: r3, value: Int(0) })
+    PureSet(Length { dst: r4, src: r2 })
+    CoreSet(Jump { target_state: s1 })
+  s1:
+    PureSet(Binary { kind: Lt, op: BinaryOp { dst: r5, a: r3, b: r4 } })
+    CoreSet(JumpIf { target_state: s2, cond: r5 })
+    CoreSet(Jump { target_state: s4 })
+  s2:
+    PureSet(Index { dst: r5, object: r2, index: r3 })
+    PureSet(Copy { dst: r6, src: r5 })
+    ExtCallSet(ActionCall { dst: r7, action_ref: TestActionRef("for_step_one"), args: [r6], resume: s5 })
+  s3:
+    PureSet(LoadConst { dst: r5, value: Int(1) })
+    PureSet(Binary { kind: Add, op: BinaryOp { dst: r3, a: r3, b: r5 } })
+    CoreSet(Jump { target_state: s1 })
+  s4:
+    CoreSet(Return { src: r1 })
+  s5:
+    CoreSet(Await { dst: r7, src: r7, resume: s6 })
+  s6:
+    ExtCallSet(ActionCall { dst: r8, action_ref: TestActionRef("for_step_two"), args: [r7], resume: s7 })
+  s7:
+    CoreSet(Await { dst: r8, src: r8, resume: s8 })
+  s8:
+    PureSet(MakeList { dst: r5, items: [r8] })
+    PureSet(Binary { kind: Add, op: BinaryOp { dst: r1, a: r1, b: r5 } })
+    CoreSet(Jump { target_state: s3 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_for_loop__for_single_accumulator.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_for_loop__for_single_accumulator.py__bytecode.snap
@@ -2,249 +2,30 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_for_loop/for_single_accumulator.py
 ---
-Ok(
-    Executable {
-        functions: [
-            Function {
-                states: [
-                    State {
-                        instructions: [
-                            PureSet(
-                                MakeList {
-                                    dst: RegisterId(
-                                        1,
-                                    ),
-                                    items: [],
-                                },
-                            ),
-                            PureSet(
-                                Copy {
-                                    dst: RegisterId(
-                                        2,
-                                    ),
-                                    src: RegisterId(
-                                        0,
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        3,
-                                    ),
-                                    value: Int(
-                                        0,
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                Length {
-                                    dst: RegisterId(
-                                        4,
-                                    ),
-                                    src: RegisterId(
-                                        2,
-                                    ),
-                                },
-                            ),
-                            CoreSet(
-                                Jump {
-                                    target_state: StateId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            PureSet(
-                                Binary {
-                                    kind: Lt,
-                                    op: BinaryOp {
-                                        dst: RegisterId(
-                                            5,
-                                        ),
-                                        a: RegisterId(
-                                            3,
-                                        ),
-                                        b: RegisterId(
-                                            4,
-                                        ),
-                                    },
-                                },
-                            ),
-                            CoreSet(
-                                JumpIf {
-                                    target_state: StateId(
-                                        2,
-                                    ),
-                                    cond: RegisterId(
-                                        5,
-                                    ),
-                                },
-                            ),
-                            CoreSet(
-                                Jump {
-                                    target_state: StateId(
-                                        4,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            PureSet(
-                                Index {
-                                    dst: RegisterId(
-                                        5,
-                                    ),
-                                    object: RegisterId(
-                                        2,
-                                    ),
-                                    index: RegisterId(
-                                        3,
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                Copy {
-                                    dst: RegisterId(
-                                        6,
-                                    ),
-                                    src: RegisterId(
-                                        5,
-                                    ),
-                                },
-                            ),
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        7,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "single_accum_process_value",
-                                    ),
-                                    args: [
-                                        RegisterId(
-                                            6,
-                                        ),
-                                    ],
-                                    resume: StateId(
-                                        5,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        5,
-                                    ),
-                                    value: Int(
-                                        1,
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                Binary {
-                                    kind: Add,
-                                    op: BinaryOp {
-                                        dst: RegisterId(
-                                            3,
-                                        ),
-                                        a: RegisterId(
-                                            3,
-                                        ),
-                                        b: RegisterId(
-                                            5,
-                                        ),
-                                    },
-                                },
-                            ),
-                            CoreSet(
-                                Jump {
-                                    target_state: StateId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Return {
-                                    src: RegisterId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        7,
-                                    ),
-                                    src: RegisterId(
-                                        7,
-                                    ),
-                                    resume: StateId(
-                                        6,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            PureSet(
-                                MakeList {
-                                    dst: RegisterId(
-                                        5,
-                                    ),
-                                    items: [
-                                        RegisterId(
-                                            7,
-                                        ),
-                                    ],
-                                },
-                            ),
-                            PureSet(
-                                Binary {
-                                    kind: Add,
-                                    op: BinaryOp {
-                                        dst: RegisterId(
-                                            1,
-                                        ),
-                                        a: RegisterId(
-                                            1,
-                                        ),
-                                        b: RegisterId(
-                                            5,
-                                        ),
-                                    },
-                                },
-                            ),
-                            CoreSet(
-                                Jump {
-                                    target_state: StateId(
-                                        3,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                ],
-                num_regs: 8,
-            },
-        ],
-    },
-)
+f0: [8 registers]
+  s0:
+    PureSet(MakeList { dst: r1, items: [] })
+    PureSet(Copy { dst: r2, src: r0 })
+    PureSet(LoadConst { dst: r3, value: Int(0) })
+    PureSet(Length { dst: r4, src: r2 })
+    CoreSet(Jump { target_state: s1 })
+  s1:
+    PureSet(Binary { kind: Lt, op: BinaryOp { dst: r5, a: r3, b: r4 } })
+    CoreSet(JumpIf { target_state: s2, cond: r5 })
+    CoreSet(Jump { target_state: s4 })
+  s2:
+    PureSet(Index { dst: r5, object: r2, index: r3 })
+    PureSet(Copy { dst: r6, src: r5 })
+    ExtCallSet(ActionCall { dst: r7, action_ref: TestActionRef("single_accum_process_value"), args: [r6], resume: s5 })
+  s3:
+    PureSet(LoadConst { dst: r5, value: Int(1) })
+    PureSet(Binary { kind: Add, op: BinaryOp { dst: r3, a: r3, b: r5 } })
+    CoreSet(Jump { target_state: s1 })
+  s4:
+    CoreSet(Return { src: r1 })
+  s5:
+    CoreSet(Await { dst: r7, src: r7, resume: s6 })
+  s6:
+    PureSet(MakeList { dst: r5, items: [r7] })
+    PureSet(Binary { kind: Add, op: BinaryOp { dst: r1, a: r1, b: r5 } })
+    CoreSet(Jump { target_state: s3 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_for_loop__for_with_append.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_for_loop__for_with_append.py__bytecode.snap
@@ -2,249 +2,30 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_for_loop/for_with_append.py
 ---
-Ok(
-    Executable {
-        functions: [
-            Function {
-                states: [
-                    State {
-                        instructions: [
-                            PureSet(
-                                MakeList {
-                                    dst: RegisterId(
-                                        1,
-                                    ),
-                                    items: [],
-                                },
-                            ),
-                            PureSet(
-                                Copy {
-                                    dst: RegisterId(
-                                        2,
-                                    ),
-                                    src: RegisterId(
-                                        0,
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        3,
-                                    ),
-                                    value: Int(
-                                        0,
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                Length {
-                                    dst: RegisterId(
-                                        4,
-                                    ),
-                                    src: RegisterId(
-                                        2,
-                                    ),
-                                },
-                            ),
-                            CoreSet(
-                                Jump {
-                                    target_state: StateId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            PureSet(
-                                Binary {
-                                    kind: Lt,
-                                    op: BinaryOp {
-                                        dst: RegisterId(
-                                            5,
-                                        ),
-                                        a: RegisterId(
-                                            3,
-                                        ),
-                                        b: RegisterId(
-                                            4,
-                                        ),
-                                    },
-                                },
-                            ),
-                            CoreSet(
-                                JumpIf {
-                                    target_state: StateId(
-                                        2,
-                                    ),
-                                    cond: RegisterId(
-                                        5,
-                                    ),
-                                },
-                            ),
-                            CoreSet(
-                                Jump {
-                                    target_state: StateId(
-                                        4,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            PureSet(
-                                Index {
-                                    dst: RegisterId(
-                                        5,
-                                    ),
-                                    object: RegisterId(
-                                        2,
-                                    ),
-                                    index: RegisterId(
-                                        3,
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                Copy {
-                                    dst: RegisterId(
-                                        6,
-                                    ),
-                                    src: RegisterId(
-                                        5,
-                                    ),
-                                },
-                            ),
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        7,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "process_value",
-                                    ),
-                                    args: [
-                                        RegisterId(
-                                            6,
-                                        ),
-                                    ],
-                                    resume: StateId(
-                                        5,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        5,
-                                    ),
-                                    value: Int(
-                                        1,
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                Binary {
-                                    kind: Add,
-                                    op: BinaryOp {
-                                        dst: RegisterId(
-                                            3,
-                                        ),
-                                        a: RegisterId(
-                                            3,
-                                        ),
-                                        b: RegisterId(
-                                            5,
-                                        ),
-                                    },
-                                },
-                            ),
-                            CoreSet(
-                                Jump {
-                                    target_state: StateId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Return {
-                                    src: RegisterId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        7,
-                                    ),
-                                    src: RegisterId(
-                                        7,
-                                    ),
-                                    resume: StateId(
-                                        6,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            PureSet(
-                                MakeList {
-                                    dst: RegisterId(
-                                        5,
-                                    ),
-                                    items: [
-                                        RegisterId(
-                                            7,
-                                        ),
-                                    ],
-                                },
-                            ),
-                            PureSet(
-                                Binary {
-                                    kind: Add,
-                                    op: BinaryOp {
-                                        dst: RegisterId(
-                                            1,
-                                        ),
-                                        a: RegisterId(
-                                            1,
-                                        ),
-                                        b: RegisterId(
-                                            5,
-                                        ),
-                                    },
-                                },
-                            ),
-                            CoreSet(
-                                Jump {
-                                    target_state: StateId(
-                                        3,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                ],
-                num_regs: 8,
-            },
-        ],
-    },
-)
+f0: [8 registers]
+  s0:
+    PureSet(MakeList { dst: r1, items: [] })
+    PureSet(Copy { dst: r2, src: r0 })
+    PureSet(LoadConst { dst: r3, value: Int(0) })
+    PureSet(Length { dst: r4, src: r2 })
+    CoreSet(Jump { target_state: s1 })
+  s1:
+    PureSet(Binary { kind: Lt, op: BinaryOp { dst: r5, a: r3, b: r4 } })
+    CoreSet(JumpIf { target_state: s2, cond: r5 })
+    CoreSet(Jump { target_state: s4 })
+  s2:
+    PureSet(Index { dst: r5, object: r2, index: r3 })
+    PureSet(Copy { dst: r6, src: r5 })
+    ExtCallSet(ActionCall { dst: r7, action_ref: TestActionRef("process_value"), args: [r6], resume: s5 })
+  s3:
+    PureSet(LoadConst { dst: r5, value: Int(1) })
+    PureSet(Binary { kind: Add, op: BinaryOp { dst: r3, a: r3, b: r5 } })
+    CoreSet(Jump { target_state: s1 })
+  s4:
+    CoreSet(Return { src: r1 })
+  s5:
+    CoreSet(Await { dst: r7, src: r7, resume: s6 })
+  s6:
+    PureSet(MakeList { dst: r5, items: [r7] })
+    PureSet(Binary { kind: Add, op: BinaryOp { dst: r1, a: r1, b: r5 } })
+    CoreSet(Jump { target_state: s3 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_generator.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_generator.py__bytecode.snap
@@ -1,13 +1,11 @@
 ---
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
-expression: bytecode for python/tests/fixtures_gather/gather_generator.py
+expression: "bytecode for python/tests/fixtures_gather/gather_generator.py [compilation error]"
 ---
-Err(
-    FunctionCompiler(
-        Unsupported(
-            Expression {
-                kind: SpreadExpr,
-            },
-        ),
+FunctionCompiler(
+    Unsupported(
+        Expression {
+            kind: SpreadExpr,
+        },
     ),
 )

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_generator_filter.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_generator_filter.py__bytecode.snap
@@ -1,13 +1,11 @@
 ---
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
-expression: bytecode for python/tests/fixtures_gather/gather_generator_filter.py
+expression: "bytecode for python/tests/fixtures_gather/gather_generator_filter.py [compilation error]"
 ---
-Err(
-    FunctionCompiler(
-        Unsupported(
-            Expression {
-                kind: SpreadExpr,
-            },
-        ),
+FunctionCompiler(
+    Unsupported(
+        Expression {
+            kind: SpreadExpr,
+        },
     ),
 )

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_listcomp.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_listcomp.py__bytecode.snap
@@ -1,13 +1,11 @@
 ---
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
-expression: bytecode for python/tests/fixtures_gather/gather_listcomp.py
+expression: "bytecode for python/tests/fixtures_gather/gather_listcomp.py [compilation error]"
 ---
-Err(
-    FunctionCompiler(
-        Unsupported(
-            Expression {
-                kind: SpreadExpr,
-            },
-        ),
+FunctionCompiler(
+    Unsupported(
+        Expression {
+            kind: SpreadExpr,
+        },
     ),
 )

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_listcomp_filter.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_listcomp_filter.py__bytecode.snap
@@ -1,13 +1,11 @@
 ---
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
-expression: bytecode for python/tests/fixtures_gather/gather_listcomp_filter.py
+expression: "bytecode for python/tests/fixtures_gather/gather_listcomp_filter.py [compilation error]"
 ---
-Err(
-    FunctionCompiler(
-        Unsupported(
-            Expression {
-                kind: SpreadExpr,
-            },
-        ),
+FunctionCompiler(
+    Unsupported(
+        Expression {
+            kind: SpreadExpr,
+        },
     ),
 )

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_listcomp_tuple_unpack.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_listcomp_tuple_unpack.py__bytecode.snap
@@ -1,13 +1,11 @@
 ---
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
-expression: bytecode for python/tests/fixtures_gather/gather_listcomp_tuple_unpack.py
+expression: "bytecode for python/tests/fixtures_gather/gather_listcomp_tuple_unpack.py [compilation error]"
 ---
-Err(
-    FunctionCompiler(
-        Unsupported(
-            Expression {
-                kind: SpreadExpr,
-            },
-        ),
+FunctionCompiler(
+    Unsupported(
+        Expression {
+            kind: SpreadExpr,
+        },
     ),
 )

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_nested.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_nested.py__bytecode.snap
@@ -2,149 +2,19 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_gather/gather_nested.py
 ---
-Ok(
-    Executable {
-        functions: [
-            Function {
-                states: [
-                    State {
-                        instructions: [
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        1,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "fetch_a",
-                                    ),
-                                    args: [],
-                                    resume: StateId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        2,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "fetch_b",
-                                    ),
-                                    args: [],
-                                    resume: StateId(
-                                        2,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        1,
-                                    ),
-                                    src: RegisterId(
-                                        1,
-                                    ),
-                                    resume: StateId(
-                                        3,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        2,
-                                    ),
-                                    src: RegisterId(
-                                        2,
-                                    ),
-                                    resume: StateId(
-                                        4,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            PureSet(
-                                MakeList {
-                                    dst: RegisterId(
-                                        0,
-                                    ),
-                                    items: [
-                                        RegisterId(
-                                            1,
-                                        ),
-                                        RegisterId(
-                                            2,
-                                        ),
-                                    ],
-                                },
-                            ),
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        3,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "combine",
-                                    ),
-                                    args: [
-                                        RegisterId(
-                                            0,
-                                        ),
-                                    ],
-                                    resume: StateId(
-                                        5,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        3,
-                                    ),
-                                    src: RegisterId(
-                                        3,
-                                    ),
-                                    resume: StateId(
-                                        6,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Return {
-                                    src: RegisterId(
-                                        3,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                ],
-                num_regs: 4,
-            },
-        ],
-    },
-)
+f0: [4 registers]
+  s0:
+    ExtCallSet(ActionCall { dst: r1, action_ref: TestActionRef("fetch_a"), args: [], resume: s1 })
+  s1:
+    ExtCallSet(ActionCall { dst: r2, action_ref: TestActionRef("fetch_b"), args: [], resume: s2 })
+  s2:
+    CoreSet(Await { dst: r1, src: r1, resume: s3 })
+  s3:
+    CoreSet(Await { dst: r2, src: r2, resume: s4 })
+  s4:
+    PureSet(MakeList { dst: r0, items: [r1, r2] })
+    ExtCallSet(ActionCall { dst: r3, action_ref: TestActionRef("combine"), args: [r0], resume: s5 })
+  s5:
+    CoreSet(Await { dst: r3, src: r3, resume: s6 })
+  s6:
+    CoreSet(Return { src: r3 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_run_action_spread.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_run_action_spread.py__bytecode.snap
@@ -1,13 +1,11 @@
 ---
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
-expression: bytecode for python/tests/fixtures_gather/gather_run_action_spread.py
+expression: "bytecode for python/tests/fixtures_gather/gather_run_action_spread.py [compilation error]"
 ---
-Err(
-    FunctionCompiler(
-        Unsupported(
-            Expression {
-                kind: SpreadExpr,
-            },
-        ),
+FunctionCompiler(
+    Unsupported(
+        Expression {
+            kind: SpreadExpr,
+        },
     ),
 )

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_simple.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_simple.py__bytecode.snap
@@ -2,110 +2,15 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_gather/gather_simple.py
 ---
-Ok(
-    Executable {
-        functions: [
-            Function {
-                states: [
-                    State {
-                        instructions: [
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        2,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "action_a",
-                                    ),
-                                    args: [],
-                                    resume: StateId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        3,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "action_b",
-                                    ),
-                                    args: [],
-                                    resume: StateId(
-                                        2,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        0,
-                                    ),
-                                    src: RegisterId(
-                                        2,
-                                    ),
-                                    resume: StateId(
-                                        3,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        1,
-                                    ),
-                                    src: RegisterId(
-                                        3,
-                                    ),
-                                    resume: StateId(
-                                        4,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            PureSet(
-                                MakeList {
-                                    dst: RegisterId(
-                                        3,
-                                    ),
-                                    items: [
-                                        RegisterId(
-                                            0,
-                                        ),
-                                        RegisterId(
-                                            1,
-                                        ),
-                                    ],
-                                },
-                            ),
-                            CoreSet(
-                                Return {
-                                    src: RegisterId(
-                                        3,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                ],
-                num_regs: 4,
-            },
-        ],
-    },
-)
+f0: [4 registers]
+  s0:
+    ExtCallSet(ActionCall { dst: r2, action_ref: TestActionRef("action_a"), args: [], resume: s1 })
+  s1:
+    ExtCallSet(ActionCall { dst: r3, action_ref: TestActionRef("action_b"), args: [], resume: s2 })
+  s2:
+    CoreSet(Await { dst: r0, src: r2, resume: s3 })
+  s3:
+    CoreSet(Await { dst: r1, src: r3, resume: s4 })
+  s4:
+    PureSet(MakeList { dst: r3, items: [r0, r1] })
+    CoreSet(Return { src: r3 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_to_variable.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_to_variable.py__bytecode.snap
@@ -2,148 +2,19 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_gather/gather_to_variable.py
 ---
-Ok(
-    Executable {
-        functions: [
-            Function {
-                states: [
-                    State {
-                        instructions: [
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        1,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "fetch_value_1",
-                                    ),
-                                    args: [],
-                                    resume: StateId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        2,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "fetch_value_2",
-                                    ),
-                                    args: [],
-                                    resume: StateId(
-                                        2,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        3,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "fetch_value_3",
-                                    ),
-                                    args: [],
-                                    resume: StateId(
-                                        3,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        1,
-                                    ),
-                                    src: RegisterId(
-                                        1,
-                                    ),
-                                    resume: StateId(
-                                        4,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        2,
-                                    ),
-                                    src: RegisterId(
-                                        2,
-                                    ),
-                                    resume: StateId(
-                                        5,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        3,
-                                    ),
-                                    src: RegisterId(
-                                        3,
-                                    ),
-                                    resume: StateId(
-                                        6,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            PureSet(
-                                MakeList {
-                                    dst: RegisterId(
-                                        0,
-                                    ),
-                                    items: [
-                                        RegisterId(
-                                            1,
-                                        ),
-                                        RegisterId(
-                                            2,
-                                        ),
-                                        RegisterId(
-                                            3,
-                                        ),
-                                    ],
-                                },
-                            ),
-                            CoreSet(
-                                Return {
-                                    src: RegisterId(
-                                        0,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                ],
-                num_regs: 4,
-            },
-        ],
-    },
-)
+f0: [4 registers]
+  s0:
+    ExtCallSet(ActionCall { dst: r1, action_ref: TestActionRef("fetch_value_1"), args: [], resume: s1 })
+  s1:
+    ExtCallSet(ActionCall { dst: r2, action_ref: TestActionRef("fetch_value_2"), args: [], resume: s2 })
+  s2:
+    ExtCallSet(ActionCall { dst: r3, action_ref: TestActionRef("fetch_value_3"), args: [], resume: s3 })
+  s3:
+    CoreSet(Await { dst: r1, src: r1, resume: s4 })
+  s4:
+    CoreSet(Await { dst: r2, src: r2, resume: s5 })
+  s5:
+    CoreSet(Await { dst: r3, src: r3, resume: s6 })
+  s6:
+    PureSet(MakeList { dst: r0, items: [r1, r2, r3] })
+    CoreSet(Return { src: r0 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_tuple_unpack.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_tuple_unpack.py__bytecode.snap
@@ -2,165 +2,20 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_gather/gather_tuple_unpack.py
 ---
-Ok(
-    Executable {
-        functions: [
-            Function {
-                states: [
-                    State {
-                        instructions: [
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        3,
-                                    ),
-                                    value: Int(
-                                        5,
-                                    ),
-                                },
-                            ),
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        2,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "compute_factorial",
-                                    ),
-                                    args: [
-                                        RegisterId(
-                                            3,
-                                        ),
-                                    ],
-                                    resume: StateId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        4,
-                                    ),
-                                    value: Int(
-                                        10,
-                                    ),
-                                },
-                            ),
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        3,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "compute_fibonacci",
-                                    ),
-                                    args: [
-                                        RegisterId(
-                                            4,
-                                        ),
-                                    ],
-                                    resume: StateId(
-                                        2,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        0,
-                                    ),
-                                    src: RegisterId(
-                                        2,
-                                    ),
-                                    resume: StateId(
-                                        3,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        1,
-                                    ),
-                                    src: RegisterId(
-                                        3,
-                                    ),
-                                    resume: StateId(
-                                        4,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        5,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "summarize_math",
-                                    ),
-                                    args: [
-                                        RegisterId(
-                                            0,
-                                        ),
-                                        RegisterId(
-                                            1,
-                                        ),
-                                    ],
-                                    resume: StateId(
-                                        5,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        5,
-                                    ),
-                                    src: RegisterId(
-                                        5,
-                                    ),
-                                    resume: StateId(
-                                        6,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Return {
-                                    src: RegisterId(
-                                        5,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                ],
-                num_regs: 6,
-            },
-        ],
-    },
-)
+f0: [6 registers]
+  s0:
+    PureSet(LoadConst { dst: r3, value: Int(5) })
+    ExtCallSet(ActionCall { dst: r2, action_ref: TestActionRef("compute_factorial"), args: [r3], resume: s1 })
+  s1:
+    PureSet(LoadConst { dst: r4, value: Int(10) })
+    ExtCallSet(ActionCall { dst: r3, action_ref: TestActionRef("compute_fibonacci"), args: [r4], resume: s2 })
+  s2:
+    CoreSet(Await { dst: r0, src: r2, resume: s3 })
+  s3:
+    CoreSet(Await { dst: r1, src: r3, resume: s4 })
+  s4:
+    ExtCallSet(ActionCall { dst: r5, action_ref: TestActionRef("summarize_math"), args: [r0, r1], resume: s5 })
+  s5:
+    CoreSet(Await { dst: r5, src: r5, resume: s6 })
+  s6:
+    CoreSet(Return { src: r5 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_with_args.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_with_args.py__bytecode.snap
@@ -2,118 +2,15 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_gather/gather_with_args.py
 ---
-Ok(
-    Executable {
-        functions: [
-            Function {
-                states: [
-                    State {
-                        instructions: [
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        3,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "compute_square",
-                                    ),
-                                    args: [
-                                        RegisterId(
-                                            0,
-                                        ),
-                                    ],
-                                    resume: StateId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        4,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "compute_cube",
-                                    ),
-                                    args: [
-                                        RegisterId(
-                                            0,
-                                        ),
-                                    ],
-                                    resume: StateId(
-                                        2,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        1,
-                                    ),
-                                    src: RegisterId(
-                                        3,
-                                    ),
-                                    resume: StateId(
-                                        3,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        2,
-                                    ),
-                                    src: RegisterId(
-                                        4,
-                                    ),
-                                    resume: StateId(
-                                        4,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            PureSet(
-                                MakeList {
-                                    dst: RegisterId(
-                                        4,
-                                    ),
-                                    items: [
-                                        RegisterId(
-                                            1,
-                                        ),
-                                        RegisterId(
-                                            2,
-                                        ),
-                                    ],
-                                },
-                            ),
-                            CoreSet(
-                                Return {
-                                    src: RegisterId(
-                                        4,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                ],
-                num_regs: 5,
-            },
-        ],
-    },
-)
+f0: [5 registers]
+  s0:
+    ExtCallSet(ActionCall { dst: r3, action_ref: TestActionRef("compute_square"), args: [r0], resume: s1 })
+  s1:
+    ExtCallSet(ActionCall { dst: r4, action_ref: TestActionRef("compute_cube"), args: [r0], resume: s2 })
+  s2:
+    CoreSet(Await { dst: r1, src: r3, resume: s3 })
+  s3:
+    CoreSet(Await { dst: r2, src: r4, resume: s4 })
+  s4:
+    PureSet(MakeList { dst: r4, items: [r1, r2] })
+    CoreSet(Return { src: r4 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_models__dataclass_action_arg.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_models__dataclass_action_arg.py__bytecode.snap
@@ -2,137 +2,17 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_models/dataclass_action_arg.py
 ---
-Ok(
-    Executable {
-        functions: [
-            Function {
-                states: [
-                    State {
-                        instructions: [
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        0,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "get_data_items",
-                                    ),
-                                    args: [],
-                                    resume: StateId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        0,
-                                    ),
-                                    src: RegisterId(
-                                        0,
-                                    ),
-                                    resume: StateId(
-                                        2,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        2,
-                                    ),
-                                    value: String(
-                                        "items",
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                MakeDict {
-                                    dst: RegisterId(
-                                        3,
-                                    ),
-                                    entries: [
-                                        DictEntry {
-                                            key: RegisterId(
-                                                2,
-                                            ),
-                                            value: RegisterId(
-                                                0,
-                                            ),
-                                        },
-                                    ],
-                                },
-                            ),
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        1,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "process_data",
-                                    ),
-                                    args: [
-                                        RegisterId(
-                                            3,
-                                        ),
-                                    ],
-                                    resume: StateId(
-                                        3,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        1,
-                                    ),
-                                    src: RegisterId(
-                                        1,
-                                    ),
-                                    resume: StateId(
-                                        4,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            PureSet(
-                                Dot {
-                                    dst: RegisterId(
-                                        3,
-                                    ),
-                                    object: RegisterId(
-                                        1,
-                                    ),
-                                    attribute: "count",
-                                },
-                            ),
-                            CoreSet(
-                                Return {
-                                    src: RegisterId(
-                                        3,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                ],
-                num_regs: 4,
-            },
-        ],
-    },
-)
+f0: [4 registers]
+  s0:
+    ExtCallSet(ActionCall { dst: r0, action_ref: TestActionRef("get_data_items"), args: [], resume: s1 })
+  s1:
+    CoreSet(Await { dst: r0, src: r0, resume: s2 })
+  s2:
+    PureSet(LoadConst { dst: r2, value: String("items") })
+    PureSet(MakeDict { dst: r3, entries: [DictEntry { key: r2, value: r0 }] })
+    ExtCallSet(ActionCall { dst: r1, action_ref: TestActionRef("process_data"), args: [r3], resume: s3 })
+  s3:
+    CoreSet(Await { dst: r1, src: r1, resume: s4 })
+  s4:
+    PureSet(Dot { dst: r3, object: r1, attribute: "count" })
+    CoreSet(Return { src: r3 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_models__dataclass_positional.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_models__dataclass_positional.py__bytecode.snap
@@ -2,140 +2,17 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_models/dataclass_positional.py
 ---
-Ok(
-    Executable {
-        functions: [
-            Function {
-                states: [
-                    State {
-                        instructions: [
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        0,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "get_x",
-                                    ),
-                                    args: [],
-                                    resume: StateId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        0,
-                                    ),
-                                    src: RegisterId(
-                                        0,
-                                    ),
-                                    resume: StateId(
-                                        2,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        1,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "get_y",
-                                    ),
-                                    args: [],
-                                    resume: StateId(
-                                        3,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        1,
-                                    ),
-                                    src: RegisterId(
-                                        1,
-                                    ),
-                                    resume: StateId(
-                                        4,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        3,
-                                    ),
-                                    value: String(
-                                        "x",
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        4,
-                                    ),
-                                    value: String(
-                                        "y",
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                MakeDict {
-                                    dst: RegisterId(
-                                        2,
-                                    ),
-                                    entries: [
-                                        DictEntry {
-                                            key: RegisterId(
-                                                3,
-                                            ),
-                                            value: RegisterId(
-                                                0,
-                                            ),
-                                        },
-                                        DictEntry {
-                                            key: RegisterId(
-                                                4,
-                                            ),
-                                            value: RegisterId(
-                                                1,
-                                            ),
-                                        },
-                                    ],
-                                },
-                            ),
-                            CoreSet(
-                                Return {
-                                    src: RegisterId(
-                                        2,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                ],
-                num_regs: 5,
-            },
-        ],
-    },
-)
+f0: [5 registers]
+  s0:
+    ExtCallSet(ActionCall { dst: r0, action_ref: TestActionRef("get_x"), args: [], resume: s1 })
+  s1:
+    CoreSet(Await { dst: r0, src: r0, resume: s2 })
+  s2:
+    ExtCallSet(ActionCall { dst: r1, action_ref: TestActionRef("get_y"), args: [], resume: s3 })
+  s3:
+    CoreSet(Await { dst: r1, src: r1, resume: s4 })
+  s4:
+    PureSet(LoadConst { dst: r3, value: String("x") })
+    PureSet(LoadConst { dst: r4, value: String("y") })
+    PureSet(MakeDict { dst: r2, entries: [DictEntry { key: r3, value: r0 }, DictEntry { key: r4, value: r1 }] })
+    CoreSet(Return { src: r2 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_models__dataclass_simple.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_models__dataclass_simple.py__bytecode.snap
@@ -2,115 +2,14 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_models/dataclass_simple.py
 ---
-Ok(
-    Executable {
-        functions: [
-            Function {
-                states: [
-                    State {
-                        instructions: [
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        0,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "fetch_value",
-                                    ),
-                                    args: [],
-                                    resume: StateId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        0,
-                                    ),
-                                    src: RegisterId(
-                                        0,
-                                    ),
-                                    resume: StateId(
-                                        2,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        2,
-                                    ),
-                                    value: String(
-                                        "value",
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        3,
-                                    ),
-                                    value: String(
-                                        "message",
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        4,
-                                    ),
-                                    value: String(
-                                        "done",
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                MakeDict {
-                                    dst: RegisterId(
-                                        1,
-                                    ),
-                                    entries: [
-                                        DictEntry {
-                                            key: RegisterId(
-                                                2,
-                                            ),
-                                            value: RegisterId(
-                                                0,
-                                            ),
-                                        },
-                                        DictEntry {
-                                            key: RegisterId(
-                                                3,
-                                            ),
-                                            value: RegisterId(
-                                                4,
-                                            ),
-                                        },
-                                    ],
-                                },
-                            ),
-                            CoreSet(
-                                Return {
-                                    src: RegisterId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                ],
-                num_regs: 5,
-            },
-        ],
-    },
-)
+f0: [5 registers]
+  s0:
+    ExtCallSet(ActionCall { dst: r0, action_ref: TestActionRef("fetch_value"), args: [], resume: s1 })
+  s1:
+    CoreSet(Await { dst: r0, src: r0, resume: s2 })
+  s2:
+    PureSet(LoadConst { dst: r2, value: String("value") })
+    PureSet(LoadConst { dst: r3, value: String("message") })
+    PureSet(LoadConst { dst: r4, value: String("done") })
+    PureSet(MakeDict { dst: r1, entries: [DictEntry { key: r2, value: r0 }, DictEntry { key: r3, value: r4 }] })
+    CoreSet(Return { src: r1 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_models__dataclass_with_defaults.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_models__dataclass_with_defaults.py__bytecode.snap
@@ -2,143 +2,16 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_models/dataclass_with_defaults.py
 ---
-Ok(
-    Executable {
-        functions: [
-            Function {
-                states: [
-                    State {
-                        instructions: [
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        0,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "get_result",
-                                    ),
-                                    args: [],
-                                    resume: StateId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        0,
-                                    ),
-                                    src: RegisterId(
-                                        0,
-                                    ),
-                                    resume: StateId(
-                                        2,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        2,
-                                    ),
-                                    value: String(
-                                        "value",
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        3,
-                                    ),
-                                    value: String(
-                                        "status",
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        4,
-                                    ),
-                                    value: String(
-                                        "pending",
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        5,
-                                    ),
-                                    value: String(
-                                        "retry_count",
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        6,
-                                    ),
-                                    value: Int(
-                                        0,
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                MakeDict {
-                                    dst: RegisterId(
-                                        1,
-                                    ),
-                                    entries: [
-                                        DictEntry {
-                                            key: RegisterId(
-                                                2,
-                                            ),
-                                            value: RegisterId(
-                                                0,
-                                            ),
-                                        },
-                                        DictEntry {
-                                            key: RegisterId(
-                                                3,
-                                            ),
-                                            value: RegisterId(
-                                                4,
-                                            ),
-                                        },
-                                        DictEntry {
-                                            key: RegisterId(
-                                                5,
-                                            ),
-                                            value: RegisterId(
-                                                6,
-                                            ),
-                                        },
-                                    ],
-                                },
-                            ),
-                            CoreSet(
-                                Return {
-                                    src: RegisterId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                ],
-                num_regs: 7,
-            },
-        ],
-    },
-)
+f0: [7 registers]
+  s0:
+    ExtCallSet(ActionCall { dst: r0, action_ref: TestActionRef("get_result"), args: [], resume: s1 })
+  s1:
+    CoreSet(Await { dst: r0, src: r0, resume: s2 })
+  s2:
+    PureSet(LoadConst { dst: r2, value: String("value") })
+    PureSet(LoadConst { dst: r3, value: String("status") })
+    PureSet(LoadConst { dst: r4, value: String("pending") })
+    PureSet(LoadConst { dst: r5, value: String("retry_count") })
+    PureSet(LoadConst { dst: r6, value: Int(0) })
+    PureSet(MakeDict { dst: r1, entries: [DictEntry { key: r2, value: r0 }, DictEntry { key: r3, value: r4 }, DictEntry { key: r5, value: r6 }] })
+    CoreSet(Return { src: r1 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_models__pydantic_action_arg.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_models__pydantic_action_arg.py__bytecode.snap
@@ -2,137 +2,17 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_models/pydantic_action_arg.py
 ---
-Ok(
-    Executable {
-        functions: [
-            Function {
-                states: [
-                    State {
-                        instructions: [
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        0,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "get_items",
-                                    ),
-                                    args: [],
-                                    resume: StateId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        0,
-                                    ),
-                                    src: RegisterId(
-                                        0,
-                                    ),
-                                    resume: StateId(
-                                        2,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        2,
-                                    ),
-                                    value: String(
-                                        "items",
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                MakeDict {
-                                    dst: RegisterId(
-                                        3,
-                                    ),
-                                    entries: [
-                                        DictEntry {
-                                            key: RegisterId(
-                                                2,
-                                            ),
-                                            value: RegisterId(
-                                                0,
-                                            ),
-                                        },
-                                    ],
-                                },
-                            ),
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        1,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "process_request",
-                                    ),
-                                    args: [
-                                        RegisterId(
-                                            3,
-                                        ),
-                                    ],
-                                    resume: StateId(
-                                        3,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        1,
-                                    ),
-                                    src: RegisterId(
-                                        1,
-                                    ),
-                                    resume: StateId(
-                                        4,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            PureSet(
-                                Dot {
-                                    dst: RegisterId(
-                                        3,
-                                    ),
-                                    object: RegisterId(
-                                        1,
-                                    ),
-                                    attribute: "count",
-                                },
-                            ),
-                            CoreSet(
-                                Return {
-                                    src: RegisterId(
-                                        3,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                ],
-                num_regs: 4,
-            },
-        ],
-    },
-)
+f0: [4 registers]
+  s0:
+    ExtCallSet(ActionCall { dst: r0, action_ref: TestActionRef("get_items"), args: [], resume: s1 })
+  s1:
+    CoreSet(Await { dst: r0, src: r0, resume: s2 })
+  s2:
+    PureSet(LoadConst { dst: r2, value: String("items") })
+    PureSet(MakeDict { dst: r3, entries: [DictEntry { key: r2, value: r0 }] })
+    ExtCallSet(ActionCall { dst: r1, action_ref: TestActionRef("process_request"), args: [r3], resume: s3 })
+  s3:
+    CoreSet(Await { dst: r1, src: r1, resume: s4 })
+  s4:
+    PureSet(Dot { dst: r3, object: r1, attribute: "count" })
+    CoreSet(Return { src: r3 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_models__pydantic_nested.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_models__pydantic_nested.py__bytecode.snap
@@ -2,115 +2,14 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_models/pydantic_nested.py
 ---
-Ok(
-    Executable {
-        functions: [
-            Function {
-                states: [
-                    State {
-                        instructions: [
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        0,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "get_coordinates",
-                                    ),
-                                    args: [],
-                                    resume: StateId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        0,
-                                    ),
-                                    src: RegisterId(
-                                        0,
-                                    ),
-                                    resume: StateId(
-                                        2,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        2,
-                                    ),
-                                    value: String(
-                                        "name",
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        3,
-                                    ),
-                                    value: String(
-                                        "test",
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        4,
-                                    ),
-                                    value: String(
-                                        "inner",
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                MakeDict {
-                                    dst: RegisterId(
-                                        1,
-                                    ),
-                                    entries: [
-                                        DictEntry {
-                                            key: RegisterId(
-                                                2,
-                                            ),
-                                            value: RegisterId(
-                                                3,
-                                            ),
-                                        },
-                                        DictEntry {
-                                            key: RegisterId(
-                                                4,
-                                            ),
-                                            value: RegisterId(
-                                                0,
-                                            ),
-                                        },
-                                    ],
-                                },
-                            ),
-                            CoreSet(
-                                Return {
-                                    src: RegisterId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                ],
-                num_regs: 5,
-            },
-        ],
-    },
-)
+f0: [5 registers]
+  s0:
+    ExtCallSet(ActionCall { dst: r0, action_ref: TestActionRef("get_coordinates"), args: [], resume: s1 })
+  s1:
+    CoreSet(Await { dst: r0, src: r0, resume: s2 })
+  s2:
+    PureSet(LoadConst { dst: r2, value: String("name") })
+    PureSet(LoadConst { dst: r3, value: String("test") })
+    PureSet(LoadConst { dst: r4, value: String("inner") })
+    PureSet(MakeDict { dst: r1, entries: [DictEntry { key: r2, value: r3 }, DictEntry { key: r4, value: r0 }] })
+    CoreSet(Return { src: r1 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_models__pydantic_return_direct.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_models__pydantic_return_direct.py__bytecode.snap
@@ -2,90 +2,11 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_models/pydantic_return_direct.py
 ---
-Ok(
-    Executable {
-        functions: [
-            Function {
-                states: [
-                    State {
-                        instructions: [
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        0,
-                                    ),
-                                    value: String(
-                                        "value",
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        1,
-                                    ),
-                                    value: Int(
-                                        1,
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        2,
-                                    ),
-                                    value: String(
-                                        "message",
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        3,
-                                    ),
-                                    value: String(
-                                        "ok",
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                MakeDict {
-                                    dst: RegisterId(
-                                        4,
-                                    ),
-                                    entries: [
-                                        DictEntry {
-                                            key: RegisterId(
-                                                0,
-                                            ),
-                                            value: RegisterId(
-                                                1,
-                                            ),
-                                        },
-                                        DictEntry {
-                                            key: RegisterId(
-                                                2,
-                                            ),
-                                            value: RegisterId(
-                                                3,
-                                            ),
-                                        },
-                                    ],
-                                },
-                            ),
-                            CoreSet(
-                                Return {
-                                    src: RegisterId(
-                                        4,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                ],
-                num_regs: 5,
-            },
-        ],
-    },
-)
+f0: [5 registers]
+  s0:
+    PureSet(LoadConst { dst: r0, value: String("value") })
+    PureSet(LoadConst { dst: r1, value: Int(1) })
+    PureSet(LoadConst { dst: r2, value: String("message") })
+    PureSet(LoadConst { dst: r3, value: String("ok") })
+    PureSet(MakeDict { dst: r4, entries: [DictEntry { key: r0, value: r1 }, DictEntry { key: r2, value: r3 }] })
+    CoreSet(Return { src: r4 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_models__pydantic_simple.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_models__pydantic_simple.py__bytecode.snap
@@ -2,115 +2,14 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_models/pydantic_simple.py
 ---
-Ok(
-    Executable {
-        functions: [
-            Function {
-                states: [
-                    State {
-                        instructions: [
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        0,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "get_value",
-                                    ),
-                                    args: [],
-                                    resume: StateId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        0,
-                                    ),
-                                    src: RegisterId(
-                                        0,
-                                    ),
-                                    resume: StateId(
-                                        2,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        2,
-                                    ),
-                                    value: String(
-                                        "value",
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        3,
-                                    ),
-                                    value: String(
-                                        "message",
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        4,
-                                    ),
-                                    value: String(
-                                        "success",
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                MakeDict {
-                                    dst: RegisterId(
-                                        1,
-                                    ),
-                                    entries: [
-                                        DictEntry {
-                                            key: RegisterId(
-                                                2,
-                                            ),
-                                            value: RegisterId(
-                                                0,
-                                            ),
-                                        },
-                                        DictEntry {
-                                            key: RegisterId(
-                                                3,
-                                            ),
-                                            value: RegisterId(
-                                                4,
-                                            ),
-                                        },
-                                    ],
-                                },
-                            ),
-                            CoreSet(
-                                Return {
-                                    src: RegisterId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                ],
-                num_regs: 5,
-            },
-        ],
-    },
-)
+f0: [5 registers]
+  s0:
+    ExtCallSet(ActionCall { dst: r0, action_ref: TestActionRef("get_value"), args: [], resume: s1 })
+  s1:
+    CoreSet(Await { dst: r0, src: r0, resume: s2 })
+  s2:
+    PureSet(LoadConst { dst: r2, value: String("value") })
+    PureSet(LoadConst { dst: r3, value: String("message") })
+    PureSet(LoadConst { dst: r4, value: String("success") })
+    PureSet(MakeDict { dst: r1, entries: [DictEntry { key: r2, value: r0 }, DictEntry { key: r3, value: r4 }] })
+    CoreSet(Return { src: r1 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_models__pydantic_with_defaults.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_models__pydantic_with_defaults.py__bytecode.snap
@@ -2,143 +2,16 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_models/pydantic_with_defaults.py
 ---
-Ok(
-    Executable {
-        functions: [
-            Function {
-                states: [
-                    State {
-                        instructions: [
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        0,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "compute_value",
-                                    ),
-                                    args: [],
-                                    resume: StateId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        0,
-                                    ),
-                                    src: RegisterId(
-                                        0,
-                                    ),
-                                    resume: StateId(
-                                        2,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        2,
-                                    ),
-                                    value: String(
-                                        "value",
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        3,
-                                    ),
-                                    value: String(
-                                        "status",
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        4,
-                                    ),
-                                    value: String(
-                                        "ok",
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        5,
-                                    ),
-                                    value: String(
-                                        "count",
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        6,
-                                    ),
-                                    value: Int(
-                                        0,
-                                    ),
-                                },
-                            ),
-                            PureSet(
-                                MakeDict {
-                                    dst: RegisterId(
-                                        1,
-                                    ),
-                                    entries: [
-                                        DictEntry {
-                                            key: RegisterId(
-                                                2,
-                                            ),
-                                            value: RegisterId(
-                                                0,
-                                            ),
-                                        },
-                                        DictEntry {
-                                            key: RegisterId(
-                                                3,
-                                            ),
-                                            value: RegisterId(
-                                                4,
-                                            ),
-                                        },
-                                        DictEntry {
-                                            key: RegisterId(
-                                                5,
-                                            ),
-                                            value: RegisterId(
-                                                6,
-                                            ),
-                                        },
-                                    ],
-                                },
-                            ),
-                            CoreSet(
-                                Return {
-                                    src: RegisterId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                ],
-                num_regs: 7,
-            },
-        ],
-    },
-)
+f0: [7 registers]
+  s0:
+    ExtCallSet(ActionCall { dst: r0, action_ref: TestActionRef("compute_value"), args: [], resume: s1 })
+  s1:
+    CoreSet(Await { dst: r0, src: r0, resume: s2 })
+  s2:
+    PureSet(LoadConst { dst: r2, value: String("value") })
+    PureSet(LoadConst { dst: r3, value: String("status") })
+    PureSet(LoadConst { dst: r4, value: String("ok") })
+    PureSet(LoadConst { dst: r5, value: String("count") })
+    PureSet(LoadConst { dst: r6, value: Int(0) })
+    PureSet(MakeDict { dst: r1, entries: [DictEntry { key: r2, value: r0 }, DictEntry { key: r3, value: r4 }, DictEntry { key: r5, value: r6 }] })
+    CoreSet(Return { src: r1 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_policy__instance_attr_policies.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_policy__instance_attr_policies.py__bytecode.snap
@@ -2,142 +2,18 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_policy/instance_attr_policies.py
 ---
-Ok(
-    Executable {
-        functions: [
-            Function {
-                states: [
-                    State {
-                        instructions: [
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        1,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "action_with_instance_retry",
-                                    ),
-                                    args: [
-                                        RegisterId(
-                                            0,
-                                        ),
-                                    ],
-                                    resume: StateId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        1,
-                                    ),
-                                    src: RegisterId(
-                                        1,
-                                    ),
-                                    resume: StateId(
-                                        2,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        2,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "action_with_instance_timeout",
-                                    ),
-                                    args: [
-                                        RegisterId(
-                                            1,
-                                        ),
-                                    ],
-                                    resume: StateId(
-                                        3,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        2,
-                                    ),
-                                    src: RegisterId(
-                                        2,
-                                    ),
-                                    resume: StateId(
-                                        4,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        3,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "action_with_both_policies",
-                                    ),
-                                    args: [
-                                        RegisterId(
-                                            2,
-                                        ),
-                                    ],
-                                    resume: StateId(
-                                        5,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        3,
-                                    ),
-                                    src: RegisterId(
-                                        3,
-                                    ),
-                                    resume: StateId(
-                                        6,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Return {
-                                    src: RegisterId(
-                                        3,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                ],
-                num_regs: 4,
-            },
-        ],
-    },
-)
+f0: [4 registers]
+  s0:
+    ExtCallSet(ActionCall { dst: r1, action_ref: TestActionRef("action_with_instance_retry"), args: [r0], resume: s1 })
+  s1:
+    CoreSet(Await { dst: r1, src: r1, resume: s2 })
+  s2:
+    ExtCallSet(ActionCall { dst: r2, action_ref: TestActionRef("action_with_instance_timeout"), args: [r1], resume: s3 })
+  s3:
+    CoreSet(Await { dst: r2, src: r2, resume: s4 })
+  s4:
+    ExtCallSet(ActionCall { dst: r3, action_ref: TestActionRef("action_with_both_policies"), args: [r2], resume: s5 })
+  s5:
+    CoreSet(Await { dst: r3, src: r3, resume: s6 })
+  s6:
+    CoreSet(Return { src: r3 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_policy__integration_crash_recovery.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_policy__integration_crash_recovery.py__bytecode.snap
@@ -2,191 +2,23 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_policy/integration_crash_recovery.py
 ---
-Ok(
-    Executable {
-        functions: [
-            Function {
-                states: [
-                    State {
-                        instructions: [
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        1,
-                                    ),
-                                    value: String(
-                                        "start",
-                                    ),
-                                },
-                            ),
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        0,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "step_one",
-                                    ),
-                                    args: [
-                                        RegisterId(
-                                            1,
-                                        ),
-                                    ],
-                                    resume: StateId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        0,
-                                    ),
-                                    src: RegisterId(
-                                        0,
-                                    ),
-                                    resume: StateId(
-                                        2,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        2,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "step_two",
-                                    ),
-                                    args: [
-                                        RegisterId(
-                                            0,
-                                        ),
-                                    ],
-                                    resume: StateId(
-                                        3,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        2,
-                                    ),
-                                    src: RegisterId(
-                                        2,
-                                    ),
-                                    resume: StateId(
-                                        4,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        3,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "step_three",
-                                    ),
-                                    args: [
-                                        RegisterId(
-                                            2,
-                                        ),
-                                    ],
-                                    resume: StateId(
-                                        5,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        3,
-                                    ),
-                                    src: RegisterId(
-                                        3,
-                                    ),
-                                    resume: StateId(
-                                        6,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        4,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "step_four",
-                                    ),
-                                    args: [
-                                        RegisterId(
-                                            3,
-                                        ),
-                                    ],
-                                    resume: StateId(
-                                        7,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        4,
-                                    ),
-                                    src: RegisterId(
-                                        4,
-                                    ),
-                                    resume: StateId(
-                                        8,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Return {
-                                    src: RegisterId(
-                                        4,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                ],
-                num_regs: 5,
-            },
-        ],
-    },
-)
+f0: [5 registers]
+  s0:
+    PureSet(LoadConst { dst: r1, value: String("start") })
+    ExtCallSet(ActionCall { dst: r0, action_ref: TestActionRef("step_one"), args: [r1], resume: s1 })
+  s1:
+    CoreSet(Await { dst: r0, src: r0, resume: s2 })
+  s2:
+    ExtCallSet(ActionCall { dst: r2, action_ref: TestActionRef("step_two"), args: [r0], resume: s3 })
+  s3:
+    CoreSet(Await { dst: r2, src: r2, resume: s4 })
+  s4:
+    ExtCallSet(ActionCall { dst: r3, action_ref: TestActionRef("step_three"), args: [r2], resume: s5 })
+  s5:
+    CoreSet(Await { dst: r3, src: r3, resume: s6 })
+  s6:
+    ExtCallSet(ActionCall { dst: r4, action_ref: TestActionRef("step_four"), args: [r3], resume: s7 })
+  s7:
+    CoreSet(Await { dst: r4, src: r4, resume: s8 })
+  s8:
+    CoreSet(Return { src: r4 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_policy__integration_exception_custom.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_policy__integration_exception_custom.py__bytecode.snap
@@ -1,13 +1,11 @@
 ---
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
-expression: bytecode for python/tests/fixtures_policy/integration_exception_custom.py
+expression: "bytecode for python/tests/fixtures_policy/integration_exception_custom.py [compilation error]"
 ---
-Err(
-    FunctionCompiler(
-        Unsupported(
-            Statement {
-                kind: TryExcept,
-            },
-        ),
+FunctionCompiler(
+    Unsupported(
+        Statement {
+            kind: TryExcept,
+        },
     ),
 )

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_policy__policy_variations.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_policy__policy_variations.py__bytecode.snap
@@ -2,298 +2,34 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_policy/policy_variations.py
 ---
-Ok(
-    Executable {
-        functions: [
-            Function {
-                states: [
-                    State {
-                        instructions: [
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        1,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "action_with_timeout_int",
-                                    ),
-                                    args: [
-                                        RegisterId(
-                                            0,
-                                        ),
-                                    ],
-                                    resume: StateId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        1,
-                                    ),
-                                    src: RegisterId(
-                                        1,
-                                    ),
-                                    resume: StateId(
-                                        2,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        2,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "action_with_timeout_minutes",
-                                    ),
-                                    args: [
-                                        RegisterId(
-                                            1,
-                                        ),
-                                    ],
-                                    resume: StateId(
-                                        3,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        2,
-                                    ),
-                                    src: RegisterId(
-                                        2,
-                                    ),
-                                    resume: StateId(
-                                        4,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        3,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "action_with_retry_backoff",
-                                    ),
-                                    args: [
-                                        RegisterId(
-                                            2,
-                                        ),
-                                    ],
-                                    resume: StateId(
-                                        5,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        3,
-                                    ),
-                                    src: RegisterId(
-                                        3,
-                                    ),
-                                    resume: StateId(
-                                        6,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        4,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "action_with_retry_exceptions",
-                                    ),
-                                    args: [
-                                        RegisterId(
-                                            3,
-                                        ),
-                                    ],
-                                    resume: StateId(
-                                        7,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        4,
-                                    ),
-                                    src: RegisterId(
-                                        4,
-                                    ),
-                                    resume: StateId(
-                                        8,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        5,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "action_with_retry_default",
-                                    ),
-                                    args: [
-                                        RegisterId(
-                                            4,
-                                        ),
-                                    ],
-                                    resume: StateId(
-                                        9,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        5,
-                                    ),
-                                    src: RegisterId(
-                                        5,
-                                    ),
-                                    resume: StateId(
-                                        10,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        6,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "action_with_timeout_hours",
-                                    ),
-                                    args: [
-                                        RegisterId(
-                                            5,
-                                        ),
-                                    ],
-                                    resume: StateId(
-                                        11,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        6,
-                                    ),
-                                    src: RegisterId(
-                                        6,
-                                    ),
-                                    resume: StateId(
-                                        12,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        7,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "action_with_timeout_days",
-                                    ),
-                                    args: [
-                                        RegisterId(
-                                            6,
-                                        ),
-                                    ],
-                                    resume: StateId(
-                                        13,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        7,
-                                    ),
-                                    src: RegisterId(
-                                        7,
-                                    ),
-                                    resume: StateId(
-                                        14,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Return {
-                                    src: RegisterId(
-                                        7,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                ],
-                num_regs: 8,
-            },
-        ],
-    },
-)
+f0: [8 registers]
+  s0:
+    ExtCallSet(ActionCall { dst: r1, action_ref: TestActionRef("action_with_timeout_int"), args: [r0], resume: s1 })
+  s1:
+    CoreSet(Await { dst: r1, src: r1, resume: s2 })
+  s2:
+    ExtCallSet(ActionCall { dst: r2, action_ref: TestActionRef("action_with_timeout_minutes"), args: [r1], resume: s3 })
+  s3:
+    CoreSet(Await { dst: r2, src: r2, resume: s4 })
+  s4:
+    ExtCallSet(ActionCall { dst: r3, action_ref: TestActionRef("action_with_retry_backoff"), args: [r2], resume: s5 })
+  s5:
+    CoreSet(Await { dst: r3, src: r3, resume: s6 })
+  s6:
+    ExtCallSet(ActionCall { dst: r4, action_ref: TestActionRef("action_with_retry_exceptions"), args: [r3], resume: s7 })
+  s7:
+    CoreSet(Await { dst: r4, src: r4, resume: s8 })
+  s8:
+    ExtCallSet(ActionCall { dst: r5, action_ref: TestActionRef("action_with_retry_default"), args: [r4], resume: s9 })
+  s9:
+    CoreSet(Await { dst: r5, src: r5, resume: s10 })
+  s10:
+    ExtCallSet(ActionCall { dst: r6, action_ref: TestActionRef("action_with_timeout_hours"), args: [r5], resume: s11 })
+  s11:
+    CoreSet(Await { dst: r6, src: r6, resume: s12 })
+  s12:
+    ExtCallSet(ActionCall { dst: r7, action_ref: TestActionRef("action_with_timeout_days"), args: [r6], resume: s13 })
+  s13:
+    CoreSet(Await { dst: r7, src: r7, resume: s14 })
+  s14:
+    CoreSet(Return { src: r7 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_side_effects__side_effect_action.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_side_effects__side_effect_action.py__bytecode.snap
@@ -2,68 +2,11 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_side_effects/side_effect_action.py
 ---
-Ok(
-    Executable {
-        functions: [
-            Function {
-                states: [
-                    State {
-                        instructions: [
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        0,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "side_effect",
-                                    ),
-                                    args: [],
-                                    resume: StateId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        0,
-                                    ),
-                                    src: RegisterId(
-                                        0,
-                                    ),
-                                    resume: StateId(
-                                        2,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        0,
-                                    ),
-                                    value: None,
-                                },
-                            ),
-                            CoreSet(
-                                Return {
-                                    src: RegisterId(
-                                        0,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                ],
-                num_regs: 1,
-            },
-        ],
-    },
-)
+f0: [1 registers]
+  s0:
+    ExtCallSet(ActionCall { dst: r0, action_ref: TestActionRef("side_effect"), args: [], resume: s1 })
+  s1:
+    CoreSet(Await { dst: r0, src: r0, resume: s2 })
+  s2:
+    PureSet(LoadConst { dst: r0, value: None })
+    CoreSet(Return { src: r0 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_sleep__sleep_aliased_import.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_sleep__sleep_aliased_import.py__bytecode.snap
@@ -2,143 +2,19 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_sleep/sleep_aliased_import.py
 ---
-Ok(
-    Executable {
-        functions: [
-            Function {
-                states: [
-                    State {
-                        instructions: [
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        0,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "get_value_aliased_import",
-                                    ),
-                                    args: [],
-                                    resume: StateId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        0,
-                                    ),
-                                    src: RegisterId(
-                                        0,
-                                    ),
-                                    resume: StateId(
-                                        2,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        2,
-                                    ),
-                                    value: Int(
-                                        3,
-                                    ),
-                                },
-                            ),
-                            ExtCallSet(
-                                Sleep {
-                                    dst: RegisterId(
-                                        1,
-                                    ),
-                                    duration: RegisterId(
-                                        2,
-                                    ),
-                                    resume: StateId(
-                                        3,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        1,
-                                    ),
-                                    src: RegisterId(
-                                        1,
-                                    ),
-                                    resume: StateId(
-                                        4,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        3,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "format_done_aliased_import",
-                                    ),
-                                    args: [
-                                        RegisterId(
-                                            0,
-                                        ),
-                                    ],
-                                    resume: StateId(
-                                        5,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        3,
-                                    ),
-                                    src: RegisterId(
-                                        3,
-                                    ),
-                                    resume: StateId(
-                                        6,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Return {
-                                    src: RegisterId(
-                                        3,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                ],
-                num_regs: 4,
-            },
-        ],
-    },
-)
+f0: [4 registers]
+  s0:
+    ExtCallSet(ActionCall { dst: r0, action_ref: TestActionRef("get_value_aliased_import"), args: [], resume: s1 })
+  s1:
+    CoreSet(Await { dst: r0, src: r0, resume: s2 })
+  s2:
+    PureSet(LoadConst { dst: r2, value: Int(3) })
+    ExtCallSet(Sleep { dst: r1, duration: r2, resume: s3 })
+  s3:
+    CoreSet(Await { dst: r1, src: r1, resume: s4 })
+  s4:
+    ExtCallSet(ActionCall { dst: r3, action_ref: TestActionRef("format_done_aliased_import"), args: [r0], resume: s5 })
+  s5:
+    CoreSet(Await { dst: r3, src: r3, resume: s6 })
+  s6:
+    CoreSet(Return { src: r3 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_sleep__sleep_from_import.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_sleep__sleep_from_import.py__bytecode.snap
@@ -2,143 +2,19 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_sleep/sleep_from_import.py
 ---
-Ok(
-    Executable {
-        functions: [
-            Function {
-                states: [
-                    State {
-                        instructions: [
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        0,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "get_value_from_import",
-                                    ),
-                                    args: [],
-                                    resume: StateId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        0,
-                                    ),
-                                    src: RegisterId(
-                                        0,
-                                    ),
-                                    resume: StateId(
-                                        2,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        2,
-                                    ),
-                                    value: Int(
-                                        2,
-                                    ),
-                                },
-                            ),
-                            ExtCallSet(
-                                Sleep {
-                                    dst: RegisterId(
-                                        1,
-                                    ),
-                                    duration: RegisterId(
-                                        2,
-                                    ),
-                                    resume: StateId(
-                                        3,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        1,
-                                    ),
-                                    src: RegisterId(
-                                        1,
-                                    ),
-                                    resume: StateId(
-                                        4,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        3,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "format_done_from_import",
-                                    ),
-                                    args: [
-                                        RegisterId(
-                                            0,
-                                        ),
-                                    ],
-                                    resume: StateId(
-                                        5,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        3,
-                                    ),
-                                    src: RegisterId(
-                                        3,
-                                    ),
-                                    resume: StateId(
-                                        6,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Return {
-                                    src: RegisterId(
-                                        3,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                ],
-                num_regs: 4,
-            },
-        ],
-    },
-)
+f0: [4 registers]
+  s0:
+    ExtCallSet(ActionCall { dst: r0, action_ref: TestActionRef("get_value_from_import"), args: [], resume: s1 })
+  s1:
+    CoreSet(Await { dst: r0, src: r0, resume: s2 })
+  s2:
+    PureSet(LoadConst { dst: r2, value: Int(2) })
+    ExtCallSet(Sleep { dst: r1, duration: r2, resume: s3 })
+  s3:
+    CoreSet(Await { dst: r1, src: r1, resume: s4 })
+  s4:
+    ExtCallSet(ActionCall { dst: r3, action_ref: TestActionRef("format_done_from_import"), args: [r0], resume: s5 })
+  s5:
+    CoreSet(Await { dst: r3, src: r3, resume: s6 })
+  s6:
+    CoreSet(Return { src: r3 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_sleep__sleep_import_asyncio.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_sleep__sleep_import_asyncio.py__bytecode.snap
@@ -2,143 +2,19 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_sleep/sleep_import_asyncio.py
 ---
-Ok(
-    Executable {
-        functions: [
-            Function {
-                states: [
-                    State {
-                        instructions: [
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        0,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "get_value_asyncio_import",
-                                    ),
-                                    args: [],
-                                    resume: StateId(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        0,
-                                    ),
-                                    src: RegisterId(
-                                        0,
-                                    ),
-                                    resume: StateId(
-                                        2,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            PureSet(
-                                LoadConst {
-                                    dst: RegisterId(
-                                        2,
-                                    ),
-                                    value: Int(
-                                        1,
-                                    ),
-                                },
-                            ),
-                            ExtCallSet(
-                                Sleep {
-                                    dst: RegisterId(
-                                        1,
-                                    ),
-                                    duration: RegisterId(
-                                        2,
-                                    ),
-                                    resume: StateId(
-                                        3,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        1,
-                                    ),
-                                    src: RegisterId(
-                                        1,
-                                    ),
-                                    resume: StateId(
-                                        4,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            ExtCallSet(
-                                ActionCall {
-                                    dst: RegisterId(
-                                        3,
-                                    ),
-                                    action_ref: TestActionRef(
-                                        "format_done_asyncio_import",
-                                    ),
-                                    args: [
-                                        RegisterId(
-                                            0,
-                                        ),
-                                    ],
-                                    resume: StateId(
-                                        5,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Await {
-                                    dst: RegisterId(
-                                        3,
-                                    ),
-                                    src: RegisterId(
-                                        3,
-                                    ),
-                                    resume: StateId(
-                                        6,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                    State {
-                        instructions: [
-                            CoreSet(
-                                Return {
-                                    src: RegisterId(
-                                        3,
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                ],
-                num_regs: 4,
-            },
-        ],
-    },
-)
+f0: [4 registers]
+  s0:
+    ExtCallSet(ActionCall { dst: r0, action_ref: TestActionRef("get_value_asyncio_import"), args: [], resume: s1 })
+  s1:
+    CoreSet(Await { dst: r0, src: r0, resume: s2 })
+  s2:
+    PureSet(LoadConst { dst: r2, value: Int(1) })
+    ExtCallSet(Sleep { dst: r1, duration: r2, resume: s3 })
+  s3:
+    CoreSet(Await { dst: r1, src: r1, resume: s4 })
+  s4:
+    ExtCallSet(ActionCall { dst: r3, action_ref: TestActionRef("format_done_asyncio_import"), args: [r0], resume: s5 })
+  s5:
+    CoreSet(Await { dst: r3, src: r3, resume: s6 })
+  s6:
+    CoreSet(Return { src: r3 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_try_except__try_multiple_calls.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_try_except__try_multiple_calls.py__bytecode.snap
@@ -1,13 +1,11 @@
 ---
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
-expression: bytecode for python/tests/fixtures_try_except/try_multiple_calls.py
+expression: "bytecode for python/tests/fixtures_try_except/try_multiple_calls.py [compilation error]"
 ---
-Err(
-    FunctionCompiler(
-        Unsupported(
-            Statement {
-                kind: TryExcept,
-            },
-        ),
+FunctionCompiler(
+    Unsupported(
+        Statement {
+            kind: TryExcept,
+        },
     ),
 )

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_try_except__try_stateful_outputs.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_try_except__try_stateful_outputs.py__bytecode.snap
@@ -1,13 +1,11 @@
 ---
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
-expression: bytecode for python/tests/fixtures_try_except/try_stateful_outputs.py
+expression: "bytecode for python/tests/fixtures_try_except/try_stateful_outputs.py [compilation error]"
 ---
-Err(
-    FunctionCompiler(
-        Unsupported(
-            Statement {
-                kind: TryExcept,
-            },
-        ),
+FunctionCompiler(
+    Unsupported(
+        Statement {
+            kind: TryExcept,
+        },
     ),
 )

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_try_except__try_with_action.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_try_except__try_with_action.py__bytecode.snap
@@ -1,13 +1,11 @@
 ---
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
-expression: bytecode for python/tests/fixtures_try_except/try_with_action.py
+expression: "bytecode for python/tests/fixtures_try_except/try_with_action.py [compilation error]"
 ---
-Err(
-    FunctionCompiler(
-        Unsupported(
-            Statement {
-                kind: TryExcept,
-            },
-        ),
+FunctionCompiler(
+    Unsupported(
+        Statement {
+            kind: TryExcept,
+        },
     ),
 )

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_workflow__workflow_helper_async.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_workflow__workflow_helper_async.py__bytecode.snap
@@ -1,14 +1,12 @@
 ---
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
-expression: bytecode for python/tests/fixtures_workflow/workflow_helper_async.py
+expression: "bytecode for python/tests/fixtures_workflow/workflow_helper_async.py [compilation error]"
 ---
-Err(
-    FunctionCompiler(
-        Unsupported(
-            FunctionCall {
-                name: "run_internal",
-                reason: KeywordArguments,
-            },
-        ),
+FunctionCompiler(
+    Unsupported(
+        FunctionCall {
+            name: "run_internal",
+            reason: KeywordArguments,
+        },
     ),
 )

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_workflow__workflow_helper_methods.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_workflow__workflow_helper_methods.py__bytecode.snap
@@ -1,14 +1,12 @@
 ---
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
-expression: bytecode for python/tests/fixtures_workflow/workflow_helper_methods.py
+expression: "bytecode for python/tests/fixtures_workflow/workflow_helper_methods.py [compilation error]"
 ---
-Err(
-    FunctionCompiler(
-        Unsupported(
-            FunctionCall {
-                name: "compute_multiplier",
-                reason: KeywordArguments,
-            },
-        ),
+FunctionCompiler(
+    Unsupported(
+        FunctionCall {
+            name: "compute_multiplier",
+            reason: KeywordArguments,
+        },
     ),
 )

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_workflow__workflow_helper_positional.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_workflow__workflow_helper_positional.py__bytecode.snap
@@ -1,14 +1,12 @@
 ---
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
-expression: bytecode for python/tests/fixtures_workflow/workflow_helper_positional.py
+expression: "bytecode for python/tests/fixtures_workflow/workflow_helper_positional.py [compilation error]"
 ---
-Err(
-    FunctionCompiler(
-        Unsupported(
-            FunctionCall {
-                name: "multiply",
-                reason: KeywordArguments,
-            },
-        ),
+FunctionCompiler(
+    Unsupported(
+        FunctionCall {
+            name: "multiply",
+            reason: KeywordArguments,
+        },
     ),
 )

--- a/crates/lib/vm-runtime-core/src/registers.rs
+++ b/crates/lib/vm-runtime-core/src/registers.rs
@@ -6,7 +6,7 @@ use index_type::{IndexTooBigError, IndexType, typed_vec::TypedVec};
 pub struct RegisterIdTooBigError;
 
 /// Index of a register in the [`Registers`] type.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, IndexType)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, IndexType)]
 #[index_type(error = RegisterIdTooBigError)]
 pub struct RegisterId(pub usize);
 
@@ -77,6 +77,12 @@ impl<Value> Registers<Value> {
     /// Panics if the register is out of bounds.
     pub fn take(&mut self, index: RegisterId) -> Option<Value> {
         self.0[index].take()
+    }
+}
+
+impl core::fmt::Debug for RegisterId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "r{}", self.0)
     }
 }
 

--- a/crates/lib/vm-runtime/tests/integration.rs
+++ b/crates/lib/vm-runtime/tests/integration.rs
@@ -33,7 +33,10 @@ fn with_conventional_entrypoint_rejects_missing_default_function() {
 
     assert_eq!(
         err.to_string(),
-        "function FunctionId(0) is not found in the functions table"
+        format!(
+            "function {:?} is not found in the functions table",
+            FunctionId(0)
+        )
     );
 }
 


### PR DESCRIPTION
This PR addresses some of the issues brought up during #410 review; this is not a 100% solution just yet, but it significantly offsets the difficulty of making sense of the snapshots during manual inspection.

The formatting is intentionally implemented to reuse the pre-existing facilities on a per-instruction level to avoid introducing more manual churn / code for supporting the formatting.

Suggestions on formatting are welcome!

---

In the future we may introduce a macro for deriving a custom / tweaked implementation for debugging the instructions; for now this does the job well enough though.

Another future improvement would be to have the AST code to pretty-formatted as well, but for that we'd need to implement a separate formatted as the existing one work with proto-generated types.