### PR TITLE
Add the ast to the snapshots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5158,6 +5158,16 @@ name = "waymark-vm-ast-old"
 version = "0.1.0"
 
 [[package]]
+name = "waymark-vm-ast-old-fmt"
+version = "0.1.0"
+dependencies = [
+ "insta",
+ "serde_json",
+ "waymark-vm-ast-old",
+ "waymark-vm-ast-old-helpers",
+]
+
+[[package]]
 name = "waymark-vm-ast-old-helpers"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5252,6 +5252,7 @@ dependencies = [
  "waymark-nonzero-duration",
  "waymark-support-test-python",
  "waymark-vm-ast-old",
+ "waymark-vm-ast-old-fmt",
  "waymark-vm-ast-old-helpers",
  "waymark-vm-bytecode",
  "waymark-vm-bytecode-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ waymark-tokio-metrics-bringup = { path = "crates/lib/tokio-metrics-bringup" }
 waymark-utils-futures = { path = "crates/lib/utils-futures" }
 waymark-utils-tokio-channel = { path = "crates/lib/utils-tokio-channel" }
 waymark-vm-ast-old = { path = "crates/lib/vm-ast-old" }
+waymark-vm-ast-old-fmt = { path = "crates/lib/vm-ast-old-fmt" }
 waymark-vm-ast-old-helpers = { path = "crates/lib/vm-ast-old-helpers" }
 waymark-vm-ast-old-proto = { path = "crates/lib/vm-ast-old-proto" }
 waymark-vm-bytecode = { path = "crates/lib/vm-bytecode" }

--- a/crates/lib/vm-ast-old-fmt/Cargo.toml
+++ b/crates/lib/vm-ast-old-fmt/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "waymark-vm-ast-old-fmt"
+edition = "2024"
+version.workspace = true
+publish.workspace = true
+
+[dependencies]
+waymark-vm-ast-old = { workspace = true }
+
+serde_json = { workspace = true }
+
+[dev-dependencies]
+waymark-vm-ast-old-helpers = { workspace = true }
+
+insta = { workspace = true }

--- a/crates/lib/vm-ast-old-fmt/src/display.rs
+++ b/crates/lib/vm-ast-old-fmt/src/display.rs
@@ -1,0 +1,174 @@
+use core::fmt;
+
+use waymark_vm_ast_old as ast;
+
+use crate::Fmt;
+
+impl<'a> fmt::Display for Fmt<'a, ast::Program> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.padded_fmt(f, 0)
+    }
+}
+
+impl<'a> fmt::Display for Fmt<'a, ast::Spanned<ast::FunctionDef>> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.padded_fmt(f, 0)
+    }
+}
+
+impl<'a> fmt::Display for Fmt<'a, ast::Spanned<ast::Block>> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.padded_fmt(f, 0)
+    }
+}
+
+impl<'a> fmt::Display for Fmt<'a, ast::Spanned<ast::Statement>> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.padded_fmt(f, 0)
+    }
+}
+
+impl<'a> fmt::Display for Fmt<'a, ast::Spanned<ast::Expr>> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.fmt_with_prec(f, 0)
+    }
+}
+
+impl<'a> fmt::Display for Fmt<'a, ast::Call> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.0 {
+            ast::Call::Action(action) => write!(f, "{}", Fmt(action)),
+            ast::Call::Function(function) => write!(f, "{}", Fmt(function)),
+        }
+    }
+}
+
+impl<'a> fmt::Display for Fmt<'a, ast::ActionCall> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("@")?;
+
+        if let Some(module_name) = &self.0.module_name {
+            f.write_str(module_name)?;
+            f.write_str(".")?;
+        }
+
+        f.write_str(&self.0.action_name)?;
+        f.write_str("(")?;
+
+        for (index, kwarg) in self.0.kwargs.iter().enumerate() {
+            if index > 0 {
+                f.write_str(", ")?;
+            }
+
+            write!(f, "{}={}", kwarg.name, Fmt(&kwarg.value))?;
+        }
+
+        f.write_str(")")?;
+
+        for policy in &self.0.policies {
+            write!(f, " {}", Fmt(policy))?;
+        }
+
+        Ok(())
+    }
+}
+
+impl<'a> fmt::Display for Fmt<'a, ast::FunctionCall> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.name())?;
+        f.write_str("(")?;
+
+        let mut needs_separator = false;
+
+        for arg in &self.0.args {
+            if needs_separator {
+                f.write_str(", ")?;
+            }
+
+            write!(f, "{}", Fmt(arg))?;
+            needs_separator = true;
+        }
+
+        for kwarg in &self.0.kwargs {
+            if needs_separator {
+                f.write_str(", ")?;
+            }
+
+            write!(f, "{}={}", kwarg.name, Fmt(&kwarg.value))?;
+            needs_separator = true;
+        }
+
+        f.write_str(")")
+    }
+}
+
+impl<'a> fmt::Display for Fmt<'a, ast::PolicyBracket> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.0 {
+            ast::PolicyBracket::Retry(retry) => {
+                f.write_str("[")?;
+
+                if !retry.exception_types.is_empty() {
+                    for (index, exception_type) in retry.exception_types.iter().enumerate() {
+                        if index > 0 {
+                            f.write_str(", ")?;
+                        }
+
+                        f.write_str(exception_type)?;
+                    }
+
+                    f.write_str(" -> ")?;
+                }
+
+                write!(f, "retry: {}", retry.max_retries)?;
+
+                if let Some(backoff) = &retry.backoff {
+                    write!(f, ", backoff: {}", Fmt(backoff))?;
+                }
+
+                f.write_str("]")
+            }
+            ast::PolicyBracket::Timeout(timeout) => {
+                write!(f, "[timeout: {}]", Fmt(&timeout.timeout))
+            }
+        }
+    }
+}
+
+impl<'a> fmt::Display for Fmt<'a, ast::DurationLiteral> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let seconds = self.0.seconds;
+
+        if seconds != 0 && seconds.is_multiple_of(3600) {
+            return write!(f, "{}h", seconds / 3600);
+        }
+
+        if seconds != 0 && seconds.is_multiple_of(60) {
+            return write!(f, "{}m", seconds / 60);
+        }
+
+        write!(f, "{seconds}s")
+    }
+}
+
+impl<'a> fmt::Display for Fmt<'a, ast::Literal> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.0 {
+            ast::Literal::Int(value) => write!(f, "{value}"),
+            ast::Literal::Float(value) => write!(f, "{value:?}"),
+            ast::Literal::String(value) => {
+                let rendered =
+                    serde_json::to_string(value).unwrap_or_else(|_| format!("\"{value}\""));
+                f.write_str(&rendered)
+            }
+            ast::Literal::Bool(value) => {
+                if *value {
+                    f.write_str("True")
+                } else {
+                    f.write_str("False")
+                }
+            }
+            ast::Literal::None => f.write_str("None"),
+        }
+    }
+}

--- a/crates/lib/vm-ast-old-fmt/src/impl.rs
+++ b/crates/lib/vm-ast-old-fmt/src/impl.rs
@@ -1,0 +1,445 @@
+use core::fmt;
+
+use waymark_vm_ast_old as ast;
+
+use crate::Fmt;
+
+const DEFAULT_INDENT: &str = "    ";
+
+impl<'a> Fmt<'a, ast::Program> {
+    pub(crate) fn padded_fmt(&self, f: &mut fmt::Formatter<'_>, padding: usize) -> fmt::Result {
+        for (index, function) in self.0.functions.iter().enumerate() {
+            if index > 0 {
+                f.write_str("\n\n")?;
+            }
+
+            Fmt(function).padded_fmt(f, padding)?;
+        }
+
+        Ok(())
+    }
+}
+
+impl<'a> Fmt<'a, ast::Spanned<ast::FunctionDef>> {
+    pub(crate) fn padded_fmt(&self, f: &mut fmt::Formatter<'_>, padding: usize) -> fmt::Result {
+        write_indent(f, padding)?;
+        write!(f, "fn {}(input: [", self.0.value.name)?;
+        write_joined_strings(f, &self.0.value.io.value.inputs)?;
+        f.write_str("], output: [")?;
+        write_joined_strings(f, &self.0.value.io.value.outputs)?;
+        f.write_str("]):\n")?;
+        Fmt(&self.0.value.body).padded_fmt(f, padding + 1)
+    }
+}
+
+impl<'a> Fmt<'a, ast::Spanned<ast::Block>> {
+    pub(crate) fn padded_fmt(&self, f: &mut fmt::Formatter<'_>, padding: usize) -> fmt::Result {
+        if self.0.value.statements.is_empty() {
+            write_indent(f, padding)?;
+            return f.write_str("pass");
+        }
+
+        for (index, statement) in self.0.value.statements.iter().enumerate() {
+            if index > 0 {
+                f.write_str("\n")?;
+            }
+
+            Fmt(statement).padded_fmt(f, padding)?;
+        }
+
+        Ok(())
+    }
+}
+
+impl<'a> Fmt<'a, ast::Spanned<ast::Statement>> {
+    pub(crate) fn padded_fmt(&self, f: &mut fmt::Formatter<'_>, padding: usize) -> fmt::Result {
+        match &self.0.value {
+            ast::Statement::Assignment { targets, value } => match &value.value {
+                ast::Expr::ParallelExpr { calls } => {
+                    Fmt(calls.as_slice()).parallel_block_fmt(f, padding, Some(targets))
+                }
+                ast::Expr::SpreadExpr {
+                    collection,
+                    loop_var,
+                    action,
+                } => {
+                    write_indent(f, padding)?;
+                    write_names_or_placeholder(f, targets)?;
+                    f.write_str(" = ")?;
+                    write_spread(f, collection, loop_var, action)
+                }
+                _ => {
+                    write_indent(f, padding)?;
+                    write_names_or_placeholder(f, targets)?;
+                    f.write_str(" = ")?;
+                    Fmt(value).fmt_with_prec(f, 0)
+                }
+            },
+            ast::Statement::ActionCall { call } => {
+                write_indent(f, padding)?;
+                write!(f, "{}", Fmt(call))
+            }
+            ast::Statement::SpreadAction {
+                collection,
+                loop_var,
+                action,
+            } => {
+                write_indent(f, padding)?;
+                write_spread(f, collection, loop_var, action)
+            }
+            ast::Statement::ParallelBlock { calls } => {
+                Fmt(calls.as_slice()).parallel_block_fmt(f, padding, None)
+            }
+            ast::Statement::ForLoop {
+                loop_vars,
+                iterable,
+                body,
+            } => {
+                write_indent(f, padding)?;
+                f.write_str("for ")?;
+                write_names_or_placeholder(f, loop_vars)?;
+                f.write_str(" in ")?;
+                Fmt(iterable).fmt_with_prec(f, 0)?;
+                f.write_str(":\n")?;
+                Fmt(body).padded_fmt(f, padding + 1)
+            }
+            ast::Statement::WhileLoop { condition, body } => {
+                write_indent(f, padding)?;
+                f.write_str("while ")?;
+                Fmt(condition).fmt_with_prec(f, 0)?;
+                f.write_str(":\n")?;
+                Fmt(body).padded_fmt(f, padding + 1)
+            }
+            ast::Statement::Conditional {
+                if_branch,
+                elif_branches,
+                else_branch,
+            } => {
+                write_indent(f, padding)?;
+                f.write_str("if ")?;
+                Fmt(&if_branch.value.condition).fmt_with_prec(f, 0)?;
+                f.write_str(":\n")?;
+                Fmt(&if_branch.value.body).padded_fmt(f, padding + 1)?;
+
+                for branch in elif_branches {
+                    f.write_str("\n")?;
+                    write_indent(f, padding)?;
+                    f.write_str("elif ")?;
+                    Fmt(&branch.value.condition).fmt_with_prec(f, 0)?;
+                    f.write_str(":\n")?;
+                    Fmt(&branch.value.body).padded_fmt(f, padding + 1)?;
+                }
+
+                if let Some(branch) = else_branch {
+                    f.write_str("\n")?;
+                    write_indent(f, padding)?;
+                    f.write_str("else:\n")?;
+                    Fmt(&branch.value.body).padded_fmt(f, padding + 1)?;
+                }
+
+                Ok(())
+            }
+            ast::Statement::TryExcept {
+                handlers,
+                try_block,
+            } => {
+                write_indent(f, padding)?;
+                f.write_str("try:\n")?;
+                Fmt(try_block).padded_fmt(f, padding + 1)?;
+
+                for handler in handlers {
+                    f.write_str("\n")?;
+                    write_indent(f, padding)?;
+                    f.write_str("except")?;
+
+                    if !handler.value.exception_types.is_empty() {
+                        f.write_str(" ")?;
+                        write_joined_strings(f, &handler.value.exception_types)?;
+                    }
+
+                    if let Some(exception_var) = handler.value.exception_var.as_deref()
+                        && !exception_var.is_empty()
+                    {
+                        write!(f, " as {exception_var}")?;
+                    }
+
+                    f.write_str(":\n")?;
+                    Fmt(&handler.value.body).padded_fmt(f, padding + 1)?;
+                }
+
+                Ok(())
+            }
+            ast::Statement::Return { value } => {
+                write_indent(f, padding)?;
+                f.write_str("return")?;
+
+                if let Some(expr) = value {
+                    f.write_str(" ")?;
+                    Fmt(expr).fmt_with_prec(f, 0)?;
+                }
+
+                Ok(())
+            }
+            ast::Statement::ExprStmt { expr } => match &expr.value {
+                ast::Expr::ParallelExpr { calls } => {
+                    Fmt(calls.as_slice()).parallel_block_fmt(f, padding, None)
+                }
+                ast::Expr::SpreadExpr {
+                    collection,
+                    loop_var,
+                    action,
+                } => {
+                    write_indent(f, padding)?;
+                    write_spread(f, collection, loop_var, action)
+                }
+                _ => {
+                    write_indent(f, padding)?;
+                    Fmt(expr).fmt_with_prec(f, 0)
+                }
+            },
+            ast::Statement::Break => {
+                write_indent(f, padding)?;
+                f.write_str("break")
+            }
+            ast::Statement::Continue => {
+                write_indent(f, padding)?;
+                f.write_str("continue")
+            }
+            ast::Statement::Sleep { duration } => {
+                write_indent(f, padding)?;
+                f.write_str("sleep ")?;
+                Fmt(duration).fmt_with_prec(f, 0)
+            }
+        }
+    }
+}
+
+impl<'a> Fmt<'a, [ast::Call]> {
+    fn parallel_block_fmt(
+        &self,
+        f: &mut fmt::Formatter<'_>,
+        padding: usize,
+        targets: Option<&[String]>,
+    ) -> fmt::Result {
+        write_indent(f, padding)?;
+
+        if let Some(targets) = targets {
+            write_names_or_placeholder(f, targets)?;
+            f.write_str(" = parallel:")?;
+        } else {
+            f.write_str("parallel:")?;
+        }
+
+        if self.0.is_empty() {
+            f.write_str("\n")?;
+            write_indent(f, padding + 1)?;
+            return f.write_str("pass");
+        }
+
+        for call in self.0 {
+            f.write_str("\n")?;
+            write_indent(f, padding + 1)?;
+            write!(f, "{}", Fmt(call))?;
+        }
+
+        Ok(())
+    }
+}
+
+impl<'a> Fmt<'a, ast::FunctionCall> {
+    pub(crate) fn name(&self) -> &str {
+        if !self.0.name.is_empty() {
+            &self.0.name
+        } else {
+            match self.0.global_function.as_ref() {
+                Some(ast::GlobalFunction::Range) => "range",
+                Some(ast::GlobalFunction::Len) => "len",
+                Some(ast::GlobalFunction::Enumerate) => "enumerate",
+                Some(ast::GlobalFunction::IsException) => "isexception",
+                None => "fn",
+            }
+        }
+    }
+}
+
+impl<'a> Fmt<'a, ast::Spanned<ast::Expr>> {
+    pub(crate) fn fmt_with_prec(
+        &self,
+        f: &mut fmt::Formatter<'_>,
+        parent_prec: i32,
+    ) -> fmt::Result {
+        match &self.0.value {
+            ast::Expr::Literal { value } => write!(f, "{}", Fmt(value)),
+            ast::Expr::Variable { name } => f.write_str(name),
+            ast::Expr::BinaryOp { left, op, right } => {
+                let (op_str, prec) = binary_operator(op);
+                write_maybe_parenthesized(f, prec, parent_prec, |f| {
+                    Fmt(left.as_ref()).fmt_with_prec(f, prec)?;
+                    write!(f, " {op_str} ")?;
+                    Fmt(right.as_ref()).fmt_with_prec(f, prec + 1)
+                })
+            }
+            ast::Expr::UnaryOp { op, operand } => {
+                let (op_str, prec) = unary_operator(op);
+                write_maybe_parenthesized(f, prec, parent_prec, |f| {
+                    f.write_str(op_str)?;
+                    Fmt(operand.as_ref()).fmt_with_prec(f, prec)
+                })
+            }
+            ast::Expr::List { elements } => {
+                f.write_str("[")?;
+
+                for (index, element) in elements.iter().enumerate() {
+                    if index > 0 {
+                        f.write_str(", ")?;
+                    }
+
+                    Fmt(element).fmt_with_prec(f, 0)?;
+                }
+
+                f.write_str("]")
+            }
+            ast::Expr::Dict { entries } => {
+                f.write_str("{")?;
+
+                for (index, entry) in entries.iter().enumerate() {
+                    if index > 0 {
+                        f.write_str(", ")?;
+                    }
+
+                    Fmt(&entry.key).fmt_with_prec(f, 0)?;
+                    f.write_str(": ")?;
+                    Fmt(&entry.value).fmt_with_prec(f, 0)?;
+                }
+
+                f.write_str("}")
+            }
+            ast::Expr::Index { object, index } => {
+                let prec = precedence("index");
+                write_maybe_parenthesized(f, prec, parent_prec, |f| {
+                    Fmt(object.as_ref()).fmt_with_prec(f, prec)?;
+                    f.write_str("[")?;
+                    Fmt(index.as_ref()).fmt_with_prec(f, 0)?;
+                    f.write_str("]")
+                })
+            }
+            ast::Expr::Dot { object, attribute } => {
+                let prec = precedence("dot");
+                write_maybe_parenthesized(f, prec, parent_prec, |f| {
+                    Fmt(object.as_ref()).fmt_with_prec(f, prec)?;
+                    write!(f, ".{attribute}")
+                })
+            }
+            ast::Expr::FunctionCall { call } => write!(f, "{}", Fmt(call)),
+            ast::Expr::ActionCall { call } => write!(f, "{}", Fmt(call)),
+            ast::Expr::ParallelExpr { calls } => {
+                f.write_str("parallel(")?;
+
+                for (index, call) in calls.iter().enumerate() {
+                    if index > 0 {
+                        f.write_str(", ")?;
+                    }
+
+                    write!(f, "{}", Fmt(call))?;
+                }
+
+                f.write_str(")")
+            }
+            ast::Expr::SpreadExpr {
+                collection,
+                loop_var,
+                action,
+            } => write_spread(f, collection, loop_var, action),
+        }
+    }
+}
+
+fn write_names_or_placeholder(f: &mut fmt::Formatter<'_>, names: &[String]) -> fmt::Result {
+    if names.is_empty() {
+        f.write_str("_")
+    } else {
+        write_joined_strings(f, names)
+    }
+}
+
+fn write_joined_strings(f: &mut fmt::Formatter<'_>, values: &[String]) -> fmt::Result {
+    for (index, value) in values.iter().enumerate() {
+        if index > 0 {
+            f.write_str(", ")?;
+        }
+
+        f.write_str(value)?;
+    }
+
+    Ok(())
+}
+
+fn write_spread(
+    f: &mut fmt::Formatter<'_>,
+    collection: &ast::Spanned<ast::Expr>,
+    loop_var: &str,
+    action: &ast::ActionCall,
+) -> fmt::Result {
+    f.write_str("spread ")?;
+    Fmt(collection).fmt_with_prec(f, 0)?;
+    write!(f, ":{loop_var} -> ")?;
+    write!(f, "{}", Fmt(action))
+}
+
+fn write_maybe_parenthesized(
+    f: &mut fmt::Formatter<'_>,
+    prec: i32,
+    parent_prec: i32,
+    inner: impl FnOnce(&mut fmt::Formatter<'_>) -> fmt::Result,
+) -> fmt::Result {
+    if prec < parent_prec {
+        f.write_str("(")?;
+        inner(f)?;
+        f.write_str(")")
+    } else {
+        inner(f)
+    }
+}
+
+fn write_indent(f: &mut fmt::Formatter<'_>, level: usize) -> fmt::Result {
+    for _ in 0..level {
+        f.write_str(DEFAULT_INDENT)?;
+    }
+
+    Ok(())
+}
+
+fn binary_operator(op: &ast::BinaryOperator) -> (&'static str, i32) {
+    match op {
+        ast::BinaryOperator::Or => ("or", 10),
+        ast::BinaryOperator::And => ("and", 20),
+        ast::BinaryOperator::Eq => ("==", 30),
+        ast::BinaryOperator::Ne => ("!=", 30),
+        ast::BinaryOperator::Lt => ("<", 30),
+        ast::BinaryOperator::Le => ("<=", 30),
+        ast::BinaryOperator::Gt => (">", 30),
+        ast::BinaryOperator::Ge => (">=", 30),
+        ast::BinaryOperator::In => ("in", 30),
+        ast::BinaryOperator::NotIn => ("not in", 30),
+        ast::BinaryOperator::Add => ("+", 40),
+        ast::BinaryOperator::Sub => ("-", 40),
+        ast::BinaryOperator::Mul => ("*", 50),
+        ast::BinaryOperator::Div => ("/", 50),
+        ast::BinaryOperator::FloorDiv => ("//", 50),
+        ast::BinaryOperator::Mod => ("%", 50),
+    }
+}
+
+fn unary_operator(op: &ast::UnaryOperator) -> (&'static str, i32) {
+    match op {
+        ast::UnaryOperator::Neg => ("-", 60),
+        ast::UnaryOperator::Not => ("not ", 60),
+    }
+}
+
+fn precedence(kind: &str) -> i32 {
+    match kind {
+        "index" | "dot" => 80,
+        _ => 0,
+    }
+}

--- a/crates/lib/vm-ast-old-fmt/src/lib.rs
+++ b/crates/lib/vm-ast-old-fmt/src/lib.rs
@@ -1,0 +1,13 @@
+//! Pretty-printer for `vm-ast-old` AST structures.
+
+mod display;
+mod r#impl;
+
+pub struct Fmt<'a, T: ?Sized>(pub &'a T);
+
+pub fn display<'a, T: ?Sized>(value: &'a T) -> Fmt<'a, T>
+where
+    Fmt<'a, T>: core::fmt::Display,
+{
+    Fmt(value)
+}

--- a/crates/lib/vm-ast-old-fmt/tests/snapshots/visual__fmt_display_prints_program.snap
+++ b/crates/lib/vm-ast-old-fmt/tests/snapshots/visual__fmt_display_prints_program.snap
@@ -1,0 +1,29 @@
+---
+source: crates/lib/vm-ast-old-fmt/tests/visual.rs
+expression: "waymark_vm_ast_old_fmt::display(&program)"
+---
+fn helper(input: [], output: [answer]):
+    pass
+
+fn main(input: [items, flag], output: [result]):
+    results = []
+    stats = {"count": len(items)}
+    grouped = parallel:
+        @worker.fetch(item=items[0]) [timeout: 30s]
+        len(items)
+    spread items:item -> @worker.process(item=item) [ValueError -> retry: 3, backoff: 1m]
+    if not payload.ready or len(items) == 0:
+        sleep 300
+    elif flag:
+        @worker.audit()
+    else:
+        @worker.notify()
+    for index, item in enumerate(items):
+        results = results + [item]
+    while payload.ready and len(results) < len(items):
+        continue
+    try:
+        result = @worker.finish(value=grouped) [timeout: 30s]
+    except ValueError as err:
+        return err
+    return {"results": results, "stats": stats}

--- a/crates/lib/vm-ast-old-fmt/tests/visual.rs
+++ b/crates/lib/vm-ast-old-fmt/tests/visual.rs
@@ -1,0 +1,209 @@
+use waymark_vm_ast_old::{
+    BinaryOperator, Call, DictEntry, DurationLiteral, ElifBranch, ElseBranch, ExceptHandler, Expr,
+    FunctionDef, GlobalFunction, IfBranch, IoDecl, PolicyBracket, RetryPolicy, Statement,
+    TimeoutPolicy,
+};
+use waymark_vm_ast_old_helpers::{
+    block, builtin_function_call, int, kwarg, module_action_call, program, return_stmt, spanned,
+    string, variable,
+};
+
+#[test]
+fn fmt_display_prints_program() {
+    let helper = spanned(FunctionDef {
+        name: "helper".to_owned(),
+        io: spanned(IoDecl {
+            inputs: Vec::new(),
+            outputs: vec!["answer".to_owned()],
+        }),
+        body: block(Vec::new()),
+    });
+
+    let main = spanned(FunctionDef {
+        name: "main".to_owned(),
+        io: spanned(IoDecl {
+            inputs: vec!["items".to_owned(), "flag".to_owned()],
+            outputs: vec!["result".to_owned()],
+        }),
+        body: block(vec![
+            spanned(Statement::Assignment {
+                targets: vec!["results".to_owned()],
+                value: spanned(Expr::List {
+                    elements: Vec::new(),
+                }),
+            }),
+            spanned(Statement::Assignment {
+                targets: vec!["stats".to_owned()],
+                value: spanned(Expr::Dict {
+                    entries: vec![DictEntry {
+                        key: string("count"),
+                        value: spanned(Expr::FunctionCall {
+                            call: builtin_function_call(
+                                GlobalFunction::Len,
+                                vec![variable("items")],
+                            ),
+                        }),
+                    }],
+                }),
+            }),
+            spanned(Statement::Assignment {
+                targets: vec!["grouped".to_owned()],
+                value: spanned(Expr::ParallelExpr {
+                    calls: vec![
+                        Call::Action(module_action_call(
+                            "worker",
+                            "fetch",
+                            vec![kwarg(
+                                "item",
+                                spanned(Expr::Index {
+                                    object: Box::new(variable("items")),
+                                    index: Box::new(int(0)),
+                                }),
+                            )],
+                            vec![PolicyBracket::Timeout(TimeoutPolicy {
+                                timeout: DurationLiteral { seconds: 30 },
+                            })],
+                        )),
+                        Call::Function(builtin_function_call(
+                            GlobalFunction::Len,
+                            vec![variable("items")],
+                        )),
+                    ],
+                }),
+            }),
+            spanned(Statement::SpreadAction {
+                collection: variable("items"),
+                loop_var: "item".to_owned(),
+                action: module_action_call(
+                    "worker",
+                    "process",
+                    vec![kwarg("item", variable("item"))],
+                    vec![PolicyBracket::Retry(RetryPolicy {
+                        exception_types: vec!["ValueError".to_owned()],
+                        max_retries: 3,
+                        backoff: Some(DurationLiteral { seconds: 60 }),
+                    })],
+                ),
+            }),
+            spanned(Statement::Conditional {
+                if_branch: spanned(IfBranch {
+                    condition: spanned(Expr::BinaryOp {
+                        left: Box::new(spanned(Expr::UnaryOp {
+                            op: waymark_vm_ast_old::UnaryOperator::Not,
+                            operand: Box::new(spanned(Expr::Dot {
+                                object: Box::new(variable("payload")),
+                                attribute: "ready".to_owned(),
+                            })),
+                        })),
+                        op: BinaryOperator::Or,
+                        right: Box::new(spanned(Expr::BinaryOp {
+                            left: Box::new(spanned(Expr::FunctionCall {
+                                call: builtin_function_call(
+                                    GlobalFunction::Len,
+                                    vec![variable("items")],
+                                ),
+                            })),
+                            op: BinaryOperator::Eq,
+                            right: Box::new(int(0)),
+                        })),
+                    }),
+                    body: block(vec![spanned(Statement::Sleep {
+                        duration: spanned(Expr::Literal {
+                            value: waymark_vm_ast_old::Literal::Int(300),
+                        }),
+                    })]),
+                }),
+                elif_branches: vec![spanned(ElifBranch {
+                    condition: variable("flag"),
+                    body: block(vec![spanned(Statement::ExprStmt {
+                        expr: spanned(Expr::ActionCall {
+                            call: module_action_call("worker", "audit", Vec::new(), Vec::new()),
+                        }),
+                    })]),
+                })],
+                else_branch: Some(spanned(ElseBranch {
+                    body: block(vec![spanned(Statement::ActionCall {
+                        call: module_action_call("worker", "notify", Vec::new(), Vec::new()),
+                    })]),
+                })),
+            }),
+            spanned(Statement::ForLoop {
+                loop_vars: vec!["index".to_owned(), "item".to_owned()],
+                iterable: spanned(Expr::FunctionCall {
+                    call: builtin_function_call(GlobalFunction::Enumerate, vec![variable("items")]),
+                }),
+                body: block(vec![spanned(Statement::Assignment {
+                    targets: vec!["results".to_owned()],
+                    value: spanned(Expr::BinaryOp {
+                        left: Box::new(variable("results")),
+                        op: BinaryOperator::Add,
+                        right: Box::new(spanned(Expr::List {
+                            elements: vec![variable("item")],
+                        })),
+                    }),
+                })]),
+            }),
+            spanned(Statement::WhileLoop {
+                condition: spanned(Expr::BinaryOp {
+                    left: Box::new(spanned(Expr::Dot {
+                        object: Box::new(variable("payload")),
+                        attribute: "ready".to_owned(),
+                    })),
+                    op: BinaryOperator::And,
+                    right: Box::new(spanned(Expr::BinaryOp {
+                        left: Box::new(spanned(Expr::FunctionCall {
+                            call: builtin_function_call(
+                                GlobalFunction::Len,
+                                vec![variable("results")],
+                            ),
+                        })),
+                        op: BinaryOperator::Lt,
+                        right: Box::new(spanned(Expr::FunctionCall {
+                            call: builtin_function_call(
+                                GlobalFunction::Len,
+                                vec![variable("items")],
+                            ),
+                        })),
+                    })),
+                }),
+                body: block(vec![spanned(Statement::Continue)]),
+            }),
+            spanned(Statement::TryExcept {
+                handlers: vec![spanned(ExceptHandler {
+                    exception_types: vec!["ValueError".to_owned()],
+                    exception_var: Some("err".to_owned()),
+                    body: block(vec![return_stmt(Some(variable("err")))]),
+                })],
+                try_block: block(vec![spanned(Statement::Assignment {
+                    targets: vec!["result".to_owned()],
+                    value: spanned(Expr::ActionCall {
+                        call: module_action_call(
+                            "worker",
+                            "finish",
+                            vec![kwarg("value", variable("grouped"))],
+                            vec![PolicyBracket::Timeout(TimeoutPolicy {
+                                timeout: DurationLiteral { seconds: 30 },
+                            })],
+                        ),
+                    }),
+                })]),
+            }),
+            return_stmt(Some(spanned(Expr::Dict {
+                entries: vec![
+                    DictEntry {
+                        key: string("results"),
+                        value: variable("results"),
+                    },
+                    DictEntry {
+                        key: string("stats"),
+                        value: variable("stats"),
+                    },
+                ],
+            }))),
+        ]),
+    });
+
+    let program = program(vec![helper, main]);
+
+    insta::assert_snapshot!(waymark_vm_ast_old_fmt::display(&program));
+}

--- a/crates/lib/vm-ast-old-helpers/src/lib.rs
+++ b/crates/lib/vm-ast-old-helpers/src/lib.rs
@@ -1,7 +1,7 @@
 use waymark_vm_ast_old::{
     ActionCall, BinaryOperator, Block, Call, ElifBranch, ElseBranch, Expr, FunctionCall,
-    FunctionDef, GlobalFunction, IfBranch, IoDecl, Kwarg, Literal, Program, Span, Spanned,
-    Statement,
+    FunctionDef, GlobalFunction, IfBranch, IoDecl, Kwarg, Literal, PolicyBracket, Program, Span,
+    Spanned, Statement,
 };
 
 pub fn span() -> Span {
@@ -234,10 +234,7 @@ pub fn action_call(name: &str, kwargs: Vec<(&str, Spanned<Expr>)>) -> ActionCall
         action_name: name.to_owned(),
         kwargs: kwargs
             .into_iter()
-            .map(|(name, value)| Kwarg {
-                name: name.to_owned(),
-                value,
-            })
+            .map(|(kwarg_name, value)| kwarg(kwarg_name, value))
             .collect(),
         policies: Vec::new(),
         module_name: None,
@@ -248,4 +245,25 @@ pub fn action_expr(name: &str, kwargs: Vec<(&str, Spanned<Expr>)>) -> Spanned<Ex
     spanned(Expr::ActionCall {
         call: action_call(name, kwargs),
     })
+}
+
+pub fn kwarg(name: &str, value: Spanned<Expr>) -> Kwarg {
+    Kwarg {
+        name: name.to_owned(),
+        value,
+    }
+}
+
+pub fn module_action_call(
+    module_name: &str,
+    name: &str,
+    kwargs: Vec<Kwarg>,
+    policies: Vec<PolicyBracket>,
+) -> ActionCall {
+    ActionCall {
+        action_name: name.to_owned(),
+        kwargs,
+        policies,
+        module_name: Some(module_name.to_owned()),
+    }
 }

--- a/crates/lib/vm-compiler-for-ast-old/Cargo.toml
+++ b/crates/lib/vm-compiler-for-ast-old/Cargo.toml
@@ -22,6 +22,7 @@ thiserror = { workspace = true }
 [dev-dependencies]
 waymark-nonzero-duration = { workspace = true }
 waymark-support-test-python = { workspace = true }
+waymark-vm-ast-old-fmt = { workspace = true }
 waymark-vm-ast-old-helpers = { workspace = true }
 waymark-vm-bytecode-fmt = { workspace = true }
 waymark-vm-compiler-for-ast-old-test-support = { workspace = true }

--- a/crates/lib/vm-compiler-for-ast-old/tests/python.rs
+++ b/crates/lib/vm-compiler-for-ast-old/tests/python.rs
@@ -88,11 +88,7 @@ async fn compile_python_tests() {
 
         let snapshot = format!("{}/ast", python_test_file.display());
         let details = format!("ast for python/tests/{}", python_test_file.display());
-        insta::assert_snapshot!(
-            snapshot,
-            waymark_vm_ast_old_fmt::display(&program),
-            &details
-        );
+        insta::assert_debug_snapshot!(snapshot, program, &details);
 
         let bytecode_result =
             waymark_vm_compiler_for_ast_old::compile::<TestSpec, TestLowering>(&program);
@@ -101,12 +97,20 @@ async fn compile_python_tests() {
 
         match bytecode_result {
             Ok(bytecode) => {
-                let details = format!("bytecode for python/tests/{}", python_test_file.display());
-                insta::assert_snapshot!(
-                    snapshot,
+                let content = format!(
+                    "{}\n---\n{}\n",
+                    // This is a hint-only-level of information, so issues with
+                    // incorrect/incomplete formatting are not critical.
+                    waymark_vm_ast_old_fmt::display(&program),
+                    // This is the actual snapshot playload; issues with
+                    // formatting are critical here, but the imlplementation
+                    // of the bytecode formatting is quite trivial, so it
+                    // is safe to rely on here.
                     waymark_vm_bytecode_fmt::display(&bytecode),
-                    &details
                 );
+
+                let details = format!("bytecode for python/tests/{}", python_test_file.display());
+                insta::assert_snapshot!(snapshot, content, &details);
             }
             Err(error) => {
                 let details = format!(

--- a/crates/lib/vm-compiler-for-ast-old/tests/python.rs
+++ b/crates/lib/vm-compiler-for-ast-old/tests/python.rs
@@ -88,7 +88,11 @@ async fn compile_python_tests() {
 
         let snapshot = format!("{}/ast", python_test_file.display());
         let details = format!("ast for python/tests/{}", python_test_file.display());
-        insta::assert_debug_snapshot!(snapshot, program, &details);
+        insta::assert_snapshot!(
+            snapshot,
+            waymark_vm_ast_old_fmt::display(&program),
+            &details
+        );
 
         let bytecode_result =
             waymark_vm_compiler_for_ast_old::compile::<TestSpec, TestLowering>(&program);

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_actions__action_kwargs.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_actions__action_kwargs.py__bytecode.snap
@@ -2,6 +2,10 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_actions/action_kwargs.py
 ---
+fn main(input: [], output: []):
+    result = @action_kwargs.greet_person(name="World", greeting="Hi")
+    return result
+---
 f0: [3 registers]
   s0:
     PureSet(LoadConst { dst: r1, value: String("World") })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_actions__action_mixed_args.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_actions__action_mixed_args.py__bytecode.snap
@@ -2,6 +2,10 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_actions/action_mixed_args.py
 ---
+fn main(input: [], output: []):
+    result = @action_mixed_args.compute_value(x=5, y=10, multiplier=2)
+    return result
+---
 f0: [4 registers]
   s0:
     PureSet(LoadConst { dst: r1, value: Int(5) })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_actions__action_no_assignment.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_actions__action_no_assignment.py__bytecode.snap
@@ -2,6 +2,12 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_actions/action_no_assignment.py
 ---
+fn main(input: [], output: []):
+    @action_no_assignment.log_event(message="starting")
+    result = @action_no_assignment.get_final_value()
+    @action_no_assignment.log_event(message="finished")
+    return result
+---
 f0: [3 registers]
   s0:
     PureSet(LoadConst { dst: r1, value: String("starting") })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_actions__action_positional_args.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_actions__action_positional_args.py__bytecode.snap
@@ -2,6 +2,10 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_actions/action_positional_args.py
 ---
+fn main(input: [], output: []):
+    result = @action_positional_args.add_numbers(a=10, b=20)
+    return result
+---
 f0: [3 registers]
   s0:
     PureSet(LoadConst { dst: r1, value: Int(10) })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_actions__action_return.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_actions__action_return.py__bytecode.snap
@@ -2,6 +2,10 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_actions/action_return.py
 ---
+fn main(input: [value], output: []):
+    _return_tmp = @action_return.compute_result(x=value)
+    return _return_tmp
+---
 f0: [2 registers]
   s0:
     ExtCallSet(ActionCall { dst: r1, action_ref: TestActionRef("compute_result"), args: [r0], resume: s1 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_actions__action_variable_args.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_actions__action_variable_args.py__bytecode.snap
@@ -2,6 +2,11 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_actions/action_variable_args.py
 ---
+fn main(input: [factor], output: []):
+    base = @action_variable_args.get_base_value()
+    result = @action_variable_args.multiply_by(value=base, factor=factor)
+    return result
+---
 f0: [3 registers]
   s0:
     ExtCallSet(ActionCall { dst: r1, action_ref: TestActionRef("get_base_value"), args: [], resume: s1 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_actions__literal_return.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_actions__literal_return.py__bytecode.snap
@@ -2,6 +2,10 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_actions/literal_return.py
 ---
+fn main(input: [], output: []):
+    @literal_return.do_something()
+    return 42
+---
 f0: [1 registers]
   s0:
     ExtCallSet(ActionCall { dst: r0, action_ref: TestActionRef("do_something"), args: [], resume: s1 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_actions__simple_action.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_actions__simple_action.py__bytecode.snap
@@ -2,6 +2,10 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_actions/simple_action.py
 ---
+fn main(input: [value], output: []):
+    result = @simple_action.process(value=value)
+    return result
+---
 f0: [2 registers]
   s0:
     ExtCallSet(ActionCall { dst: r1, action_ref: TestActionRef("process"), args: [r0], resume: s1 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_actions__variable_return.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_actions__variable_return.py__bytecode.snap
@@ -2,6 +2,10 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_actions/variable_return.py
 ---
+fn main(input: [value], output: []):
+    result = @variable_return.compute_result_for_variable_return(x=value)
+    return result
+---
 f0: [2 registers]
   s0:
     ExtCallSet(ActionCall { dst: r1, action_ref: TestActionRef("compute_result_for_variable_return"), args: [r0], resume: s1 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_comprehension__dict_comprehension_assignment.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_comprehension__dict_comprehension_assignment.py__bytecode.snap
@@ -2,6 +2,13 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_comprehension/dict_comprehension_assignment.py
 ---
+fn main(input: [users], output: []):
+    active_lookup = {}
+    for user in users:
+        if user.active:
+            active_lookup[user.id] = user.name
+    return active_lookup
+---
 f0: [8 registers]
   s0:
     PureSet(MakeDict { dst: r1, entries: [] })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_comprehension__dict_comprehension_tuple.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_comprehension__dict_comprehension_tuple.py__bytecode.snap
@@ -2,6 +2,12 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_comprehension/dict_comprehension_tuple.py
 ---
+fn main(input: [pairs], output: []):
+    mapping = {}
+    for key, value in pairs:
+        mapping[key] = value
+    return mapping
+---
 f0: [10 registers]
   s0:
     PureSet(MakeDict { dst: r1, entries: [] })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_comprehension__list_comprehension_assignment.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_comprehension__list_comprehension_assignment.py__bytecode.snap
@@ -2,6 +2,13 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_comprehension/list_comprehension_assignment.py
 ---
+fn main(input: [users], output: []):
+    active_users = []
+    for user in users:
+        if user.active:
+            active_users = active_users + [user]
+    return active_users
+---
 f0: [7 registers]
   s0:
     PureSet(MakeList { dst: r1, items: [] })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_comprehension__list_comprehension_ifexp.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_comprehension__list_comprehension_ifexp.py__bytecode.snap
@@ -2,6 +2,15 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_comprehension/list_comprehension_ifexp.py
 ---
+fn main(input: [users], output: []):
+    statuses = []
+    for user in users:
+        if user.active:
+            statuses = statuses + [user.name]
+        else:
+            statuses = statuses + ["inactive"]
+    return statuses
+---
 f0: [8 registers]
   s0:
     PureSet(MakeList { dst: r1, items: [] })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_conditional__if_await_action_condition.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_conditional__if_await_action_condition.py__bytecode.snap
@@ -2,6 +2,12 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_conditional/if_await_action_condition.py
 ---
+fn main(input: [value], output: []):
+    __if_cond_1__ = @if_await_action_condition.is_even(value=value)
+    if __if_cond_1__:
+        return 1
+    return 0
+---
 f0: [3 registers]
   s0:
     ExtCallSet(ActionCall { dst: r1, action_ref: TestActionRef("is_even"), args: [r0], resume: s1 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_conditional__if_multiple_calls.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_conditional__if_multiple_calls.py__bytecode.snap
@@ -2,6 +2,14 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_conditional/if_multiple_calls.py
 ---
+fn main(input: [value], output: []):
+    if value > 0:
+        a = @if_multiple_calls.if_step_one(value=value)
+        b = @if_multiple_calls.if_step_two(value=a)
+        return b
+    else:
+        return 0
+---
 f0: [5 registers]
   s0:
     PureSet(LoadConst { dst: r1, value: Int(0) })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_control_flow__for_multi_action.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_control_flow__for_multi_action.py__bytecode.snap
@@ -2,6 +2,15 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_control_flow/for_multi_action.py
 ---
+fn main(input: [], output: []):
+    items = [1, 2, 3]
+    results = []
+    for item in items:
+        first = @for_multi_action.step_one_for(x=item)
+        second = @for_multi_action.step_two_for(x=first)
+        results = results + [second]
+    return results
+---
 f0: [11 registers]
   s0:
     PureSet(LoadConst { dst: r1, value: Int(1) })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_control_flow__for_simple.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_control_flow__for_simple.py__bytecode.snap
@@ -2,6 +2,14 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_control_flow/for_simple.py
 ---
+fn main(input: [], output: []):
+    items = ["a", "b", "c"]
+    results = []
+    for item in items:
+        processed = @for_simple.process_item_simple(item=item)
+        results = results + [processed]
+    return results
+---
 f0: [10 registers]
   s0:
     PureSet(LoadConst { dst: r1, value: String("a") })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_control_flow__if_elif_else.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_control_flow__if_elif_else.py__bytecode.snap
@@ -2,6 +2,17 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_control_flow/if_elif_else.py
 ---
+fn main(input: [value], output: []):
+    if value == 1:
+        result = @if_elif_else.handle_case_a()
+    elif value == 2:
+        result = @if_elif_else.handle_case_b()
+    elif value == 3:
+        result = @if_elif_else.handle_case_c()
+    else:
+        result = @if_elif_else.handle_default()
+    return result
+---
 f0: [4 registers]
   s0:
     PureSet(LoadConst { dst: r1, value: Int(1) })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_control_flow__if_multi_action.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_control_flow__if_multi_action.py__bytecode.snap
@@ -2,6 +2,17 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_control_flow/if_multi_action.py
 ---
+fn main(input: [flag], output: []):
+    if flag:
+        a = @if_multi_action.action_if_1()
+        b = @if_multi_action.action_if_2(x=a)
+        result = b
+    else:
+        c = @if_multi_action.action_else_1()
+        d = @if_multi_action.action_else_2(x=c)
+        result = d
+    return result
+---
 f0: [6 registers]
   s0:
     CoreSet(JumpIf { target_state: s2, cond: r0 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_control_flow__if_no_else_continue.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_control_flow__if_no_else_continue.py__bytecode.snap
@@ -2,6 +2,14 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_control_flow/if_no_else_continue.py
 ---
+fn main(input: [], output: []):
+    response = @if_no_else_continue.get_items()
+    count = 0
+    if response.items:
+        count = @if_no_else_continue.process_items(items=response.items)
+    result = @if_no_else_continue.finalize(count=count)
+    return result
+---
 f0: [4 registers]
   s0:
     ExtCallSet(ActionCall { dst: r0, action_ref: TestActionRef("get_items"), args: [], resume: s1 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_control_flow__if_simple.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_control_flow__if_simple.py__bytecode.snap
@@ -2,6 +2,13 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_control_flow/if_simple.py
 ---
+fn main(input: [flag], output: []):
+    if flag:
+        result = @if_simple.handle_true_case()
+    else:
+        result = @if_simple.handle_false_case()
+    return result
+---
 f0: [2 registers]
   s0:
     CoreSet(JumpIf { target_state: s2, cond: r0 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_control_flow__if_with_accumulator.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_control_flow__if_with_accumulator.py__bytecode.snap
@@ -2,6 +2,19 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_control_flow/if_with_accumulator.py
 ---
+fn main(input: [value], output: []):
+    results = []
+    if value > 50:
+        x = @if_with_accumulator.if_accum_process_high(value=value)
+        y = @if_with_accumulator.if_accum_finalize(result=x)
+        results = results + [y]
+    else:
+        z = @if_with_accumulator.if_accum_process_low(value=value)
+        results = results + [z]
+    if results:
+        return results[0]
+    return "empty"
+---
 f0: [7 registers]
   s0:
     PureSet(MakeList { dst: r1, items: [] })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_control_flow__while_simple.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_control_flow__while_simple.py__bytecode.snap
@@ -2,6 +2,12 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_control_flow/while_simple.py
 ---
+fn main(input: [limit], output: []):
+    i = 0
+    while i < limit:
+        i = @while_simple.increment(value=i)
+    return i
+---
 f0: [3 registers]
   s0:
     PureSet(LoadConst { dst: r1, value: Int(0) })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_for_loop__for_break.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_for_loop__for_break.py__bytecode.snap
@@ -2,6 +2,15 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_for_loop/for_break.py
 ---
+fn main(input: [items], output: []):
+    result = "not found"
+    for item in items:
+        found = @for_break.check_item(value=item)
+        if found:
+            result = @for_break.process_found(value=item)
+            break
+    return result
+---
 f0: [8 registers]
   s0:
     PureSet(LoadConst { dst: r1, value: String("not found") })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_for_loop__for_concat_accumulator.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_for_loop__for_concat_accumulator.py__bytecode.snap
@@ -2,6 +2,13 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_for_loop/for_concat_accumulator.py
 ---
+fn main(input: [items], output: []):
+    results = []
+    for item in items:
+        processed = @for_concat_accumulator.concat_accum_process_value(value=item)
+        results = results + [processed]
+    return results
+---
 f0: [8 registers]
   s0:
     PureSet(MakeList { dst: r1, items: [] })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_for_loop__for_continue.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_for_loop__for_continue.py__bytecode.snap
@@ -2,6 +2,16 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_for_loop/for_continue.py
 ---
+fn main(input: [items], output: []):
+    total = 0
+    for item in items:
+        skip = @for_continue.should_skip(value=item)
+        if skip:
+            continue
+        result = @for_continue.process_item(value=item)
+        total = total + result
+    return total
+---
 f0: [9 registers]
   s0:
     PureSet(LoadConst { dst: r1, value: Int(0) })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_for_loop__for_counter_accumulator.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_for_loop__for_counter_accumulator.py__bytecode.snap
@@ -2,6 +2,14 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_for_loop/for_counter_accumulator.py
 ---
+fn main(input: [items], output: []):
+    count = 0
+    for item in items:
+        is_valid = @for_counter_accumulator.counter_accum_check_valid(item=item)
+        if is_valid:
+            count = count + 1
+    return count
+---
 f0: [8 registers]
   s0:
     PureSet(LoadConst { dst: r1, value: Int(0) })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_for_loop__for_multiple_calls.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_for_loop__for_multiple_calls.py__bytecode.snap
@@ -2,6 +2,14 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_for_loop/for_multiple_calls.py
 ---
+fn main(input: [items], output: []):
+    results = []
+    for item in items:
+        a = @for_multiple_calls.for_step_one(item=item)
+        b = @for_multiple_calls.for_step_two(value=a)
+        results = results + [b]
+    return results
+---
 f0: [9 registers]
   s0:
     PureSet(MakeList { dst: r1, items: [] })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_for_loop__for_single_accumulator.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_for_loop__for_single_accumulator.py__bytecode.snap
@@ -2,6 +2,13 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_for_loop/for_single_accumulator.py
 ---
+fn main(input: [items], output: []):
+    results = []
+    for item in items:
+        processed = @for_single_accumulator.single_accum_process_value(value=item)
+        results = results + [processed]
+    return results
+---
 f0: [8 registers]
   s0:
     PureSet(MakeList { dst: r1, items: [] })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_for_loop__for_with_append.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_for_loop__for_with_append.py__bytecode.snap
@@ -2,6 +2,13 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_for_loop/for_with_append.py
 ---
+fn main(input: [items], output: []):
+    results = []
+    for item in items:
+        processed = @for_with_append.process_value(value=item)
+        results = results + [processed]
+    return results
+---
 f0: [8 registers]
   s0:
     PureSet(MakeList { dst: r1, items: [] })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_nested.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_nested.py__bytecode.snap
@@ -2,6 +2,13 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_gather/gather_nested.py
 ---
+fn main(input: [], output: []):
+    results = parallel:
+        @gather_nested.fetch_a()
+        @gather_nested.fetch_b()
+    total = @gather_nested.combine(values=results)
+    return total
+---
 f0: [4 registers]
   s0:
     ExtCallSet(ActionCall { dst: r1, action_ref: TestActionRef("fetch_a"), args: [], resume: s1 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_simple.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_simple.py__bytecode.snap
@@ -2,6 +2,12 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_gather/gather_simple.py
 ---
+fn main(input: [], output: []):
+    a, b = parallel:
+        @gather_simple.action_a()
+        @gather_simple.action_b()
+    return [a, b]
+---
 f0: [4 registers]
   s0:
     ExtCallSet(ActionCall { dst: r2, action_ref: TestActionRef("action_a"), args: [], resume: s1 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_to_variable.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_to_variable.py__bytecode.snap
@@ -2,6 +2,13 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_gather/gather_to_variable.py
 ---
+fn main(input: [], output: []):
+    results = parallel:
+        @gather_to_variable.fetch_value_1()
+        @gather_to_variable.fetch_value_2()
+        @gather_to_variable.fetch_value_3()
+    return results
+---
 f0: [4 registers]
   s0:
     ExtCallSet(ActionCall { dst: r1, action_ref: TestActionRef("fetch_value_1"), args: [], resume: s1 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_tuple_unpack.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_tuple_unpack.py__bytecode.snap
@@ -2,6 +2,13 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_gather/gather_tuple_unpack.py
 ---
+fn main(input: [], output: []):
+    factorial_value, fib_value = parallel:
+        @gather_tuple_unpack.compute_factorial(n=5)
+        @gather_tuple_unpack.compute_fibonacci(n=10)
+    summary = @gather_tuple_unpack.summarize_math(factorial_value=factorial_value, fib_value=fib_value)
+    return summary
+---
 f0: [6 registers]
   s0:
     PureSet(LoadConst { dst: r3, value: Int(5) })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_with_args.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_with_args.py__bytecode.snap
@@ -2,6 +2,12 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_gather/gather_with_args.py
 ---
+fn main(input: [value], output: []):
+    square, cube = parallel:
+        @gather_with_args.compute_square(n=value)
+        @gather_with_args.compute_cube(n=value)
+    return [square, cube]
+---
 f0: [5 registers]
   s0:
     ExtCallSet(ActionCall { dst: r3, action_ref: TestActionRef("compute_square"), args: [r0], resume: s1 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_models__dataclass_action_arg.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_models__dataclass_action_arg.py__bytecode.snap
@@ -2,6 +2,11 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_models/dataclass_action_arg.py
 ---
+fn main(input: [], output: []):
+    items = @dataclass_action_arg.get_data_items()
+    result = @dataclass_action_arg.process_data(request={"items": items})
+    return result.count
+---
 f0: [4 registers]
   s0:
     ExtCallSet(ActionCall { dst: r0, action_ref: TestActionRef("get_data_items"), args: [], resume: s1 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_models__dataclass_positional.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_models__dataclass_positional.py__bytecode.snap
@@ -2,6 +2,12 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_models/dataclass_positional.py
 ---
+fn main(input: [], output: []):
+    x = @dataclass_positional.get_x()
+    y = @dataclass_positional.get_y()
+    point = {"x": x, "y": y}
+    return point
+---
 f0: [5 registers]
   s0:
     ExtCallSet(ActionCall { dst: r0, action_ref: TestActionRef("get_x"), args: [], resume: s1 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_models__dataclass_simple.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_models__dataclass_simple.py__bytecode.snap
@@ -2,6 +2,11 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_models/dataclass_simple.py
 ---
+fn main(input: [], output: []):
+    value = @dataclass_simple.fetch_value()
+    result = {"value": value, "message": "done"}
+    return result
+---
 f0: [5 registers]
   s0:
     ExtCallSet(ActionCall { dst: r0, action_ref: TestActionRef("fetch_value"), args: [], resume: s1 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_models__dataclass_with_defaults.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_models__dataclass_with_defaults.py__bytecode.snap
@@ -2,6 +2,11 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_models/dataclass_with_defaults.py
 ---
+fn main(input: [], output: []):
+    value = @dataclass_with_defaults.get_result()
+    result = {"value": value, "status": "pending", "retry_count": 0}
+    return result
+---
 f0: [7 registers]
   s0:
     ExtCallSet(ActionCall { dst: r0, action_ref: TestActionRef("get_result"), args: [], resume: s1 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_models__pydantic_action_arg.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_models__pydantic_action_arg.py__bytecode.snap
@@ -2,6 +2,11 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_models/pydantic_action_arg.py
 ---
+fn main(input: [], output: []):
+    items = @pydantic_action_arg.get_items()
+    result = @pydantic_action_arg.process_request(request={"items": items})
+    return result.count
+---
 f0: [4 registers]
   s0:
     ExtCallSet(ActionCall { dst: r0, action_ref: TestActionRef("get_items"), args: [], resume: s1 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_models__pydantic_nested.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_models__pydantic_nested.py__bytecode.snap
@@ -2,6 +2,11 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_models/pydantic_nested.py
 ---
+fn main(input: [], output: []):
+    coords = @pydantic_nested.get_coordinates()
+    result = {"name": "test", "inner": coords}
+    return result
+---
 f0: [5 registers]
   s0:
     ExtCallSet(ActionCall { dst: r0, action_ref: TestActionRef("get_coordinates"), args: [], resume: s1 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_models__pydantic_return_direct.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_models__pydantic_return_direct.py__bytecode.snap
@@ -2,6 +2,9 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_models/pydantic_return_direct.py
 ---
+fn main(input: [], output: []):
+    return {"value": 1, "message": "ok"}
+---
 f0: [5 registers]
   s0:
     PureSet(LoadConst { dst: r0, value: String("value") })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_models__pydantic_simple.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_models__pydantic_simple.py__bytecode.snap
@@ -2,6 +2,11 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_models/pydantic_simple.py
 ---
+fn main(input: [], output: []):
+    value = @pydantic_simple.get_value()
+    result = {"value": value, "message": "success"}
+    return result
+---
 f0: [5 registers]
   s0:
     ExtCallSet(ActionCall { dst: r0, action_ref: TestActionRef("get_value"), args: [], resume: s1 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_models__pydantic_with_defaults.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_models__pydantic_with_defaults.py__bytecode.snap
@@ -2,6 +2,11 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_models/pydantic_with_defaults.py
 ---
+fn main(input: [], output: []):
+    value = @pydantic_with_defaults.compute_value()
+    result = {"value": value, "status": "ok", "count": 0}
+    return result
+---
 f0: [7 registers]
   s0:
     ExtCallSet(ActionCall { dst: r0, action_ref: TestActionRef("compute_value"), args: [], resume: s1 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_policy__instance_attr_policies.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_policy__instance_attr_policies.py__bytecode.snap
@@ -2,6 +2,12 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_policy/instance_attr_policies.py
 ---
+fn main(input: [value], output: []):
+    a = @instance_attr_policies.action_with_instance_retry(value=value) [retry: 2, backoff: 10s]
+    b = @instance_attr_policies.action_with_instance_timeout(value=a) [timeout: 2m]
+    c = @instance_attr_policies.action_with_both_policies(value=b) [retry: 1] [timeout: 2m]
+    return c
+---
 f0: [4 registers]
   s0:
     ExtCallSet(ActionCall { dst: r1, action_ref: TestActionRef("action_with_instance_retry"), args: [r0], resume: s1 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_policy__integration_crash_recovery.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_policy__integration_crash_recovery.py__bytecode.snap
@@ -2,6 +2,13 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_policy/integration_crash_recovery.py
 ---
+fn main(input: [], output: []):
+    a = @integration_crash_recovery.step_one(value="start") [timeout: 2s]
+    b = @integration_crash_recovery.step_two(value=a) [timeout: 2s]
+    c = @integration_crash_recovery.step_three(value=b) [timeout: 2s]
+    d = @integration_crash_recovery.step_four(value=c) [timeout: 2s]
+    return d
+---
 f0: [5 registers]
   s0:
     PureSet(LoadConst { dst: r1, value: String("start") })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_policy__policy_variations.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_policy__policy_variations.py__bytecode.snap
@@ -2,6 +2,16 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_policy/policy_variations.py
 ---
+fn main(input: [value], output: []):
+    a = @policy_variations.action_with_timeout_int(value=value) [timeout: 1m]
+    b = @policy_variations.action_with_timeout_minutes(value=a) [timeout: 2m]
+    c = @policy_variations.action_with_retry_backoff(value=b) [retry: 2, backoff: 5s]
+    d = @policy_variations.action_with_retry_exceptions(value=c) [ValueError, KeyError -> retry: 1]
+    d_retry_default = @policy_variations.action_with_retry_default(value=d) [retry: 100]
+    e = @policy_variations.action_with_timeout_hours(value=d_retry_default) [timeout: 1h]
+    f = @policy_variations.action_with_timeout_days(value=e) [timeout: 24h]
+    return f
+---
 f0: [8 registers]
   s0:
     ExtCallSet(ActionCall { dst: r1, action_ref: TestActionRef("action_with_timeout_int"), args: [r0], resume: s1 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_side_effects__side_effect_action.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_side_effects__side_effect_action.py__bytecode.snap
@@ -2,6 +2,10 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_side_effects/side_effect_action.py
 ---
+fn main(input: [], output: []):
+    @side_effect_action.side_effect()
+    return
+---
 f0: [1 registers]
   s0:
     ExtCallSet(ActionCall { dst: r0, action_ref: TestActionRef("side_effect"), args: [], resume: s1 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_sleep__sleep_aliased_import.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_sleep__sleep_aliased_import.py__bytecode.snap
@@ -2,6 +2,12 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_sleep/sleep_aliased_import.py
 ---
+fn main(input: [], output: []):
+    val = @sleep_aliased_import.get_value_aliased_import()
+    sleep 3
+    _return_tmp = @sleep_aliased_import.format_done_aliased_import(value=val)
+    return _return_tmp
+---
 f0: [4 registers]
   s0:
     ExtCallSet(ActionCall { dst: r0, action_ref: TestActionRef("get_value_aliased_import"), args: [], resume: s1 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_sleep__sleep_from_import.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_sleep__sleep_from_import.py__bytecode.snap
@@ -2,6 +2,12 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_sleep/sleep_from_import.py
 ---
+fn main(input: [], output: []):
+    val = @sleep_from_import.get_value_from_import()
+    sleep 2
+    _return_tmp = @sleep_from_import.format_done_from_import(value=val)
+    return _return_tmp
+---
 f0: [4 registers]
   s0:
     ExtCallSet(ActionCall { dst: r0, action_ref: TestActionRef("get_value_from_import"), args: [], resume: s1 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_sleep__sleep_import_asyncio.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_sleep__sleep_import_asyncio.py__bytecode.snap
@@ -2,6 +2,12 @@
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
 expression: bytecode for python/tests/fixtures_sleep/sleep_import_asyncio.py
 ---
+fn main(input: [], output: []):
+    val = @sleep_import_asyncio.get_value_asyncio_import()
+    sleep 1
+    _return_tmp = @sleep_import_asyncio.format_done_asyncio_import(value=val)
+    return _return_tmp
+---
 f0: [4 registers]
   s0:
     ExtCallSet(ActionCall { dst: r0, action_ref: TestActionRef("get_value_asyncio_import"), args: [], resume: s1 })


### PR DESCRIPTION
This is an addition after the #413 that adds formatted ast to the compiler snapshots. This should result is a significant time reduction when reviewing the snapshots by presenting all the relevant content together and eliminating the need to navigate the files manually.

This doesn't yet cover the desired state from #410 discussion, but it's a substantial improvement in the direction of making the compiler development easier.