### PR TITLE
Eliminate synthetics from for loops

### DIFF
--- a/crates/lib/vm-compiler-for-ast-old/src/function/compiler/lowering/for_loop.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/function/compiler/lowering/for_loop.rs
@@ -18,9 +18,7 @@
 //! `enumerate(...)` is unwrapped during header classification to keep
 //! iteration mechanics independent of variable-binding shape.
 
-use waymark_vm_ast_old::{
-    Block, Expr, FunctionCall, GlobalFunction, Kwarg, Literal, Span, Spanned,
-};
+use waymark_vm_ast_old::{Block, Expr, FunctionCall, GlobalFunction, Kwarg, Literal, Spanned};
 use waymark_vm_bytecode_core::StateId;
 use waymark_vm_instructions_pureset::BinaryOpKind;
 use waymark_vm_runtime_core::RegisterId;
@@ -833,7 +831,11 @@ where
         target_register: RegisterId,
         value: i64,
     ) -> Result<(), ErrorFor<Spec, Lowering>> {
-        self.compile_expr_into_register(&synthetic_int_expr(value), target_register)
+        let literal = self.lower_int_literal(value)?;
+        self.context
+            .emitter
+            .emit_load_const(target_register, literal);
+        Ok(())
     }
 
     /// Compiles an integer literal into a temporary register.
@@ -841,10 +843,19 @@ where
         &mut self,
         value: i64,
     ) -> Result<RegisterHandle, ErrorFor<Spec, Lowering>> {
-        self.value_compiler().compile_expr(
-            &synthetic_int_expr(value),
-            super::value::ResultTarget::Allocate,
-        )
+        let register =
+            RegisterHandle::Temporary(self.context.local_frame.allocate_temporary_register());
+        self.emit_int_literal_into_register(register.register(), value)?;
+        Ok(register)
+    }
+
+    /// Lowers an integer literal into the target VM constant representation.
+    fn lower_int_literal(
+        &self,
+        value: i64,
+    ) -> Result<<Spec as waymark_vm_instructions_pureset::Spec>::ConstValue, ErrorFor<Spec, Lowering>>
+    {
+        Lowering::lower_literal(&Literal::Int(value)).map_err(Error::LiteralLowering)
     }
 
     /// Emits `target_register = target_register + immediate`.
@@ -890,19 +901,4 @@ fn builtin_call_name(call: &FunctionCall, fallback: &str) -> String {
     }
 
     call.name.clone()
-}
-
-/// Creates a synthetic integer literal expression for compiler-internal lowering.
-fn synthetic_int_expr(value: i64) -> Spanned<Expr> {
-    Spanned {
-        value: Expr::Literal {
-            value: Literal::Int(value),
-        },
-        span: Span {
-            start_line: 0,
-            start_col: 0,
-            end_line: 0,
-            end_col: 0,
-        },
-    }
 }

--- a/crates/lib/vm-compiler-for-ast-old/src/tests/for_loops.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/tests/for_loops.rs
@@ -174,7 +174,31 @@ fn compiles_for_loops_over_single_arg_range() {
         ],
     )]);
 
-    compile::<TestSpec, TestLowering>(&program).expect("range(stop) for loops should compile");
+    let executable =
+        compile::<TestSpec, TestLowering>(&program).expect("range(stop) for loops should compile");
+
+    insta::assert_snapshot!(waymark_vm_bytecode_fmt::display(&executable), @r#"
+    f0: [5 registers]
+      s0:
+        PureSet(LoadConst { dst: r0, value: Int(0) })
+        PureSet(LoadConst { dst: r1, value: Int(0) })
+        PureSet(LoadConst { dst: r2, value: Int(4) })
+        CoreSet(Jump { target_state: s1 })
+      s1:
+        PureSet(Binary { kind: Lt, op: BinaryOp { dst: r3, a: r1, b: r2 } })
+        CoreSet(JumpIf { target_state: s2, cond: r3 })
+        CoreSet(Jump { target_state: s4 })
+      s2:
+        PureSet(Copy { dst: r4, src: r1 })
+        PureSet(Binary { kind: Add, op: BinaryOp { dst: r0, a: r0, b: r4 } })
+        CoreSet(Jump { target_state: s3 })
+      s3:
+        PureSet(LoadConst { dst: r3, value: Int(1) })
+        PureSet(Binary { kind: Add, op: BinaryOp { dst: r1, a: r1, b: r3 } })
+        CoreSet(Jump { target_state: s1 })
+      s4:
+        CoreSet(Return { src: r0 })
+    "#);
 }
 
 #[test]


### PR DESCRIPTION
This is a simple PR that switches from the synthetic ast generation to direct literal lowering in the for loops.

The other synthetics eliminations I mentioned (spreads) are internalized in the initial PR that adds their support (in fact, none of the initial ones I've used for local PoC were necessary with the last reworks).