### PR TITLE
Implement spreads support

### DIFF
--- a/crates/lib/vm-ast-old-helpers/src/lib.rs
+++ b/crates/lib/vm-ast-old-helpers/src/lib.rs
@@ -86,6 +86,26 @@ pub fn parallel_expr(calls: Vec<Call>) -> Spanned<Expr> {
     spanned(Expr::ParallelExpr { calls })
 }
 
+pub fn spread_stmt(
+    collection: Spanned<Expr>,
+    loop_var: &str,
+    action: ActionCall,
+) -> Spanned<Statement> {
+    spanned(Statement::SpreadAction {
+        collection,
+        loop_var: loop_var.to_owned(),
+        action,
+    })
+}
+
+pub fn spread_expr(collection: Spanned<Expr>, loop_var: &str, action: ActionCall) -> Spanned<Expr> {
+    spanned(Expr::SpreadExpr {
+        collection: Box::new(collection),
+        loop_var: loop_var.to_owned(),
+        action,
+    })
+}
+
 pub fn conditional_stmt(
     if_condition: Spanned<Expr>,
     if_body: Vec<Spanned<Statement>>,

--- a/crates/lib/vm-compiler-for-ast-old/src/function/compiler/lowering/assignment.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/function/compiler/lowering/assignment.rs
@@ -1,6 +1,6 @@
 //! Assignment lowering.
 
-use waymark_vm_ast_old::{Expr, Spanned};
+use waymark_vm_ast_old::{ActionCall, Expr, Spanned};
 
 use crate::Marked;
 use crate::function::compiler::env::AssignmentTargetMarker;
@@ -8,8 +8,10 @@ use crate::function::compiler::env::LocalSlot;
 
 use super::CompilerContextMut;
 use super::ErrorFor;
+use super::ForLoopCompiler;
 use super::ParallelCompiler;
 use super::ValueCompiler;
+use super::r#loop::LoopControlStack;
 use super::plan::assignment::AssignmentStatementPlan;
 
 /// Lowers assignment statements into bytecode.
@@ -58,6 +60,14 @@ where
             AssignmentStatementPlan::Direct { target, value } => {
                 self.compile_direct_assignment(target, value)?;
             }
+            AssignmentStatementPlan::Spread {
+                target,
+                collection,
+                loop_var,
+                action,
+            } => {
+                self.compile_spread_assignment(target, collection, loop_var, action)?;
+            }
             AssignmentStatementPlan::Parallel { assignment } => {
                 self.parallel_compiler().compile_assignment(assignment)?;
             }
@@ -87,6 +97,32 @@ where
         Ok(())
     }
 
+    /// Compiles one spread-expression assignment into a collected result list.
+    fn compile_spread_assignment(
+        &mut self,
+        target: Marked<LocalSlot, AssignmentTargetMarker>,
+        collection: &Spanned<Expr>,
+        loop_var: &str,
+        action: &ActionCall,
+    ) -> Result<(), ErrorFor<Spec, Lowering>> {
+        let accumulator_register = self.context.local_frame.allocate_register();
+        self.for_loop_compiler().compile_spread_expr(
+            collection,
+            loop_var,
+            action,
+            accumulator_register,
+        )?;
+
+        if accumulator_register != target.register() {
+            self.context
+                .emitter
+                .emit_copy(target.register(), accumulator_register);
+        }
+
+        target.mark_initialized(self.context.flow_state);
+        Ok(())
+    }
+
     /// Creates a value compiler borrowing the current context.
     fn value_compiler(&mut self) -> ValueCompiler<'_, 'table, Spec, Lowering> {
         ValueCompiler::new(self.context.reborrow_ref())
@@ -95,6 +131,11 @@ where
     /// Creates a parallel compiler borrowing the current context mutably.
     fn parallel_compiler(&mut self) -> ParallelCompiler<'_, 'table, Spec, Lowering> {
         ParallelCompiler::new(self.context.reborrow_mut())
+    }
+
+    /// Creates a for-loop compiler for internal spread lowering.
+    fn for_loop_compiler(&mut self) -> ForLoopCompiler<'_, 'table, Spec, Lowering> {
+        ForLoopCompiler::new(self.context.reborrow_mut(), LoopControlStack::new())
     }
 }
 

--- a/crates/lib/vm-compiler-for-ast-old/src/function/compiler/lowering/for_loop.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/function/compiler/lowering/for_loop.rs
@@ -18,10 +18,14 @@
 //! `enumerate(...)` is unwrapped during header classification to keep
 //! iteration mechanics independent of variable-binding shape.
 
-use waymark_vm_ast_old::{Block, Expr, FunctionCall, GlobalFunction, Kwarg, Literal, Spanned};
+use waymark_vm_ast_old::{
+    ActionCall, Block, Expr, FunctionCall, GlobalFunction, Kwarg, Literal, Spanned,
+};
 use waymark_vm_bytecode_core::StateId;
 use waymark_vm_instructions_pureset::BinaryOpKind;
 use waymark_vm_runtime_core::RegisterId;
+
+use crate::Marked;
 
 use super::CompilerContextMut;
 use super::ErrorFor;
@@ -32,6 +36,7 @@ use super::env::{FlowState, RegisterHandle};
 use super::r#loop::LoopControlStack;
 use super::plan::call::UnsupportedFunctionCall;
 use super::plan::r#loop::ForLoopPlan;
+use super::suspend::PromiseMarker;
 use super::{Error, LoopControlKind};
 
 /// Lowers `for` loops into bytecode states and register updates.
@@ -258,6 +263,87 @@ where
         }
     }
 
+    /// Compiles a spread statement as a looped series of action calls.
+    pub fn compile_spread_statement(
+        &mut self,
+        iterable: &Spanned<Expr>,
+        loop_var: &str,
+        action: &ActionCall,
+    ) -> Result<(), ErrorFor<Spec, Lowering>> {
+        let promises_register = self.context.local_frame.allocate_register();
+        self.context
+            .emitter
+            .emit_make_list(promises_register, Vec::new());
+
+        match ResolvedForLoop::build::<Spec, Lowering>(iterable)? {
+            ResolvedForLoop::Indexed { iterable, .. } => {
+                self.compile_indexed_spread(iterable, loop_var, action, promises_register)?
+            }
+            ResolvedForLoop::Range {
+                range: RangeLoop::Positive { start, end },
+                ..
+            } => {
+                self.compile_positive_range_spread(start, end, loop_var, action, promises_register)?
+            }
+            ResolvedForLoop::Range {
+                range: RangeLoop::Stepped { start, end, step },
+                ..
+            } => self.compile_stepped_range_spread(
+                start,
+                end,
+                step,
+                loop_var,
+                action,
+                promises_register,
+            )?,
+        }
+
+        self.compile_spread_join(promises_register, None, iterable)
+    }
+
+    /// Compiles a spread expression into `result_register`.
+    pub fn compile_spread_expr(
+        &mut self,
+        iterable: &Spanned<Expr>,
+        loop_var: &str,
+        action: &ActionCall,
+        result_register: RegisterId,
+    ) -> Result<(), ErrorFor<Spec, Lowering>> {
+        self.context
+            .emitter
+            .emit_make_list(result_register, Vec::new());
+
+        let promises_register = self.context.local_frame.allocate_register();
+        self.context
+            .emitter
+            .emit_make_list(promises_register, Vec::new());
+
+        match ResolvedForLoop::build::<Spec, Lowering>(iterable)? {
+            ResolvedForLoop::Indexed { iterable, .. } => {
+                self.compile_indexed_spread(iterable, loop_var, action, promises_register)?
+            }
+            ResolvedForLoop::Range {
+                range: RangeLoop::Positive { start, end },
+                ..
+            } => {
+                self.compile_positive_range_spread(start, end, loop_var, action, promises_register)?
+            }
+            ResolvedForLoop::Range {
+                range: RangeLoop::Stepped { start, end, step },
+                ..
+            } => self.compile_stepped_range_spread(
+                start,
+                end,
+                step,
+                loop_var,
+                action,
+                promises_register,
+            )?,
+        }
+
+        self.compile_spread_join(promises_register, Some(result_register), iterable)
+    }
+
     /// Compiles a `for` loop that walks an arbitrary indexable iterable
     /// (lists, tuples, strings, etc.) by stepping through `0..len(iterable)`.
     ///
@@ -320,6 +406,57 @@ where
                     binding,
                     item_register.register(),
                     Some(index_register),
+                )
+            },
+            |compiler| compiler.emit_add_assign_immediate(index_register, 1),
+        )
+    }
+
+    /// Compiles a spread over an indexed iterable.
+    fn compile_indexed_spread(
+        &mut self,
+        iterable: &Spanned<Expr>,
+        loop_var: &str,
+        action: &ActionCall,
+        promises_register: RegisterId,
+    ) -> Result<(), ErrorFor<Spec, Lowering>> {
+        let iterable_register = self.context.local_frame.allocate_register();
+        self.compile_expr_into_register(iterable, iterable_register)?;
+
+        let index_register = self.context.local_frame.allocate_register();
+        self.emit_int_literal_into_register(index_register, 0)?;
+
+        let length_register = self.context.local_frame.allocate_register();
+        self.context
+            .emitter
+            .emit_length(length_register, iterable_register);
+
+        let empty_body = self.empty_block(iterable);
+
+        self.compile_loop_skeleton(
+            &empty_body,
+            |compiler, for_loop| {
+                compiler.emit_compare_and_branch(
+                    BinaryOpKind::Lt,
+                    index_register,
+                    length_register,
+                    for_loop.body_state(),
+                    for_loop.loop_scope().target(LoopControlKind::Break),
+                );
+                Ok(())
+            },
+            |compiler| {
+                let item_register = compiler.context.local_frame.allocate_temporary_register();
+                compiler.context.emitter.emit_index(
+                    item_register.register(),
+                    iterable_register,
+                    index_register,
+                );
+                compiler.compile_spread_fanout_iteration(
+                    loop_var,
+                    item_register.register(),
+                    action,
+                    promises_register,
                 )
             },
             |compiler| compiler.emit_add_assign_immediate(index_register, 1),
@@ -389,6 +526,50 @@ where
                 compiler.emit_add_assign_immediate(current_register, 1)?;
                 compiler.emit_enumerate_increment(enumerate_index_register)
             },
+        )
+    }
+
+    /// Compiles a spread over `range(stop)` or `range(start, stop)`.
+    fn compile_positive_range_spread(
+        &mut self,
+        start: Option<&Spanned<Expr>>,
+        end: &Spanned<Expr>,
+        loop_var: &str,
+        action: &ActionCall,
+        promises_register: RegisterId,
+    ) -> Result<(), ErrorFor<Spec, Lowering>> {
+        let current_register = self.context.local_frame.allocate_register();
+        match start {
+            Some(start) => self.compile_expr_into_register(start, current_register)?,
+            None => self.emit_int_literal_into_register(current_register, 0)?,
+        }
+
+        let end_register = self.context.local_frame.allocate_register();
+        self.compile_expr_into_register(end, end_register)?;
+
+        let empty_body = self.empty_block(end);
+
+        self.compile_loop_skeleton(
+            &empty_body,
+            |compiler, for_loop| {
+                compiler.emit_compare_and_branch(
+                    BinaryOpKind::Lt,
+                    current_register,
+                    end_register,
+                    for_loop.body_state(),
+                    for_loop.loop_scope().target(LoopControlKind::Break),
+                );
+                Ok(())
+            },
+            |compiler| {
+                compiler.compile_spread_fanout_iteration(
+                    loop_var,
+                    current_register,
+                    action,
+                    promises_register,
+                )
+            },
+            |compiler| compiler.emit_add_assign_immediate(current_register, 1),
         )
     }
 
@@ -512,6 +693,142 @@ where
                 );
                 compiler.emit_enumerate_increment(enumerate_index_register)
             },
+        )
+    }
+
+    /// Compiles a spread over `range(start, end, step)`.
+    fn compile_stepped_range_spread(
+        &mut self,
+        start: &Spanned<Expr>,
+        end: &Spanned<Expr>,
+        step: &Spanned<Expr>,
+        loop_var: &str,
+        action: &ActionCall,
+        promises_register: RegisterId,
+    ) -> Result<(), ErrorFor<Spec, Lowering>> {
+        let current_register = self.context.local_frame.allocate_register();
+        self.compile_expr_into_register(start, current_register)?;
+
+        let end_register = self.context.local_frame.allocate_register();
+        self.compile_expr_into_register(end, end_register)?;
+
+        let step_register = self.context.local_frame.allocate_register();
+        self.compile_expr_into_register(step, step_register)?;
+
+        let empty_body = self.empty_block(step);
+
+        self.compile_loop_skeleton(
+            &empty_body,
+            |compiler, for_loop| {
+                let break_target = for_loop.loop_scope().target(LoopControlKind::Break);
+                let incoming_flow = for_loop.condition_flow();
+
+                let positive_condition_state = compiler.new_state();
+                let negative_condition_state = compiler.new_state();
+
+                let zero_register = compiler.compile_temporary_int_literal(0)?;
+                let positive_register = compiler.context.local_frame.allocate_temporary_register();
+                compiler.context.emitter.emit_binary(
+                    BinaryOpKind::Gt,
+                    positive_register.register(),
+                    step_register,
+                    zero_register.register(),
+                );
+                compiler
+                    .context
+                    .emitter
+                    .emit_jump_if(positive_condition_state, positive_register.register());
+
+                let negative_register = compiler.context.local_frame.allocate_temporary_register();
+                compiler.context.emitter.emit_binary(
+                    BinaryOpKind::Lt,
+                    negative_register.register(),
+                    step_register,
+                    zero_register.register(),
+                );
+                compiler
+                    .context
+                    .emitter
+                    .emit_jump_if(negative_condition_state, negative_register.register());
+                compiler.context.emitter.emit_jump(break_target);
+
+                compiler.switch_to_with_flow(positive_condition_state, incoming_flow.clone());
+                compiler.emit_compare_and_branch(
+                    BinaryOpKind::Lt,
+                    current_register,
+                    end_register,
+                    for_loop.body_state(),
+                    break_target,
+                );
+
+                compiler.switch_to_with_flow(negative_condition_state, incoming_flow);
+                compiler.emit_compare_and_branch(
+                    BinaryOpKind::Gt,
+                    current_register,
+                    end_register,
+                    for_loop.body_state(),
+                    break_target,
+                );
+
+                Ok(())
+            },
+            |compiler| {
+                compiler.compile_spread_fanout_iteration(
+                    loop_var,
+                    current_register,
+                    action,
+                    promises_register,
+                )
+            },
+            |compiler| {
+                compiler.context.emitter.emit_binary(
+                    BinaryOpKind::Add,
+                    current_register,
+                    current_register,
+                    step_register,
+                );
+                Ok(())
+            },
+        )
+    }
+
+    /// Awaits all fan-out promises after the spread has started them.
+    fn compile_spread_join(
+        &mut self,
+        promises_register: RegisterId,
+        result_register: Option<RegisterId>,
+        template: &Spanned<Expr>,
+    ) -> Result<(), ErrorFor<Spec, Lowering>> {
+        let index_register = self.context.local_frame.allocate_register();
+        self.emit_int_literal_into_register(index_register, 0)?;
+
+        let length_register = self.context.local_frame.allocate_register();
+        self.context
+            .emitter
+            .emit_length(length_register, promises_register);
+
+        let empty_body = self.empty_block(template);
+
+        self.compile_loop_skeleton(
+            &empty_body,
+            |compiler, for_loop| {
+                compiler.emit_compare_and_branch(
+                    BinaryOpKind::Lt,
+                    index_register,
+                    length_register,
+                    for_loop.body_state(),
+                    for_loop.loop_scope().target(LoopControlKind::Break),
+                );
+                Ok(())
+            },
+            |compiler| {
+                compiler.compile_spread_join_iteration(
+                    promises_register,
+                    index_register,
+                    result_register,
+                )
+            },
+            |compiler| compiler.emit_add_assign_immediate(index_register, 1),
         )
     }
 
@@ -789,6 +1106,82 @@ where
                 .emit_copy(target.register(), source_register);
         }
         self.context.flow_state.mark_initialized(target);
+    }
+
+    /// Starts one spread action and appends the pending promise to the list.
+    fn compile_spread_fanout_iteration(
+        &mut self,
+        loop_var: &str,
+        item_register: RegisterId,
+        action: &ActionCall,
+        promises_register: RegisterId,
+    ) -> Result<(), ErrorFor<Spec, Lowering>> {
+        let promise_register = self.start_spread_action(loop_var, item_register, action)?;
+        self.append_list_item(promises_register, promise_register.register());
+
+        Ok(())
+    }
+
+    /// Awaits one previously-started spread promise and optionally collects it.
+    fn compile_spread_join_iteration(
+        &mut self,
+        promises_register: RegisterId,
+        index_register: RegisterId,
+        result_register: Option<RegisterId>,
+    ) -> Result<(), ErrorFor<Spec, Lowering>> {
+        let promise_register = Marked::mark(RegisterHandle::Temporary(
+            self.context.local_frame.allocate_temporary_register(),
+        ));
+        self.context.emitter.emit_index(
+            promise_register.register(),
+            promises_register,
+            index_register,
+        );
+        self.value_compiler()
+            .compile_await(promise_register.register(), &promise_register);
+
+        if let Some(result_register) = result_register {
+            self.append_list_item(result_register, promise_register.register());
+        }
+
+        Ok(())
+    }
+
+    /// Starts the spread action call with the current loop item bound.
+    fn start_spread_action(
+        &mut self,
+        loop_var: &str,
+        item_register: RegisterId,
+        action: &ActionCall,
+    ) -> Result<Marked<RegisterHandle, PromiseMarker>, ErrorFor<Spec, Lowering>> {
+        let mut value_compiler = self
+            .value_compiler()
+            .with_scoped_binding(loop_var, item_register);
+        value_compiler.compile_action_start(action, super::value::ResultTarget::Allocate)
+    }
+
+    /// Appends one item register into a list accumulator.
+    fn append_list_item(&mut self, list_register: RegisterId, item_register: RegisterId) {
+        let single_item_register = self.context.local_frame.allocate_temporary_register();
+        self.context
+            .emitter
+            .emit_make_list(single_item_register.register(), vec![item_register]);
+        self.context.emitter.emit_binary(
+            BinaryOpKind::Add,
+            list_register,
+            list_register,
+            single_item_register.register(),
+        );
+    }
+
+    /// Builds an empty block that lets spread lowering reuse the shared loop skeleton.
+    fn empty_block(&self, template: &Spanned<Expr>) -> Spanned<Block> {
+        Spanned {
+            value: Block {
+                statements: Vec::new(),
+            },
+            span: template.span,
+        }
     }
 
     /// Switches the emitter and flow state to a reserved state id.

--- a/crates/lib/vm-compiler-for-ast-old/src/function/compiler/lowering/statement.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/function/compiler/lowering/statement.rs
@@ -1,6 +1,8 @@
 //! Statement lowering.
 
-use waymark_vm_ast_old::{Block, ElifBranch, ElseBranch, Expr, IfBranch, Spanned, Statement};
+use waymark_vm_ast_old::{
+    ActionCall, Block, ElifBranch, ElseBranch, Expr, IfBranch, Spanned, Statement,
+};
 
 use super::AssignmentCompiler;
 use super::CompilerContextMut;
@@ -88,6 +90,13 @@ where
             }
             StatementPlan::ActionCall { call } => {
                 self.value_compiler().compile_action_statement(call)?;
+            }
+            StatementPlan::SpreadAction {
+                collection,
+                loop_var,
+                action,
+            } => {
+                self.compile_spread_action(collection, loop_var, action)?;
             }
             StatementPlan::Return { value } => {
                 self.value_compiler().compile_return_statement(value)?;
@@ -272,6 +281,17 @@ where
         body: &Spanned<Block>,
     ) -> Result<(), ErrorFor<Spec, Lowering>> {
         self.for_loop_compiler().compile(loop_vars, iterable, body)
+    }
+
+    /// Compiles a spread statement as an internal loop over action calls.
+    fn compile_spread_action(
+        &mut self,
+        collection: &Spanned<Expr>,
+        loop_var: &str,
+        action: &ActionCall,
+    ) -> Result<(), ErrorFor<Spec, Lowering>> {
+        self.for_loop_compiler()
+            .compile_spread_statement(collection, loop_var, action)
     }
 
     /// Compiles a `break` statement.

--- a/crates/lib/vm-compiler-for-ast-old/src/function/compiler/lowering/value.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/function/compiler/lowering/value.rs
@@ -26,6 +26,9 @@ where
 {
     /// Shared compiler context used for value lowering.
     context: CompilerContextRef<'borrow, 'table, Spec, Lowering>,
+
+    /// Optional register binding that shadows one local variable name.
+    scoped_binding: Option<ScopedVariableBinding>,
 }
 
 /// Where an expression result should be written.
@@ -38,6 +41,16 @@ pub enum ResultTarget {
     Existing(RegisterId),
 }
 
+/// One temporary variable binding injected by a higher-level lowering helper.
+#[derive(Debug, Clone)]
+struct ScopedVariableBinding {
+    /// Variable name to shadow during value compilation.
+    name: String,
+
+    /// Register that should satisfy reads of `name`.
+    register: RegisterId,
+}
+
 impl<'borrow, 'table, Spec, Lowering> ValueCompiler<'borrow, 'table, Spec, Lowering>
 where
     Spec: waymark_vm_compiler_for_ast_old_core::SpecRequirements,
@@ -45,7 +58,19 @@ where
 {
     /// Creates a value compiler over the provided context.
     pub fn new(context: CompilerContextRef<'borrow, 'table, Spec, Lowering>) -> Self {
-        Self { context }
+        Self {
+            context,
+            scoped_binding: None,
+        }
+    }
+
+    /// Returns a compiler view where reads of `name` resolve to `register`.
+    pub fn with_scoped_binding(mut self, name: impl Into<String>, register: RegisterId) -> Self {
+        self.scoped_binding = Some(ScopedVariableBinding {
+            name: name.into(),
+            register,
+        });
+        self
     }
 
     /// Compiles an expression and returns the register containing its result.
@@ -86,12 +111,30 @@ where
         self.compile_literal(&Literal::None, ResultTarget::Allocate)
     }
 
+    /// Compiles an action call used as a value expression.
+    pub fn compile_action_expr(
+        &mut self,
+        call: &ActionCall,
+        target: ResultTarget,
+    ) -> Result<RegisterHandle, ErrorFor<Spec, Lowering>> {
+        self.compile_call(self.plan_action_call(call)?, target)
+    }
+
+    /// Starts an action call and returns the promise register that holds it.
+    pub fn compile_action_start(
+        &mut self,
+        call: &ActionCall,
+        target: ResultTarget,
+    ) -> Result<Marked<RegisterHandle, PromiseMarker>, ErrorFor<Spec, Lowering>> {
+        self.compile_call_start(self.plan_action_call(call)?, target)
+    }
+
     /// Compiles an action call used as a statement.
     pub fn compile_action_statement(
         &mut self,
         call: &ActionCall,
     ) -> Result<(), ErrorFor<Spec, Lowering>> {
-        let _ = self.compile_call(self.plan_action_call(call)?, ResultTarget::Allocate)?;
+        let _ = self.compile_action_expr(call, ResultTarget::Allocate)?;
         Ok(())
     }
 
@@ -412,6 +455,12 @@ where
 
     /// Resolves an initialized local variable into its register.
     fn resolve_variable(&self, name: &str) -> Result<RegisterHandle, ErrorFor<Spec, Lowering>> {
+        if let Some(binding) = &self.scoped_binding
+            && binding.name == name
+        {
+            return Ok(RegisterHandle::Existing(binding.register));
+        }
+
         let Some(local) = self
             .context
             .local_frame

--- a/crates/lib/vm-compiler-for-ast-old/src/function/compiler/plan/assignment.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/function/compiler/plan/assignment.rs
@@ -1,7 +1,7 @@
 //! Assignment planning.
 
 use nonempty_collections::NESlice;
-use waymark_vm_ast_old::{Expr, Spanned};
+use waymark_vm_ast_old::{ActionCall, Expr, Spanned};
 
 use super::ErrorFor;
 use super::parallel::ParallelAssignmentPlan;
@@ -23,6 +23,21 @@ where
 
         /// Expression to evaluate and assign.
         value: &'a Spanned<Expr>,
+    },
+
+    /// A spread expression assignment lowered through looped action fan-out.
+    Spread {
+        /// Assignment target that will receive the collected list.
+        target: Marked<LocalSlot, AssignmentTargetMarker>,
+
+        /// Collection expression evaluated by the spread.
+        collection: &'a Spanned<Expr>,
+
+        /// Loop variable bound for each spread item.
+        loop_var: &'a str,
+
+        /// Action invoked per collection item.
+        action: &'a ActionCall,
     },
 
     /// An assignment sourced from a parallel expression.
@@ -69,6 +84,20 @@ where
             .into());
         }
 
+        if let Expr::SpreadExpr {
+            collection,
+            loop_var,
+            action,
+        } = &value.value
+        {
+            return Ok(Self::Spread {
+                target: resolve_target(&targets[0]),
+                collection,
+                loop_var,
+                action,
+            });
+        }
+
         Ok(Self::Direct {
             target: resolve_target(&targets[0]),
             value,
@@ -82,7 +111,7 @@ mod tests {
 
     use nonempty_collections::{IntoNonEmptyIterator as _, NonEmptyIterator as _};
     use waymark_vm_ast_old::Expr;
-    use waymark_vm_ast_old_helpers::{action_call, int, parallel_expr};
+    use waymark_vm_ast_old_helpers::{action_call, int, parallel_expr, spread_expr, variable};
     use waymark_vm_compiler_for_ast_old_test_support::{TestLowering, TestSpec};
     use waymark_vm_runtime_core::RegisterId;
 
@@ -133,6 +162,9 @@ mod tests {
             }
             AssignmentStatementPlan::Parallel { .. } => {
                 panic!("non-parallel assignment should build a direct plan")
+            }
+            AssignmentStatementPlan::Spread { .. } => {
+                panic!("literal assignments should not build spread plans")
             }
         }
     }
@@ -250,6 +282,9 @@ mod tests {
             AssignmentStatementPlan::Direct { .. } => {
                 panic!("parallel expressions should build a parallel assignment plan")
             }
+            AssignmentStatementPlan::Spread { .. } => {
+                panic!("parallel expressions should not build spread plans")
+            }
         }
     }
 
@@ -268,6 +303,53 @@ mod tests {
             error,
             Error::Unsupported(crate::function::compiler::plan::Unsupported::AssignmentNoTargets)
         ));
+    }
+
+    #[test]
+    fn spread_assignment_resolves_single_target_and_preserves_payload() {
+        let function_table = build_function_table();
+        let mut local_frame = LocalFrame::new();
+        let mut flow_state = FlowState::new();
+        let targets = vec!["results".to_owned()];
+        let value = spread_expr(
+            variable("items"),
+            "item",
+            action_call("double", vec![("value", variable("item"))]),
+        );
+
+        let plan = AssignmentStatementPlan::<TestSpec>::build::<TestLowering, _>(
+            &targets,
+            &value,
+            &function_table,
+            |target| {
+                Marked::<LocalSlot, AssignmentTargetMarker>::get_or_declare(
+                    &mut local_frame,
+                    &mut flow_state,
+                    target,
+                )
+            },
+        )
+        .expect("spread assignment should build");
+
+        match plan {
+            AssignmentStatementPlan::Spread {
+                target,
+                collection,
+                loop_var,
+                action,
+            } => {
+                assert_eq!(target.register(), RegisterId(0));
+                assert!(matches!(collection.value, Expr::Variable { ref name } if name == "items"));
+                assert_eq!(loop_var, "item");
+                assert_eq!(action.action_name, "double");
+            }
+            AssignmentStatementPlan::Direct { .. } => {
+                panic!("spread expressions should build spread plans")
+            }
+            AssignmentStatementPlan::Parallel { .. } => {
+                panic!("spread expressions should not build parallel plans")
+            }
+        }
     }
 
     #[test]

--- a/crates/lib/vm-compiler-for-ast-old/src/function/compiler/plan/statement.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/function/compiler/plan/statement.rs
@@ -31,6 +31,18 @@ where
         call: &'a ActionCall,
     },
 
+    /// Fan out one action call across a collection.
+    SpreadAction {
+        /// Collection expression evaluated by the spread.
+        collection: &'a Spanned<Expr>,
+
+        /// Loop variable bound for each collection item.
+        loop_var: &'a str,
+
+        /// Action invoked for every item.
+        action: &'a ActionCall,
+    },
+
     /// Return from the current function.
     Return {
         /// Optional expression whose value should be returned.
@@ -98,9 +110,6 @@ where
 /// Statement variants that the current lowering pipeline rejects.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum UnsupportedStatementKind {
-    /// Spread-action statements.
-    SpreadAction,
-
     /// `try`/`except` blocks.
     TryExcept,
 }
@@ -120,6 +129,15 @@ where
         match statement {
             Statement::Assignment { targets, value } => Ok(Self::Assignment { targets, value }),
             Statement::ActionCall { call } => Ok(Self::ActionCall { call }),
+            Statement::SpreadAction {
+                collection,
+                loop_var,
+                action,
+            } => Ok(Self::SpreadAction {
+                collection,
+                loop_var,
+                action,
+            }),
             Statement::Return { value } => Ok(Self::Return {
                 value: value.as_ref(),
             }),
@@ -149,10 +167,6 @@ where
             }),
             Statement::Break => Ok(Self::Break),
             Statement::Continue => Ok(Self::Continue),
-            Statement::SpreadAction { .. } => Err(Unsupported::Statement {
-                kind: UnsupportedStatementKind::SpreadAction,
-            }
-            .into()),
             Statement::TryExcept { .. } => Err(Unsupported::Statement {
                 kind: UnsupportedStatementKind::TryExcept,
             }
@@ -164,7 +178,6 @@ where
 impl core::fmt::Display for UnsupportedStatementKind {
     fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         formatter.write_str(match self {
-            Self::SpreadAction => "SpreadAction",
             Self::TryExcept => "TryExcept",
         })
     }
@@ -231,6 +244,11 @@ mod tests {
             "notify",
             Vec::new(),
         ))]);
+        let spread = spanned(Statement::SpreadAction {
+            collection: variable("items"),
+            loop_var: "item".to_owned(),
+            action: action_call("notify", vec![("value", variable("item"))]),
+        });
 
         assert!(matches!(
             StatementPlan::<TestSpec>::build::<TestLowering>(&conditional.value, &function_table)
@@ -253,6 +271,15 @@ mod tests {
             StatementPlan::ParallelBlock { .. }
         ));
         assert!(matches!(
+            StatementPlan::<TestSpec>::build::<TestLowering>(&spread.value, &function_table)
+                .expect("spread actions should build"),
+            StatementPlan::SpreadAction {
+                loop_var,
+                action,
+                ..
+            } if loop_var == "item" && action.action_name == "notify"
+        ));
+        assert!(matches!(
             StatementPlan::<TestSpec>::build::<TestLowering>(&break_stmt().value, &function_table)
                 .expect("break should build"),
             StatementPlan::<TestSpec>::Break
@@ -270,23 +297,13 @@ mod tests {
     #[test]
     fn rejects_unsupported_statement_variants() {
         let function_table = build_function_table();
-        let unsupported = [
-            (
-                spanned(Statement::SpreadAction {
-                    collection: variable("items"),
-                    loop_var: "item".to_owned(),
-                    action: action_call("notify", Vec::new()),
-                }),
-                UnsupportedStatementKind::SpreadAction,
-            ),
-            (
-                spanned(Statement::TryExcept {
-                    handlers: Vec::<Spanned<waymark_vm_ast_old::ExceptHandler>>::new(),
-                    try_block: block(Vec::new()),
-                }),
-                UnsupportedStatementKind::TryExcept,
-            ),
-        ];
+        let unsupported = [(
+            spanned(Statement::TryExcept {
+                handlers: Vec::<Spanned<waymark_vm_ast_old::ExceptHandler>>::new(),
+                try_block: block(Vec::new()),
+            }),
+            UnsupportedStatementKind::TryExcept,
+        )];
 
         for (statement, kind) in unsupported {
             let error =

--- a/crates/lib/vm-compiler-for-ast-old/src/tests/mod.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/tests/mod.rs
@@ -12,6 +12,7 @@ mod function_table;
 mod loops;
 mod lowering_errors;
 mod parallel;
+mod spreads;
 mod variables;
 
 /// Distinguishable error variant raised by [`ActionFailingLowering`] so tests

--- a/crates/lib/vm-compiler-for-ast-old/src/tests/spreads.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/tests/spreads.rs
@@ -1,0 +1,96 @@
+//! Tests for spread-statement and spread-expression lowering.
+
+use waymark_vm_ast_old_helpers::{
+    action_call, assignment, function, program, return_stmt, spread_expr, spread_stmt, variable,
+};
+use waymark_vm_compiler_for_ast_old_test_support::{TestLowering, TestSpec};
+
+use crate::compile;
+
+#[test]
+fn compiles_spread_action_statements() {
+    let program = program(vec![function(
+        "main",
+        &["items"],
+        vec![
+            spread_stmt(
+                variable("items"),
+                "item",
+                action_call("notify", vec![("value", variable("item"))]),
+            ),
+            return_stmt(None),
+        ],
+    )]);
+
+    compile::<TestSpec, TestLowering>(&program).expect("spread statements should compile");
+}
+
+#[test]
+fn spread_expression_assignments_lower_to_looped_action_collection() {
+    let program = program(vec![function(
+        "main",
+        &["items"],
+        vec![
+            assignment(
+                "results",
+                spread_expr(
+                    variable("items"),
+                    "item",
+                    action_call("double", vec![("value", variable("item"))]),
+                ),
+            ),
+            return_stmt(Some(variable("results"))),
+        ],
+    )]);
+
+    let executable =
+        compile::<TestSpec, TestLowering>(&program).expect("spread expressions should compile");
+
+    insta::assert_snapshot!(waymark_vm_bytecode_fmt::display(&executable), @r#"
+    f0: [12 registers]
+      s0:
+        PureSet(MakeList { dst: r2, items: [] })
+        PureSet(MakeList { dst: r3, items: [] })
+        PureSet(Copy { dst: r4, src: r0 })
+        PureSet(LoadConst { dst: r5, value: Int(0) })
+        PureSet(Length { dst: r6, src: r4 })
+        CoreSet(Jump { target_state: s1 })
+      s1:
+        PureSet(Binary { kind: Lt, op: BinaryOp { dst: r7, a: r5, b: r6 } })
+        CoreSet(JumpIf { target_state: s2, cond: r7 })
+        CoreSet(Jump { target_state: s4 })
+      s2:
+        PureSet(Index { dst: r7, object: r4, index: r5 })
+        ExtCallSet(ActionCall { dst: r8, action_ref: TestActionRef("double"), args: [r7], resume: s5 })
+      s3:
+        PureSet(LoadConst { dst: r7, value: Int(1) })
+        PureSet(Binary { kind: Add, op: BinaryOp { dst: r5, a: r5, b: r7 } })
+        CoreSet(Jump { target_state: s1 })
+      s4:
+        PureSet(LoadConst { dst: r10, value: Int(0) })
+        PureSet(Length { dst: r11, src: r3 })
+        CoreSet(Jump { target_state: s6 })
+      s5:
+        PureSet(MakeList { dst: r9, items: [r8] })
+        PureSet(Binary { kind: Add, op: BinaryOp { dst: r3, a: r3, b: r9 } })
+        CoreSet(Jump { target_state: s3 })
+      s6:
+        PureSet(Binary { kind: Lt, op: BinaryOp { dst: r7, a: r10, b: r11 } })
+        CoreSet(JumpIf { target_state: s7, cond: r7 })
+        CoreSet(Jump { target_state: s9 })
+      s7:
+        PureSet(Index { dst: r7, object: r3, index: r10 })
+        CoreSet(Await { dst: r7, src: r7, resume: s10 })
+      s8:
+        PureSet(LoadConst { dst: r7, value: Int(1) })
+        PureSet(Binary { kind: Add, op: BinaryOp { dst: r10, a: r10, b: r7 } })
+        CoreSet(Jump { target_state: s6 })
+      s9:
+        PureSet(Copy { dst: r1, src: r2 })
+        CoreSet(Return { src: r1 })
+      s10:
+        PureSet(MakeList { dst: r8, items: [r7] })
+        PureSet(Binary { kind: Add, op: BinaryOp { dst: r2, a: r2, b: r8 } })
+        CoreSet(Jump { target_state: s8 })
+    "#);
+}

--- a/crates/lib/vm-compiler-for-ast-old/tests/integration.rs
+++ b/crates/lib/vm-compiler-for-ast-old/tests/integration.rs
@@ -9,8 +9,8 @@ use waymark_vm_ast_old::{
 use waymark_vm_ast_old_helpers::{
     action_call, action_expr, assignment, assignment_targets, binary_expr, break_stmt,
     conditional_stmt, continue_stmt, float, function, function_call, function_expr, int,
-    parallel_expr, parallel_stmt, program, return_stmt, sleep_stmt, spanned, string, unary_expr,
-    variable, while_stmt,
+    parallel_expr, parallel_stmt, program, return_stmt, sleep_stmt, spanned, spread_expr, string,
+    unary_expr, variable, while_stmt,
 };
 use waymark_vm_bytecode_core::{FunctionId, InstructionId, StateId};
 use waymark_vm_compiler_for_ast_old_test_support::{TestActionRef, TestReadyValue, TestValue};
@@ -765,6 +765,79 @@ fn compiles_parallel_action_blocks_with_multiple_outstanding_extcalls() {
         ))) => assert_eq!(value, 7),
         other => panic!("unexpected final runtime effect: {other:?}"),
     }
+}
+
+#[test]
+fn compiles_spread_expressions_to_completion() {
+    let program = program(vec![function(
+        "main",
+        &["items"],
+        vec![
+            assignment(
+                "results",
+                spread_expr(
+                    variable("items"),
+                    "item",
+                    action_call("double", vec![("value", variable("item"))]),
+                ),
+            ),
+            return_stmt(Some(variable("results"))),
+        ],
+    )]);
+
+    let executable = compile_program(&program);
+    let mut runtime = runtime_with_args(
+        executable,
+        vec![TestReadyValue::List(vec![
+            TestValue::Ready(TestReadyValue::Int(1)),
+            TestValue::Ready(TestReadyValue::Int(2)),
+            TestValue::Ready(TestReadyValue::Int(3)),
+        ])],
+    );
+
+    let mut pending_promises = Vec::new();
+
+    for input in [1, 2, 3] {
+        let promise = match runtime.run().unwrap_or_else(|error| {
+            panic!(
+                "spread action for {input} should start before earlier promises resolve: {error:?}"
+            )
+        }) {
+            Effect::ExtCallSet(waymark_vm_interpreter_extcallset::Effect::ActionCall {
+                promise_state_id,
+                action_ref,
+                args,
+            }) => {
+                assert!(matches!(&action_ref, TestActionRef(name) if name == "double"));
+                assert_eq!(args, vec![TestReadyValue::Int(input)]);
+                promise_state_id
+            }
+            other => panic!("unexpected runtime effect for spread item {input}: {other:?}"),
+        };
+
+        pending_promises.push(promise);
+    }
+
+    for (promise, output) in pending_promises.into_iter().zip([2, 4, 6]) {
+        runtime
+            .resolve_promise(promise, TestReadyValue::Int(output))
+            .unwrap_or_else(|error| {
+                panic!("spread promise producing {output} should resolve: {error:?}")
+            });
+    }
+
+    assert_eq!(
+        completed_value(
+            runtime
+                .run()
+                .expect("spread program should complete after all promises resolve")
+        ),
+        TestReadyValue::List(vec![
+            TestValue::Ready(TestReadyValue::Int(2)),
+            TestValue::Ready(TestReadyValue::Int(4)),
+            TestValue::Ready(TestReadyValue::Int(6)),
+        ])
+    );
 }
 
 #[test]

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_generator.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_generator.py__bytecode.snap
@@ -1,11 +1,53 @@
 ---
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
-expression: "bytecode for python/tests/fixtures_gather/gather_generator.py [compilation error]"
+expression: bytecode for python/tests/fixtures_gather/gather_generator.py
 ---
-FunctionCompiler(
-    Unsupported(
-        Expression {
-            kind: SpreadExpr,
-        },
-    ),
-)
+fn main(input: [items, multiplier], output: []):
+    results = spread items:item -> @gather_generator.process_item(item=item, multiplier=multiplier)
+    return results
+---
+f0: [13 registers]
+  s0:
+    PureSet(MakeList { dst: r3, items: [] })
+    PureSet(MakeList { dst: r4, items: [] })
+    PureSet(Copy { dst: r5, src: r0 })
+    PureSet(LoadConst { dst: r6, value: Int(0) })
+    PureSet(Length { dst: r7, src: r5 })
+    CoreSet(Jump { target_state: s1 })
+  s1:
+    PureSet(Binary { kind: Lt, op: BinaryOp { dst: r8, a: r6, b: r7 } })
+    CoreSet(JumpIf { target_state: s2, cond: r8 })
+    CoreSet(Jump { target_state: s4 })
+  s2:
+    PureSet(Index { dst: r8, object: r5, index: r6 })
+    ExtCallSet(ActionCall { dst: r9, action_ref: TestActionRef("process_item"), args: [r8, r1], resume: s5 })
+  s3:
+    PureSet(LoadConst { dst: r8, value: Int(1) })
+    PureSet(Binary { kind: Add, op: BinaryOp { dst: r6, a: r6, b: r8 } })
+    CoreSet(Jump { target_state: s1 })
+  s4:
+    PureSet(LoadConst { dst: r11, value: Int(0) })
+    PureSet(Length { dst: r12, src: r4 })
+    CoreSet(Jump { target_state: s6 })
+  s5:
+    PureSet(MakeList { dst: r10, items: [r9] })
+    PureSet(Binary { kind: Add, op: BinaryOp { dst: r4, a: r4, b: r10 } })
+    CoreSet(Jump { target_state: s3 })
+  s6:
+    PureSet(Binary { kind: Lt, op: BinaryOp { dst: r8, a: r11, b: r12 } })
+    CoreSet(JumpIf { target_state: s7, cond: r8 })
+    CoreSet(Jump { target_state: s9 })
+  s7:
+    PureSet(Index { dst: r8, object: r4, index: r11 })
+    CoreSet(Await { dst: r8, src: r8, resume: s10 })
+  s8:
+    PureSet(LoadConst { dst: r8, value: Int(1) })
+    PureSet(Binary { kind: Add, op: BinaryOp { dst: r11, a: r11, b: r8 } })
+    CoreSet(Jump { target_state: s6 })
+  s9:
+    PureSet(Copy { dst: r2, src: r3 })
+    CoreSet(Return { src: r2 })
+  s10:
+    PureSet(MakeList { dst: r9, items: [r8] })
+    PureSet(Binary { kind: Add, op: BinaryOp { dst: r3, a: r3, b: r9 } })
+    CoreSet(Jump { target_state: s8 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_generator_filter.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_generator_filter.py__bytecode.snap
@@ -1,11 +1,83 @@
 ---
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
-expression: "bytecode for python/tests/fixtures_gather/gather_generator_filter.py [compilation error]"
+expression: bytecode for python/tests/fixtures_gather/gather_generator_filter.py
 ---
-FunctionCompiler(
-    Unsupported(
-        Expression {
-            kind: SpreadExpr,
-        },
-    ),
-)
+fn main(input: [users], output: []):
+    __spread_items_1__ = []
+    for user in users:
+        if user.active:
+            __spread_items_1__ = __spread_items_1__ + [user]
+    results = spread __spread_items_1__:user -> @gather_generator_filter.process_user(user=user)
+    return results
+---
+f0: [17 registers]
+  s0:
+    PureSet(MakeList { dst: r1, items: [] })
+    PureSet(Copy { dst: r2, src: r0 })
+    PureSet(LoadConst { dst: r3, value: Int(0) })
+    PureSet(Length { dst: r4, src: r2 })
+    CoreSet(Jump { target_state: s1 })
+  s1:
+    PureSet(Binary { kind: Lt, op: BinaryOp { dst: r5, a: r3, b: r4 } })
+    CoreSet(JumpIf { target_state: s2, cond: r5 })
+    CoreSet(Jump { target_state: s4 })
+  s2:
+    PureSet(Index { dst: r5, object: r2, index: r3 })
+    PureSet(Copy { dst: r6, src: r5 })
+    PureSet(Dot { dst: r5, object: r6, attribute: "active" })
+    CoreSet(JumpIf { target_state: s6, cond: r5 })
+    CoreSet(Jump { target_state: s5 })
+  s3:
+    PureSet(LoadConst { dst: r5, value: Int(1) })
+    PureSet(Binary { kind: Add, op: BinaryOp { dst: r3, a: r3, b: r5 } })
+    CoreSet(Jump { target_state: s1 })
+  s4:
+    PureSet(MakeList { dst: r8, items: [] })
+    PureSet(MakeList { dst: r9, items: [] })
+    PureSet(Copy { dst: r10, src: r1 })
+    PureSet(LoadConst { dst: r11, value: Int(0) })
+    PureSet(Length { dst: r12, src: r10 })
+    CoreSet(Jump { target_state: s7 })
+  s5:
+    CoreSet(Jump { target_state: s3 })
+  s6:
+    PureSet(MakeList { dst: r5, items: [r6] })
+    PureSet(Binary { kind: Add, op: BinaryOp { dst: r1, a: r1, b: r5 } })
+    CoreSet(Jump { target_state: s5 })
+  s7:
+    PureSet(Binary { kind: Lt, op: BinaryOp { dst: r5, a: r11, b: r12 } })
+    CoreSet(JumpIf { target_state: s8, cond: r5 })
+    CoreSet(Jump { target_state: s10 })
+  s8:
+    PureSet(Index { dst: r5, object: r10, index: r11 })
+    ExtCallSet(ActionCall { dst: r13, action_ref: TestActionRef("process_user"), args: [r5], resume: s11 })
+  s9:
+    PureSet(LoadConst { dst: r5, value: Int(1) })
+    PureSet(Binary { kind: Add, op: BinaryOp { dst: r11, a: r11, b: r5 } })
+    CoreSet(Jump { target_state: s7 })
+  s10:
+    PureSet(LoadConst { dst: r15, value: Int(0) })
+    PureSet(Length { dst: r16, src: r9 })
+    CoreSet(Jump { target_state: s12 })
+  s11:
+    PureSet(MakeList { dst: r14, items: [r13] })
+    PureSet(Binary { kind: Add, op: BinaryOp { dst: r9, a: r9, b: r14 } })
+    CoreSet(Jump { target_state: s9 })
+  s12:
+    PureSet(Binary { kind: Lt, op: BinaryOp { dst: r5, a: r15, b: r16 } })
+    CoreSet(JumpIf { target_state: s13, cond: r5 })
+    CoreSet(Jump { target_state: s15 })
+  s13:
+    PureSet(Index { dst: r5, object: r9, index: r15 })
+    CoreSet(Await { dst: r5, src: r5, resume: s16 })
+  s14:
+    PureSet(LoadConst { dst: r5, value: Int(1) })
+    PureSet(Binary { kind: Add, op: BinaryOp { dst: r15, a: r15, b: r5 } })
+    CoreSet(Jump { target_state: s12 })
+  s15:
+    PureSet(Copy { dst: r7, src: r8 })
+    CoreSet(Return { src: r7 })
+  s16:
+    PureSet(MakeList { dst: r13, items: [r5] })
+    PureSet(Binary { kind: Add, op: BinaryOp { dst: r8, a: r8, b: r13 } })
+    CoreSet(Jump { target_state: s14 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_listcomp.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_listcomp.py__bytecode.snap
@@ -1,11 +1,53 @@
 ---
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
-expression: "bytecode for python/tests/fixtures_gather/gather_listcomp.py [compilation error]"
+expression: bytecode for python/tests/fixtures_gather/gather_listcomp.py
 ---
-FunctionCompiler(
-    Unsupported(
-        Expression {
-            kind: SpreadExpr,
-        },
-    ),
-)
+fn main(input: [items, multiplier], output: []):
+    results = spread items:item -> @gather_listcomp.process_item(item=item, multiplier=multiplier)
+    return results
+---
+f0: [13 registers]
+  s0:
+    PureSet(MakeList { dst: r3, items: [] })
+    PureSet(MakeList { dst: r4, items: [] })
+    PureSet(Copy { dst: r5, src: r0 })
+    PureSet(LoadConst { dst: r6, value: Int(0) })
+    PureSet(Length { dst: r7, src: r5 })
+    CoreSet(Jump { target_state: s1 })
+  s1:
+    PureSet(Binary { kind: Lt, op: BinaryOp { dst: r8, a: r6, b: r7 } })
+    CoreSet(JumpIf { target_state: s2, cond: r8 })
+    CoreSet(Jump { target_state: s4 })
+  s2:
+    PureSet(Index { dst: r8, object: r5, index: r6 })
+    ExtCallSet(ActionCall { dst: r9, action_ref: TestActionRef("process_item"), args: [r8, r1], resume: s5 })
+  s3:
+    PureSet(LoadConst { dst: r8, value: Int(1) })
+    PureSet(Binary { kind: Add, op: BinaryOp { dst: r6, a: r6, b: r8 } })
+    CoreSet(Jump { target_state: s1 })
+  s4:
+    PureSet(LoadConst { dst: r11, value: Int(0) })
+    PureSet(Length { dst: r12, src: r4 })
+    CoreSet(Jump { target_state: s6 })
+  s5:
+    PureSet(MakeList { dst: r10, items: [r9] })
+    PureSet(Binary { kind: Add, op: BinaryOp { dst: r4, a: r4, b: r10 } })
+    CoreSet(Jump { target_state: s3 })
+  s6:
+    PureSet(Binary { kind: Lt, op: BinaryOp { dst: r8, a: r11, b: r12 } })
+    CoreSet(JumpIf { target_state: s7, cond: r8 })
+    CoreSet(Jump { target_state: s9 })
+  s7:
+    PureSet(Index { dst: r8, object: r4, index: r11 })
+    CoreSet(Await { dst: r8, src: r8, resume: s10 })
+  s8:
+    PureSet(LoadConst { dst: r8, value: Int(1) })
+    PureSet(Binary { kind: Add, op: BinaryOp { dst: r11, a: r11, b: r8 } })
+    CoreSet(Jump { target_state: s6 })
+  s9:
+    PureSet(Copy { dst: r2, src: r3 })
+    CoreSet(Return { src: r2 })
+  s10:
+    PureSet(MakeList { dst: r9, items: [r8] })
+    PureSet(Binary { kind: Add, op: BinaryOp { dst: r3, a: r3, b: r9 } })
+    CoreSet(Jump { target_state: s8 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_listcomp_filter.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_listcomp_filter.py__bytecode.snap
@@ -1,11 +1,83 @@
 ---
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
-expression: "bytecode for python/tests/fixtures_gather/gather_listcomp_filter.py [compilation error]"
+expression: bytecode for python/tests/fixtures_gather/gather_listcomp_filter.py
 ---
-FunctionCompiler(
-    Unsupported(
-        Expression {
-            kind: SpreadExpr,
-        },
-    ),
-)
+fn main(input: [users], output: []):
+    __spread_items_1__ = []
+    for user in users:
+        if user.active:
+            __spread_items_1__ = __spread_items_1__ + [user]
+    results = spread __spread_items_1__:user -> @gather_listcomp_filter.process_user(user=user)
+    return results
+---
+f0: [17 registers]
+  s0:
+    PureSet(MakeList { dst: r1, items: [] })
+    PureSet(Copy { dst: r2, src: r0 })
+    PureSet(LoadConst { dst: r3, value: Int(0) })
+    PureSet(Length { dst: r4, src: r2 })
+    CoreSet(Jump { target_state: s1 })
+  s1:
+    PureSet(Binary { kind: Lt, op: BinaryOp { dst: r5, a: r3, b: r4 } })
+    CoreSet(JumpIf { target_state: s2, cond: r5 })
+    CoreSet(Jump { target_state: s4 })
+  s2:
+    PureSet(Index { dst: r5, object: r2, index: r3 })
+    PureSet(Copy { dst: r6, src: r5 })
+    PureSet(Dot { dst: r5, object: r6, attribute: "active" })
+    CoreSet(JumpIf { target_state: s6, cond: r5 })
+    CoreSet(Jump { target_state: s5 })
+  s3:
+    PureSet(LoadConst { dst: r5, value: Int(1) })
+    PureSet(Binary { kind: Add, op: BinaryOp { dst: r3, a: r3, b: r5 } })
+    CoreSet(Jump { target_state: s1 })
+  s4:
+    PureSet(MakeList { dst: r8, items: [] })
+    PureSet(MakeList { dst: r9, items: [] })
+    PureSet(Copy { dst: r10, src: r1 })
+    PureSet(LoadConst { dst: r11, value: Int(0) })
+    PureSet(Length { dst: r12, src: r10 })
+    CoreSet(Jump { target_state: s7 })
+  s5:
+    CoreSet(Jump { target_state: s3 })
+  s6:
+    PureSet(MakeList { dst: r5, items: [r6] })
+    PureSet(Binary { kind: Add, op: BinaryOp { dst: r1, a: r1, b: r5 } })
+    CoreSet(Jump { target_state: s5 })
+  s7:
+    PureSet(Binary { kind: Lt, op: BinaryOp { dst: r5, a: r11, b: r12 } })
+    CoreSet(JumpIf { target_state: s8, cond: r5 })
+    CoreSet(Jump { target_state: s10 })
+  s8:
+    PureSet(Index { dst: r5, object: r10, index: r11 })
+    ExtCallSet(ActionCall { dst: r13, action_ref: TestActionRef("process_user"), args: [r5], resume: s11 })
+  s9:
+    PureSet(LoadConst { dst: r5, value: Int(1) })
+    PureSet(Binary { kind: Add, op: BinaryOp { dst: r11, a: r11, b: r5 } })
+    CoreSet(Jump { target_state: s7 })
+  s10:
+    PureSet(LoadConst { dst: r15, value: Int(0) })
+    PureSet(Length { dst: r16, src: r9 })
+    CoreSet(Jump { target_state: s12 })
+  s11:
+    PureSet(MakeList { dst: r14, items: [r13] })
+    PureSet(Binary { kind: Add, op: BinaryOp { dst: r9, a: r9, b: r14 } })
+    CoreSet(Jump { target_state: s9 })
+  s12:
+    PureSet(Binary { kind: Lt, op: BinaryOp { dst: r5, a: r15, b: r16 } })
+    CoreSet(JumpIf { target_state: s13, cond: r5 })
+    CoreSet(Jump { target_state: s15 })
+  s13:
+    PureSet(Index { dst: r5, object: r9, index: r15 })
+    CoreSet(Await { dst: r5, src: r5, resume: s16 })
+  s14:
+    PureSet(LoadConst { dst: r5, value: Int(1) })
+    PureSet(Binary { kind: Add, op: BinaryOp { dst: r15, a: r15, b: r5 } })
+    CoreSet(Jump { target_state: s12 })
+  s15:
+    PureSet(Copy { dst: r7, src: r8 })
+    CoreSet(Return { src: r7 })
+  s16:
+    PureSet(MakeList { dst: r13, items: [r5] })
+    PureSet(Binary { kind: Add, op: BinaryOp { dst: r8, a: r8, b: r13 } })
+    CoreSet(Jump { target_state: s14 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_listcomp_tuple_unpack.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_listcomp_tuple_unpack.py__bytecode.snap
@@ -1,11 +1,57 @@
 ---
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
-expression: "bytecode for python/tests/fixtures_gather/gather_listcomp_tuple_unpack.py [compilation error]"
+expression: bytecode for python/tests/fixtures_gather/gather_listcomp_tuple_unpack.py
 ---
-FunctionCompiler(
-    Unsupported(
-        Expression {
-            kind: SpreadExpr,
-        },
-    ),
-)
+fn main(input: [pairs], output: []):
+    results = spread pairs:__spread_item_1__ -> @gather_listcomp_tuple_unpack.process_pair(name=__spread_item_1__[0], score=__spread_item_1__[1])
+    return results
+---
+f0: [14 registers]
+  s0:
+    PureSet(MakeList { dst: r2, items: [] })
+    PureSet(MakeList { dst: r3, items: [] })
+    PureSet(Copy { dst: r4, src: r0 })
+    PureSet(LoadConst { dst: r5, value: Int(0) })
+    PureSet(Length { dst: r6, src: r4 })
+    CoreSet(Jump { target_state: s1 })
+  s1:
+    PureSet(Binary { kind: Lt, op: BinaryOp { dst: r7, a: r5, b: r6 } })
+    CoreSet(JumpIf { target_state: s2, cond: r7 })
+    CoreSet(Jump { target_state: s4 })
+  s2:
+    PureSet(Index { dst: r7, object: r4, index: r5 })
+    PureSet(LoadConst { dst: r9, value: Int(0) })
+    PureSet(Index { dst: r10, object: r7, index: r9 })
+    PureSet(LoadConst { dst: r9, value: Int(1) })
+    PureSet(Index { dst: r11, object: r7, index: r9 })
+    ExtCallSet(ActionCall { dst: r8, action_ref: TestActionRef("process_pair"), args: [r10, r11], resume: s5 })
+  s3:
+    PureSet(LoadConst { dst: r7, value: Int(1) })
+    PureSet(Binary { kind: Add, op: BinaryOp { dst: r5, a: r5, b: r7 } })
+    CoreSet(Jump { target_state: s1 })
+  s4:
+    PureSet(LoadConst { dst: r12, value: Int(0) })
+    PureSet(Length { dst: r13, src: r3 })
+    CoreSet(Jump { target_state: s6 })
+  s5:
+    PureSet(MakeList { dst: r11, items: [r8] })
+    PureSet(Binary { kind: Add, op: BinaryOp { dst: r3, a: r3, b: r11 } })
+    CoreSet(Jump { target_state: s3 })
+  s6:
+    PureSet(Binary { kind: Lt, op: BinaryOp { dst: r7, a: r12, b: r13 } })
+    CoreSet(JumpIf { target_state: s7, cond: r7 })
+    CoreSet(Jump { target_state: s9 })
+  s7:
+    PureSet(Index { dst: r7, object: r3, index: r12 })
+    CoreSet(Await { dst: r7, src: r7, resume: s10 })
+  s8:
+    PureSet(LoadConst { dst: r7, value: Int(1) })
+    PureSet(Binary { kind: Add, op: BinaryOp { dst: r12, a: r12, b: r7 } })
+    CoreSet(Jump { target_state: s6 })
+  s9:
+    PureSet(Copy { dst: r1, src: r2 })
+    CoreSet(Return { src: r1 })
+  s10:
+    PureSet(MakeList { dst: r8, items: [r7] })
+    PureSet(Binary { kind: Add, op: BinaryOp { dst: r2, a: r2, b: r8 } })
+    CoreSet(Jump { target_state: s8 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_run_action_spread.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_run_action_spread.py__bytecode.snap
@@ -1,11 +1,58 @@
 ---
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
-expression: "bytecode for python/tests/fixtures_gather/gather_run_action_spread.py [compilation error]"
+expression: bytecode for python/tests/fixtures_gather/gather_run_action_spread.py
 ---
-FunctionCompiler(
-    Unsupported(
-        Expression {
-            kind: SpreadExpr,
-        },
-    ),
-)
+fn main(input: [items], output: []):
+    results = spread items:item -> @gather_run_action_spread.process_item(item=item) [retry: 2] [timeout: 30s]
+    _return_tmp = @gather_run_action_spread.combine_results(results=results)
+    return _return_tmp
+---
+f0: [13 registers]
+  s0:
+    PureSet(MakeList { dst: r2, items: [] })
+    PureSet(MakeList { dst: r3, items: [] })
+    PureSet(Copy { dst: r4, src: r0 })
+    PureSet(LoadConst { dst: r5, value: Int(0) })
+    PureSet(Length { dst: r6, src: r4 })
+    CoreSet(Jump { target_state: s1 })
+  s1:
+    PureSet(Binary { kind: Lt, op: BinaryOp { dst: r7, a: r5, b: r6 } })
+    CoreSet(JumpIf { target_state: s2, cond: r7 })
+    CoreSet(Jump { target_state: s4 })
+  s2:
+    PureSet(Index { dst: r7, object: r4, index: r5 })
+    ExtCallSet(ActionCall { dst: r8, action_ref: TestActionRef("process_item"), args: [r7], resume: s5 })
+  s3:
+    PureSet(LoadConst { dst: r7, value: Int(1) })
+    PureSet(Binary { kind: Add, op: BinaryOp { dst: r5, a: r5, b: r7 } })
+    CoreSet(Jump { target_state: s1 })
+  s4:
+    PureSet(LoadConst { dst: r10, value: Int(0) })
+    PureSet(Length { dst: r11, src: r3 })
+    CoreSet(Jump { target_state: s6 })
+  s5:
+    PureSet(MakeList { dst: r9, items: [r8] })
+    PureSet(Binary { kind: Add, op: BinaryOp { dst: r3, a: r3, b: r9 } })
+    CoreSet(Jump { target_state: s3 })
+  s6:
+    PureSet(Binary { kind: Lt, op: BinaryOp { dst: r7, a: r10, b: r11 } })
+    CoreSet(JumpIf { target_state: s7, cond: r7 })
+    CoreSet(Jump { target_state: s9 })
+  s7:
+    PureSet(Index { dst: r7, object: r3, index: r10 })
+    CoreSet(Await { dst: r7, src: r7, resume: s10 })
+  s8:
+    PureSet(LoadConst { dst: r7, value: Int(1) })
+    PureSet(Binary { kind: Add, op: BinaryOp { dst: r10, a: r10, b: r7 } })
+    CoreSet(Jump { target_state: s6 })
+  s9:
+    PureSet(Copy { dst: r1, src: r2 })
+    ExtCallSet(ActionCall { dst: r12, action_ref: TestActionRef("combine_results"), args: [r1], resume: s11 })
+  s10:
+    PureSet(MakeList { dst: r8, items: [r7] })
+    PureSet(Binary { kind: Add, op: BinaryOp { dst: r2, a: r2, b: r8 } })
+    CoreSet(Jump { target_state: s8 })
+  s11:
+    CoreSet(Await { dst: r12, src: r12, resume: s12 })
+  s12:
+    CoreSet(Return { src: r12 })


### PR DESCRIPTION
This PR implements spreads support at the compiler. With #411 this is much easier to do (as it should've been really, it was a mistake to put the promises at the top-level of the registers).

Also, #413 and #414 really help with validation - it's much quicker to read the snapshots now.

---

With the VM, there is really no difference between spreading over actions and in-VM-fns; we might want to refactor the AST generation later to enable this capability.