### PR TITLE
Optimize indexed spreads register usage

### DIFF
--- a/crates/lib/vm-compiler-for-ast-old/src/function/compiler/lowering/for_loop.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/function/compiler/lowering/for_loop.rs
@@ -107,6 +107,16 @@ enum RangeLoop<'expr> {
     },
 }
 
+/// Persistent registers from indexed spread fan-out that the join can reuse.
+#[derive(Clone, Copy)]
+struct IndexedSpreadJoinRegisters {
+    /// Loop counter register from fan-out, reset to `0` before join.
+    index_register: RegisterId,
+
+    /// Cached `len(iterable)` register from fan-out, reused as join bound.
+    length_register: RegisterId,
+}
+
 impl<'expr> ResolvedForLoop<'expr> {
     /// Classifies the `for` loop header into one lowering strategy.
     fn build<Spec, Lowering>(
@@ -275,30 +285,32 @@ where
             .emitter
             .emit_make_list(promises_register, Vec::new());
 
-        match ResolvedForLoop::build::<Spec, Lowering>(iterable)? {
+        let join_registers = match ResolvedForLoop::build::<Spec, Lowering>(iterable)? {
             ResolvedForLoop::Indexed { iterable, .. } => {
-                self.compile_indexed_spread(iterable, loop_var, action, promises_register)?
+                Some(self.compile_indexed_spread(iterable, loop_var, action, promises_register)?)
             }
             ResolvedForLoop::Range {
                 range: RangeLoop::Positive { start, end },
                 ..
             } => {
-                self.compile_positive_range_spread(start, end, loop_var, action, promises_register)?
+                self.compile_positive_range_spread(
+                    start,
+                    end,
+                    loop_var,
+                    action,
+                    promises_register,
+                )?;
+                None
             }
             ResolvedForLoop::Range {
                 range: RangeLoop::Stepped { start, end, step },
                 ..
-            } => self.compile_stepped_range_spread(
-                start,
-                end,
-                step,
-                loop_var,
-                action,
-                promises_register,
-            )?,
-        }
+            } => self
+                .compile_stepped_range_spread(start, end, step, loop_var, action, promises_register)
+                .map(|()| None)?,
+        };
 
-        self.compile_spread_join(promises_register, None, iterable)
+        self.compile_spread_join(promises_register, None, iterable, join_registers)
     }
 
     /// Compiles a spread expression into `result_register`.
@@ -318,30 +330,37 @@ where
             .emitter
             .emit_make_list(promises_register, Vec::new());
 
-        match ResolvedForLoop::build::<Spec, Lowering>(iterable)? {
+        let join_registers = match ResolvedForLoop::build::<Spec, Lowering>(iterable)? {
             ResolvedForLoop::Indexed { iterable, .. } => {
-                self.compile_indexed_spread(iterable, loop_var, action, promises_register)?
+                Some(self.compile_indexed_spread(iterable, loop_var, action, promises_register)?)
             }
             ResolvedForLoop::Range {
                 range: RangeLoop::Positive { start, end },
                 ..
             } => {
-                self.compile_positive_range_spread(start, end, loop_var, action, promises_register)?
+                self.compile_positive_range_spread(
+                    start,
+                    end,
+                    loop_var,
+                    action,
+                    promises_register,
+                )?;
+                None
             }
             ResolvedForLoop::Range {
                 range: RangeLoop::Stepped { start, end, step },
                 ..
-            } => self.compile_stepped_range_spread(
-                start,
-                end,
-                step,
-                loop_var,
-                action,
-                promises_register,
-            )?,
-        }
+            } => self
+                .compile_stepped_range_spread(start, end, step, loop_var, action, promises_register)
+                .map(|()| None)?,
+        };
 
-        self.compile_spread_join(promises_register, Some(result_register), iterable)
+        self.compile_spread_join(
+            promises_register,
+            Some(result_register),
+            iterable,
+            join_registers,
+        )
     }
 
     /// Compiles a `for` loop that walks an arbitrary indexable iterable
@@ -419,7 +438,7 @@ where
         loop_var: &str,
         action: &ActionCall,
         promises_register: RegisterId,
-    ) -> Result<(), ErrorFor<Spec, Lowering>> {
+    ) -> Result<IndexedSpreadJoinRegisters, ErrorFor<Spec, Lowering>> {
         let iterable_register = self.context.local_frame.allocate_register();
         self.compile_expr_into_register(iterable, iterable_register)?;
 
@@ -460,7 +479,12 @@ where
                 )
             },
             |compiler| compiler.emit_add_assign_immediate(index_register, 1),
-        )
+        )?;
+
+        Ok(IndexedSpreadJoinRegisters {
+            index_register,
+            length_register,
+        })
     }
 
     /// Compiles `range(stop)` and `range(start, stop)` loops with implicit
@@ -798,14 +822,28 @@ where
         promises_register: RegisterId,
         result_register: Option<RegisterId>,
         template: &Spanned<Expr>,
+        join_registers: Option<IndexedSpreadJoinRegisters>,
     ) -> Result<(), ErrorFor<Spec, Lowering>> {
-        let index_register = self.context.local_frame.allocate_register();
-        self.emit_int_literal_into_register(index_register, 0)?;
+        let (index_register, length_register) = match join_registers {
+            Some(join_registers) => {
+                self.emit_int_literal_into_register(join_registers.index_register, 0)?;
+                (
+                    join_registers.index_register,
+                    join_registers.length_register,
+                )
+            }
+            None => {
+                let index_register = self.context.local_frame.allocate_register();
+                self.emit_int_literal_into_register(index_register, 0)?;
 
-        let length_register = self.context.local_frame.allocate_register();
-        self.context
-            .emitter
-            .emit_length(length_register, promises_register);
+                let length_register = self.context.local_frame.allocate_register();
+                self.context
+                    .emitter
+                    .emit_length(length_register, promises_register);
+
+                (index_register, length_register)
+            }
+        };
 
         let empty_body = self.empty_block(template);
 

--- a/crates/lib/vm-compiler-for-ast-old/src/tests/spreads.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/tests/spreads.rs
@@ -47,7 +47,7 @@ fn spread_expression_assignments_lower_to_looped_action_collection() {
         compile::<TestSpec, TestLowering>(&program).expect("spread expressions should compile");
 
     insta::assert_snapshot!(waymark_vm_bytecode_fmt::display(&executable), @r#"
-    f0: [11 registers]
+    f0: [9 registers]
       s0:
         PureSet(MakeList { dst: r2, items: [] })
         PureSet(MakeList { dst: r3, items: [] })
@@ -67,22 +67,21 @@ fn spread_expression_assignments_lower_to_looped_action_collection() {
         PureSet(Binary { kind: Add, op: BinaryOp { dst: r5, a: r5, b: r7 } })
         CoreSet(Jump { target_state: s1 })
       s4:
-        PureSet(LoadConst { dst: r9, value: Int(0) })
-        PureSet(Length { dst: r10, src: r3 })
+        PureSet(LoadConst { dst: r5, value: Int(0) })
         CoreSet(Jump { target_state: s6 })
       s5:
         PureSet(ListAppend { dst: r3, list: r3, item: r8 })
         CoreSet(Jump { target_state: s3 })
       s6:
-        PureSet(Binary { kind: Lt, op: BinaryOp { dst: r7, a: r9, b: r10 } })
+        PureSet(Binary { kind: Lt, op: BinaryOp { dst: r7, a: r5, b: r6 } })
         CoreSet(JumpIf { target_state: s7, cond: r7 })
         CoreSet(Jump { target_state: s9 })
       s7:
-        PureSet(Index { dst: r7, object: r3, index: r9 })
+        PureSet(Index { dst: r7, object: r3, index: r5 })
         CoreSet(Await { dst: r7, src: r7, resume: s10 })
       s8:
         PureSet(LoadConst { dst: r7, value: Int(1) })
-        PureSet(Binary { kind: Add, op: BinaryOp { dst: r9, a: r9, b: r7 } })
+        PureSet(Binary { kind: Add, op: BinaryOp { dst: r5, a: r5, b: r7 } })
         CoreSet(Jump { target_state: s6 })
       s9:
         PureSet(Copy { dst: r1, src: r2 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_generator.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_generator.py__bytecode.snap
@@ -6,7 +6,7 @@ fn main(input: [items, multiplier], output: []):
     results = spread items:item -> @gather_generator.process_item(item=item, multiplier=multiplier)
     return results
 ---
-f0: [12 registers]
+f0: [10 registers]
   s0:
     PureSet(MakeList { dst: r3, items: [] })
     PureSet(MakeList { dst: r4, items: [] })
@@ -26,22 +26,21 @@ f0: [12 registers]
     PureSet(Binary { kind: Add, op: BinaryOp { dst: r6, a: r6, b: r8 } })
     CoreSet(Jump { target_state: s1 })
   s4:
-    PureSet(LoadConst { dst: r10, value: Int(0) })
-    PureSet(Length { dst: r11, src: r4 })
+    PureSet(LoadConst { dst: r6, value: Int(0) })
     CoreSet(Jump { target_state: s6 })
   s5:
     PureSet(ListAppend { dst: r4, list: r4, item: r9 })
     CoreSet(Jump { target_state: s3 })
   s6:
-    PureSet(Binary { kind: Lt, op: BinaryOp { dst: r8, a: r10, b: r11 } })
+    PureSet(Binary { kind: Lt, op: BinaryOp { dst: r8, a: r6, b: r7 } })
     CoreSet(JumpIf { target_state: s7, cond: r8 })
     CoreSet(Jump { target_state: s9 })
   s7:
-    PureSet(Index { dst: r8, object: r4, index: r10 })
+    PureSet(Index { dst: r8, object: r4, index: r6 })
     CoreSet(Await { dst: r8, src: r8, resume: s10 })
   s8:
     PureSet(LoadConst { dst: r8, value: Int(1) })
-    PureSet(Binary { kind: Add, op: BinaryOp { dst: r10, a: r10, b: r8 } })
+    PureSet(Binary { kind: Add, op: BinaryOp { dst: r6, a: r6, b: r8 } })
     CoreSet(Jump { target_state: s6 })
   s9:
     PureSet(Copy { dst: r2, src: r3 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_generator_filter.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_generator_filter.py__bytecode.snap
@@ -10,7 +10,7 @@ fn main(input: [users], output: []):
     results = spread __spread_items_1__:user -> @gather_generator_filter.process_user(user=user)
     return results
 ---
-f0: [16 registers]
+f0: [14 registers]
   s0:
     PureSet(MakeList { dst: r1, items: [] })
     PureSet(Copy { dst: r2, src: r0 })
@@ -56,22 +56,21 @@ f0: [16 registers]
     PureSet(Binary { kind: Add, op: BinaryOp { dst: r11, a: r11, b: r5 } })
     CoreSet(Jump { target_state: s7 })
   s10:
-    PureSet(LoadConst { dst: r14, value: Int(0) })
-    PureSet(Length { dst: r15, src: r9 })
+    PureSet(LoadConst { dst: r11, value: Int(0) })
     CoreSet(Jump { target_state: s12 })
   s11:
     PureSet(ListAppend { dst: r9, list: r9, item: r13 })
     CoreSet(Jump { target_state: s9 })
   s12:
-    PureSet(Binary { kind: Lt, op: BinaryOp { dst: r5, a: r14, b: r15 } })
+    PureSet(Binary { kind: Lt, op: BinaryOp { dst: r5, a: r11, b: r12 } })
     CoreSet(JumpIf { target_state: s13, cond: r5 })
     CoreSet(Jump { target_state: s15 })
   s13:
-    PureSet(Index { dst: r5, object: r9, index: r14 })
+    PureSet(Index { dst: r5, object: r9, index: r11 })
     CoreSet(Await { dst: r5, src: r5, resume: s16 })
   s14:
     PureSet(LoadConst { dst: r5, value: Int(1) })
-    PureSet(Binary { kind: Add, op: BinaryOp { dst: r14, a: r14, b: r5 } })
+    PureSet(Binary { kind: Add, op: BinaryOp { dst: r11, a: r11, b: r5 } })
     CoreSet(Jump { target_state: s12 })
   s15:
     PureSet(Copy { dst: r7, src: r8 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_listcomp.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_listcomp.py__bytecode.snap
@@ -6,7 +6,7 @@ fn main(input: [items, multiplier], output: []):
     results = spread items:item -> @gather_listcomp.process_item(item=item, multiplier=multiplier)
     return results
 ---
-f0: [12 registers]
+f0: [10 registers]
   s0:
     PureSet(MakeList { dst: r3, items: [] })
     PureSet(MakeList { dst: r4, items: [] })
@@ -26,22 +26,21 @@ f0: [12 registers]
     PureSet(Binary { kind: Add, op: BinaryOp { dst: r6, a: r6, b: r8 } })
     CoreSet(Jump { target_state: s1 })
   s4:
-    PureSet(LoadConst { dst: r10, value: Int(0) })
-    PureSet(Length { dst: r11, src: r4 })
+    PureSet(LoadConst { dst: r6, value: Int(0) })
     CoreSet(Jump { target_state: s6 })
   s5:
     PureSet(ListAppend { dst: r4, list: r4, item: r9 })
     CoreSet(Jump { target_state: s3 })
   s6:
-    PureSet(Binary { kind: Lt, op: BinaryOp { dst: r8, a: r10, b: r11 } })
+    PureSet(Binary { kind: Lt, op: BinaryOp { dst: r8, a: r6, b: r7 } })
     CoreSet(JumpIf { target_state: s7, cond: r8 })
     CoreSet(Jump { target_state: s9 })
   s7:
-    PureSet(Index { dst: r8, object: r4, index: r10 })
+    PureSet(Index { dst: r8, object: r4, index: r6 })
     CoreSet(Await { dst: r8, src: r8, resume: s10 })
   s8:
     PureSet(LoadConst { dst: r8, value: Int(1) })
-    PureSet(Binary { kind: Add, op: BinaryOp { dst: r10, a: r10, b: r8 } })
+    PureSet(Binary { kind: Add, op: BinaryOp { dst: r6, a: r6, b: r8 } })
     CoreSet(Jump { target_state: s6 })
   s9:
     PureSet(Copy { dst: r2, src: r3 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_listcomp_filter.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_listcomp_filter.py__bytecode.snap
@@ -10,7 +10,7 @@ fn main(input: [users], output: []):
     results = spread __spread_items_1__:user -> @gather_listcomp_filter.process_user(user=user)
     return results
 ---
-f0: [16 registers]
+f0: [14 registers]
   s0:
     PureSet(MakeList { dst: r1, items: [] })
     PureSet(Copy { dst: r2, src: r0 })
@@ -56,22 +56,21 @@ f0: [16 registers]
     PureSet(Binary { kind: Add, op: BinaryOp { dst: r11, a: r11, b: r5 } })
     CoreSet(Jump { target_state: s7 })
   s10:
-    PureSet(LoadConst { dst: r14, value: Int(0) })
-    PureSet(Length { dst: r15, src: r9 })
+    PureSet(LoadConst { dst: r11, value: Int(0) })
     CoreSet(Jump { target_state: s12 })
   s11:
     PureSet(ListAppend { dst: r9, list: r9, item: r13 })
     CoreSet(Jump { target_state: s9 })
   s12:
-    PureSet(Binary { kind: Lt, op: BinaryOp { dst: r5, a: r14, b: r15 } })
+    PureSet(Binary { kind: Lt, op: BinaryOp { dst: r5, a: r11, b: r12 } })
     CoreSet(JumpIf { target_state: s13, cond: r5 })
     CoreSet(Jump { target_state: s15 })
   s13:
-    PureSet(Index { dst: r5, object: r9, index: r14 })
+    PureSet(Index { dst: r5, object: r9, index: r11 })
     CoreSet(Await { dst: r5, src: r5, resume: s16 })
   s14:
     PureSet(LoadConst { dst: r5, value: Int(1) })
-    PureSet(Binary { kind: Add, op: BinaryOp { dst: r14, a: r14, b: r5 } })
+    PureSet(Binary { kind: Add, op: BinaryOp { dst: r11, a: r11, b: r5 } })
     CoreSet(Jump { target_state: s12 })
   s15:
     PureSet(Copy { dst: r7, src: r8 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_listcomp_tuple_unpack.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_listcomp_tuple_unpack.py__bytecode.snap
@@ -6,7 +6,7 @@ fn main(input: [pairs], output: []):
     results = spread pairs:__spread_item_1__ -> @gather_listcomp_tuple_unpack.process_pair(name=__spread_item_1__[0], score=__spread_item_1__[1])
     return results
 ---
-f0: [14 registers]
+f0: [12 registers]
   s0:
     PureSet(MakeList { dst: r2, items: [] })
     PureSet(MakeList { dst: r3, items: [] })
@@ -30,22 +30,21 @@ f0: [14 registers]
     PureSet(Binary { kind: Add, op: BinaryOp { dst: r5, a: r5, b: r7 } })
     CoreSet(Jump { target_state: s1 })
   s4:
-    PureSet(LoadConst { dst: r12, value: Int(0) })
-    PureSet(Length { dst: r13, src: r3 })
+    PureSet(LoadConst { dst: r5, value: Int(0) })
     CoreSet(Jump { target_state: s6 })
   s5:
     PureSet(ListAppend { dst: r3, list: r3, item: r8 })
     CoreSet(Jump { target_state: s3 })
   s6:
-    PureSet(Binary { kind: Lt, op: BinaryOp { dst: r7, a: r12, b: r13 } })
+    PureSet(Binary { kind: Lt, op: BinaryOp { dst: r7, a: r5, b: r6 } })
     CoreSet(JumpIf { target_state: s7, cond: r7 })
     CoreSet(Jump { target_state: s9 })
   s7:
-    PureSet(Index { dst: r7, object: r3, index: r12 })
+    PureSet(Index { dst: r7, object: r3, index: r5 })
     CoreSet(Await { dst: r7, src: r7, resume: s10 })
   s8:
     PureSet(LoadConst { dst: r7, value: Int(1) })
-    PureSet(Binary { kind: Add, op: BinaryOp { dst: r12, a: r12, b: r7 } })
+    PureSet(Binary { kind: Add, op: BinaryOp { dst: r5, a: r5, b: r7 } })
     CoreSet(Jump { target_state: s6 })
   s9:
     PureSet(Copy { dst: r1, src: r2 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_run_action_spread.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_run_action_spread.py__bytecode.snap
@@ -7,7 +7,7 @@ fn main(input: [items], output: []):
     _return_tmp = @gather_run_action_spread.combine_results(results=results)
     return _return_tmp
 ---
-f0: [12 registers]
+f0: [10 registers]
   s0:
     PureSet(MakeList { dst: r2, items: [] })
     PureSet(MakeList { dst: r3, items: [] })
@@ -27,30 +27,29 @@ f0: [12 registers]
     PureSet(Binary { kind: Add, op: BinaryOp { dst: r5, a: r5, b: r7 } })
     CoreSet(Jump { target_state: s1 })
   s4:
-    PureSet(LoadConst { dst: r9, value: Int(0) })
-    PureSet(Length { dst: r10, src: r3 })
+    PureSet(LoadConst { dst: r5, value: Int(0) })
     CoreSet(Jump { target_state: s6 })
   s5:
     PureSet(ListAppend { dst: r3, list: r3, item: r8 })
     CoreSet(Jump { target_state: s3 })
   s6:
-    PureSet(Binary { kind: Lt, op: BinaryOp { dst: r7, a: r9, b: r10 } })
+    PureSet(Binary { kind: Lt, op: BinaryOp { dst: r7, a: r5, b: r6 } })
     CoreSet(JumpIf { target_state: s7, cond: r7 })
     CoreSet(Jump { target_state: s9 })
   s7:
-    PureSet(Index { dst: r7, object: r3, index: r9 })
+    PureSet(Index { dst: r7, object: r3, index: r5 })
     CoreSet(Await { dst: r7, src: r7, resume: s10 })
   s8:
     PureSet(LoadConst { dst: r7, value: Int(1) })
-    PureSet(Binary { kind: Add, op: BinaryOp { dst: r9, a: r9, b: r7 } })
+    PureSet(Binary { kind: Add, op: BinaryOp { dst: r5, a: r5, b: r7 } })
     CoreSet(Jump { target_state: s6 })
   s9:
     PureSet(Copy { dst: r1, src: r2 })
-    ExtCallSet(ActionCall { dst: r11, action_ref: TestActionRef("combine_results"), args: [r1], resume: s11 })
+    ExtCallSet(ActionCall { dst: r9, action_ref: TestActionRef("combine_results"), args: [r1], resume: s11 })
   s10:
     PureSet(ListAppend { dst: r2, list: r2, item: r7 })
     CoreSet(Jump { target_state: s8 })
   s11:
-    CoreSet(Await { dst: r11, src: r11, resume: s12 })
+    CoreSet(Await { dst: r9, src: r9, resume: s12 })
   s12:
-    CoreSet(Return { src: r11 })
+    CoreSet(Return { src: r9 })


### PR DESCRIPTION
Save registers and instructions by reusing the length register for the result collection phase