### PR TITLE
Optimize away extra copies for spread iteration

### DIFF
--- a/crates/lib/vm-compiler-for-ast-old/src/function/compiler/lowering/for_loop.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/function/compiler/lowering/for_loop.rs
@@ -439,8 +439,7 @@ where
         action: &ActionCall,
         promises_register: RegisterId,
     ) -> Result<IndexedSpreadJoinRegisters, ErrorFor<Spec, Lowering>> {
-        let iterable_register = self.context.local_frame.allocate_register();
-        self.compile_expr_into_register(iterable, iterable_register)?;
+        let iterable_register = self.resolve_indexed_spread_iterable_register(iterable)?;
 
         let index_register = self.context.local_frame.allocate_register();
         self.emit_int_literal_into_register(index_register, 0)?;
@@ -485,6 +484,29 @@ where
             index_register,
             length_register,
         })
+    }
+
+    /// Resolves the iterable register for indexed spread fan-out.
+    ///
+    /// A spread has no user-authored loop body, so reusing a bare
+    /// local/parameter register is safe: nothing in the fan-out path can
+    /// rebind that local before the loop finishes. Plain `for` loops keep the
+    /// explicit copy because their body or loop bindings can overwrite the
+    /// source local (for example `for items in items:`).
+    fn resolve_indexed_spread_iterable_register(
+        &mut self,
+        iterable: &Spanned<Expr>,
+    ) -> Result<RegisterId, ErrorFor<Spec, Lowering>> {
+        if matches!(&iterable.value, Expr::Variable { .. }) {
+            return Ok(self
+                .value_compiler()
+                .compile_expr(iterable, super::value::ResultTarget::Allocate)?
+                .register());
+        }
+
+        let iterable_register = self.context.local_frame.allocate_register();
+        self.compile_expr_into_register(iterable, iterable_register)?;
+        Ok(iterable_register)
     }
 
     /// Compiles `range(stop)` and `range(start, stop)` loops with implicit

--- a/crates/lib/vm-compiler-for-ast-old/src/tests/spreads.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/tests/spreads.rs
@@ -48,47 +48,46 @@ fn spread_expression_assignments_lower_to_looped_action_collection() {
         compile::<TestSpec, TestLowering>(&program).expect("spread expressions should compile");
 
     insta::assert_snapshot!(waymark_vm_bytecode_fmt::display(&executable), @r#"
-    f0: [9 registers]
+    f0: [8 registers]
       s0:
         PureSet(MakeList { dst: r2, items: [] })
         PureSet(MakeList { dst: r3, items: [] })
-        PureSet(Copy { dst: r4, src: r0 })
-        PureSet(LoadConst { dst: r5, value: Int(0) })
-        PureSet(Length { dst: r6, src: r4 })
+        PureSet(LoadConst { dst: r4, value: Int(0) })
+        PureSet(Length { dst: r5, src: r0 })
         CoreSet(Jump { target_state: s1 })
       s1:
-        PureSet(Binary { kind: Lt, op: BinaryOp { dst: r7, a: r5, b: r6 } })
-        CoreSet(JumpIf { target_state: s2, cond: r7 })
+        PureSet(Binary { kind: Lt, op: BinaryOp { dst: r6, a: r4, b: r5 } })
+        CoreSet(JumpIf { target_state: s2, cond: r6 })
         CoreSet(Jump { target_state: s4 })
       s2:
-        PureSet(Index { dst: r7, object: r4, index: r5 })
-        ExtCallSet(ActionCall { dst: r8, action_ref: TestActionRef("double"), args: [r7], resume: s5 })
+        PureSet(Index { dst: r6, object: r0, index: r4 })
+        ExtCallSet(ActionCall { dst: r7, action_ref: TestActionRef("double"), args: [r6], resume: s5 })
       s3:
-        PureSet(LoadConst { dst: r7, value: Int(1) })
-        PureSet(Binary { kind: Add, op: BinaryOp { dst: r5, a: r5, b: r7 } })
+        PureSet(LoadConst { dst: r6, value: Int(1) })
+        PureSet(Binary { kind: Add, op: BinaryOp { dst: r4, a: r4, b: r6 } })
         CoreSet(Jump { target_state: s1 })
       s4:
-        PureSet(LoadConst { dst: r5, value: Int(0) })
+        PureSet(LoadConst { dst: r4, value: Int(0) })
         CoreSet(Jump { target_state: s6 })
       s5:
-        PureSet(ListAppend { dst: r3, list: r3, item: r8 })
+        PureSet(ListAppend { dst: r3, list: r3, item: r7 })
         CoreSet(Jump { target_state: s3 })
       s6:
-        PureSet(Binary { kind: Lt, op: BinaryOp { dst: r7, a: r5, b: r6 } })
-        CoreSet(JumpIf { target_state: s7, cond: r7 })
+        PureSet(Binary { kind: Lt, op: BinaryOp { dst: r6, a: r4, b: r5 } })
+        CoreSet(JumpIf { target_state: s7, cond: r6 })
         CoreSet(Jump { target_state: s9 })
       s7:
-        PureSet(Index { dst: r7, object: r3, index: r5 })
-        CoreSet(Await { dst: r7, src: r7, resume: s10 })
+        PureSet(Index { dst: r6, object: r3, index: r4 })
+        CoreSet(Await { dst: r6, src: r6, resume: s10 })
       s8:
-        PureSet(LoadConst { dst: r7, value: Int(1) })
-        PureSet(Binary { kind: Add, op: BinaryOp { dst: r5, a: r5, b: r7 } })
+        PureSet(LoadConst { dst: r6, value: Int(1) })
+        PureSet(Binary { kind: Add, op: BinaryOp { dst: r4, a: r4, b: r6 } })
         CoreSet(Jump { target_state: s6 })
       s9:
         PureSet(Copy { dst: r1, src: r2 })
         CoreSet(Return { src: r1 })
       s10:
-        PureSet(ListAppend { dst: r2, list: r2, item: r7 })
+        PureSet(ListAppend { dst: r2, list: r2, item: r6 })
         CoreSet(Jump { target_state: s8 })
     "#);
 }
@@ -115,44 +114,43 @@ fn zero_target_spread_assignments_compile_as_side_effect_spreads() {
         .expect("zero-target spread assignments should compile as side-effect spreads");
 
     insta::assert_snapshot!(waymark_vm_bytecode_fmt::display(&executable), @r#"
-    f0: [7 registers]
+    f0: [6 registers]
       s0:
         PureSet(MakeList { dst: r1, items: [] })
-        PureSet(Copy { dst: r2, src: r0 })
-        PureSet(LoadConst { dst: r3, value: Int(0) })
-        PureSet(Length { dst: r4, src: r2 })
+        PureSet(LoadConst { dst: r2, value: Int(0) })
+        PureSet(Length { dst: r3, src: r0 })
         CoreSet(Jump { target_state: s1 })
       s1:
-        PureSet(Binary { kind: Lt, op: BinaryOp { dst: r5, a: r3, b: r4 } })
-        CoreSet(JumpIf { target_state: s2, cond: r5 })
+        PureSet(Binary { kind: Lt, op: BinaryOp { dst: r4, a: r2, b: r3 } })
+        CoreSet(JumpIf { target_state: s2, cond: r4 })
         CoreSet(Jump { target_state: s4 })
       s2:
-        PureSet(Index { dst: r5, object: r2, index: r3 })
-        ExtCallSet(ActionCall { dst: r6, action_ref: TestActionRef("notify"), args: [r5], resume: s5 })
+        PureSet(Index { dst: r4, object: r0, index: r2 })
+        ExtCallSet(ActionCall { dst: r5, action_ref: TestActionRef("notify"), args: [r4], resume: s5 })
       s3:
-        PureSet(LoadConst { dst: r5, value: Int(1) })
-        PureSet(Binary { kind: Add, op: BinaryOp { dst: r3, a: r3, b: r5 } })
+        PureSet(LoadConst { dst: r4, value: Int(1) })
+        PureSet(Binary { kind: Add, op: BinaryOp { dst: r2, a: r2, b: r4 } })
         CoreSet(Jump { target_state: s1 })
       s4:
-        PureSet(LoadConst { dst: r3, value: Int(0) })
+        PureSet(LoadConst { dst: r2, value: Int(0) })
         CoreSet(Jump { target_state: s6 })
       s5:
-        PureSet(ListAppend { dst: r1, list: r1, item: r6 })
+        PureSet(ListAppend { dst: r1, list: r1, item: r5 })
         CoreSet(Jump { target_state: s3 })
       s6:
-        PureSet(Binary { kind: Lt, op: BinaryOp { dst: r5, a: r3, b: r4 } })
-        CoreSet(JumpIf { target_state: s7, cond: r5 })
+        PureSet(Binary { kind: Lt, op: BinaryOp { dst: r4, a: r2, b: r3 } })
+        CoreSet(JumpIf { target_state: s7, cond: r4 })
         CoreSet(Jump { target_state: s9 })
       s7:
-        PureSet(Index { dst: r5, object: r1, index: r3 })
-        CoreSet(Await { dst: r5, src: r5, resume: s10 })
+        PureSet(Index { dst: r4, object: r1, index: r2 })
+        CoreSet(Await { dst: r4, src: r4, resume: s10 })
       s8:
-        PureSet(LoadConst { dst: r5, value: Int(1) })
-        PureSet(Binary { kind: Add, op: BinaryOp { dst: r3, a: r3, b: r5 } })
+        PureSet(LoadConst { dst: r4, value: Int(1) })
+        PureSet(Binary { kind: Add, op: BinaryOp { dst: r2, a: r2, b: r4 } })
         CoreSet(Jump { target_state: s6 })
       s9:
-        PureSet(LoadConst { dst: r5, value: None })
-        CoreSet(Return { src: r5 })
+        PureSet(LoadConst { dst: r4, value: None })
+        CoreSet(Return { src: r4 })
       s10:
         CoreSet(Jump { target_state: s8 })
     "#);

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_generator.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_generator.py__bytecode.snap
@@ -6,45 +6,44 @@ fn main(input: [items, multiplier], output: []):
     results = spread items:item -> @gather_generator.process_item(item=item, multiplier=multiplier)
     return results
 ---
-f0: [10 registers]
+f0: [9 registers]
   s0:
     PureSet(MakeList { dst: r3, items: [] })
     PureSet(MakeList { dst: r4, items: [] })
-    PureSet(Copy { dst: r5, src: r0 })
-    PureSet(LoadConst { dst: r6, value: Int(0) })
-    PureSet(Length { dst: r7, src: r5 })
+    PureSet(LoadConst { dst: r5, value: Int(0) })
+    PureSet(Length { dst: r6, src: r0 })
     CoreSet(Jump { target_state: s1 })
   s1:
-    PureSet(Binary { kind: Lt, op: BinaryOp { dst: r8, a: r6, b: r7 } })
-    CoreSet(JumpIf { target_state: s2, cond: r8 })
+    PureSet(Binary { kind: Lt, op: BinaryOp { dst: r7, a: r5, b: r6 } })
+    CoreSet(JumpIf { target_state: s2, cond: r7 })
     CoreSet(Jump { target_state: s4 })
   s2:
-    PureSet(Index { dst: r8, object: r5, index: r6 })
-    ExtCallSet(ActionCall { dst: r9, action_ref: TestActionRef("process_item"), args: [r8, r1], resume: s5 })
+    PureSet(Index { dst: r7, object: r0, index: r5 })
+    ExtCallSet(ActionCall { dst: r8, action_ref: TestActionRef("process_item"), args: [r7, r1], resume: s5 })
   s3:
-    PureSet(LoadConst { dst: r8, value: Int(1) })
-    PureSet(Binary { kind: Add, op: BinaryOp { dst: r6, a: r6, b: r8 } })
+    PureSet(LoadConst { dst: r7, value: Int(1) })
+    PureSet(Binary { kind: Add, op: BinaryOp { dst: r5, a: r5, b: r7 } })
     CoreSet(Jump { target_state: s1 })
   s4:
-    PureSet(LoadConst { dst: r6, value: Int(0) })
+    PureSet(LoadConst { dst: r5, value: Int(0) })
     CoreSet(Jump { target_state: s6 })
   s5:
-    PureSet(ListAppend { dst: r4, list: r4, item: r9 })
+    PureSet(ListAppend { dst: r4, list: r4, item: r8 })
     CoreSet(Jump { target_state: s3 })
   s6:
-    PureSet(Binary { kind: Lt, op: BinaryOp { dst: r8, a: r6, b: r7 } })
-    CoreSet(JumpIf { target_state: s7, cond: r8 })
+    PureSet(Binary { kind: Lt, op: BinaryOp { dst: r7, a: r5, b: r6 } })
+    CoreSet(JumpIf { target_state: s7, cond: r7 })
     CoreSet(Jump { target_state: s9 })
   s7:
-    PureSet(Index { dst: r8, object: r4, index: r6 })
-    CoreSet(Await { dst: r8, src: r8, resume: s10 })
+    PureSet(Index { dst: r7, object: r4, index: r5 })
+    CoreSet(Await { dst: r7, src: r7, resume: s10 })
   s8:
-    PureSet(LoadConst { dst: r8, value: Int(1) })
-    PureSet(Binary { kind: Add, op: BinaryOp { dst: r6, a: r6, b: r8 } })
+    PureSet(LoadConst { dst: r7, value: Int(1) })
+    PureSet(Binary { kind: Add, op: BinaryOp { dst: r5, a: r5, b: r7 } })
     CoreSet(Jump { target_state: s6 })
   s9:
     PureSet(Copy { dst: r2, src: r3 })
     CoreSet(Return { src: r2 })
   s10:
-    PureSet(ListAppend { dst: r3, list: r3, item: r8 })
+    PureSet(ListAppend { dst: r3, list: r3, item: r7 })
     CoreSet(Jump { target_state: s8 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_generator_filter.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_generator_filter.py__bytecode.snap
@@ -10,7 +10,7 @@ fn main(input: [users], output: []):
     results = spread __spread_items_1__:user -> @gather_generator_filter.process_user(user=user)
     return results
 ---
-f0: [14 registers]
+f0: [13 registers]
   s0:
     PureSet(MakeList { dst: r1, items: [] })
     PureSet(Copy { dst: r2, src: r0 })
@@ -34,9 +34,8 @@ f0: [14 registers]
   s4:
     PureSet(MakeList { dst: r8, items: [] })
     PureSet(MakeList { dst: r9, items: [] })
-    PureSet(Copy { dst: r10, src: r1 })
-    PureSet(LoadConst { dst: r11, value: Int(0) })
-    PureSet(Length { dst: r12, src: r10 })
+    PureSet(LoadConst { dst: r10, value: Int(0) })
+    PureSet(Length { dst: r11, src: r1 })
     CoreSet(Jump { target_state: s7 })
   s5:
     CoreSet(Jump { target_state: s3 })
@@ -45,32 +44,32 @@ f0: [14 registers]
     PureSet(Binary { kind: Add, op: BinaryOp { dst: r1, a: r1, b: r5 } })
     CoreSet(Jump { target_state: s5 })
   s7:
-    PureSet(Binary { kind: Lt, op: BinaryOp { dst: r5, a: r11, b: r12 } })
+    PureSet(Binary { kind: Lt, op: BinaryOp { dst: r5, a: r10, b: r11 } })
     CoreSet(JumpIf { target_state: s8, cond: r5 })
     CoreSet(Jump { target_state: s10 })
   s8:
-    PureSet(Index { dst: r5, object: r10, index: r11 })
-    ExtCallSet(ActionCall { dst: r13, action_ref: TestActionRef("process_user"), args: [r5], resume: s11 })
+    PureSet(Index { dst: r5, object: r1, index: r10 })
+    ExtCallSet(ActionCall { dst: r12, action_ref: TestActionRef("process_user"), args: [r5], resume: s11 })
   s9:
     PureSet(LoadConst { dst: r5, value: Int(1) })
-    PureSet(Binary { kind: Add, op: BinaryOp { dst: r11, a: r11, b: r5 } })
+    PureSet(Binary { kind: Add, op: BinaryOp { dst: r10, a: r10, b: r5 } })
     CoreSet(Jump { target_state: s7 })
   s10:
-    PureSet(LoadConst { dst: r11, value: Int(0) })
+    PureSet(LoadConst { dst: r10, value: Int(0) })
     CoreSet(Jump { target_state: s12 })
   s11:
-    PureSet(ListAppend { dst: r9, list: r9, item: r13 })
+    PureSet(ListAppend { dst: r9, list: r9, item: r12 })
     CoreSet(Jump { target_state: s9 })
   s12:
-    PureSet(Binary { kind: Lt, op: BinaryOp { dst: r5, a: r11, b: r12 } })
+    PureSet(Binary { kind: Lt, op: BinaryOp { dst: r5, a: r10, b: r11 } })
     CoreSet(JumpIf { target_state: s13, cond: r5 })
     CoreSet(Jump { target_state: s15 })
   s13:
-    PureSet(Index { dst: r5, object: r9, index: r11 })
+    PureSet(Index { dst: r5, object: r9, index: r10 })
     CoreSet(Await { dst: r5, src: r5, resume: s16 })
   s14:
     PureSet(LoadConst { dst: r5, value: Int(1) })
-    PureSet(Binary { kind: Add, op: BinaryOp { dst: r11, a: r11, b: r5 } })
+    PureSet(Binary { kind: Add, op: BinaryOp { dst: r10, a: r10, b: r5 } })
     CoreSet(Jump { target_state: s12 })
   s15:
     PureSet(Copy { dst: r7, src: r8 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_listcomp.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_listcomp.py__bytecode.snap
@@ -6,45 +6,44 @@ fn main(input: [items, multiplier], output: []):
     results = spread items:item -> @gather_listcomp.process_item(item=item, multiplier=multiplier)
     return results
 ---
-f0: [10 registers]
+f0: [9 registers]
   s0:
     PureSet(MakeList { dst: r3, items: [] })
     PureSet(MakeList { dst: r4, items: [] })
-    PureSet(Copy { dst: r5, src: r0 })
-    PureSet(LoadConst { dst: r6, value: Int(0) })
-    PureSet(Length { dst: r7, src: r5 })
+    PureSet(LoadConst { dst: r5, value: Int(0) })
+    PureSet(Length { dst: r6, src: r0 })
     CoreSet(Jump { target_state: s1 })
   s1:
-    PureSet(Binary { kind: Lt, op: BinaryOp { dst: r8, a: r6, b: r7 } })
-    CoreSet(JumpIf { target_state: s2, cond: r8 })
+    PureSet(Binary { kind: Lt, op: BinaryOp { dst: r7, a: r5, b: r6 } })
+    CoreSet(JumpIf { target_state: s2, cond: r7 })
     CoreSet(Jump { target_state: s4 })
   s2:
-    PureSet(Index { dst: r8, object: r5, index: r6 })
-    ExtCallSet(ActionCall { dst: r9, action_ref: TestActionRef("process_item"), args: [r8, r1], resume: s5 })
+    PureSet(Index { dst: r7, object: r0, index: r5 })
+    ExtCallSet(ActionCall { dst: r8, action_ref: TestActionRef("process_item"), args: [r7, r1], resume: s5 })
   s3:
-    PureSet(LoadConst { dst: r8, value: Int(1) })
-    PureSet(Binary { kind: Add, op: BinaryOp { dst: r6, a: r6, b: r8 } })
+    PureSet(LoadConst { dst: r7, value: Int(1) })
+    PureSet(Binary { kind: Add, op: BinaryOp { dst: r5, a: r5, b: r7 } })
     CoreSet(Jump { target_state: s1 })
   s4:
-    PureSet(LoadConst { dst: r6, value: Int(0) })
+    PureSet(LoadConst { dst: r5, value: Int(0) })
     CoreSet(Jump { target_state: s6 })
   s5:
-    PureSet(ListAppend { dst: r4, list: r4, item: r9 })
+    PureSet(ListAppend { dst: r4, list: r4, item: r8 })
     CoreSet(Jump { target_state: s3 })
   s6:
-    PureSet(Binary { kind: Lt, op: BinaryOp { dst: r8, a: r6, b: r7 } })
-    CoreSet(JumpIf { target_state: s7, cond: r8 })
+    PureSet(Binary { kind: Lt, op: BinaryOp { dst: r7, a: r5, b: r6 } })
+    CoreSet(JumpIf { target_state: s7, cond: r7 })
     CoreSet(Jump { target_state: s9 })
   s7:
-    PureSet(Index { dst: r8, object: r4, index: r6 })
-    CoreSet(Await { dst: r8, src: r8, resume: s10 })
+    PureSet(Index { dst: r7, object: r4, index: r5 })
+    CoreSet(Await { dst: r7, src: r7, resume: s10 })
   s8:
-    PureSet(LoadConst { dst: r8, value: Int(1) })
-    PureSet(Binary { kind: Add, op: BinaryOp { dst: r6, a: r6, b: r8 } })
+    PureSet(LoadConst { dst: r7, value: Int(1) })
+    PureSet(Binary { kind: Add, op: BinaryOp { dst: r5, a: r5, b: r7 } })
     CoreSet(Jump { target_state: s6 })
   s9:
     PureSet(Copy { dst: r2, src: r3 })
     CoreSet(Return { src: r2 })
   s10:
-    PureSet(ListAppend { dst: r3, list: r3, item: r8 })
+    PureSet(ListAppend { dst: r3, list: r3, item: r7 })
     CoreSet(Jump { target_state: s8 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_listcomp_filter.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_listcomp_filter.py__bytecode.snap
@@ -10,7 +10,7 @@ fn main(input: [users], output: []):
     results = spread __spread_items_1__:user -> @gather_listcomp_filter.process_user(user=user)
     return results
 ---
-f0: [14 registers]
+f0: [13 registers]
   s0:
     PureSet(MakeList { dst: r1, items: [] })
     PureSet(Copy { dst: r2, src: r0 })
@@ -34,9 +34,8 @@ f0: [14 registers]
   s4:
     PureSet(MakeList { dst: r8, items: [] })
     PureSet(MakeList { dst: r9, items: [] })
-    PureSet(Copy { dst: r10, src: r1 })
-    PureSet(LoadConst { dst: r11, value: Int(0) })
-    PureSet(Length { dst: r12, src: r10 })
+    PureSet(LoadConst { dst: r10, value: Int(0) })
+    PureSet(Length { dst: r11, src: r1 })
     CoreSet(Jump { target_state: s7 })
   s5:
     CoreSet(Jump { target_state: s3 })
@@ -45,32 +44,32 @@ f0: [14 registers]
     PureSet(Binary { kind: Add, op: BinaryOp { dst: r1, a: r1, b: r5 } })
     CoreSet(Jump { target_state: s5 })
   s7:
-    PureSet(Binary { kind: Lt, op: BinaryOp { dst: r5, a: r11, b: r12 } })
+    PureSet(Binary { kind: Lt, op: BinaryOp { dst: r5, a: r10, b: r11 } })
     CoreSet(JumpIf { target_state: s8, cond: r5 })
     CoreSet(Jump { target_state: s10 })
   s8:
-    PureSet(Index { dst: r5, object: r10, index: r11 })
-    ExtCallSet(ActionCall { dst: r13, action_ref: TestActionRef("process_user"), args: [r5], resume: s11 })
+    PureSet(Index { dst: r5, object: r1, index: r10 })
+    ExtCallSet(ActionCall { dst: r12, action_ref: TestActionRef("process_user"), args: [r5], resume: s11 })
   s9:
     PureSet(LoadConst { dst: r5, value: Int(1) })
-    PureSet(Binary { kind: Add, op: BinaryOp { dst: r11, a: r11, b: r5 } })
+    PureSet(Binary { kind: Add, op: BinaryOp { dst: r10, a: r10, b: r5 } })
     CoreSet(Jump { target_state: s7 })
   s10:
-    PureSet(LoadConst { dst: r11, value: Int(0) })
+    PureSet(LoadConst { dst: r10, value: Int(0) })
     CoreSet(Jump { target_state: s12 })
   s11:
-    PureSet(ListAppend { dst: r9, list: r9, item: r13 })
+    PureSet(ListAppend { dst: r9, list: r9, item: r12 })
     CoreSet(Jump { target_state: s9 })
   s12:
-    PureSet(Binary { kind: Lt, op: BinaryOp { dst: r5, a: r11, b: r12 } })
+    PureSet(Binary { kind: Lt, op: BinaryOp { dst: r5, a: r10, b: r11 } })
     CoreSet(JumpIf { target_state: s13, cond: r5 })
     CoreSet(Jump { target_state: s15 })
   s13:
-    PureSet(Index { dst: r5, object: r9, index: r11 })
+    PureSet(Index { dst: r5, object: r9, index: r10 })
     CoreSet(Await { dst: r5, src: r5, resume: s16 })
   s14:
     PureSet(LoadConst { dst: r5, value: Int(1) })
-    PureSet(Binary { kind: Add, op: BinaryOp { dst: r11, a: r11, b: r5 } })
+    PureSet(Binary { kind: Add, op: BinaryOp { dst: r10, a: r10, b: r5 } })
     CoreSet(Jump { target_state: s12 })
   s15:
     PureSet(Copy { dst: r7, src: r8 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_listcomp_tuple_unpack.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_listcomp_tuple_unpack.py__bytecode.snap
@@ -6,49 +6,48 @@ fn main(input: [pairs], output: []):
     results = spread pairs:__spread_item_1__ -> @gather_listcomp_tuple_unpack.process_pair(name=__spread_item_1__[0], score=__spread_item_1__[1])
     return results
 ---
-f0: [12 registers]
+f0: [11 registers]
   s0:
     PureSet(MakeList { dst: r2, items: [] })
     PureSet(MakeList { dst: r3, items: [] })
-    PureSet(Copy { dst: r4, src: r0 })
-    PureSet(LoadConst { dst: r5, value: Int(0) })
-    PureSet(Length { dst: r6, src: r4 })
+    PureSet(LoadConst { dst: r4, value: Int(0) })
+    PureSet(Length { dst: r5, src: r0 })
     CoreSet(Jump { target_state: s1 })
   s1:
-    PureSet(Binary { kind: Lt, op: BinaryOp { dst: r7, a: r5, b: r6 } })
-    CoreSet(JumpIf { target_state: s2, cond: r7 })
+    PureSet(Binary { kind: Lt, op: BinaryOp { dst: r6, a: r4, b: r5 } })
+    CoreSet(JumpIf { target_state: s2, cond: r6 })
     CoreSet(Jump { target_state: s4 })
   s2:
-    PureSet(Index { dst: r7, object: r4, index: r5 })
-    PureSet(LoadConst { dst: r9, value: Int(0) })
-    PureSet(Index { dst: r10, object: r7, index: r9 })
-    PureSet(LoadConst { dst: r9, value: Int(1) })
-    PureSet(Index { dst: r11, object: r7, index: r9 })
-    ExtCallSet(ActionCall { dst: r8, action_ref: TestActionRef("process_pair"), args: [r10, r11], resume: s5 })
+    PureSet(Index { dst: r6, object: r0, index: r4 })
+    PureSet(LoadConst { dst: r8, value: Int(0) })
+    PureSet(Index { dst: r9, object: r6, index: r8 })
+    PureSet(LoadConst { dst: r8, value: Int(1) })
+    PureSet(Index { dst: r10, object: r6, index: r8 })
+    ExtCallSet(ActionCall { dst: r7, action_ref: TestActionRef("process_pair"), args: [r9, r10], resume: s5 })
   s3:
-    PureSet(LoadConst { dst: r7, value: Int(1) })
-    PureSet(Binary { kind: Add, op: BinaryOp { dst: r5, a: r5, b: r7 } })
+    PureSet(LoadConst { dst: r6, value: Int(1) })
+    PureSet(Binary { kind: Add, op: BinaryOp { dst: r4, a: r4, b: r6 } })
     CoreSet(Jump { target_state: s1 })
   s4:
-    PureSet(LoadConst { dst: r5, value: Int(0) })
+    PureSet(LoadConst { dst: r4, value: Int(0) })
     CoreSet(Jump { target_state: s6 })
   s5:
-    PureSet(ListAppend { dst: r3, list: r3, item: r8 })
+    PureSet(ListAppend { dst: r3, list: r3, item: r7 })
     CoreSet(Jump { target_state: s3 })
   s6:
-    PureSet(Binary { kind: Lt, op: BinaryOp { dst: r7, a: r5, b: r6 } })
-    CoreSet(JumpIf { target_state: s7, cond: r7 })
+    PureSet(Binary { kind: Lt, op: BinaryOp { dst: r6, a: r4, b: r5 } })
+    CoreSet(JumpIf { target_state: s7, cond: r6 })
     CoreSet(Jump { target_state: s9 })
   s7:
-    PureSet(Index { dst: r7, object: r3, index: r5 })
-    CoreSet(Await { dst: r7, src: r7, resume: s10 })
+    PureSet(Index { dst: r6, object: r3, index: r4 })
+    CoreSet(Await { dst: r6, src: r6, resume: s10 })
   s8:
-    PureSet(LoadConst { dst: r7, value: Int(1) })
-    PureSet(Binary { kind: Add, op: BinaryOp { dst: r5, a: r5, b: r7 } })
+    PureSet(LoadConst { dst: r6, value: Int(1) })
+    PureSet(Binary { kind: Add, op: BinaryOp { dst: r4, a: r4, b: r6 } })
     CoreSet(Jump { target_state: s6 })
   s9:
     PureSet(Copy { dst: r1, src: r2 })
     CoreSet(Return { src: r1 })
   s10:
-    PureSet(ListAppend { dst: r2, list: r2, item: r7 })
+    PureSet(ListAppend { dst: r2, list: r2, item: r6 })
     CoreSet(Jump { target_state: s8 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_run_action_spread.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_run_action_spread.py__bytecode.snap
@@ -7,49 +7,48 @@ fn main(input: [items], output: []):
     _return_tmp = @gather_run_action_spread.combine_results(results=results)
     return _return_tmp
 ---
-f0: [10 registers]
+f0: [9 registers]
   s0:
     PureSet(MakeList { dst: r2, items: [] })
     PureSet(MakeList { dst: r3, items: [] })
-    PureSet(Copy { dst: r4, src: r0 })
-    PureSet(LoadConst { dst: r5, value: Int(0) })
-    PureSet(Length { dst: r6, src: r4 })
+    PureSet(LoadConst { dst: r4, value: Int(0) })
+    PureSet(Length { dst: r5, src: r0 })
     CoreSet(Jump { target_state: s1 })
   s1:
-    PureSet(Binary { kind: Lt, op: BinaryOp { dst: r7, a: r5, b: r6 } })
-    CoreSet(JumpIf { target_state: s2, cond: r7 })
+    PureSet(Binary { kind: Lt, op: BinaryOp { dst: r6, a: r4, b: r5 } })
+    CoreSet(JumpIf { target_state: s2, cond: r6 })
     CoreSet(Jump { target_state: s4 })
   s2:
-    PureSet(Index { dst: r7, object: r4, index: r5 })
-    ExtCallSet(ActionCall { dst: r8, action_ref: TestActionRef("process_item"), args: [r7], resume: s5 })
+    PureSet(Index { dst: r6, object: r0, index: r4 })
+    ExtCallSet(ActionCall { dst: r7, action_ref: TestActionRef("process_item"), args: [r6], resume: s5 })
   s3:
-    PureSet(LoadConst { dst: r7, value: Int(1) })
-    PureSet(Binary { kind: Add, op: BinaryOp { dst: r5, a: r5, b: r7 } })
+    PureSet(LoadConst { dst: r6, value: Int(1) })
+    PureSet(Binary { kind: Add, op: BinaryOp { dst: r4, a: r4, b: r6 } })
     CoreSet(Jump { target_state: s1 })
   s4:
-    PureSet(LoadConst { dst: r5, value: Int(0) })
+    PureSet(LoadConst { dst: r4, value: Int(0) })
     CoreSet(Jump { target_state: s6 })
   s5:
-    PureSet(ListAppend { dst: r3, list: r3, item: r8 })
+    PureSet(ListAppend { dst: r3, list: r3, item: r7 })
     CoreSet(Jump { target_state: s3 })
   s6:
-    PureSet(Binary { kind: Lt, op: BinaryOp { dst: r7, a: r5, b: r6 } })
-    CoreSet(JumpIf { target_state: s7, cond: r7 })
+    PureSet(Binary { kind: Lt, op: BinaryOp { dst: r6, a: r4, b: r5 } })
+    CoreSet(JumpIf { target_state: s7, cond: r6 })
     CoreSet(Jump { target_state: s9 })
   s7:
-    PureSet(Index { dst: r7, object: r3, index: r5 })
-    CoreSet(Await { dst: r7, src: r7, resume: s10 })
+    PureSet(Index { dst: r6, object: r3, index: r4 })
+    CoreSet(Await { dst: r6, src: r6, resume: s10 })
   s8:
-    PureSet(LoadConst { dst: r7, value: Int(1) })
-    PureSet(Binary { kind: Add, op: BinaryOp { dst: r5, a: r5, b: r7 } })
+    PureSet(LoadConst { dst: r6, value: Int(1) })
+    PureSet(Binary { kind: Add, op: BinaryOp { dst: r4, a: r4, b: r6 } })
     CoreSet(Jump { target_state: s6 })
   s9:
     PureSet(Copy { dst: r1, src: r2 })
-    ExtCallSet(ActionCall { dst: r9, action_ref: TestActionRef("combine_results"), args: [r1], resume: s11 })
+    ExtCallSet(ActionCall { dst: r8, action_ref: TestActionRef("combine_results"), args: [r1], resume: s11 })
   s10:
-    PureSet(ListAppend { dst: r2, list: r2, item: r7 })
+    PureSet(ListAppend { dst: r2, list: r2, item: r6 })
     CoreSet(Jump { target_state: s8 })
   s11:
-    CoreSet(Await { dst: r9, src: r9, resume: s12 })
+    CoreSet(Await { dst: r8, src: r8, resume: s12 })
   s12:
-    CoreSet(Return { src: r9 })
+    CoreSet(Return { src: r8 })


### PR DESCRIPTION
Avoid copying the index values when we know they don't change (since we know there is no loop body in spreads).