### PR TITLE
Add support for spreads without targets

### DIFF
--- a/crates/lib/vm-compiler-for-ast-old/src/function/compiler/lowering/assignment.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/function/compiler/lowering/assignment.rs
@@ -68,6 +68,13 @@ where
             } => {
                 self.compile_spread_assignment(target, collection, loop_var, action)?;
             }
+            AssignmentStatementPlan::SpreadDiscard {
+                collection,
+                loop_var,
+                action,
+            } => {
+                self.compile_spread_discard(collection, loop_var, action)?;
+            }
             AssignmentStatementPlan::Parallel { assignment } => {
                 self.parallel_compiler().compile_assignment(assignment)?;
             }
@@ -121,6 +128,17 @@ where
 
         target.mark_initialized(self.context.flow_state);
         Ok(())
+    }
+
+    /// Compiles a side-effect-only spread assignment emitted by the frontend.
+    fn compile_spread_discard(
+        &mut self,
+        collection: &Spanned<Expr>,
+        loop_var: &str,
+        action: &ActionCall,
+    ) -> Result<(), ErrorFor<Spec, Lowering>> {
+        self.for_loop_compiler()
+            .compile_spread_statement(collection, loop_var, action)
     }
 
     /// Creates a value compiler borrowing the current context.

--- a/crates/lib/vm-compiler-for-ast-old/src/function/compiler/plan/assignment.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/function/compiler/plan/assignment.rs
@@ -40,6 +40,18 @@ where
         action: &'a ActionCall,
     },
 
+    /// A spread expression evaluated only for its side effects.
+    SpreadDiscard {
+        /// Collection expression evaluated by the spread.
+        collection: &'a Spanned<Expr>,
+
+        /// Loop variable bound for each spread item.
+        loop_var: &'a str,
+
+        /// Action invoked per collection item.
+        action: &'a ActionCall,
+    },
+
     /// An assignment sourced from a parallel expression.
     Parallel {
         /// Validated parallel-assignment plan.
@@ -63,6 +75,19 @@ where
         F: FnMut(&str) -> Marked<LocalSlot, AssignmentTargetMarker>,
     {
         let Some(targets) = NESlice::try_from_slice(targets) else {
+            if let Expr::SpreadExpr {
+                collection,
+                loop_var,
+                action,
+            } = &value.value
+            {
+                return Ok(Self::SpreadDiscard {
+                    collection,
+                    loop_var,
+                    action,
+                });
+            }
+
             return Err(super::plan::Unsupported::AssignmentNoTargets.into());
         };
 
@@ -165,6 +190,9 @@ mod tests {
             }
             AssignmentStatementPlan::Spread { .. } => {
                 panic!("literal assignments should not build spread plans")
+            }
+            AssignmentStatementPlan::SpreadDiscard { .. } => {
+                panic!("literal assignments should not build discard spread plans")
             }
         }
     }
@@ -285,11 +313,14 @@ mod tests {
             AssignmentStatementPlan::Spread { .. } => {
                 panic!("parallel expressions should not build spread plans")
             }
+            AssignmentStatementPlan::SpreadDiscard { .. } => {
+                panic!("parallel expressions should not build discard spread plans")
+            }
         }
     }
 
     #[test]
-    fn assignments_reject_zero_targets_before_parallel_planning() {
+    fn non_spread_assignments_reject_zero_targets_before_parallel_planning() {
         let function_table = build_function_table();
         let error = AssignmentStatementPlan::<TestSpec>::build::<TestLowering, _>(
             &[],
@@ -303,6 +334,45 @@ mod tests {
             error,
             Error::Unsupported(crate::function::compiler::plan::Unsupported::AssignmentNoTargets)
         ));
+    }
+
+    #[test]
+    fn zero_target_spread_assignments_build_discard_plan() {
+        let function_table = build_function_table();
+        let value = spread_expr(
+            variable("items"),
+            "item",
+            action_call("double", vec![("value", variable("item"))]),
+        );
+
+        let plan = AssignmentStatementPlan::<TestSpec>::build::<TestLowering, _>(
+            &[],
+            &value,
+            &function_table,
+            |_| panic!("discard spreads should not resolve assignment targets"),
+        )
+        .expect("zero-target spread assignment should build");
+
+        match plan {
+            AssignmentStatementPlan::SpreadDiscard {
+                collection,
+                loop_var,
+                action,
+            } => {
+                assert!(matches!(collection.value, Expr::Variable { ref name } if name == "items"));
+                assert_eq!(loop_var, "item");
+                assert_eq!(action.action_name, "double");
+            }
+            AssignmentStatementPlan::Direct { .. } => {
+                panic!("discard spread should not build a direct plan")
+            }
+            AssignmentStatementPlan::Spread { .. } => {
+                panic!("discard spread should not build a targeted spread plan")
+            }
+            AssignmentStatementPlan::Parallel { .. } => {
+                panic!("discard spread should not build a parallel plan")
+            }
+        }
     }
 
     #[test]
@@ -348,6 +418,9 @@ mod tests {
             }
             AssignmentStatementPlan::Parallel { .. } => {
                 panic!("spread expressions should not build parallel plans")
+            }
+            AssignmentStatementPlan::SpreadDiscard { .. } => {
+                panic!("targeted spread expressions should not build discard plans")
             }
         }
     }

--- a/crates/lib/vm-compiler-for-ast-old/src/function/compiler/plan/expr.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/function/compiler/plan/expr.rs
@@ -89,19 +89,12 @@ pub enum ExpressionPlan<'a> {
     },
 }
 
-/// Expression variants that the generic value-lowering path rejects.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum UnsupportedExpressionKind {
-    /// Spread expressions.
-    SpreadExpr,
-}
-
 impl<'a> ExpressionPlan<'a> {
     /// Builds an expression plan for an AST expression used as a generic value.
     ///
-    /// Parallel expressions are excluded from this path because the compiler
-    /// only lowers them through the dedicated assignment planner, which needs
-    /// access to the assignment targets.
+    /// Parallel and spread expressions are excluded from this path because the
+    /// compiler only lowers them through dedicated assignment planners, which
+    /// need surrounding statement context.
     pub fn build(expr: &'a Spanned<Expr>) -> Result<Self, Unsupported> {
         match &expr.value {
             Expr::Literal { value } => Ok(Self::Literal { value }),
@@ -121,19 +114,9 @@ impl<'a> ExpressionPlan<'a> {
             Expr::Dict { entries } => Ok(Self::Dict { entries }),
             Expr::Index { object, index } => Ok(Self::Index { object, index }),
             Expr::Dot { object, attribute } => Ok(Self::Dot { object, attribute }),
+            Expr::SpreadExpr { .. } => Err(Unsupported::SpreadExprOutsideAssignment),
             Expr::ParallelExpr { .. } => Err(Unsupported::ParallelExprOutsideAssignment),
-            Expr::SpreadExpr { .. } => Err(Unsupported::Expression {
-                kind: UnsupportedExpressionKind::SpreadExpr,
-            }),
         }
-    }
-}
-
-impl core::fmt::Display for UnsupportedExpressionKind {
-    fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        formatter.write_str(match self {
-            Self::SpreadExpr => "SpreadExpr",
-        })
     }
 }
 
@@ -253,25 +236,21 @@ mod tests {
     }
 
     #[test]
-    fn rejects_currently_unsupported_expression_variants() {
-        let unsupported = [(
-            spanned(Expr::SpreadExpr {
-                collection: Box::new(variable("items")),
-                loop_var: "item".to_owned(),
-                action: action_call("notify", vec![("value", variable("item"))]),
-            }),
-            UnsupportedExpressionKind::SpreadExpr,
-        )];
+    fn rejects_spread_expressions_outside_assignment_context() {
+        let expr = spanned(Expr::SpreadExpr {
+            collection: Box::new(variable("items")),
+            loop_var: "item".to_owned(),
+            action: action_call("notify", vec![("value", variable("item"))]),
+        });
 
-        for (expr, kind) in unsupported {
-            let error =
-                ExpressionPlan::build(&expr).expect_err("unsupported expressions should fail");
+        let error = ExpressionPlan::build(&expr)
+            .expect_err("spread expressions should stay assignment-specific");
 
-            assert!(matches!(
-                error,
-                Unsupported::Expression { kind: actual } if actual == kind
-            ));
-        }
+        assert!(matches!(error, Unsupported::SpreadExprOutsideAssignment));
+        assert_eq!(
+            error.to_string(),
+            "spread expressions are only supported on the right-hand side of assignments"
+        );
     }
 
     #[test]

--- a/crates/lib/vm-compiler-for-ast-old/src/function/compiler/plan/unsupported.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/function/compiler/plan/unsupported.rs
@@ -3,8 +3,8 @@
 use std::num::NonZeroUsize;
 
 pub use super::{
-    call::UnsupportedFunctionCall, expr::UnsupportedExpressionKind,
-    parallel::UnsupportedParallelExprAssignment, statement::UnsupportedStatementKind,
+    call::UnsupportedFunctionCall, parallel::UnsupportedParallelExprAssignment,
+    statement::UnsupportedStatementKind,
 };
 
 /// Unsupported AST constructs or VM capabilities encountered during
@@ -18,16 +18,13 @@ pub enum Unsupported {
         kind: UnsupportedStatementKind,
     },
 
-    /// An expression variant is not compiled yet.
-    #[error("expression `{kind}` is not supported by the compiler yet")]
-    Expression {
-        /// The unsupported expression kind.
-        kind: UnsupportedExpressionKind,
-    },
-
     /// A parallel expression appeared outside the assignment planner.
     #[error("parallel expressions are only supported on the right-hand side of assignments")]
     ParallelExprOutsideAssignment,
+
+    /// A spread expression appeared outside the assignment planner.
+    #[error("spread expressions are only supported on the right-hand side of assignments")]
+    SpreadExprOutsideAssignment,
 
     /// A function call shape cannot be represented by the current VM.
     #[error("function call `{name}` is not supported: {reason}")]
@@ -39,8 +36,8 @@ pub enum Unsupported {
         reason: UnsupportedFunctionCall,
     },
 
-    /// assignment with no targets are not supported by the current VM subset.
-    #[error("assignment with no targets is not supported by the compiler yet")]
+    /// Zero-target assignments are only supported for side-effect spread forms.
+    #[error("assignment with no targets is only supported for spread expressions")]
     AssignmentNoTargets,
 
     /// Multiple assignment targets are not supported by the current VM subset.

--- a/crates/lib/vm-compiler-for-ast-old/src/tests/spreads.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/tests/spreads.rs
@@ -1,7 +1,8 @@
 //! Tests for spread-statement and spread-expression lowering.
 
 use waymark_vm_ast_old_helpers::{
-    action_call, assignment, function, program, return_stmt, spread_expr, spread_stmt, variable,
+    action_call, assignment, assignment_targets, function, program, return_stmt, spread_expr,
+    spread_stmt, variable,
 };
 use waymark_vm_compiler_for_ast_old_test_support::{TestLowering, TestSpec};
 
@@ -88,6 +89,71 @@ fn spread_expression_assignments_lower_to_looped_action_collection() {
         CoreSet(Return { src: r1 })
       s10:
         PureSet(ListAppend { dst: r2, list: r2, item: r7 })
+        CoreSet(Jump { target_state: s8 })
+    "#);
+}
+
+#[test]
+fn zero_target_spread_assignments_compile_as_side_effect_spreads() {
+    let program = program(vec![function(
+        "main",
+        &["items"],
+        vec![
+            assignment_targets(
+                &[],
+                spread_expr(
+                    variable("items"),
+                    "item",
+                    action_call("notify", vec![("value", variable("item"))]),
+                ),
+            ),
+            return_stmt(None),
+        ],
+    )]);
+
+    let executable = compile::<TestSpec, TestLowering>(&program)
+        .expect("zero-target spread assignments should compile as side-effect spreads");
+
+    insta::assert_snapshot!(waymark_vm_bytecode_fmt::display(&executable), @r#"
+    f0: [7 registers]
+      s0:
+        PureSet(MakeList { dst: r1, items: [] })
+        PureSet(Copy { dst: r2, src: r0 })
+        PureSet(LoadConst { dst: r3, value: Int(0) })
+        PureSet(Length { dst: r4, src: r2 })
+        CoreSet(Jump { target_state: s1 })
+      s1:
+        PureSet(Binary { kind: Lt, op: BinaryOp { dst: r5, a: r3, b: r4 } })
+        CoreSet(JumpIf { target_state: s2, cond: r5 })
+        CoreSet(Jump { target_state: s4 })
+      s2:
+        PureSet(Index { dst: r5, object: r2, index: r3 })
+        ExtCallSet(ActionCall { dst: r6, action_ref: TestActionRef("notify"), args: [r5], resume: s5 })
+      s3:
+        PureSet(LoadConst { dst: r5, value: Int(1) })
+        PureSet(Binary { kind: Add, op: BinaryOp { dst: r3, a: r3, b: r5 } })
+        CoreSet(Jump { target_state: s1 })
+      s4:
+        PureSet(LoadConst { dst: r3, value: Int(0) })
+        CoreSet(Jump { target_state: s6 })
+      s5:
+        PureSet(ListAppend { dst: r1, list: r1, item: r6 })
+        CoreSet(Jump { target_state: s3 })
+      s6:
+        PureSet(Binary { kind: Lt, op: BinaryOp { dst: r5, a: r3, b: r4 } })
+        CoreSet(JumpIf { target_state: s7, cond: r5 })
+        CoreSet(Jump { target_state: s9 })
+      s7:
+        PureSet(Index { dst: r5, object: r1, index: r3 })
+        CoreSet(Await { dst: r5, src: r5, resume: s10 })
+      s8:
+        PureSet(LoadConst { dst: r5, value: Int(1) })
+        PureSet(Binary { kind: Add, op: BinaryOp { dst: r3, a: r3, b: r5 } })
+        CoreSet(Jump { target_state: s6 })
+      s9:
+        PureSet(LoadConst { dst: r5, value: None })
+        CoreSet(Return { src: r5 })
+      s10:
         CoreSet(Jump { target_state: s8 })
     "#);
 }


### PR DESCRIPTION
I've realized I didn't add this path in #417, so here we go.

This PR adds support for the spreads that don't consume the call values; also, this PR eliminates the spreads as unsupported expressions, as expected (this is how we know we've implemented them fully now).