### PR TITLE
Add runtime snapshotting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3957,6 +3957,7 @@ checksum = "436de2fdc42c0f07890f4b51dcc90a468b0b12280f49caff1cf57ce2e646817c"
 dependencies = [
  "const_fn",
  "rustversion",
+ "serde",
  "typed_floats_macros",
 ]
 
@@ -5203,6 +5204,7 @@ name = "waymark-vm-bytecode-core"
 version = "0.1.0"
 dependencies = [
  "index_type",
+ "serde",
 ]
 
 [[package]]
@@ -5336,6 +5338,9 @@ dependencies = [
 [[package]]
 name = "waymark-vm-exception-handler"
 version = "0.1.0"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "waymark-vm-executable"
@@ -5469,6 +5474,8 @@ dependencies = [
 name = "waymark-vm-runtime"
 version = "0.1.0"
 dependencies = [
+ "rmp-serde",
+ "serde",
  "thiserror",
  "tracing",
  "waymark-vm-executable",
@@ -5484,6 +5491,7 @@ name = "waymark-vm-runtime-core"
 version = "0.1.0"
 dependencies = [
  "index_type",
+ "serde",
  "thiserror",
  "waymark-vm-exception-handler",
  "waymark-vm-runtime-exception",
@@ -5496,6 +5504,7 @@ dependencies = [
 name = "waymark-vm-runtime-exception"
 version = "0.1.0"
 dependencies = [
+ "serde",
  "thiserror",
  "waymark-vm-runtime-value",
 ]
@@ -5505,6 +5514,7 @@ name = "waymark-vm-runtime-promise-core"
 version = "0.1.0"
 dependencies = [
  "index_type",
+ "serde",
  "thiserror",
 ]
 
@@ -5512,6 +5522,7 @@ dependencies = [
 name = "waymark-vm-runtime-promise-value"
 version = "0.1.0"
 dependencies = [
+ "serde",
  "thiserror",
  "waymark-nonzero-duration",
  "waymark-vm-interpreter-coreset",
@@ -5526,6 +5537,7 @@ dependencies = [
 name = "waymark-vm-runtime-test"
 version = "0.1.0"
 dependencies = [
+ "serde",
  "thiserror",
  "waymark-vm-bytecode",
  "waymark-vm-bytecode-core",
@@ -5547,6 +5559,7 @@ name = "waymark-vm-value"
 version = "0.1.0"
 dependencies = [
  "indexmap 2.13.0",
+ "serde",
  "static_assertions",
  "thiserror",
  "typed_floats",

--- a/crates/lib/vm-bytecode-core/Cargo.toml
+++ b/crates/lib/vm-bytecode-core/Cargo.toml
@@ -6,3 +6,9 @@ publish.workspace = true
 
 [dependencies]
 index_type = { workspace = true }
+serde = { workspace = true, optional = true }
+
+[features]
+default = []
+
+serde = ["dep:serde", "serde/derive"]

--- a/crates/lib/vm-bytecode-core/src/lib.rs
+++ b/crates/lib/vm-bytecode-core/src/lib.rs
@@ -6,16 +6,19 @@ use index_type::{IndexTooBigError, IndexType};
 
 /// Identifies a function within a VM executable.
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, IndexType, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[index_type(error = FunctionIdTooBigError)]
 pub struct FunctionId(pub usize);
 
 /// Identifies a state-machine state within a function.
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, IndexType, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[index_type(error = StateIdTooBigError)]
 pub struct StateId(pub usize);
 
 /// Identifies an instruction within a state.
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, IndexType, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[index_type(error = InstructionIdTooBigError)]
 pub struct InstructionId(pub usize);
 

--- a/crates/lib/vm-exception-handler/Cargo.toml
+++ b/crates/lib/vm-exception-handler/Cargo.toml
@@ -5,3 +5,9 @@ version.workspace = true
 publish.workspace = true
 
 [dependencies]
+serde = { workspace = true, optional = true }
+
+[features]
+default = []
+
+serde = ["dep:serde", "serde/derive"]

--- a/crates/lib/vm-exception-handler/src/lib.rs
+++ b/crates/lib/vm-exception-handler/src/lib.rs
@@ -11,6 +11,7 @@ pub type ExceptionHandlerBlocks<StateId, RegisterId> =
 
 /// A catch target for a raised VM exception.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ExceptionHandler<StateId, RegisterId> {
     /// State to transfer control to when this handler matches.
     pub handler_state: StateId,

--- a/crates/lib/vm-runtime-core/Cargo.toml
+++ b/crates/lib/vm-runtime-core/Cargo.toml
@@ -10,7 +10,18 @@ waymark-vm-runtime-exception = { workspace = true }
 waymark-vm-runtime-promise-core = { workspace = true }
 
 index_type = { workspace = true }
+serde = { workspace = true, optional = true }
 thiserror = { workspace = true }
+
+[features]
+default = []
+
+serde = [
+  "dep:serde",
+  "waymark-vm-exception-handler/serde",
+  "waymark-vm-runtime-exception/serde",
+  "waymark-vm-runtime-promise-core/serde",
+]
 
 [dev-dependencies]
 waymark-vm-runtime-promise-value = { workspace = true }

--- a/crates/lib/vm-runtime-core/src/continuation.rs
+++ b/crates/lib/vm-runtime-core/src/continuation.rs
@@ -4,6 +4,8 @@ use crate::{Frame, RegisterId};
 /// after a certain async value is resolved.
 ///
 /// `Resumer` determines how we resume the execution for this continuation.
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Continuation<FunctionId, StateId, Value, Resumer> {
     /// The frame to resume the execution from.
     prepared_resume_frame: Frame<FunctionId, StateId, Value>,
@@ -18,6 +20,8 @@ pub struct Continuation<FunctionId, StateId, Value, Resumer> {
 ///
 /// Typical use is for continuations that suspend on an asynchronously obtained
 /// value.
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ResumeWithValue {
     /// The register to assign the resulting value of this continuation to.
     pub dst: RegisterId,

--- a/crates/lib/vm-runtime-core/src/frame.rs
+++ b/crates/lib/vm-runtime-core/src/frame.rs
@@ -4,6 +4,8 @@ use waymark_vm_runtime_promise_core::PromiseStateId;
 use crate::{ExceptionHandlers, Registers};
 
 /// A frame shape used in runtime.
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Frame<FunctionId, StateId, Value> {
     /// A function this frame is executing.
     pub func: FunctionId,
@@ -25,7 +27,8 @@ pub struct Frame<FunctionId, StateId, Value> {
 }
 
 /// The kind of a frame.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum FrameKind {
     /// Top level frame.
     ///

--- a/crates/lib/vm-runtime-core/src/frame_exception_handlers.rs
+++ b/crates/lib/vm-runtime-core/src/frame_exception_handlers.rs
@@ -8,6 +8,8 @@ use crate::RegisterId;
 pub struct PopExceptionHandlersError;
 
 /// Frame-local stack of active exception-handler blocks.
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ExceptionHandlers<StateId>(Vec<ExceptionHandlerBlock<StateId, RegisterId>>);
 
 impl<StateId> Default for ExceptionHandlers<StateId> {

--- a/crates/lib/vm-runtime-core/src/promise_state.rs
+++ b/crates/lib/vm-runtime-core/src/promise_state.rs
@@ -15,6 +15,8 @@ pub struct ResolvingAlreadyResolvedPromiseError<Value> {
 }
 
 /// A runtime internal state associated with a promise.
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum PromiseState<FunctionId, StateId, Value> {
     /// A list of continuations to resume when a promise resolves.
     ///

--- a/crates/lib/vm-runtime-core/src/promise_states.rs
+++ b/crates/lib/vm-runtime-core/src/promise_states.rs
@@ -8,6 +8,7 @@ pub type RejectPromiseError<Value> =
     ResolvePromiseError<waymark_vm_runtime_exception::Exception<Value>>;
 
 /// A list of promise states.
+#[derive(Debug, Clone)]
 pub struct PromiseStates<FunctionId, StateId, Value>(
     TypedVec<PromiseStateId, PromiseState<FunctionId, StateId, Value>>,
 );
@@ -128,6 +129,35 @@ impl<Value> ResolvePromiseError<Value> {
                     new_value,
                 })
             }
+        }
+    }
+}
+
+#[cfg(feature = "serde")]
+mod serde_impls {
+    use super::PromiseStates;
+    use index_type::IndexType;
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    impl<FunctionId: Serialize, StateId: Serialize, Value: Serialize> Serialize
+        for PromiseStates<FunctionId, StateId, Value>
+    {
+        fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+            use serde::ser::SerializeSeq;
+            let mut seq = serializer.serialize_seq(Some(self.0.len().to_scalar()))?;
+            for element in &self.0 {
+                seq.serialize_element(element)?;
+            }
+            seq.end()
+        }
+    }
+
+    impl<'de, FunctionId: Deserialize<'de>, StateId: Deserialize<'de>, Value: Deserialize<'de>>
+        Deserialize<'de> for PromiseStates<FunctionId, StateId, Value>
+    {
+        fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+            let inner: Vec<_> = Vec::deserialize(deserializer)?;
+            Ok(Self(inner.into_iter().collect()))
         }
     }
 }

--- a/crates/lib/vm-runtime-core/src/registers.rs
+++ b/crates/lib/vm-runtime-core/src/registers.rs
@@ -7,6 +7,7 @@ pub struct RegisterIdTooBigError;
 
 /// Index of a register in the [`Registers`] type.
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, IndexType)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[index_type(error = RegisterIdTooBigError)]
 pub struct RegisterId(pub usize);
 
@@ -15,6 +16,12 @@ pub struct RegisterId(pub usize);
 /// Used to store values per frame.
 #[derive(Debug)]
 pub struct Registers<Value>(TypedVec<RegisterId, Option<Value>>);
+
+impl<Value: Clone> Clone for Registers<Value> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
 
 impl<Value> std::ops::Index<RegisterId> for Registers<Value> {
     type Output = Value;
@@ -83,6 +90,31 @@ impl<Value> Registers<Value> {
 impl core::fmt::Debug for RegisterId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "r{}", self.0)
+    }
+}
+
+#[cfg(feature = "serde")]
+mod serde_impls {
+    use super::Registers;
+    use index_type::IndexType;
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    impl<Value: Serialize> Serialize for Registers<Value> {
+        fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+            use serde::ser::SerializeSeq;
+            let mut seq = serializer.serialize_seq(Some(self.0.len().to_scalar()))?;
+            for element in &self.0 {
+                seq.serialize_element(element)?;
+            }
+            seq.end()
+        }
+    }
+
+    impl<'de, Value: Deserialize<'de>> Deserialize<'de> for Registers<Value> {
+        fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+            let inner: Vec<Option<Value>> = Vec::deserialize(deserializer)?;
+            Ok(Self(inner.into_iter().collect()))
+        }
     }
 }
 

--- a/crates/lib/vm-runtime-core/src/runtime_state.rs
+++ b/crates/lib/vm-runtime-core/src/runtime_state.rs
@@ -11,6 +11,8 @@ use crate::{Frame, PromiseStates, RejectPromiseError, ResolvePromiseError};
 ///
 /// The access to the runtime state is indirectly provided to the interpreters
 /// via the [`crate::CaptureRuntimeView`].
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct RuntimeState<FunctionId, StateId, Value> {
     /// The queue of the ready-to-execute frames.
     ///

--- a/crates/lib/vm-runtime-exception/Cargo.toml
+++ b/crates/lib/vm-runtime-exception/Cargo.toml
@@ -7,4 +7,10 @@ publish.workspace = true
 [dependencies]
 waymark-vm-runtime-value = { workspace = true }
 
+serde = { workspace = true, optional = true, features = ["derive"] }
 thiserror = { workspace = true }
+
+[features]
+default = []
+
+serde = ["dep:serde", "serde/derive"]

--- a/crates/lib/vm-runtime-exception/src/lib.rs
+++ b/crates/lib/vm-runtime-exception/src/lib.rs
@@ -4,6 +4,7 @@
 
 /// The exception type.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Exception<Details> {
     /// The exception's type identifier.
     pub type_id: String,

--- a/crates/lib/vm-runtime-promise-core/Cargo.toml
+++ b/crates/lib/vm-runtime-promise-core/Cargo.toml
@@ -6,4 +6,10 @@ publish.workspace = true
 
 [dependencies]
 index_type = { workspace = true }
+serde = { workspace = true, optional = true, features = ["derive"] }
 thiserror = { workspace = true }
+
+[features]
+default = []
+
+serde = ["dep:serde", "serde/derive"]

--- a/crates/lib/vm-runtime-promise-core/src/lib.rs
+++ b/crates/lib/vm-runtime-promise-core/src/lib.rs
@@ -14,6 +14,7 @@ pub struct PromiseStateIdTooBigError;
 
 /// Index of a [`PromiseState`] in the promise states store.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, IndexType, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[index_type(error = PromiseStateIdTooBigError)]
 pub struct PromiseStateId(pub usize);
 

--- a/crates/lib/vm-runtime-promise-value/Cargo.toml
+++ b/crates/lib/vm-runtime-promise-value/Cargo.toml
@@ -13,4 +13,10 @@ waymark-vm-runtime-exception = { workspace = true }
 waymark-vm-runtime-promise-core = { workspace = true }
 waymark-vm-runtime-value = { workspace = true }
 
+serde = { workspace = true, optional = true, features = ["derive"] }
 thiserror = { workspace = true }
+
+[features]
+default = []
+
+serde = ["dep:serde", "waymark-vm-runtime-promise-core/serde"]

--- a/crates/lib/vm-runtime-promise-value/src/lib.rs
+++ b/crates/lib/vm-runtime-promise-value/src/lib.rs
@@ -7,6 +7,7 @@ mod pureset;
 use waymark_vm_runtime_promise_core::{PromiseStateId, UnresolvedPromiseError};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum PromiseValue<T> {
     Ready(T),
     Pending(PromiseStateId),

--- a/crates/lib/vm-runtime-test/Cargo.toml
+++ b/crates/lib/vm-runtime-test/Cargo.toml
@@ -6,13 +6,14 @@ publish.workspace = true
 
 [dependencies]
 waymark-vm-bytecode = { workspace = true }
-waymark-vm-bytecode-core = { workspace = true }
+waymark-vm-bytecode-core = { workspace = true, features = ["serde"] }
 waymark-vm-interpreter = { workspace = true }
 waymark-vm-interpreter-coreset = { workspace = true }
 waymark-vm-runtime = { workspace = true }
 waymark-vm-runtime-core = { workspace = true }
 waymark-vm-runtime-exception = { workspace = true }
-waymark-vm-runtime-promise-value = { workspace = true }
+waymark-vm-runtime-promise-value = { workspace = true, features = ["serde"] }
 waymark-vm-runtime-value = { workspace = true }
 
+serde = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }

--- a/crates/lib/vm-runtime-test/src/lib.rs
+++ b/crates/lib/vm-runtime-test/src/lib.rs
@@ -30,6 +30,7 @@
 //! - Per-interpreter `TestSpec`/`TestValue` aliases — those live in each
 //!   interpreter crate's `tests/support/mod.rs`.
 
+use serde::{Deserialize, Serialize};
 use waymark_vm_interpreter::{ExecutionOutcome, Interpreter};
 use waymark_vm_runtime::{CallSpec, FunctionNotFoundError, Runtime};
 use waymark_vm_runtime_core::{
@@ -76,7 +77,7 @@ pub type TestExecutable = waymark_vm_bytecode::Executable<TestInstruction>;
 
 pub type TestFunction = waymark_vm_bytecode::Function<TestInstruction>;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum TestReadyValue {
     Int(i32),
     Exception(Box<Exception<PromiseValue<TestReadyValue>>>),

--- a/crates/lib/vm-runtime/Cargo.toml
+++ b/crates/lib/vm-runtime/Cargo.toml
@@ -7,12 +7,15 @@ publish.workspace = true
 [dependencies]
 waymark-vm-executable = { workspace = true }
 waymark-vm-interpreter = { workspace = true }
-waymark-vm-runtime-core = { workspace = true }
+waymark-vm-runtime-core = { workspace = true, features = ["serde"] }
 waymark-vm-runtime-exception = { workspace = true }
 waymark-vm-runtime-promise-core = { workspace = true }
 
+serde = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
 waymark-vm-runtime-test = { workspace = true }
+
+rmp-serde = { workspace = true }

--- a/crates/lib/vm-runtime/src/lib.rs
+++ b/crates/lib/vm-runtime/src/lib.rs
@@ -5,6 +5,7 @@
 
 #![warn(missing_docs)]
 
+pub mod snapshot;
 pub mod step;
 
 use std::collections::VecDeque;
@@ -242,5 +243,15 @@ where
                     waymark_vm_runtime_exception::Exception { type_id, details }
                 })
             })
+    }
+}
+
+impl<Executable, Interpreter, Value> Runtime<Executable, Interpreter, Value>
+where
+    Executable: waymark_vm_executable::FunctionStates,
+{
+    /// Returns `true` if the runtime has ready frames to execute.
+    pub fn has_ready_frames(&self) -> bool {
+        !self.state.ready.is_empty()
     }
 }

--- a/crates/lib/vm-runtime/src/snapshot.rs
+++ b/crates/lib/vm-runtime/src/snapshot.rs
@@ -1,0 +1,46 @@
+//! Serialization and deserialization of the VM runtime state.
+
+use crate::Runtime;
+
+use waymark_vm_runtime_core::RuntimeState;
+
+impl<Executable, Interpreter, Value> Runtime<Executable, Interpreter, Value>
+where
+    Executable: waymark_vm_executable::FunctionStates,
+    Executable::FunctionId: serde::Serialize,
+    Executable::StateId: serde::Serialize,
+    Value: serde::Serialize,
+{
+    /// Serialize the runtime state using the provided [`Serializer`](serde::Serializer).
+    pub fn snapshot<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serde::Serialize::serialize(&self.state, serializer)
+    }
+}
+
+impl<Executable, Interpreter, Value> Runtime<Executable, Interpreter, Value>
+where
+    Executable: waymark_vm_executable::FunctionStates,
+    Executable::FunctionId: for<'de> serde::Deserialize<'de>,
+    Executable::StateId: for<'de> serde::Deserialize<'de>,
+    Value: for<'de> serde::Deserialize<'de>,
+{
+    /// Restore a runtime from a snapshot [`Deserializer`](serde::Deserializer).
+    ///
+    /// Takes the same interpreter and executable that were used to create
+    /// the original runtime, along with a deserializer positioned at the
+    /// previously snapshotted state.
+    pub fn from_snapshot<'de, D: serde::Deserializer<'de>>(
+        interpreter: Interpreter,
+        executable: Executable,
+        deserializer: D,
+    ) -> Result<Self, D::Error> {
+        let state: RuntimeState<Executable::FunctionId, Executable::StateId, Value> =
+            serde::Deserialize::deserialize(deserializer)?;
+
+        Ok(Self {
+            interpreter,
+            executable,
+            state,
+        })
+    }
+}

--- a/crates/lib/vm-runtime/tests/integration.rs
+++ b/crates/lib/vm-runtime/tests/integration.rs
@@ -360,3 +360,136 @@ fn state_entry_hook_can_redirect_exceptional_resumes_when_the_interpreter_wants(
         TestEffect::Message("handled")
     );
 }
+
+#[test]
+fn snapshot_suspended_and_from_snapshot_preserves_suspended_promises() {
+    let make_executable = || {
+        executable(vec![function(
+            1,
+            vec![
+                vec![TestInstruction::Suspend {
+                    dst: RegisterId(0),
+                    resume: StateId(1),
+                }],
+                vec![TestInstruction::EmitRegister(RegisterId(0))],
+            ],
+        )])
+    };
+
+    // Create runtime and run until it suspends.
+    let mut runtime = waymark_vm_runtime::Runtime::with_conventional_entrypoint(
+        TestInterpreter,
+        make_executable(),
+    )
+    .expect("entrypoint should exist");
+
+    assert!(matches!(runtime.run(), Err(RunError::NoReadyFrame)));
+
+    // Snapshot the suspended runtime.
+    let mut buf = Vec::new();
+    runtime
+        .snapshot(&mut rmp_serde::Serializer::new(&mut buf))
+        .expect("suspended runtime should snapshot");
+
+    // Restore into a new runtime with a fresh executable.
+    let mut de = rmp_serde::Deserializer::new(&buf[..]);
+    let mut restored =
+        waymark_vm_runtime::Runtime::from_snapshot(TestInterpreter, make_executable(), &mut de)
+            .expect("snapshotted bytes should restore");
+
+    // Resolve the promise in the restored runtime.
+    restored
+        .resolve_promise(PromiseStateId(0), TestReadyValue::Int(42))
+        .expect("promise should resolve after restore");
+
+    assert_eq!(
+        restored.run().expect("restored runtime should emit"),
+        TestEffect::Value(TestReadyValue::Int(42))
+    );
+}
+
+#[test]
+fn snapshot_suspended_and_from_snapshot_preserves_rejected_promises() {
+    let make_executable = || {
+        executable(vec![function(
+            1,
+            vec![
+                vec![TestInstruction::Suspend {
+                    dst: RegisterId(0),
+                    resume: StateId(1),
+                }],
+                vec![TestInstruction::EmitException],
+            ],
+        )])
+    };
+
+    let mut runtime = waymark_vm_runtime::Runtime::with_conventional_entrypoint(
+        TestInterpreter,
+        make_executable(),
+    )
+    .expect("entrypoint should exist");
+
+    assert!(matches!(runtime.run(), Err(RunError::NoReadyFrame)));
+
+    // Snapshot.
+    let mut buf = Vec::new();
+    runtime
+        .snapshot(&mut rmp_serde::Serializer::new(&mut buf))
+        .expect("suspended runtime should snapshot");
+
+    // Restore.
+    let mut de = rmp_serde::Deserializer::new(&buf[..]);
+    let mut restored =
+        waymark_vm_runtime::Runtime::from_snapshot(TestInterpreter, make_executable(), &mut de)
+            .expect("snapshotted bytes should restore");
+
+    // Reject the promise.
+    restored
+        .reject_promise(
+            PromiseStateId(0),
+            Exception {
+                type_id: "ValueError".to_owned(),
+                details: TestReadyValue::Int(41),
+            },
+        )
+        .expect("promise should reject after restore");
+
+    assert_eq!(
+        restored
+            .run()
+            .expect("restored runtime should emit exception"),
+        TestEffect::UnhandledException(Exception {
+            type_id: "ValueError".to_owned(),
+            details: TestReadyValue::Int(41),
+        })
+    );
+}
+
+#[test]
+fn allow_live_snapshots_runtime_with_ready_frames() {
+    let runtime = runtime(executable(vec![function(
+        0,
+        vec![vec![TestInstruction::Emit("still-alive")]],
+    )]));
+
+    let mut buf = Vec::new();
+    runtime
+        .snapshot(&mut rmp_serde::Serializer::new(&mut buf))
+        .expect("snapshot_active should snapshot with ready frames");
+
+    let mut de = rmp_serde::Deserializer::new(&buf[..]);
+    let mut restored = waymark_vm_runtime::Runtime::from_snapshot(
+        TestInterpreter,
+        executable(vec![function(
+            0,
+            vec![vec![TestInstruction::Emit("still-alive")]],
+        )]),
+        &mut de,
+    )
+    .expect("live snapshot should restore");
+
+    assert_eq!(
+        restored.run().expect("restored runtime should emit"),
+        TestEffect::Message("still-alive")
+    );
+}

--- a/crates/lib/vm-value/Cargo.toml
+++ b/crates/lib/vm-value/Cargo.toml
@@ -4,6 +4,17 @@ edition = "2024"
 version.workspace = true
 publish.workspace = true
 
+[features]
+default = []
+
+serde = [
+  "dep:serde",
+  "waymark-vm-runtime-promise-value/serde",
+  "waymark-vm-runtime-exception/serde",
+  "typed_floats/serde",
+  "indexmap/serde",
+]
+
 [dependencies]
 waymark-nonzero-duration = { workspace = true }
 waymark-vm-instructions-pureset = { workspace = true }
@@ -15,6 +26,7 @@ waymark-vm-runtime-promise-value = { workspace = true }
 waymark-vm-runtime-value = { workspace = true }
 
 indexmap = { workspace = true }
+serde = { workspace = true, optional = true, features = ["derive"] }
 thiserror = { workspace = true }
 typed_floats = { workspace = true }
 

--- a/crates/lib/vm-value/src/lib.rs
+++ b/crates/lib/vm-value/src/lib.rs
@@ -13,6 +13,7 @@ mod pythonic;
 
 /// The VM value that is ready.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ReadyValue {
     /// Integer value.
     Int(i64),


### PR DESCRIPTION
This PR adds `serde` support for some types and implements the new `snapshot`/`from_snapshot` calls for VM.

This PR also adds `has_ready_frames` to the `Runtime` so the consumers can check whether there are any ready frames  in the `Runtime` or not.

---

Note: the current API of the `Runtime` hides the `state` and exposes a limited and controlled API for accessing it, which is very much intended and, as a general abstraction boundary, not supposed to change.

---

This is a first PR in the series that adds proper integration of the new VMs into the waymark main code; it is stable enough that we can merge it already.