### PR TITLE
More serde implementations for VM types (and small correction to the previous work in this domain)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5501,6 +5501,7 @@ dependencies = [
  "index_type",
  "serde",
  "thiserror",
+ "waymark-typed-vec-serde",
  "waymark-vm-exception-handler",
  "waymark-vm-runtime-exception",
  "waymark-vm-runtime-promise-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5295,6 +5295,7 @@ dependencies = [
 name = "waymark-vm-compiler-for-ast-old-const-value"
 version = "0.1.0"
 dependencies = [
+ "serde",
  "thiserror",
  "typed_floats",
  "waymark-vm-ast-old",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5361,6 +5361,7 @@ name = "waymark-vm-instructions-coreset"
 version = "0.1.0"
 dependencies = [
  "derive-where",
+ "serde",
  "waymark-vm-exception-handler",
 ]
 
@@ -5369,6 +5370,7 @@ name = "waymark-vm-instructions-extcallset"
 version = "0.1.0"
 dependencies = [
  "derive-where",
+ "serde",
 ]
 
 [[package]]
@@ -5376,6 +5378,7 @@ name = "waymark-vm-instructions-fullset"
 version = "0.1.0"
 dependencies = [
  "derive-where",
+ "serde",
  "waymark-vm-instructions-coreset",
  "waymark-vm-instructions-extcallset",
  "waymark-vm-instructions-pureset",
@@ -5386,6 +5389,7 @@ name = "waymark-vm-instructions-pureset"
 version = "0.1.0"
 dependencies = [
  "derive-where",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5203,6 +5203,8 @@ name = "waymark-vm-bytecode"
 version = "0.1.0"
 dependencies = [
  "index_type",
+ "serde",
+ "waymark-typed-vec-serde",
  "waymark-vm-bytecode-core",
  "waymark-vm-executable",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5143,6 +5143,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "waymark-typed-vec-serde"
+version = "0.1.0"
+dependencies = [
+ "index_type",
+ "serde",
+]
+
+[[package]]
 name = "waymark-utils-futures"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ waymark-timed = { path = "crates/lib/timed" }
 waymark-timed-channel = { path = "crates/lib/timed-channel" }
 waymark-timed-future = { path = "crates/lib/timed-future" }
 waymark-tokio-metrics-bringup = { path = "crates/lib/tokio-metrics-bringup" }
+waymark-typed-vec-serde = { path = "crates/lib/typed-vec-serde" }
 waymark-utils-futures = { path = "crates/lib/utils-futures" }
 waymark-utils-tokio-channel = { path = "crates/lib/utils-tokio-channel" }
 waymark-vm-ast-old = { path = "crates/lib/vm-ast-old" }

--- a/crates/lib/typed-vec-serde/Cargo.toml
+++ b/crates/lib/typed-vec-serde/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "waymark-typed-vec-serde"
+edition = "2024"
+version.workspace = true
+publish.workspace = true
+
+[dependencies]
+index_type = { workspace = true }
+serde = { workspace = true }

--- a/crates/lib/typed-vec-serde/src/lib.rs
+++ b/crates/lib/typed-vec-serde/src/lib.rs
@@ -1,0 +1,28 @@
+//! Serde support for `index_type::typed_vec::TypedVec`.
+
+#![warn(missing_docs)]
+
+use index_type::{IndexType, typed_vec::TypedVec};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+/// Serialize a `TypedVec` as a plain sequence.
+pub fn serialize<I, T, S>(vec: &TypedVec<I, T>, serializer: S) -> Result<S::Ok, S::Error>
+where
+    I: IndexType,
+    T: Serialize,
+    S: Serializer,
+{
+    let values: Vec<&T> = vec.iter().collect();
+    values.serialize(serializer)
+}
+
+/// Deserialize a `TypedVec` from a plain sequence.
+pub fn deserialize<'de, I, T, D>(deserializer: D) -> Result<TypedVec<I, T>, D::Error>
+where
+    I: IndexType,
+    T: Deserialize<'de>,
+    D: Deserializer<'de>,
+{
+    let values = Vec::<T>::deserialize(deserializer)?;
+    Ok(TypedVec::from_iter(values))
+}

--- a/crates/lib/vm-bytecode/Cargo.toml
+++ b/crates/lib/vm-bytecode/Cargo.toml
@@ -9,3 +9,8 @@ waymark-vm-bytecode-core = { workspace = true }
 waymark-vm-executable = { workspace = true }
 
 index_type = { workspace = true }
+serde = { workspace = true, optional = true }
+waymark-typed-vec-serde = { workspace = true, optional = true }
+
+[features]
+serde = ["dep:serde", "dep:waymark-typed-vec-serde", "waymark-vm-bytecode-core/serde"]

--- a/crates/lib/vm-bytecode/src/lib.rs
+++ b/crates/lib/vm-bytecode/src/lib.rs
@@ -9,15 +9,33 @@ use waymark_vm_bytecode_core::{FunctionId, InstructionId, StateId};
 ///
 /// A collection of functions.
 #[derive(Debug)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(bound(
+        serialize = "Instruction: serde::Serialize",
+        deserialize = "Instruction: serde::Deserialize<'de>",
+    ))
+)]
 pub struct Executable<Instruction> {
     /// Functions this executable contains.
+    #[cfg_attr(feature = "serde", serde(with = "waymark_typed_vec_serde"))]
     pub functions: TypedVec<FunctionId, Function<Instruction>>,
 }
 
 /// A function with the given `Instruction`s.
 #[derive(Debug)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(bound(
+        serialize = "Instruction: serde::Serialize",
+        deserialize = "Instruction: serde::Deserialize<'de>",
+    ))
+)]
 pub struct Function<Instruction> {
     /// States (as in state-machine states) this function consists of.
+    #[cfg_attr(feature = "serde", serde(with = "waymark_typed_vec_serde"))]
     pub states: TypedVec<StateId, State<Instruction>>,
 
     /// The number of registers this function uses;
@@ -26,8 +44,17 @@ pub struct Function<Instruction> {
 
 /// A state (as in state-machine states) with the given `Instruction`s.
 #[derive(Debug)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(bound(
+        serialize = "Instruction: serde::Serialize",
+        deserialize = "Instruction: serde::Deserialize<'de>",
+    ))
+)]
 pub struct State<Instruction> {
     /// The sequence of `Instruction`s.
+    #[cfg_attr(feature = "serde", serde(with = "waymark_typed_vec_serde"))]
     pub instructions: TypedVec<InstructionId, Instruction>,
 }
 

--- a/crates/lib/vm-compiler-for-ast-old-const-value/Cargo.toml
+++ b/crates/lib/vm-compiler-for-ast-old-const-value/Cargo.toml
@@ -8,5 +8,13 @@ publish.workspace = true
 waymark-vm-ast-old = { workspace = true }
 waymark-vm-value = { workspace = true }
 
+serde = { workspace = true, optional = true }
 thiserror = { workspace = true }
 typed_floats = { workspace = true }
+
+[features]
+serde = [
+  "dep:serde",
+  "serde/derive",
+  "waymark-vm-value/serde",
+]

--- a/crates/lib/vm-compiler-for-ast-old-const-value/src/lib.rs
+++ b/crates/lib/vm-compiler-for-ast-old-const-value/src/lib.rs
@@ -10,6 +10,7 @@ use typed_floats::NonNaNFinite;
 /// A subset of [`waymark_vm_value::Value`] that can be lowered from
 /// the [`waymark_vm_ast_old::Literal`].
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ConstValue {
     /// Integer value.
     Int(i64),

--- a/crates/lib/vm-instructions-coreset/Cargo.toml
+++ b/crates/lib/vm-instructions-coreset/Cargo.toml
@@ -8,3 +8,7 @@ publish.workspace = true
 waymark-vm-exception-handler = { workspace = true }
 
 derive-where = { workspace = true }
+serde = { workspace = true, optional = true }
+
+[features]
+serde = ["dep:serde", "serde/derive", "waymark-vm-exception-handler/serde"]

--- a/crates/lib/vm-instructions-coreset/src/lib.rs
+++ b/crates/lib/vm-instructions-coreset/src/lib.rs
@@ -23,6 +23,22 @@ pub trait Spec: 'static {
 
 /// The core instructions set.
 #[derive_where(Debug)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(bound(
+        serialize = "
+            Spec::RegisterId: serde::Serialize,
+            Spec::FunctionId: serde::Serialize,
+            Spec::StateId: serde::Serialize,
+        ",
+        deserialize = "
+            Spec::RegisterId: serde::Deserialize<'de>,
+            Spec::FunctionId: serde::Deserialize<'de>,
+            Spec::StateId: serde::Deserialize<'de>,
+        ",
+    ))
+)]
 pub enum CoreSet<Spec: self::Spec> {
     /// Call a function.
     ///

--- a/crates/lib/vm-instructions-extcallset/Cargo.toml
+++ b/crates/lib/vm-instructions-extcallset/Cargo.toml
@@ -6,3 +6,7 @@ publish.workspace = true
 
 [dependencies]
 derive-where = { workspace = true }
+serde = { workspace = true, optional = true }
+
+[features]
+serde = ["dep:serde", "serde/derive"]

--- a/crates/lib/vm-instructions-extcallset/src/lib.rs
+++ b/crates/lib/vm-instructions-extcallset/src/lib.rs
@@ -20,6 +20,22 @@ pub trait Spec: 'static {
 
 /// The external-call instructions set.
 #[derive_where(Debug)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(bound(
+        serialize = "
+            Spec::RegisterId: serde::Serialize,
+            Spec::StateId: serde::Serialize,
+            Spec::ActionRef: serde::Serialize,
+        ",
+        deserialize = "
+            Spec::RegisterId: serde::Deserialize<'de>,
+            Spec::StateId: serde::Deserialize<'de>,
+            Spec::ActionRef: serde::Deserialize<'de>,
+        ",
+    ))
+)]
 pub enum ExtCallSet<Spec: self::Spec> {
     /// Start an action call execution.
     ///

--- a/crates/lib/vm-instructions-fullset/Cargo.toml
+++ b/crates/lib/vm-instructions-fullset/Cargo.toml
@@ -10,3 +10,13 @@ waymark-vm-instructions-extcallset = { workspace = true }
 waymark-vm-instructions-pureset = { workspace = true }
 
 derive-where = { workspace = true }
+serde = { workspace = true, optional = true }
+
+[features]
+serde = [
+  "dep:serde",
+  "serde/derive",
+  "waymark-vm-instructions-coreset/serde",
+  "waymark-vm-instructions-extcallset/serde",
+  "waymark-vm-instructions-pureset/serde",
+]

--- a/crates/lib/vm-instructions-fullset/src/lib.rs
+++ b/crates/lib/vm-instructions-fullset/src/lib.rs
@@ -31,6 +31,22 @@ impl<T> Spec for T where
 
 /// The full instructions set.
 #[derive_where(Debug)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(bound(
+        serialize = "
+            waymark_vm_instructions_coreset::CoreSet<Spec>: serde::Serialize,
+            waymark_vm_instructions_extcallset::ExtCallSet<Spec>: serde::Serialize,
+            waymark_vm_instructions_pureset::PureSet<Spec>: serde::Serialize,
+        ",
+        deserialize = "
+            waymark_vm_instructions_coreset::CoreSet<Spec>: serde::Deserialize<'de>,
+            waymark_vm_instructions_extcallset::ExtCallSet<Spec>: serde::Deserialize<'de>,
+            waymark_vm_instructions_pureset::PureSet<Spec>: serde::Deserialize<'de>,
+        ",
+    ))
+)]
 pub enum FullSet<Spec: self::Spec> {
     /// Core instructions set.
     CoreSet(waymark_vm_instructions_coreset::CoreSet<Spec>),

--- a/crates/lib/vm-instructions-pureset/Cargo.toml
+++ b/crates/lib/vm-instructions-pureset/Cargo.toml
@@ -6,3 +6,7 @@ publish.workspace = true
 
 [dependencies]
 derive-where = { workspace = true }
+serde = { workspace = true, optional = true }
+
+[features]
+serde = ["dep:serde", "serde/derive"]

--- a/crates/lib/vm-instructions-pureset/src/lib.rs
+++ b/crates/lib/vm-instructions-pureset/src/lib.rs
@@ -21,6 +21,7 @@ pub trait Spec: 'static {
 
 /// An unary operation.
 #[derive(Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UnaryOp<RegisterId> {
     /// The register to store the result of the operation at.
     pub dst: RegisterId,
@@ -31,6 +32,7 @@ pub struct UnaryOp<RegisterId> {
 
 /// A binary operation.
 #[derive(Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BinaryOp<RegisterId> {
     /// The register to store the result of the operation at.
     pub dst: RegisterId,
@@ -44,6 +46,7 @@ pub struct BinaryOp<RegisterId> {
 
 /// The kind of binary operation to apply.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum BinaryOpKind {
     /// Add two values together.
     Add,
@@ -96,6 +99,7 @@ pub enum BinaryOpKind {
 
 /// The kind of unary operation to apply.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum UnaryOpKind {
     /// Negate a value.
     Neg,
@@ -106,6 +110,7 @@ pub enum UnaryOpKind {
 
 /// One dictionary entry.
 #[derive(Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DictEntry<RegisterId> {
     /// The register that contains the entry key.
     pub key: RegisterId,
@@ -116,6 +121,20 @@ pub struct DictEntry<RegisterId> {
 
 /// Pure instructions set.
 #[derive_where(Debug)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(bound(
+        serialize = "
+            Spec::RegisterId: serde::Serialize,
+            Spec::ConstValue: serde::Serialize,
+        ",
+        deserialize = "
+            Spec::RegisterId: serde::Deserialize<'de>,
+            Spec::ConstValue: serde::Deserialize<'de>,
+        ",
+    ))
+)]
 pub enum PureSet<Spec: self::Spec> {
     /// Load a constant value into the register.
     LoadConst {

--- a/crates/lib/vm-runtime-core/Cargo.toml
+++ b/crates/lib/vm-runtime-core/Cargo.toml
@@ -5,6 +5,7 @@ version.workspace = true
 publish.workspace = true
 
 [dependencies]
+waymark-typed-vec-serde = { workspace = true, optional = true }
 waymark-vm-exception-handler = { workspace = true }
 waymark-vm-runtime-exception = { workspace = true }
 waymark-vm-runtime-promise-core = { workspace = true }
@@ -18,6 +19,7 @@ default = []
 
 serde = [
   "dep:serde",
+  "dep:waymark-typed-vec-serde",
   "waymark-vm-exception-handler/serde",
   "waymark-vm-runtime-exception/serde",
   "waymark-vm-runtime-promise-core/serde",

--- a/crates/lib/vm-runtime-core/src/continuation.rs
+++ b/crates/lib/vm-runtime-core/src/continuation.rs
@@ -4,7 +4,7 @@ use crate::{Frame, RegisterId};
 /// after a certain async value is resolved.
 ///
 /// `Resumer` determines how we resume the execution for this continuation.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Continuation<FunctionId, StateId, Value, Resumer> {
     /// The frame to resume the execution from.
@@ -20,7 +20,7 @@ pub struct Continuation<FunctionId, StateId, Value, Resumer> {
 ///
 /// Typical use is for continuations that suspend on an asynchronously obtained
 /// value.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ResumeWithValue {
     /// The register to assign the resulting value of this continuation to.

--- a/crates/lib/vm-runtime-core/src/frame.rs
+++ b/crates/lib/vm-runtime-core/src/frame.rs
@@ -4,7 +4,7 @@ use waymark_vm_runtime_promise_core::PromiseStateId;
 use crate::{ExceptionHandlers, Registers};
 
 /// A frame shape used in runtime.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Frame<FunctionId, StateId, Value> {
     /// A function this frame is executing.
@@ -27,7 +27,7 @@ pub struct Frame<FunctionId, StateId, Value> {
 }
 
 /// The kind of a frame.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum FrameKind {
     /// Top level frame.

--- a/crates/lib/vm-runtime-core/src/frame_exception_handlers.rs
+++ b/crates/lib/vm-runtime-core/src/frame_exception_handlers.rs
@@ -8,7 +8,7 @@ use crate::RegisterId;
 pub struct PopExceptionHandlersError;
 
 /// Frame-local stack of active exception-handler blocks.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ExceptionHandlers<StateId>(Vec<ExceptionHandlerBlock<StateId, RegisterId>>);
 

--- a/crates/lib/vm-runtime-core/src/promise_state.rs
+++ b/crates/lib/vm-runtime-core/src/promise_state.rs
@@ -15,7 +15,7 @@ pub struct ResolvingAlreadyResolvedPromiseError<Value> {
 }
 
 /// A runtime internal state associated with a promise.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum PromiseState<FunctionId, StateId, Value> {
     /// A list of continuations to resume when a promise resolves.

--- a/crates/lib/vm-runtime-core/src/promise_states.rs
+++ b/crates/lib/vm-runtime-core/src/promise_states.rs
@@ -8,7 +8,7 @@ pub type RejectPromiseError<Value> =
     ResolvePromiseError<waymark_vm_runtime_exception::Exception<Value>>;
 
 /// A list of promise states.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct PromiseStates<FunctionId, StateId, Value>(
     TypedVec<PromiseStateId, PromiseState<FunctionId, StateId, Value>>,
 );

--- a/crates/lib/vm-runtime-core/src/promise_states.rs
+++ b/crates/lib/vm-runtime-core/src/promise_states.rs
@@ -9,7 +9,16 @@ pub type RejectPromiseError<Value> =
 
 /// A list of promise states.
 #[derive(Debug)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(bound(
+        serialize = "FunctionId: serde::Serialize, StateId: serde::Serialize, Value: serde::Serialize",
+        deserialize = "FunctionId: serde::Deserialize<'de>, StateId: serde::Deserialize<'de>, Value: serde::Deserialize<'de>",
+    ))
+)]
 pub struct PromiseStates<FunctionId, StateId, Value>(
+    #[cfg_attr(feature = "serde", serde(with = "waymark_typed_vec_serde"))]
     TypedVec<PromiseStateId, PromiseState<FunctionId, StateId, Value>>,
 );
 
@@ -129,35 +138,6 @@ impl<Value> ResolvePromiseError<Value> {
                     new_value,
                 })
             }
-        }
-    }
-}
-
-#[cfg(feature = "serde")]
-mod serde_impls {
-    use super::PromiseStates;
-    use index_type::IndexType;
-    use serde::{Deserialize, Deserializer, Serialize, Serializer};
-
-    impl<FunctionId: Serialize, StateId: Serialize, Value: Serialize> Serialize
-        for PromiseStates<FunctionId, StateId, Value>
-    {
-        fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-            use serde::ser::SerializeSeq;
-            let mut seq = serializer.serialize_seq(Some(self.0.len().to_scalar()))?;
-            for element in &self.0 {
-                seq.serialize_element(element)?;
-            }
-            seq.end()
-        }
-    }
-
-    impl<'de, FunctionId: Deserialize<'de>, StateId: Deserialize<'de>, Value: Deserialize<'de>>
-        Deserialize<'de> for PromiseStates<FunctionId, StateId, Value>
-    {
-        fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-            let inner: Vec<_> = Vec::deserialize(deserializer)?;
-            Ok(Self(inner.into_iter().collect()))
         }
     }
 }

--- a/crates/lib/vm-runtime-core/src/registers.rs
+++ b/crates/lib/vm-runtime-core/src/registers.rs
@@ -17,12 +17,6 @@ pub struct RegisterId(pub usize);
 #[derive(Debug)]
 pub struct Registers<Value>(TypedVec<RegisterId, Option<Value>>);
 
-impl<Value: Clone> Clone for Registers<Value> {
-    fn clone(&self) -> Self {
-        Self(self.0.clone())
-    }
-}
-
 impl<Value> std::ops::Index<RegisterId> for Registers<Value> {
     type Output = Value;
 

--- a/crates/lib/vm-runtime-core/src/registers.rs
+++ b/crates/lib/vm-runtime-core/src/registers.rs
@@ -15,7 +15,18 @@ pub struct RegisterId(pub usize);
 ///
 /// Used to store values per frame.
 #[derive(Debug)]
-pub struct Registers<Value>(TypedVec<RegisterId, Option<Value>>);
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(bound(
+        serialize = "Value: serde::Serialize",
+        deserialize = "Value: serde::Deserialize<'de>",
+    ))
+)]
+pub struct Registers<Value>(
+    #[cfg_attr(feature = "serde", serde(with = "waymark_typed_vec_serde"))]
+    TypedVec<RegisterId, Option<Value>>,
+);
 
 impl<Value> std::ops::Index<RegisterId> for Registers<Value> {
     type Output = Value;
@@ -84,31 +95,6 @@ impl<Value> Registers<Value> {
 impl core::fmt::Debug for RegisterId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "r{}", self.0)
-    }
-}
-
-#[cfg(feature = "serde")]
-mod serde_impls {
-    use super::Registers;
-    use index_type::IndexType;
-    use serde::{Deserialize, Deserializer, Serialize, Serializer};
-
-    impl<Value: Serialize> Serialize for Registers<Value> {
-        fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-            use serde::ser::SerializeSeq;
-            let mut seq = serializer.serialize_seq(Some(self.0.len().to_scalar()))?;
-            for element in &self.0 {
-                seq.serialize_element(element)?;
-            }
-            seq.end()
-        }
-    }
-
-    impl<'de, Value: Deserialize<'de>> Deserialize<'de> for Registers<Value> {
-        fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-            let inner: Vec<Option<Value>> = Vec::deserialize(deserializer)?;
-            Ok(Self(inner.into_iter().collect()))
-        }
     }
 }
 

--- a/crates/lib/vm-runtime-core/src/runtime_state.rs
+++ b/crates/lib/vm-runtime-core/src/runtime_state.rs
@@ -11,7 +11,7 @@ use crate::{Frame, PromiseStates, RejectPromiseError, ResolvePromiseError};
 ///
 /// The access to the runtime state is indirectly provided to the interpreters
 /// via the [`crate::CaptureRuntimeView`].
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct RuntimeState<FunctionId, StateId, Value> {
     /// The queue of the ready-to-execute frames.


### PR DESCRIPTION
This PRs is a continuation of https://github.com/piercefreeman/waymark/pull/429.

It add `serde` implementations needed for serializing the executables.
It also reworks some quirks that would cause inefficient code duplication by providing a shared `serde` implementation for `index_type`l I've already requested `serde` support upstream, see https://github.com/roeeshoshani/index_type/issues/27.

---

This PR also removes bad `Clone` impls - we should be very careful with what it allowed to be cloned; some types are just not intended to be clone-able, and should be shared via external means.