### PR TITLE
Add vm-codec-core and vm-codec-rmp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5259,6 +5259,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "waymark-vm-codec-core"
+version = "0.1.0"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "waymark-vm-codec-rmp"
+version = "0.1.0"
+dependencies = [
+ "rmp-serde",
+ "waymark-vm-codec-core",
+]
+
+[[package]]
 name = "waymark-vm-compiler-for-ast-old"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,7 @@ waymark-vm-ast-old-proto = { path = "crates/lib/vm-ast-old-proto" }
 waymark-vm-bytecode = { path = "crates/lib/vm-bytecode" }
 waymark-vm-bytecode-core = { path = "crates/lib/vm-bytecode-core" }
 waymark-vm-bytecode-fmt = { path = "crates/lib/vm-bytecode-fmt" }
+waymark-vm-codec-core = { path = "crates/lib/vm-codec-core" }
 waymark-vm-compiler-for-ast-old = { path = "crates/lib/vm-compiler-for-ast-old" }
 waymark-vm-compiler-for-ast-old-const-value = { path = "crates/lib/vm-compiler-for-ast-old-const-value" }
 waymark-vm-compiler-for-ast-old-core = { path = "crates/lib/vm-compiler-for-ast-old-core" }

--- a/crates/lib/vm-codec-core/Cargo.toml
+++ b/crates/lib/vm-codec-core/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "waymark-vm-codec-core"
+edition = "2024"
+version.workspace = true
+publish.workspace = true
+
+[dependencies]
+serde = { workspace = true }

--- a/crates/lib/vm-codec-core/src/arc.rs
+++ b/crates/lib/vm-codec-core/src/arc.rs
@@ -1,0 +1,41 @@
+//! Blanket `Arc<T>` implementations for codec traits.
+
+use std::sync::Arc;
+
+use crate::{DeserializerProvider, SerializerProvider};
+
+impl<P: SerializerProvider + 'static> SerializerProvider for Arc<P> {
+    type Serializer<'buf>
+        = P::Serializer<'buf>
+    where
+        Self: 'buf,
+        P: 'buf;
+
+    type Ok = P::Ok;
+
+    type Error = P::Error;
+
+    fn with_serializer<F, R>(&self, buffer: &mut Vec<u8>, f: F) -> R
+    where
+        for<'buf> F: FnOnce(Self::Serializer<'buf>) -> R,
+    {
+        P::with_serializer(self, buffer, f)
+    }
+}
+
+impl<P: DeserializerProvider + 'static> DeserializerProvider for Arc<P> {
+    type Deserializer<'de>
+        = P::Deserializer<'de>
+    where
+        Self: 'de,
+        P: 'de;
+
+    type Error = P::Error;
+
+    fn with_deserializer<F, T>(&self, data: &[u8], f: F) -> Result<T, Self::Error>
+    where
+        for<'de> F: FnOnce(Self::Deserializer<'de>) -> Result<T, Self::Error>,
+    {
+        P::with_deserializer(self, data, f)
+    }
+}

--- a/crates/lib/vm-codec-core/src/lib.rs
+++ b/crates/lib/vm-codec-core/src/lib.rs
@@ -1,0 +1,45 @@
+//! Codec abstraction for serialization/deserialization of runtime values.
+
+#![warn(missing_docs)]
+
+mod arc;
+mod tuple;
+
+/// Serializes values into a byte buffer.
+pub trait SerializerProvider {
+    /// The serializer type, borrowing the output buffer.
+    type Serializer<'buf>: serde::Serializer<Ok = Self::Ok, Error = Self::Error>
+    where
+        Self: 'buf;
+
+    /// Type returned when serialization succeeds.
+    type Ok;
+
+    /// Error returned when serialization fails.
+    type Error: std::fmt::Debug;
+
+    /// Call `f` with a serializer that writes into `buffer`.
+    ///
+    /// The implementor creates a serializer, hands `&mut` of it to `f`,
+    /// and the result is written into `buffer`.  This allows the caller
+    /// to use `value.snapshot(serializer)`-style APIs.
+    fn with_serializer<F, R>(&self, buffer: &mut Vec<u8>, f: F) -> R
+    where
+        for<'buf> F: FnOnce(Self::Serializer<'buf>) -> R;
+}
+
+/// Deserializes values from a byte slice.
+pub trait DeserializerProvider {
+    /// The deserializer type, borrowing the input data.
+    type Deserializer<'de>: serde::Deserializer<'de, Error = Self::Error>
+    where
+        Self: 'de;
+
+    /// Error returned when deserialization fails.
+    type Error: std::fmt::Debug;
+
+    /// Call `f` with a deserializer that reads from `data`.
+    fn with_deserializer<F, T>(&self, data: &[u8], f: F) -> Result<T, Self::Error>
+    where
+        for<'de> F: FnOnce(Self::Deserializer<'de>) -> Result<T, Self::Error>;
+}

--- a/crates/lib/vm-codec-core/src/tuple.rs
+++ b/crates/lib/vm-codec-core/src/tuple.rs
@@ -1,0 +1,37 @@
+//! Blanket implementations for tuples of codec traits.
+
+use crate::{DeserializerProvider, SerializerProvider};
+
+impl<A: SerializerProvider + 'static, B: 'static> SerializerProvider for (A, B) {
+    type Serializer<'buf>
+        = A::Serializer<'buf>
+    where
+        Self: 'buf;
+
+    type Ok = A::Ok;
+
+    type Error = A::Error;
+
+    fn with_serializer<F, R>(&self, buffer: &mut Vec<u8>, f: F) -> R
+    where
+        for<'buf> F: FnOnce(Self::Serializer<'buf>) -> R,
+    {
+        A::with_serializer(&self.0, buffer, f)
+    }
+}
+
+impl<A: 'static, B: DeserializerProvider + 'static> DeserializerProvider for (A, B) {
+    type Deserializer<'de>
+        = B::Deserializer<'de>
+    where
+        Self: 'de;
+
+    type Error = B::Error;
+
+    fn with_deserializer<F, T>(&self, data: &[u8], f: F) -> Result<T, Self::Error>
+    where
+        for<'de> F: FnOnce(Self::Deserializer<'de>) -> Result<T, Self::Error>,
+    {
+        B::with_deserializer(&self.1, data, f)
+    }
+}

--- a/crates/lib/vm-codec-rmp/Cargo.toml
+++ b/crates/lib/vm-codec-rmp/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "waymark-vm-codec-rmp"
+edition = "2024"
+version.workspace = true
+publish.workspace = true
+
+[dependencies]
+waymark-vm-codec-core = { workspace = true }
+
+rmp-serde = { workspace = true }

--- a/crates/lib/vm-codec-rmp/src/lib.rs
+++ b/crates/lib/vm-codec-rmp/src/lib.rs
@@ -1,0 +1,46 @@
+//! MessagePack codec.
+
+#![warn(missing_docs)]
+
+use rmp_serde::config::DefaultConfig;
+use waymark_vm_codec_core::{DeserializerProvider, SerializerProvider};
+
+/// MessagePack codec backed by [`rmp_serde`].
+#[derive(Debug, Clone, Copy, Default)]
+pub struct RmpCodec;
+
+impl SerializerProvider for RmpCodec {
+    type Serializer<'buf>
+        = &'buf mut rmp_serde::Serializer<&'buf mut Vec<u8>, DefaultConfig>
+    where
+        Self: 'buf;
+
+    type Ok = ();
+
+    type Error = rmp_serde::encode::Error;
+
+    fn with_serializer<F, R>(&self, buffer: &mut Vec<u8>, f: F) -> R
+    where
+        for<'buf> F: FnOnce(Self::Serializer<'buf>) -> R,
+    {
+        let mut ser = rmp_serde::Serializer::new(&mut *buffer);
+        f(&mut ser)
+    }
+}
+
+impl DeserializerProvider for RmpCodec {
+    type Deserializer<'de>
+        = &'de mut rmp_serde::Deserializer<rmp_serde::decode::ReadReader<&'de [u8]>>
+    where
+        Self: 'de;
+
+    type Error = rmp_serde::decode::Error;
+
+    fn with_deserializer<F, T>(&self, data: &[u8], f: F) -> Result<T, Self::Error>
+    where
+        for<'de> F: FnOnce(Self::Deserializer<'de>) -> Result<T, Self::Error>,
+    {
+        let mut de = rmp_serde::Deserializer::new(data);
+        f(&mut de)
+    }
+}


### PR DESCRIPTION
This PR adds support for swappable codecs - technically, `serde` serializer/deserializer implementation providers rather than some encoder/decoder - but the naming is better this way and has no conflicts as with serde.

We now have new `SerializerProvider` and `DeserializerProvider` traits, which allow generalizing around the formats.

---

Having traits for this is important to have, because when we deal in generic parameters with trait bounds they are actually opaque: meaning if we have generics `A` and `B` we can't pass `B` where `A` is expected; thus we sort of get unique kinded types for free - but also flexible ability to swap the implementation for free, cause traits are also interfaces.

---

This PR also provides a rudimentary `rmp-serde` implementation for a codec - for the MessagePack format; this implementation can be tweaked further (i.e. some settings in the default config could be adjusted) - but this it left out of the current PR for now. It would make sense to go over them once we start benchmarking.

---

The codecs infrastructure is intended to be used primarily for internal serialization/deserialization - meaning for things like executables and vm runtime state snapshots; things like action calls parameters, workflow initialization parameters and completion results are be deal with by a separate subsystem called "converter"s - which will be added in the subsequent PRs.
The difference is that codecs are just a generalization of serde, while converters for more like `From`/`Into` but allow the existence of multiple opinionated conversions from/to the same type pairs, while also being generalize-able.