### PR TITLE
Add workload pinning subsystem

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5948,6 +5948,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "waymark-workload-pinning-backend"
+version = "0.1.0"
+dependencies = [
+ "nonempty-collections",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5955,6 +5955,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "waymark-workload-pinning-manager"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "mockall",
+ "nonempty-collections",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "waymark-nonzero-duration",
+ "waymark-workload-pinning-backend",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,6 +125,7 @@ waymark-worker-status-backend = { path = "crates/lib/worker-status-backend" }
 waymark-worker-status-core = { path = "crates/lib/worker-status-core" }
 waymark-worker-status-reporter = { path = "crates/lib/worker-status-reporter" }
 waymark-workflow-registry-backend = { path = "crates/lib/workflow-registry-backend" }
+waymark-workload-pinning-backend = { path = "crates/lib/workload-pinning-backend" }
 
 anyhow = "1"
 async-stream = "0.3"

--- a/crates/lib/workload-pinning-backend/Cargo.toml
+++ b/crates/lib/workload-pinning-backend/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "waymark-workload-pinning-backend"
+edition = "2024"
+version.workspace = true
+publish.workspace = true
+
+[dependencies]
+nonempty-collections = { workspace = true }

--- a/crates/lib/workload-pinning-backend/src/common.rs
+++ b/crates/lib/workload-pinning-backend/src/common.rs
@@ -1,0 +1,48 @@
+//! Common types shared by all workload pinning backend traits.
+
+/// Shared time representation used across all backend traits.
+pub trait HasTimestamp {
+    /// The time representation used by this backend.
+    type Timestamp;
+}
+
+/// Shared Node ID type used across all backend traits.
+pub trait HasNodeId {
+    /// The Node ID used by this backend.
+    type NodeId;
+}
+
+/// Shared Instance ID type used across all backend traits.
+pub trait HasInstanceId {
+    /// The Instance ID used by this backend.
+    type InstanceId;
+}
+
+/// The pinning to apply.
+#[derive(Clone, Debug)]
+pub struct Pinning<NodeId, Timestamp> {
+    /// The id of the node owning this pinning.
+    pub node_id: NodeId,
+
+    /// Timestamp at which this claim stops being valid unless refreshed.
+    pub expires_at: Timestamp,
+}
+
+/// The status of the instance pinning.
+#[derive(Clone, Debug)]
+pub struct PinningStatus<InstanceId, Pinning> {
+    /// Instance this pinning status is for.
+    pub instance_id: InstanceId,
+
+    /// Current pinning after the operation, or `None` if the instance
+    /// is unpinned.
+    pub pinning: Option<Pinning>,
+}
+
+/// Shorthand for a [`Pinning`] using the associated types of `T`.
+pub type PinningFor<T> =
+    Pinning<<T as crate::HasNodeId>::NodeId, <T as crate::HasTimestamp>::Timestamp>;
+
+/// Shorthand for a [`PinningStatus`] using the associated types of `T`.
+pub type PinningStatusFor<T> =
+    PinningStatus<<T as crate::HasInstanceId>::InstanceId, PinningFor<T>>;

--- a/crates/lib/workload-pinning-backend/src/keepalive.rs
+++ b/crates/lib/workload-pinning-backend/src/keepalive.rs
@@ -1,0 +1,19 @@
+//! Keepalive (refresh) pinnings on instances.
+
+use nonempty_collections::{IntoNonEmptyIterator, NEVec};
+
+use crate::{HasInstanceId, HasNodeId, HasTimestamp, PinningFor, PinningStatusFor};
+
+/// The ability to maintain pins on instances.
+pub trait KeepaliveInstancePinnings: HasNodeId + HasInstanceId + HasTimestamp {
+    /// Error returned when refreshing pinning fails.
+    type Error: std::fmt::Debug;
+
+    /// Refresh pinning expiry for owned instances.
+    fn refresh_pinnings<'a>(
+        &'a self,
+        now: Self::Timestamp,
+        pinning: PinningFor<Self>,
+        instance_ids: impl IntoNonEmptyIterator<Item = Self::InstanceId> + 'a,
+    ) -> impl Future<Output = Result<NEVec<PinningStatusFor<Self>>, Self::Error>> + Send + 'a;
+}

--- a/crates/lib/workload-pinning-backend/src/lib.rs
+++ b/crates/lib/workload-pinning-backend/src/lib.rs
@@ -1,0 +1,25 @@
+//! Backend traits for workload pinning.
+//!
+//! Defines the contract that a database backend must fulfill to support
+//! workload pinning.
+//!
+//! For convenience, [`Backend`] is a blanket supertrait requiring all three.
+
+#![warn(missing_docs)]
+
+mod common;
+
+pub mod keepalive;
+pub mod poll;
+pub mod release;
+
+pub use self::common::*;
+
+pub use self::keepalive::KeepaliveInstancePinnings;
+pub use self::poll::PollUnpinnedInstances;
+pub use self::release::ReleasePinnings;
+
+/// All workload pinning backend traits.
+pub trait Backend: PollUnpinnedInstances + KeepaliveInstancePinnings + ReleasePinnings {}
+
+impl<T> Backend for T where T: PollUnpinnedInstances + KeepaliveInstancePinnings + ReleasePinnings {}

--- a/crates/lib/workload-pinning-backend/src/poll.rs
+++ b/crates/lib/workload-pinning-backend/src/poll.rs
@@ -1,0 +1,30 @@
+//! Poll for unpinned instances.
+
+use std::num::NonZeroUsize;
+
+use nonempty_collections::NEVec;
+
+use crate::{HasInstanceId, HasNodeId, HasTimestamp, PinningFor};
+
+/// The ability to poll and pin the instances that are present in
+/// the system but are not pinned to a particular node, effectively claiming
+/// them.
+pub trait PollUnpinnedInstances: HasTimestamp + HasNodeId + HasInstanceId {
+    /// An error that can occur while polling.
+    type Error: std::fmt::Debug;
+
+    /// Return up to `max_items` instances without blocking.
+    ///
+    /// Instances are guaranteed to be freshly pinned with
+    /// the provided `pinning`.
+    ///
+    /// `now` is used for expiration checks of stale pinnings.
+    ///
+    /// Returns `Ok(None)` if no instances were available.
+    fn poll_unlocked(
+        &self,
+        now: Self::Timestamp,
+        pinning: PinningFor<Self>,
+        max_items: NonZeroUsize,
+    ) -> impl Future<Output = Result<Option<NEVec<Self::InstanceId>>, Self::Error>> + Send + '_;
+}

--- a/crates/lib/workload-pinning-backend/src/release.rs
+++ b/crates/lib/workload-pinning-backend/src/release.rs
@@ -1,0 +1,18 @@
+//! Release pinnings from instances.
+
+use nonempty_collections::IntoNonEmptyIterator;
+
+use crate::{HasInstanceId, HasNodeId};
+
+/// The ability to release held pinnings on workload queue entries.
+pub trait ReleasePinnings: HasNodeId + HasInstanceId {
+    /// Error returned when releasing pinning fails.
+    type Error: std::fmt::Debug;
+
+    /// Release instance pinnings when evicting workloads.
+    fn release_pinnings<'a>(
+        &'a self,
+        node_id: Self::NodeId,
+        instance_ids: impl IntoNonEmptyIterator<Item = Self::InstanceId> + 'a,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send + 'a;
+}

--- a/crates/lib/workload-pinning-manager/Cargo.toml
+++ b/crates/lib/workload-pinning-manager/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "waymark-workload-pinning-manager"
+edition = "2024"
+version.workspace = true
+publish.workspace = true
+
+[dependencies]
+waymark-nonzero-duration = { workspace = true }
+waymark-workload-pinning-backend = { workspace = true }
+
+chrono = { workspace = true, default-features = false, features = ["clock"] }
+nonempty-collections = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["macros", "sync", "time"] }
+tokio-util = { workspace = true }
+tracing = { workspace = true }
+
+[dev-dependencies]
+waymark-nonzero-duration = { workspace = true }
+waymark-workload-pinning-backend = { workspace = true }
+
+chrono = { workspace = true, default-features = false, features = ["clock"] }
+mockall = { workspace = true }
+tokio = { workspace = true, features = ["rt", "rt-multi-thread"] }
+
+[lib]
+doctest = false

--- a/crates/lib/workload-pinning-manager/src/lib.rs
+++ b/crates/lib/workload-pinning-manager/src/lib.rs
@@ -1,0 +1,189 @@
+//! Workload pinning manager routines.
+
+#![warn(missing_docs)]
+
+mod maintenance;
+mod outcome;
+mod pinned_handle;
+mod poll;
+
+#[cfg(test)]
+mod test_utils {
+    pub mod helpers;
+    pub mod mock;
+}
+
+pub use self::maintenance::*;
+pub use self::outcome::*;
+pub use self::pinned_handle::*;
+pub use self::poll::*;
+
+use std::num::NonZeroUsize;
+use std::sync::Arc;
+
+use nonempty_collections::{IntoIteratorExt as _, NEVec};
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, info, warn};
+use waymark_nonzero_duration::NonZeroDuration;
+
+/// Parameters for the workload management loop.
+pub struct Params<Backend>
+where
+    Backend: waymark_workload_pinning_backend::HasNodeId,
+    Backend: waymark_workload_pinning_backend::HasInstanceId,
+{
+    /// Token to signal graceful shutdown of the poll loop.
+    ///
+    /// Cancelling this token stops accepting new workloads (polling ceases)
+    /// while in-flight work is allowed to complete naturally — the
+    /// maintenance loop keeps heartbeating and processing evictions
+    /// until all active instances drain.
+    ///
+    /// For an immediate stop of everything, use
+    /// [`force_shutdown_token`](Params::force_shutdown_token).
+    pub shutdown_token: CancellationToken,
+
+    /// Token to signal force shutdown of the maintenance loop.
+    ///
+    /// Cancelling this token stops the maintenance loop immediately
+    /// without waiting for in-flight work to drain.
+    ///
+    /// Use [`shutdown_token`](Params::shutdown_token) to stop accepting new
+    /// workloads while letting in-flight work drain naturally.
+    pub force_shutdown_token: CancellationToken,
+
+    /// Backend for database operations (poll, pin, unpin).
+    pub backend: Arc<Backend>,
+
+    /// The node identifier for this executor instance.
+    pub node_id: Backend::NodeId,
+
+    /// Channel for sending newly pinned handles to external consumers.
+    pub pinned_tx: tokio::sync::mpsc::Sender<NEVec<PinnedHandle<Backend::InstanceId>>>,
+
+    /// Maximum number of workloads to run concurrently.
+    pub max_pinned: NonZeroUsize,
+
+    /// How long a pinning lasts before it needs to be refreshed.
+    pub pinning_ttl: NonZeroDuration,
+
+    /// How often to refresh pinnings on active workloads.
+    pub pinning_heartbeat: NonZeroDuration,
+}
+
+/// Run the workload management loop.
+///
+/// Returns a [`RunOutcomeFor`] that preserves the independent results of
+/// the poll loop, maintenance loop, and cleanup phase so callers can
+/// inspect every stage of the run lifecycle.
+pub async fn run<Backend>(params: Params<Backend>) -> RunOutcomeFor<Backend>
+where
+    Backend:
+        waymark_workload_pinning_backend::HasTimestamp<Timestamp = chrono::DateTime<chrono::Utc>>,
+    Backend: waymark_workload_pinning_backend::PollUnpinnedInstances,
+    Backend: waymark_workload_pinning_backend::KeepaliveInstancePinnings,
+    Backend: waymark_workload_pinning_backend::ReleasePinnings,
+    Backend: Send + Sync + 'static,
+    <Backend as waymark_workload_pinning_backend::PollUnpinnedInstances>::Error: std::fmt::Debug,
+    <Backend as waymark_workload_pinning_backend::KeepaliveInstancePinnings>::Error:
+        std::fmt::Debug,
+    <Backend as waymark_workload_pinning_backend::ReleasePinnings>::Error: std::fmt::Debug,
+    Backend::NodeId: Clone,
+    Backend::InstanceId: Clone + std::hash::Hash + Eq,
+{
+    let Params {
+        shutdown_token,
+        force_shutdown_token,
+        backend,
+        node_id,
+        pinned_tx,
+        max_pinned,
+        pinning_ttl,
+        pinning_heartbeat,
+    } = params;
+
+    info!(
+        max_pinned = max_pinned.get(),
+        pinning_ttl_ms = pinning_ttl.get().as_millis(),
+        pinning_heartbeat_ms = pinning_heartbeat.get().as_millis(),
+        "workload manager starting"
+    );
+
+    let (evict_tx, evict_rx) = tokio::sync::mpsc::unbounded_channel();
+
+    // Poll → Maintain: dispatch newly-pinned IDs with a oneshot to get back the count.
+    let (batch_tx, batch_rx) = tokio::sync::mpsc::channel::<(
+        NEVec<Backend::InstanceId>,
+        tokio::sync::oneshot::Sender<usize>,
+    )>(1);
+    // Maintain → Poll: push updated count after evictions.
+    let (count_tx, count_rx) = tokio::sync::mpsc::unbounded_channel::<usize>();
+
+    // Give the poll loop a child token so it can be cancelled internally
+    // without affecting the caller's shutdown_token. The child is also
+    // cancelled automatically when the caller cancels the parent.
+    let poll_shutdown = shutdown_token.child_token();
+    drop(shutdown_token);
+
+    let poll_future = poll::run_poll_loop(poll::PollParams {
+        backend: Arc::clone(&backend),
+        node_id: node_id.clone(),
+        pinned_tx,
+        evict_tx,
+        batch_tx,
+        count_rx,
+        shutdown_token: poll_shutdown.clone(),
+        max_pinned,
+        pinning_ttl,
+    });
+
+    let maintenance_future = maintenance::run_maintenance_loop(maintenance::MaintainParams {
+        backend: Arc::clone(&backend),
+        node_id: node_id.clone(),
+        batch_rx,
+        evict_rx,
+        count_tx,
+        shutdown_token: force_shutdown_token,
+        pinning_heartbeat,
+        pinning_ttl,
+    });
+
+    // When the maintenance loop exits — for any reason — cancel the
+    // poll loop's child token so it exits promptly. There is no point
+    // accepting new work without maintenance.
+    // (Poll exits never cancel maintenance; maintenance must always drain.)
+    let maintenance_future = async move {
+        let _cancel_poll = poll_shutdown.drop_guard();
+        maintenance_future.await
+    };
+
+    let (poll_result, maintenance_result) = tokio::join!(poll_future, maintenance_future);
+
+    // The maintenance loop returns active IDs alongside any error so
+    // they can be released during cleanup.  On a clean exit the set
+    // is always empty and there is nothing to release.
+    let (maintenance_error, active_ids) = match maintenance_result {
+        Ok(()) => (None, None),
+        Err((error, ids)) => (Some(error), Some(ids)),
+    };
+
+    let mut cleanup_error = None;
+    if let Some(ids) = active_ids
+        && let Some(ids) = ids.try_into_nonempty_iter()
+    {
+        debug!("releasing pinnings on shutdown");
+        if let Err(error) = backend.release_pinnings(node_id, ids).await {
+            warn!(?error, "failed to release pinnings during cleanup");
+            cleanup_error = Some(error);
+        }
+    }
+
+    RunOutcome {
+        poll_error: poll_result.err(),
+        maintenance_error,
+        cleanup_error,
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/lib/workload-pinning-manager/src/maintenance/error.rs
+++ b/crates/lib/workload-pinning-manager/src/maintenance/error.rs
@@ -1,0 +1,23 @@
+//! Error types for the maintenance loop.
+
+/// Errors that can occur in the maintenance loop.
+#[derive(Debug, thiserror::Error)]
+pub enum MaintenanceError<KeepaliveError, ReleaseError> {
+    /// Refreshing pinnings failed.
+    #[error("refresh pinnings: {0}")]
+    Refresh(#[source] KeepaliveError),
+
+    /// Releasing pinnings failed.
+    #[error("release pinnings: {0}")]
+    Release(#[source] ReleaseError),
+
+    /// The loop was force-shutdown.
+    #[error("maintenance loop force shutdown")]
+    ForceShutdown,
+}
+
+/// Convenience alias for [`MaintenanceError`] parameterized on a backend.
+pub type MaintenanceErrorFor<Backend> = MaintenanceError<
+    <Backend as waymark_workload_pinning_backend::KeepaliveInstancePinnings>::Error,
+    <Backend as waymark_workload_pinning_backend::ReleasePinnings>::Error,
+>;

--- a/crates/lib/workload-pinning-manager/src/maintenance/mod.rs
+++ b/crates/lib/workload-pinning-manager/src/maintenance/mod.rs
@@ -1,0 +1,178 @@
+//! Maintenance loop — handles evictions, pinnings refresh, and batch registration.
+//!
+//! # Exit contract
+//!
+//! The maintenance loop keeps running as long as there is work to do.
+//! Work exists whenever **either** condition holds:
+//!
+//! - `batch_rx` is still open — the poll loop is alive and may dispatch
+//!   newly-pinned instance IDs at any time.
+//! - `active_ids` is non-empty — there are in-flight instances whose
+//!   pinnings must be refreshed and whose evictions must be processed.
+//!
+//! The **terminal state** is reached when **both** conditions are false:
+//! `batch_rx` has been closed (the poll loop has exited) **and**
+//! `active_ids` is empty (all in-flight work has been evicted). At that
+//! point no future work can arrive and the loop exits cleanly.
+//!
+//! On exit (whether clean or errored) the remaining `active_ids` set is
+//! sent through `cleanup_tx` so the caller can release any pinnings
+//! that were still held.
+//!
+//! The maintenance loop listens to its own shutdown token for emergency
+//! cancellation — this is separate from the poll loop's graceful-shutdown
+//! token. Under normal operation the loop exits naturally when the poll
+//! loop has stopped and all active IDs have been evicted.
+//!
+//! # Heartbeat retry policy
+//!
+//! Heartbeat refreshes are critical for keeping pinnings alive.
+//! If a refresh fails the loop immediately retries once — this handles
+//! transient database errors without waiting for the next tick interval.
+//! If the retry also fails the loop exits with [`Error::Refresh`] so the
+//! caller can release the pinnings cleanly before they expire.
+
+mod error;
+
+pub use self::error::*;
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use nonempty_collections::{IntoIteratorExt as _, NEVec};
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, info, warn};
+use waymark_nonzero_duration::NonZeroDuration;
+
+pub(super) struct MaintainParams<Backend>
+where
+    Backend: waymark_workload_pinning_backend::HasNodeId,
+    Backend: waymark_workload_pinning_backend::HasInstanceId,
+{
+    pub backend: Arc<Backend>,
+    pub node_id: Backend::NodeId,
+    pub batch_rx: tokio::sync::mpsc::Receiver<(
+        NEVec<Backend::InstanceId>,
+        tokio::sync::oneshot::Sender<usize>,
+    )>,
+    pub evict_rx: tokio::sync::mpsc::UnboundedReceiver<Backend::InstanceId>,
+    pub count_tx: tokio::sync::mpsc::UnboundedSender<usize>,
+    pub shutdown_token: CancellationToken,
+    pub pinning_heartbeat: NonZeroDuration,
+    pub pinning_ttl: NonZeroDuration,
+}
+
+pub(super) async fn run_maintenance_loop<Backend>(
+    params: MaintainParams<Backend>,
+) -> Result<(), (MaintenanceErrorFor<Backend>, HashSet<Backend::InstanceId>)>
+where
+    Backend: waymark_workload_pinning_backend::PollUnpinnedInstances,
+    Backend: waymark_workload_pinning_backend::KeepaliveInstancePinnings<
+            Timestamp = chrono::DateTime<chrono::Utc>,
+        >,
+    Backend: waymark_workload_pinning_backend::ReleasePinnings,
+    Backend::NodeId: Clone,
+    Backend::InstanceId: Clone + std::hash::Hash + Eq,
+{
+    let MaintainParams {
+        backend,
+        node_id,
+        mut batch_rx,
+        mut evict_rx,
+        count_tx,
+        shutdown_token,
+        pinning_heartbeat,
+        pinning_ttl,
+    } = params;
+
+    let mut active_ids: HashSet<Backend::InstanceId> = HashSet::new();
+    let mut poll_exited = false;
+    let shutdown = shutdown_token.child_token().cancelled_owned();
+    let mut shutdown = std::pin::pin!(shutdown);
+    let mut heartbeat_tick = tokio::time::interval(pinning_heartbeat.get());
+    heartbeat_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+    let result = loop {
+        if poll_exited && active_ids.is_empty() {
+            break Ok(());
+        }
+
+        tokio::select! {
+            result = batch_rx.recv(), if !poll_exited => {
+                match result {
+                    Some((ids, reply)) => {
+                        for id in ids.iter() {
+                            active_ids.insert(id.clone());
+                        }
+                        let _ = reply.send(active_ids.len());
+                    }
+                    None => {
+                        poll_exited = true;
+                        if !active_ids.is_empty() {
+                            info!("poll loop exited, {} active IDs remain", active_ids.len());
+                        }
+                    }
+                }
+            }
+            Some(id) = evict_rx.recv() => {
+                if let Err(error) = (*backend).release_pinnings(node_id.clone(), NEVec::new(id.clone())).await {
+                    break Err((MaintenanceError::Release(error), active_ids));
+                }
+                active_ids.remove(&id);
+                let _ = count_tx.send(active_ids.len());
+            }
+            _ = heartbeat_tick.tick() => {
+                let Some(ids) = active_ids.iter().cloned().try_into_nonempty_iter() else {
+                    continue;
+                };
+                match refresh_active_pinnings(&*backend, chrono::Utc::now(), node_id.clone(), ids.clone(), pinning_ttl).await {
+                    Ok(()) => {}
+                    Err(error) => {
+                        warn!(?error, "heartbeat refresh failed, retrying immediately");
+                        // Retry once immediately — must complete before pins expire.
+                        if let Err(error) = refresh_active_pinnings(&*backend, chrono::Utc::now(), node_id.clone(), ids, pinning_ttl).await {
+                            break Err((MaintenanceError::Refresh(error), active_ids));
+                        }
+                    }
+                }
+            }
+            _ = &mut shutdown => {
+                warn!("maintenance loop force shutdown");
+                break Err((MaintenanceError::ForceShutdown, active_ids));
+            }
+        }
+    };
+
+    debug!("maintenance loop exiting");
+    result
+}
+
+/// Refresh pinnings on all active workloads.
+pub(super) async fn refresh_active_pinnings<Backend>(
+    backend: &Backend,
+    now: chrono::DateTime<chrono::Utc>,
+    node_id: Backend::NodeId,
+    ids: impl nonempty_collections::IntoNonEmptyIterator<Item = Backend::InstanceId>,
+    pinning_ttl: NonZeroDuration,
+) -> Result<(), <Backend as waymark_workload_pinning_backend::KeepaliveInstancePinnings>::Error>
+where
+    Backend: waymark_workload_pinning_backend::KeepaliveInstancePinnings<
+            Timestamp = chrono::DateTime<chrono::Utc>,
+        >,
+{
+    let expires_at = now + chrono::Duration::from_std(pinning_ttl.get()).unwrap();
+
+    let pinning = waymark_workload_pinning_backend::Pinning {
+        node_id,
+        expires_at,
+    };
+
+    backend.refresh_pinnings(now, pinning, ids).await?;
+
+    debug!("refreshed workload pinnings");
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/lib/workload-pinning-manager/src/maintenance/tests.rs
+++ b/crates/lib/workload-pinning-manager/src/maintenance/tests.rs
@@ -1,0 +1,648 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use mockall::predicate;
+use nonempty_collections::{NEVec, nev};
+use tokio::sync::mpsc;
+use tokio::sync::oneshot;
+use tokio_util::sync::CancellationToken;
+use waymark_workload_pinning_backend::PinningStatus;
+
+use super::{MaintainParams, refresh_active_pinnings, run_maintenance_loop};
+use crate::poll::poll_and_pin;
+use crate::test_utils::helpers::{
+    long_heartbeat, short_heartbeat, test_max_concurrent, test_node_id, test_pinning,
+    test_pinning_ttl,
+};
+use crate::test_utils::mock::MockBackend;
+
+/// The maintain loop should exit cleanly when batch_rx is closed and
+/// there are no active IDs — no possible work remains.
+#[tokio::test]
+async fn maintain_loop_exits_when_batch_closed_and_empty() {
+    let backend = Arc::new(MockBackend::new());
+
+    let (batch_tx, batch_rx) = mpsc::channel::<(NEVec<u64>, oneshot::Sender<usize>)>(1);
+    let (evict_tx, evict_rx) = mpsc::unbounded_channel::<u64>();
+    let (count_tx, _count_rx) = mpsc::unbounded_channel::<usize>();
+
+    // Close both channels — no work can ever arrive.
+    drop(batch_tx);
+    drop(evict_tx);
+
+    let result = tokio::time::timeout(
+        Duration::from_secs(5),
+        run_maintenance_loop(MaintainParams {
+            backend,
+            node_id: test_node_id(),
+            batch_rx,
+            evict_rx,
+            count_tx,
+            shutdown_token: CancellationToken::new(),
+            pinning_heartbeat: long_heartbeat(),
+            pinning_ttl: test_pinning_ttl(),
+        }),
+    )
+    .await
+    .expect("maintain loop should exit promptly");
+
+    assert!(result.is_ok(), "expected Ok, got {result:?}");
+}
+
+/// The maintain loop should continue running when batch_rx is closed
+/// but active IDs remain — heartbeats and evictions still matter.
+/// It should exit once the last active ID is evicted.
+#[tokio::test(flavor = "multi_thread")]
+async fn maintain_loop_continues_until_last_eviction_after_batch_closed() {
+    let id = 1u64;
+    let node_id = test_node_id();
+
+    let mut backend = MockBackend::new();
+    backend
+        .expect_release_pinnings()
+        .with(predicate::eq(node_id), predicate::eq(nev![id]))
+        .return_once(move |_, _| Box::pin(std::future::ready(Ok(()))));
+    // The heartbeat interval is long enough that refresh should never
+    // fire, but allow it optionally so the test doesn't panic if it does.
+    backend
+        .expect_refresh_pinnings()
+        .times(0..)
+        .returning(move |_, _, _| {
+            let pinning = test_pinning(node_id, 1);
+            Box::pin(std::future::ready(Ok(nev![PinningStatus {
+                instance_id: id,
+                pinning: Some(pinning),
+            }])))
+        });
+
+    let backend = Arc::new(backend);
+
+    let (batch_tx, batch_rx) = mpsc::channel::<(NEVec<u64>, oneshot::Sender<usize>)>(1);
+    let (evict_tx, evict_rx) = mpsc::unbounded_channel::<u64>();
+    let (count_tx, _count_rx) = mpsc::unbounded_channel::<usize>();
+
+    // Stage a batch.  The reply oneshot is kept alive so we can wait
+    // for the maintenance loop to acknowledge the ID before evicting.
+    let (reply_tx, reply_rx) = oneshot::channel::<usize>();
+    batch_tx
+        .send((nev![id], reply_tx))
+        .await
+        .expect("batch send");
+
+    // Close the batch channel — poll loop is gone.
+    drop(batch_tx);
+
+    let loop_future = run_maintenance_loop(MaintainParams {
+        backend: Arc::clone(&backend),
+        node_id,
+        batch_rx,
+        evict_rx,
+        count_tx,
+        shutdown_token: CancellationToken::new(),
+        pinning_heartbeat: long_heartbeat(),
+        pinning_ttl: test_pinning_ttl(),
+    });
+    tokio::pin!(loop_future);
+
+    // Drive the loop until it processes the batch and sends the reply.
+    // The reply confirms the ID is in the active pool — only then is it
+    // safe to evict.
+    let batch_size = tokio::select! {
+        size = reply_rx => size.expect("maintain loop should ack the batch"),
+        result = &mut loop_future => {
+            panic!("loop exited before processing batch: {result:?}");
+        }
+        _ = tokio::time::sleep(Duration::from_secs(5)) => {
+            panic!("batch was never processed");
+        }
+    };
+    assert_eq!(batch_size, 1);
+
+    // Now evict the ID — the loop should drain and exit.
+    evict_tx.send(id).expect("evict send");
+
+    let result = tokio::time::timeout(Duration::from_secs(5), &mut loop_future)
+        .await
+        .expect("maintain loop should exit after last eviction");
+
+    assert!(result.is_ok(), "expected Ok, got {result:?}");
+}
+
+/// When active IDs exist and the poll loop is still running, the
+/// maintenance loop must fire heartbeat ticks and refresh pinnings.
+/// A multi-threaded runtime is used so timer wakeups are delivered
+/// reliably without stale timer-wheel state bleeding between tests.
+#[tokio::test(flavor = "multi_thread")]
+async fn maintain_loop_heartbeats_fire_for_active_ids() {
+    let id = 1u64;
+    let node_id = test_node_id();
+    let pinning = test_pinning(node_id, 1);
+
+    // Signal that refresh_pinnings was called.
+    let (refresh_tx, mut refresh_rx) = mpsc::unbounded_channel::<()>();
+
+    let mut backend = MockBackend::new();
+    backend
+        .expect_refresh_pinnings()
+        .times(2..)
+        .returning(move |_, _, _| {
+            refresh_tx.send(()).ok();
+            Box::pin(std::future::ready(Ok(nev![PinningStatus {
+                instance_id: id,
+                pinning: Some(pinning.clone()),
+            }])))
+        });
+    backend
+        .expect_release_pinnings()
+        .with(predicate::eq(node_id), predicate::eq(nev![id]))
+        .return_once(move |_, _| Box::pin(std::future::ready(Ok(()))));
+
+    let backend = Arc::new(backend);
+
+    let (batch_tx, batch_rx) = mpsc::channel::<(NEVec<u64>, oneshot::Sender<usize>)>(1);
+    let (evict_tx, evict_rx) = mpsc::unbounded_channel::<u64>();
+    let (count_tx, _count_rx) = mpsc::unbounded_channel::<usize>();
+
+    // Stage a batch so there is an active ID to heartbeat.
+    let (reply_tx, _reply_rx) = oneshot::channel::<usize>();
+    batch_tx
+        .send((nev![id], reply_tx))
+        .await
+        .expect("batch send");
+
+    // Keep batch_tx alive — poll loop is "still running".
+    let loop_future = run_maintenance_loop(MaintainParams {
+        backend: Arc::clone(&backend),
+        node_id,
+        batch_rx,
+        evict_rx,
+        count_tx,
+        shutdown_token: CancellationToken::new(),
+        pinning_heartbeat: short_heartbeat(),
+        pinning_ttl: test_pinning_ttl(),
+    });
+    tokio::pin!(loop_future);
+
+    // Wait for two heartbeats — proves the tick is truly periodic,
+    // not a one-off race win against the immediate first tick. The
+    // loop future is kept as a branch so it continues to be polled
+    // and can fire subsequent heartbeat ticks.
+    let mut heartbeat_count = 0usize;
+    while heartbeat_count < 2 {
+        tokio::select! {
+            _ = refresh_rx.recv() => {
+                heartbeat_count += 1;
+            }
+            _ = tokio::time::sleep(Duration::from_secs(5)) => {
+                panic!("only {heartbeat_count} heartbeats fired before timeout");
+            }
+            result = &mut loop_future => {
+                panic!("loop exited after {heartbeat_count} heartbeats: {result:?}");
+            }
+        }
+    }
+
+    // Clean up: close the batch channel and evict the active ID so
+    // the loop can drain and exit naturally.
+    drop(batch_tx);
+    evict_tx.send(id).expect("evict send");
+
+    let result = tokio::time::timeout(Duration::from_secs(5), &mut loop_future)
+        .await
+        .expect("loop should exit after cleanup");
+
+    assert!(result.is_ok(), "expected Ok, got {result:?}");
+
+    // Explicit: refresh_pinnings was called at least twice and
+    // release_pinnings was called exactly once.
+    let mut mock = Arc::into_inner(backend)
+        .unwrap_or_else(|| panic!("backend should be exclusively owned after loop exits"));
+    mock.checkpoint();
+}
+
+/// After the poll loop dies (batch_tx dropped), the maintenance loop
+/// must keep refreshing pinnings for all remaining active IDs until
+/// every one is evicted. Heartbeats do not stop just because the poll
+/// loop is gone — they continue for as long as there is in-flight work.
+#[tokio::test(flavor = "multi_thread")]
+async fn maintain_loop_heartbeats_after_batch_closed() {
+    let id = 1u64;
+    let node_id = test_node_id();
+    let pinning = test_pinning(node_id, 1);
+
+    // Signal that refresh_pinnings was called.
+    let (refresh_tx, mut refresh_rx) = mpsc::unbounded_channel::<()>();
+
+    let mut backend = MockBackend::new();
+    backend
+        .expect_refresh_pinnings()
+        .times(2..)
+        .returning(move |_, _, _| {
+            refresh_tx.send(()).ok();
+            Box::pin(std::future::ready(Ok(nev![PinningStatus {
+                instance_id: id,
+                pinning: Some(pinning.clone()),
+            }])))
+        });
+    backend
+        .expect_release_pinnings()
+        .with(predicate::eq(node_id), predicate::eq(nev![id]))
+        .return_once(move |_, _| Box::pin(std::future::ready(Ok(()))));
+
+    let backend = Arc::new(backend);
+
+    let (batch_tx, batch_rx) = mpsc::channel::<(NEVec<u64>, oneshot::Sender<usize>)>(1);
+    let (evict_tx, evict_rx) = mpsc::unbounded_channel::<u64>();
+    let (count_tx, _count_rx) = mpsc::unbounded_channel::<usize>();
+
+    // Stage a batch.
+    let (reply_tx, _reply_rx) = oneshot::channel::<usize>();
+    batch_tx
+        .send((nev![id], reply_tx))
+        .await
+        .expect("batch send");
+
+    // Poll loop is dead — but maintenance must still heartbeat.
+    drop(batch_tx);
+
+    let loop_future = run_maintenance_loop(MaintainParams {
+        backend: Arc::clone(&backend),
+        node_id,
+        batch_rx,
+        evict_rx,
+        count_tx,
+        shutdown_token: CancellationToken::new(),
+        pinning_heartbeat: short_heartbeat(),
+        pinning_ttl: test_pinning_ttl(),
+    });
+    tokio::pin!(loop_future);
+
+    // Wait for two heartbeats after batch is closed — proves the tick
+    // is truly periodic even when the poll loop is dead. The loop
+    // future is kept as a branch so it continues to be polled and can
+    // fire subsequent heartbeat ticks.
+    let mut heartbeat_count = 0usize;
+    while heartbeat_count < 2 {
+        tokio::select! {
+            _ = refresh_rx.recv() => {
+                heartbeat_count += 1;
+            }
+            _ = tokio::time::sleep(Duration::from_secs(5)) => {
+                panic!("only {heartbeat_count} heartbeats fired after batch closed");
+            }
+            result = &mut loop_future => {
+                panic!("loop exited after {heartbeat_count} heartbeats: {result:?}");
+            }
+        }
+    }
+
+    // Evict the last ID — loop should now drain and exit.
+    evict_tx.send(id).expect("evict send");
+
+    let result = tokio::time::timeout(Duration::from_secs(5), &mut loop_future)
+        .await
+        .expect("loop should exit after eviction");
+
+    assert!(result.is_ok(), "expected Ok, got {result:?}");
+
+    // Explicit: refresh_pinnings was called at least twice and
+    // release_pinnings was called exactly once.
+    let mut mock = Arc::into_inner(backend)
+        .unwrap_or_else(|| panic!("backend should be exclusively owned after loop exits"));
+    mock.checkpoint();
+}
+#[tokio::test]
+async fn manager_refreshes_pinnings_on_active_vms() {
+    let id = 1u64;
+
+    let mut backend = MockBackend::new();
+    backend
+        .expect_poll_unlocked()
+        .with(
+            predicate::always(),
+            predicate::always(),
+            predicate::always(),
+        )
+        .return_once(move |_, _, _| Box::pin(std::future::ready(Ok(Some(nev![id])))));
+    backend
+        .expect_refresh_pinnings()
+        .with(
+            predicate::always(),
+            predicate::always(),
+            predicate::eq(nev![id]),
+        )
+        .return_once(move |_, _, _| {
+            let pinning = test_pinning(test_node_id(), 1);
+            let statuses = nev![PinningStatus {
+                instance_id: id,
+                pinning: Some(pinning),
+            }];
+            Box::pin(std::future::ready(Ok(statuses)))
+        });
+
+    let ids = poll_and_pin(
+        &backend,
+        test_node_id(),
+        test_max_concurrent(),
+        test_pinning_ttl(),
+    )
+    .await
+    .expect("poll and pin")
+    .expect("instances available");
+
+    refresh_active_pinnings(
+        &backend,
+        crate::test_utils::helpers::test_now(),
+        test_node_id(),
+        ids,
+        test_pinning_ttl(),
+    )
+    .await
+    .expect("refresh pinnings");
+}
+
+#[tokio::test]
+async fn refresh_pinnings_propagates_error() {
+    let id = 1u64;
+
+    let mut backend = MockBackend::new();
+    backend
+        .expect_poll_unlocked()
+        .with(
+            predicate::always(),
+            predicate::always(),
+            predicate::always(),
+        )
+        .return_once(move |_, _, _| Box::pin(std::future::ready(Ok(Some(nev![id])))));
+    backend
+        .expect_refresh_pinnings()
+        .with(
+            predicate::always(),
+            predicate::always(),
+            predicate::eq(nev![id]),
+        )
+        .return_once(move |_, _, _| {
+            Box::pin(std::future::ready(Err(crate::test_utils::mock::MockError)))
+        });
+
+    let ids = poll_and_pin(
+        &backend,
+        test_node_id(),
+        test_max_concurrent(),
+        test_pinning_ttl(),
+    )
+    .await
+    .expect("poll and pin")
+    .expect("instances available");
+
+    let result = refresh_active_pinnings(
+        &backend,
+        crate::test_utils::helpers::test_now(),
+        test_node_id(),
+        ids,
+        test_pinning_ttl(),
+    )
+    .await;
+
+    assert!(result.is_err());
+}
+
+/// When releasing a pinning fails, the maintenance loop must exit with
+/// the error and return the remaining active IDs.
+#[tokio::test]
+async fn maintain_loop_exits_on_release_error() {
+    let id = 1u64;
+    let node_id = test_node_id();
+
+    let mut backend = MockBackend::new();
+    backend
+        .expect_release_pinnings()
+        .with(predicate::eq(node_id), predicate::eq(nev![id]))
+        .return_once(move |_, _| {
+            Box::pin(std::future::ready(Err(crate::test_utils::mock::MockError)))
+        });
+    backend
+        .expect_refresh_pinnings()
+        .times(0..)
+        .returning(move |_, _, _| {
+            let pinning = test_pinning(node_id, 1);
+            Box::pin(std::future::ready(Ok(nev![PinningStatus {
+                instance_id: id,
+                pinning: Some(pinning),
+            }])))
+        });
+
+    let backend = Arc::new(backend);
+
+    let (batch_tx, batch_rx) = mpsc::channel::<(NEVec<u64>, oneshot::Sender<usize>)>(1);
+    let (evict_tx, evict_rx) = mpsc::unbounded_channel::<u64>();
+    let (count_tx, _count_rx) = mpsc::unbounded_channel::<usize>();
+
+    let (reply_tx, reply_rx) = oneshot::channel::<usize>();
+    batch_tx
+        .send((nev![id], reply_tx))
+        .await
+        .expect("batch send");
+    drop(batch_tx);
+
+    let loop_future = run_maintenance_loop(MaintainParams {
+        backend: Arc::clone(&backend),
+        node_id,
+        batch_rx,
+        evict_rx,
+        count_tx,
+        shutdown_token: CancellationToken::new(),
+        pinning_heartbeat: long_heartbeat(),
+        pinning_ttl: test_pinning_ttl(),
+    });
+    tokio::pin!(loop_future);
+
+    // Wait for the batch ack — the ID must be in active_ids before
+    // we evict, otherwise the eviction is a no-op.
+    let batch_size = tokio::select! {
+        size = reply_rx => size.expect("maintain loop should ack the batch"),
+        result = &mut loop_future => {
+            panic!("loop exited before processing batch: {result:?}");
+        }
+        _ = tokio::time::sleep(Duration::from_secs(5)) => {
+            panic!("batch was never processed");
+        }
+    };
+    assert_eq!(batch_size, 1);
+
+    // Evict the ID — the release call will fail.
+    evict_tx.send(id).expect("evict send");
+
+    let result = tokio::time::timeout(Duration::from_secs(5), &mut loop_future)
+        .await
+        .expect("loop should exit on release error");
+
+    match result {
+        Err((crate::MaintenanceError::Release(_), ids)) => {
+            assert!(
+                ids.contains(&id),
+                "the failed-to-release id must remain in active_ids, got {ids:?}"
+            );
+        }
+        other => panic!("expected Release error, got {other:?}"),
+    }
+}
+
+/// When the shutdown token fires, the maintenance loop must exit
+/// immediately with [`crate::MaintenanceError::ForceShutdown`] and
+/// return whatever active IDs remain.
+#[tokio::test]
+async fn maintain_loop_exits_on_force_shutdown() {
+    let id = 1u64;
+    let node_id = test_node_id();
+
+    let mut backend = MockBackend::new();
+    backend
+        .expect_refresh_pinnings()
+        .times(0..)
+        .returning(move |_, _, _| {
+            let pinning = test_pinning(node_id, 1);
+            Box::pin(std::future::ready(Ok(nev![PinningStatus {
+                instance_id: id,
+                pinning: Some(pinning),
+            }])))
+        });
+
+    let backend = Arc::new(backend);
+
+    let (batch_tx, batch_rx) = mpsc::channel::<(NEVec<u64>, oneshot::Sender<usize>)>(1);
+    let (evict_tx, evict_rx) = mpsc::unbounded_channel::<u64>();
+    let (count_tx, _count_rx) = mpsc::unbounded_channel::<usize>();
+
+    let (reply_tx, reply_rx) = oneshot::channel::<usize>();
+    batch_tx
+        .send((nev![id], reply_tx))
+        .await
+        .expect("batch send");
+    drop(batch_tx);
+
+    let shutdown = CancellationToken::new();
+    let loop_future = run_maintenance_loop(MaintainParams {
+        backend: Arc::clone(&backend),
+        node_id,
+        batch_rx,
+        evict_rx,
+        count_tx,
+        shutdown_token: shutdown.clone(),
+        pinning_heartbeat: long_heartbeat(),
+        pinning_ttl: test_pinning_ttl(),
+    });
+    tokio::pin!(loop_future);
+
+    // Wait for the batch ack before firing shutdown — the ID must be
+    // in active_ids so the error return includes it.
+    let batch_size = tokio::select! {
+        size = reply_rx => size.expect("maintain loop should ack the batch"),
+        result = &mut loop_future => {
+            panic!("loop exited before processing batch: {result:?}");
+        }
+        _ = tokio::time::sleep(Duration::from_secs(5)) => {
+            panic!("batch was never processed");
+        }
+    };
+    assert_eq!(batch_size, 1);
+
+    // Fire the shutdown token — the loop must exit even though an
+    // active ID is still present.
+    shutdown.cancel();
+
+    let result = tokio::time::timeout(Duration::from_secs(5), &mut loop_future)
+        .await
+        .expect("loop should exit on force shutdown");
+
+    match result {
+        Err((crate::MaintenanceError::ForceShutdown, ids)) => {
+            assert!(
+                ids.contains(&id),
+                "active IDs should contain the un-evicted ID"
+            );
+        }
+        other => panic!("expected ForceShutdown error, got {other:?}"),
+    }
+
+    // Clean up: prevent the evict channel from dangling.
+    drop(evict_tx);
+}
+
+/// When a heartbeat refresh fails after its one retry, the maintenance
+/// loop must exit with [`crate::MaintenanceError::Refresh`] and ship the
+/// remaining active IDs so the caller can release them.
+#[tokio::test(flavor = "multi_thread")]
+async fn maintain_loop_exits_on_refresh_error() {
+    let id = 1u64;
+    let node_id = test_node_id();
+
+    let mut backend = MockBackend::new();
+    backend
+        .expect_refresh_pinnings()
+        .times(2) // initial + one retry
+        .returning(move |_, _, _| {
+            Box::pin(std::future::ready(Err(crate::test_utils::mock::MockError)))
+        });
+    // release should never fire — the refresh failure exits the loop first
+    backend
+        .expect_release_pinnings()
+        .times(0)
+        .returning(move |_, _| Box::pin(std::future::ready(Ok(()))));
+
+    let backend = Arc::new(backend);
+
+    let (batch_tx, batch_rx) = mpsc::channel::<(NEVec<u64>, oneshot::Sender<usize>)>(1);
+    let (evict_tx, evict_rx) = mpsc::unbounded_channel::<u64>();
+    let (count_tx, _count_rx) = mpsc::unbounded_channel::<usize>();
+
+    // Stage a batch so there is an active ID to trigger a heartbeat.
+    let (reply_tx, reply_rx) = oneshot::channel::<usize>();
+    batch_tx
+        .send((nev![id], reply_tx))
+        .await
+        .expect("batch send");
+    drop(batch_tx);
+
+    let loop_future = run_maintenance_loop(MaintainParams {
+        backend: Arc::clone(&backend),
+        node_id,
+        batch_rx,
+        evict_rx,
+        count_tx,
+        shutdown_token: CancellationToken::new(),
+        pinning_heartbeat: short_heartbeat(),
+        pinning_ttl: test_pinning_ttl(),
+    });
+    tokio::pin!(loop_future);
+
+    // Wait for the batch ack.
+    let batch_size = tokio::select! {
+        size = reply_rx => size.expect("maintain loop should ack the batch"),
+        result = &mut loop_future => {
+            panic!("loop exited before processing batch: {result:?}");
+        }
+        _ = tokio::time::sleep(Duration::from_secs(5)) => {
+            panic!("batch was never processed");
+        }
+    };
+    assert_eq!(batch_size, 1);
+
+    // Heartbeats fire, fail twice, and the loop exits with Refresh.
+    let result = tokio::time::timeout(Duration::from_secs(10), &mut loop_future)
+        .await
+        .expect("loop should exit on refresh error");
+
+    match result {
+        Err((crate::MaintenanceError::Refresh(_), ids)) => {
+            assert!(
+                ids.contains(&id),
+                "active IDs should contain the un-evicted ID after refresh failure"
+            );
+        }
+        other => panic!("expected Refresh error, got {other:?}"),
+    }
+
+    // Clean up: prevent the evict channel from dangling.
+    drop(evict_tx);
+}

--- a/crates/lib/workload-pinning-manager/src/outcome.rs
+++ b/crates/lib/workload-pinning-manager/src/outcome.rs
@@ -1,0 +1,50 @@
+//! The outcome of a workload pinning manager run.
+
+use crate::{MaintenanceError, PollLoopError};
+
+/// The outcome of a workload pinning manager run.
+///
+/// Each sub-system result is preserved independently so callers can
+/// inspect exactly what happened rather than receiving a collapsed error.
+///
+/// Use [`RunOutcomeFor`] to construct this type from a backend.
+#[derive(Debug)]
+#[must_use = "the run outcome should be inspected for errors"]
+pub struct RunOutcome<PollError, KeepaliveError, ReleaseError> {
+    /// Error from the poll loop, if any.
+    pub poll_error: Option<PollLoopError<PollError>>,
+
+    /// Error from the maintenance loop, if any.
+    pub maintenance_error: Option<MaintenanceError<KeepaliveError, ReleaseError>>,
+
+    /// If cleanup failed, the error from releasing remaining pinnings.
+    /// `None` means either there were no remaining pinnings or they were
+    /// released successfully.
+    pub cleanup_error: Option<ReleaseError>,
+}
+
+/// Convenience alias for [`RunOutcome`] parameterized on a backend.
+pub type RunOutcomeFor<Backend> = RunOutcome<
+    <Backend as waymark_workload_pinning_backend::PollUnpinnedInstances>::Error,
+    <Backend as waymark_workload_pinning_backend::KeepaliveInstancePinnings>::Error,
+    <Backend as waymark_workload_pinning_backend::ReleasePinnings>::Error,
+>;
+
+impl<PollError, KeepaliveError, ReleaseError> RunOutcome<PollError, KeepaliveError, ReleaseError> {
+    /// Returns `true` if every error field is `None`.
+    pub fn is_ok(&self) -> bool {
+        matches!(
+            self,
+            Self {
+                poll_error: None,
+                maintenance_error: None,
+                cleanup_error: None
+            }
+        )
+    }
+
+    /// Returns `true` if any error field is `Some`.
+    pub fn is_err(&self) -> bool {
+        !self.is_ok()
+    }
+}

--- a/crates/lib/workload-pinning-manager/src/pinned_handle.rs
+++ b/crates/lib/workload-pinning-manager/src/pinned_handle.rs
@@ -1,0 +1,48 @@
+//! Handle for a pinned instance.
+//!
+//! See [`PinnedHandle`].
+
+/// A handle to a pinned instance.
+///
+/// When dropped, the instance ID is sent back to the workload manager
+/// for unpinning.
+#[must_use]
+pub struct PinnedHandle<InstanceId> {
+    id: Option<InstanceId>,
+    evict_tx: tokio::sync::mpsc::UnboundedSender<InstanceId>,
+}
+
+impl<InstanceId> PinnedHandle<InstanceId> {
+    /// Create a new pinned handle.
+    pub(crate) fn new(
+        id: InstanceId,
+        evict_tx: tokio::sync::mpsc::UnboundedSender<InstanceId>,
+    ) -> Self {
+        Self {
+            id: Some(id),
+            evict_tx,
+        }
+    }
+
+    /// Return a reference to the wrapped instance ID.
+    pub fn id(&self) -> &InstanceId {
+        // SAFETY: `PinnedHandle` is not dropped, so the `id` must be present.
+        unsafe { self.id.as_ref().unwrap_unchecked() }
+    }
+}
+
+impl<InstanceId> Drop for PinnedHandle<InstanceId> {
+    fn drop(&mut self) {
+        if let Some(id) = self.id.take() {
+            let _ = self.evict_tx.send(id);
+        }
+    }
+}
+
+impl<InstanceId: std::fmt::Debug> std::fmt::Debug for PinnedHandle<InstanceId> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PinnedHandle")
+            .field("id", self.id())
+            .finish_non_exhaustive()
+    }
+}

--- a/crates/lib/workload-pinning-manager/src/poll/error.rs
+++ b/crates/lib/workload-pinning-manager/src/poll/error.rs
@@ -1,0 +1,26 @@
+//! Error types for the poll loop.
+
+/// Errors that can occur in the poll loop.
+#[derive(Debug, thiserror::Error)]
+pub enum PollLoopError<PollError> {
+    /// Polling from the backend failed.
+    #[error("poll: {0}")]
+    Poll(#[source] PollError),
+
+    /// The maintenance loop channel closed — the poll loop cannot register
+    /// new work.
+    #[error("maintenance loop closed")]
+    MaintenanceClosed,
+
+    /// The maintenance loop did not acknowledge a batch registration.
+    #[error("maintenance loop did not acknowledge batch")]
+    MaintenanceUnresponsive,
+
+    /// The pinned-handle receiver closed — the consumer is gone.
+    #[error("pinned handle receiver closed")]
+    PinnedReceiverClosed,
+}
+
+/// Convenience alias for [`PollLoopError`] parameterized on a backend.
+pub type PollLoopErrorFor<Backend> =
+    PollLoopError<<Backend as waymark_workload_pinning_backend::PollUnpinnedInstances>::Error>;

--- a/crates/lib/workload-pinning-manager/src/poll/mod.rs
+++ b/crates/lib/workload-pinning-manager/src/poll/mod.rs
@@ -1,0 +1,190 @@
+//! Poll loop — polls for unpinned instances and dispatches handles.
+
+mod error;
+
+pub use self::error::*;
+
+use std::num::NonZeroUsize;
+use std::sync::Arc;
+
+use chrono::Utc;
+use nonempty_collections::{IntoNonEmptyIterator as _, NEVec, NonEmptyIterator as _};
+use tokio_util::sync::CancellationToken;
+use tracing::info;
+use waymark_nonzero_duration::NonZeroDuration;
+
+use crate::PinnedHandle;
+
+pub(super) struct PollParams<Backend>
+where
+    Backend: waymark_workload_pinning_backend::HasNodeId,
+    Backend: waymark_workload_pinning_backend::HasInstanceId,
+{
+    pub backend: Arc<Backend>,
+    pub node_id: Backend::NodeId,
+    pub pinned_tx: tokio::sync::mpsc::Sender<NEVec<PinnedHandle<Backend::InstanceId>>>,
+    pub evict_tx: tokio::sync::mpsc::UnboundedSender<Backend::InstanceId>,
+    pub batch_tx: tokio::sync::mpsc::Sender<(
+        NEVec<Backend::InstanceId>,
+        tokio::sync::oneshot::Sender<usize>,
+    )>,
+    pub count_rx: tokio::sync::mpsc::UnboundedReceiver<usize>,
+    pub shutdown_token: CancellationToken,
+    pub max_pinned: NonZeroUsize,
+    pub pinning_ttl: NonZeroDuration,
+}
+
+pub(super) async fn run_poll_loop<Backend>(
+    params: PollParams<Backend>,
+) -> Result<(), PollLoopErrorFor<Backend>>
+where
+    Backend: waymark_workload_pinning_backend::PollUnpinnedInstances<
+            Timestamp = chrono::DateTime<chrono::Utc>,
+        >,
+    Backend: waymark_workload_pinning_backend::HasTimestamp,
+    Backend::NodeId: Clone,
+    Backend::InstanceId: Clone + std::hash::Hash + Eq,
+{
+    let PollParams {
+        backend,
+        node_id,
+        pinned_tx,
+        evict_tx,
+        batch_tx,
+        mut count_rx,
+        shutdown_token,
+        max_pinned,
+        pinning_ttl,
+    } = params;
+
+    let mut current_count = 0usize;
+    let shutdown = shutdown_token.child_token().cancelled_owned();
+    let mut shutdown = std::pin::pin!(shutdown);
+
+    loop {
+        let available = max_pinned.get().saturating_sub(current_count);
+        if let Some(max_items) = NonZeroUsize::new(available) {
+            tokio::select! {
+                _ = &mut shutdown => {
+                    info!("poll loop shutting down");
+                    break Ok(());
+                }
+                Some(updated) = count_rx.recv() => {
+                    current_count = updated;
+                }
+                result = poll_and_dispatch(
+                    &*backend,
+                    node_id.clone(),
+                    max_items,
+                    pinning_ttl,
+                    &batch_tx,
+                    &pinned_tx,
+                    &evict_tx,
+                ) => {
+                    match result {
+                        Ok(Some(count)) => current_count = count,
+                        Ok(None) => { /* no instances — count unchanged */ }
+                        Err(error) => break Err(error),
+                    }
+                }
+            }
+        } else {
+            tokio::select! {
+                _ = &mut shutdown => {
+                    info!("poll loop shutting down");
+                    break Ok(());
+                }
+                Some(updated) = count_rx.recv() => {
+                    current_count = updated;
+                }
+            }
+        }
+    }
+}
+
+/// Poll for new workloads and pin them.
+///
+/// Returns the newly pinned instance IDs, or `None` if no instances were available.
+pub(super) async fn poll_and_pin<Backend>(
+    backend: &Backend,
+    node_id: Backend::NodeId,
+    max_items: NonZeroUsize,
+    pinning_ttl: NonZeroDuration,
+) -> Result<
+    Option<NEVec<Backend::InstanceId>>,
+    <Backend as waymark_workload_pinning_backend::PollUnpinnedInstances>::Error,
+>
+where
+    Backend: waymark_workload_pinning_backend::PollUnpinnedInstances<
+            Timestamp = chrono::DateTime<chrono::Utc>,
+        >,
+{
+    let now = Utc::now();
+
+    let expires_at =
+        now + chrono::Duration::from_std(pinning_ttl.get()).unwrap_or(chrono::Duration::MAX);
+
+    let pinning = waymark_workload_pinning_backend::Pinning {
+        node_id,
+        expires_at,
+    };
+
+    backend.poll_unlocked(now, pinning, max_items).await
+}
+
+/// Poll, register with the maintain loop, and publish handles.
+///
+/// Returns the updated active count from the maintain loop, or `None` if no
+/// instances were available to dispatch (count is unchanged).
+async fn poll_and_dispatch<Backend>(
+    backend: &Backend,
+    node_id: Backend::NodeId,
+    max_items: NonZeroUsize,
+    pinning_ttl: NonZeroDuration,
+    batch_tx: &tokio::sync::mpsc::Sender<(
+        NEVec<Backend::InstanceId>,
+        tokio::sync::oneshot::Sender<usize>,
+    )>,
+    pinned_tx: &tokio::sync::mpsc::Sender<NEVec<PinnedHandle<Backend::InstanceId>>>,
+    evict_tx: &tokio::sync::mpsc::UnboundedSender<Backend::InstanceId>,
+) -> Result<Option<usize>, PollLoopErrorFor<Backend>>
+where
+    Backend: waymark_workload_pinning_backend::PollUnpinnedInstances<
+            Timestamp = chrono::DateTime<chrono::Utc>,
+        >,
+    Backend: waymark_workload_pinning_backend::HasTimestamp,
+    Backend::InstanceId: Clone,
+{
+    let ids = poll_and_pin(backend, node_id, max_items, pinning_ttl)
+        .await
+        .map_err(PollLoopError::Poll)?;
+
+    let Some(ids) = ids else {
+        // No instances to dispatch — count unchanged.
+        return Ok(None);
+    };
+
+    let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+    batch_tx
+        .send((ids.clone(), reply_tx))
+        .await
+        .map_err(|_| PollLoopError::MaintenanceClosed)?;
+
+    let count = reply_rx
+        .await
+        .map_err(|_| PollLoopError::MaintenanceUnresponsive)?;
+
+    let handles: NEVec<_> = ids
+        .into_nonempty_iter()
+        .map(|id| PinnedHandle::new(id, evict_tx.clone()))
+        .collect();
+    pinned_tx
+        .send(handles)
+        .await
+        .map_err(|_| PollLoopError::PinnedReceiverClosed)?;
+
+    Ok(Some(count))
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/lib/workload-pinning-manager/src/poll/tests.rs
+++ b/crates/lib/workload-pinning-manager/src/poll/tests.rs
@@ -1,0 +1,178 @@
+use std::collections::HashSet;
+use std::sync::Arc;
+use std::time::Duration;
+
+use mockall::predicate;
+use nonempty_collections::{NEVec, nev};
+use tokio_util::sync::CancellationToken;
+
+use super::{PollParams, poll_and_pin, run_poll_loop};
+use crate::test_utils::helpers::{test_max_concurrent, test_node_id, test_pinning_ttl};
+use crate::test_utils::mock::MockBackend;
+
+#[tokio::test]
+async fn manager_polls_and_pins_instances() {
+    let id1 = 1u64;
+    let id2 = 2u64;
+
+    let mut backend = MockBackend::new();
+    backend
+        .expect_poll_unlocked()
+        .with(
+            predicate::always(),
+            predicate::always(),
+            predicate::always(),
+        )
+        .return_once(move |_, _, _| Box::pin(std::future::ready(Ok(Some(nev![id1, id2])))));
+
+    let pinning_ttl = test_pinning_ttl();
+
+    let ids = poll_and_pin(&backend, test_node_id(), test_max_concurrent(), pinning_ttl)
+        .await
+        .expect("poll and pin")
+        .expect("instances available");
+
+    let active_ids: HashSet<u64> = HashSet::from_iter(ids);
+    assert_eq!(active_ids.len(), 2);
+    assert!(active_ids.contains(&id1));
+    assert!(active_ids.contains(&id2));
+}
+
+#[tokio::test]
+async fn manager_polls_and_pins_instances_none_when_no_work() {
+    let mut backend = MockBackend::new();
+    backend
+        .expect_poll_unlocked()
+        .with(
+            predicate::always(),
+            predicate::always(),
+            predicate::always(),
+        )
+        .return_once(move |_, _, _| Box::pin(std::future::ready(Ok(None))));
+
+    let pinning_ttl = test_pinning_ttl();
+
+    let result = poll_and_pin(&backend, test_node_id(), test_max_concurrent(), pinning_ttl)
+        .await
+        .expect("poll and pin");
+
+    assert!(result.is_none());
+}
+
+#[tokio::test]
+async fn poll_and_pin_propagates_error() {
+    let mut backend = MockBackend::new();
+    backend
+        .expect_poll_unlocked()
+        .with(
+            predicate::always(),
+            predicate::always(),
+            predicate::always(),
+        )
+        .return_once(move |_, _, _| {
+            Box::pin(std::future::ready(Err(crate::test_utils::mock::MockError)))
+        });
+
+    let result = poll_and_pin(
+        &backend,
+        test_node_id(),
+        test_max_concurrent(),
+        test_pinning_ttl(),
+    )
+    .await;
+
+    assert!(result.is_err());
+}
+
+/// Dropping all count_tx senders must not cause the poll loop to exit —
+/// it should continue polling. The count channel is advisory, not a
+/// liveness signal.
+#[tokio::test]
+async fn poll_loop_continues_when_count_channel_closes() {
+    let mut backend = MockBackend::new();
+    backend
+        .expect_poll_unlocked()
+        .returning(move |_, _, _| Box::pin(std::future::ready(Ok(None))));
+
+    let backend = Arc::new(backend);
+
+    let (_pinned_tx, _pinned_rx) = tokio::sync::mpsc::channel(1);
+    let (_evict_tx, _evict_rx) = tokio::sync::mpsc::unbounded_channel();
+    let (_batch_tx, _batch_rx) = tokio::sync::mpsc::channel(1);
+    let (count_tx, count_rx) = tokio::sync::mpsc::unbounded_channel();
+
+    // Close the count channel — all senders gone.
+    drop(count_tx);
+
+    let result = tokio::time::timeout(
+        Duration::from_millis(200),
+        run_poll_loop(PollParams {
+            backend,
+            node_id: test_node_id(),
+            pinned_tx: _pinned_tx,
+            evict_tx: _evict_tx,
+            batch_tx: _batch_tx,
+            count_rx,
+            shutdown_token: CancellationToken::new(),
+            max_pinned: test_max_concurrent(),
+            pinning_ttl: test_pinning_ttl(),
+        }),
+    )
+    .await;
+
+    assert!(
+        result.is_err(),
+        "poll loop should continue polling when count channel closes"
+    );
+}
+
+/// When the pinned-handle receiver is closed, the poll loop must exit
+/// with [`crate::PollLoopError::PinnedReceiverClosed`].
+#[tokio::test]
+async fn poll_loop_exits_on_pinned_receiver_closed() {
+    let mut backend = MockBackend::new();
+    backend
+        .expect_poll_unlocked()
+        .return_once(move |_, _, _| Box::pin(std::future::ready(Ok(Some(nev![1u64])))));
+
+    let backend = Arc::new(backend);
+
+    let (pinned_tx, pinned_rx) = tokio::sync::mpsc::channel(1);
+    let (evict_tx, _evict_rx) = tokio::sync::mpsc::unbounded_channel();
+    let (batch_tx, mut batch_rx) =
+        tokio::sync::mpsc::channel::<(NEVec<u64>, tokio::sync::oneshot::Sender<usize>)>(1);
+    let (count_tx, count_rx) = tokio::sync::mpsc::unbounded_channel();
+
+    // Drop the pinned-handle receiver before the loop dispatches.
+    drop(pinned_rx);
+
+    // Spawn a helper to consume the batch and reply — without this the
+    // poll loop hangs waiting for the batch ack.
+    let batch_acker = tokio::spawn(async move {
+        while let Some((_ids, reply)) = batch_rx.recv().await {
+            let _ = reply.send(0);
+        }
+    });
+
+    let result = run_poll_loop(PollParams {
+        backend,
+        node_id: test_node_id(),
+        pinned_tx,
+        evict_tx,
+        batch_tx,
+        count_rx,
+        shutdown_token: CancellationToken::new(),
+        max_pinned: test_max_concurrent(),
+        pinning_ttl: test_pinning_ttl(),
+    })
+    .await;
+
+    batch_acker.abort();
+
+    match result {
+        Err(crate::PollLoopError::PinnedReceiverClosed) => {} // expected
+        other => panic!("expected PinnedReceiverClosed, got {other:?}"),
+    }
+
+    drop(count_tx);
+}

--- a/crates/lib/workload-pinning-manager/src/test_utils/helpers.rs
+++ b/crates/lib/workload-pinning-manager/src/test_utils/helpers.rs
@@ -1,0 +1,41 @@
+//! Shared test helper functions.
+
+use std::num::NonZeroUsize;
+use std::time::Duration;
+
+use waymark_nonzero_duration::NonZeroDuration;
+
+pub(crate) fn test_pinning_ttl() -> NonZeroDuration {
+    NonZeroDuration::new(Duration::from_secs(30)).unwrap()
+}
+
+pub(crate) fn test_max_concurrent() -> NonZeroUsize {
+    NonZeroUsize::new(3).unwrap()
+}
+
+pub(crate) fn test_node_id() -> u64 {
+    42
+}
+
+pub(crate) fn long_heartbeat() -> NonZeroDuration {
+    NonZeroDuration::new(Duration::from_secs(3600)).unwrap()
+}
+
+pub(crate) fn short_heartbeat() -> NonZeroDuration {
+    NonZeroDuration::new(Duration::from_millis(100)).unwrap()
+}
+
+pub(crate) fn test_now() -> chrono::DateTime<chrono::Utc> {
+    chrono::DateTime::from_timestamp(1_700_000_000, 0).unwrap()
+}
+
+pub(crate) fn test_pinning(
+    node_id: u64,
+    ttl_offset: i32,
+) -> waymark_workload_pinning_backend::Pinning<u64, chrono::DateTime<chrono::Utc>> {
+    let ttl = chrono::Duration::from_std(test_pinning_ttl().get()).unwrap();
+    waymark_workload_pinning_backend::Pinning {
+        node_id,
+        expires_at: test_now() + ttl * ttl_offset,
+    }
+}

--- a/crates/lib/workload-pinning-manager/src/test_utils/mock.rs
+++ b/crates/lib/workload-pinning-manager/src/test_utils/mock.rs
@@ -1,0 +1,98 @@
+//! Mock backend and error type for tests.
+
+use std::future::Future;
+use std::num::NonZeroUsize;
+
+use nonempty_collections::{IntoNonEmptyIterator, NEVec, NonEmptyIterator};
+use waymark_workload_pinning_backend::{Pinning, PinningStatus};
+
+#[derive(Debug, Clone, thiserror::Error)]
+#[error("mock error")]
+pub struct MockError;
+
+mockall::mock! {
+    pub Backend {
+        pub fn poll_unlocked(
+            &self,
+            now: chrono::DateTime<chrono::Utc>,
+            pinning: Pinning<u64, chrono::DateTime<chrono::Utc>>,
+            max_items: NonZeroUsize,
+        ) -> impl Future<Output = Result<Option<NEVec<u64>>, MockError>> + Send;
+
+        pub fn refresh_pinnings(
+            &self,
+            now: chrono::DateTime<chrono::Utc>,
+            pinning: Pinning<u64, chrono::DateTime<chrono::Utc>>,
+            instance_ids: NEVec<u64>,
+        ) -> impl Future<
+            Output = Result<
+                NEVec<PinningStatus<u64, Pinning<u64, chrono::DateTime<chrono::Utc>>>>,
+                MockError,
+            >,
+        > + Send;
+
+        pub fn release_pinnings(
+            &self,
+            node_id: u64,
+            instance_ids: NEVec<u64>,
+        ) -> impl Future<Output = Result<(), MockError>> + Send;
+    }
+}
+
+impl waymark_workload_pinning_backend::HasTimestamp for MockBackend {
+    type Timestamp = chrono::DateTime<chrono::Utc>;
+}
+
+impl waymark_workload_pinning_backend::HasNodeId for MockBackend {
+    type NodeId = u64;
+}
+
+impl waymark_workload_pinning_backend::HasInstanceId for MockBackend {
+    type InstanceId = u64;
+}
+
+impl waymark_workload_pinning_backend::PollUnpinnedInstances for MockBackend {
+    type Error = MockError;
+
+    async fn poll_unlocked(
+        &self,
+        now: Self::Timestamp,
+        pinning: Pinning<Self::NodeId, Self::Timestamp>,
+        max_items: NonZeroUsize,
+    ) -> Result<Option<NEVec<Self::InstanceId>>, Self::Error> {
+        self.poll_unlocked(now, pinning, max_items).await
+    }
+}
+
+impl waymark_workload_pinning_backend::KeepaliveInstancePinnings for MockBackend {
+    type Error = MockError;
+
+    fn refresh_pinnings<'a>(
+        &'a self,
+        now: chrono::DateTime<chrono::Utc>,
+        pinning: Pinning<u64, chrono::DateTime<chrono::Utc>>,
+        instance_ids: impl IntoNonEmptyIterator<Item = u64> + 'a,
+    ) -> impl Future<
+        Output = Result<
+            NEVec<PinningStatus<u64, Pinning<u64, chrono::DateTime<chrono::Utc>>>>,
+            Self::Error,
+        >,
+    > + Send
+    + 'a {
+        let ids: NEVec<u64> = instance_ids.into_nonempty_iter().collect();
+        self.refresh_pinnings(now, pinning, ids)
+    }
+}
+
+impl waymark_workload_pinning_backend::ReleasePinnings for MockBackend {
+    type Error = MockError;
+
+    fn release_pinnings<'a>(
+        &'a self,
+        node_id: u64,
+        instance_ids: impl IntoNonEmptyIterator<Item = u64> + 'a,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send + 'a {
+        let ids: NEVec<u64> = instance_ids.into_nonempty_iter().collect();
+        self.release_pinnings(node_id, ids)
+    }
+}

--- a/crates/lib/workload-pinning-manager/src/tests.rs
+++ b/crates/lib/workload-pinning-manager/src/tests.rs
@@ -1,0 +1,300 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use mockall::predicate;
+use nonempty_collections::nev;
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+use waymark_nonzero_duration::NonZeroDuration;
+use waymark_workload_pinning_backend::PinningStatus;
+
+use crate::test_utils::helpers::{
+    short_heartbeat, test_max_concurrent, test_node_id, test_pinning, test_pinning_ttl,
+};
+use crate::test_utils::mock::{MockBackend, MockError};
+use crate::{Params, PinnedHandle, run};
+
+/// A normal shutdown via cancellation should exit cleanly.
+#[tokio::test]
+async fn run_exits_on_cancellation() {
+    let mut backend = MockBackend::new();
+    backend
+        .expect_poll_unlocked()
+        .returning(move |_, _, _| Box::pin(std::future::ready(Ok(None))));
+
+    let backend = Arc::new(backend);
+
+    let (pinned_tx, _pinned_rx) =
+        mpsc::channel::<nonempty_collections::NEVec<PinnedHandle<u64>>>(1);
+    let cancel = CancellationToken::new();
+
+    let run_future = run(Params {
+        shutdown_token: cancel.clone(),
+        force_shutdown_token: CancellationToken::new(),
+        backend,
+        node_id: test_node_id(),
+        pinned_tx,
+        max_pinned: test_max_concurrent(),
+        pinning_ttl: test_pinning_ttl(),
+        pinning_heartbeat: short_heartbeat(),
+    });
+
+    tokio::pin!(run_future);
+
+    // Let the loops start up, then cancel.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    cancel.cancel();
+
+    let outcome = tokio::time::timeout(Duration::from_secs(5), &mut run_future)
+        .await
+        .expect("run should exit promptly after cancellation");
+
+    assert!(
+        outcome.poll_error.is_none(),
+        "expected no poll error, got {:?}",
+        outcome.poll_error
+    );
+    assert!(
+        outcome.maintenance_error.is_none(),
+        "expected no maintenance error, got {:?}",
+        outcome.maintenance_error
+    );
+}
+
+/// When poll hits an error, run should propagate it and still clean up.
+#[tokio::test]
+async fn run_propagates_poll_error() {
+    let node_id = test_node_id();
+
+    let mut backend = MockBackend::new();
+    backend
+        .expect_poll_unlocked()
+        .with(
+            predicate::always(),
+            predicate::always(),
+            predicate::always(),
+        )
+        .returning(move |_, _, _| Box::pin(std::future::ready(Err(MockError))));
+
+    let backend = Arc::new(backend);
+
+    let (pinned_tx, _pinned_rx) =
+        mpsc::channel::<nonempty_collections::NEVec<PinnedHandle<u64>>>(1);
+    let cancel = CancellationToken::new();
+
+    let run_future = run(Params {
+        shutdown_token: cancel,
+        force_shutdown_token: CancellationToken::new(),
+        backend,
+        node_id,
+        pinned_tx,
+        max_pinned: test_max_concurrent(),
+        pinning_ttl: test_pinning_ttl(),
+        pinning_heartbeat: short_heartbeat(),
+    });
+
+    let outcome = tokio::time::timeout(Duration::from_secs(5), run_future)
+        .await
+        .expect("run should exit promptly on poll error");
+
+    match outcome.poll_error {
+        Some(_) => {} // expected
+        other => panic!("expected Poll error on poll_error, got {other:?}"),
+    }
+}
+
+/// When the poll loop fails, the maintenance loop must continue
+/// heartbeating and processing evictions until all in-flight work
+/// drains naturally. Poll errors never cancel maintenance.
+#[tokio::test]
+async fn maintenance_drains_after_poll_error() {
+    let id = 1u64;
+    let node_id = test_node_id();
+    let pinning = test_pinning(node_id, 1);
+
+    let mut backend = MockBackend::new();
+    // First poll returns an instance; second poll errors.
+    let mut poll_calls = 0;
+    backend.expect_poll_unlocked().returning(move |_, _, _| {
+        poll_calls += 1;
+        if poll_calls == 1 {
+            Box::pin(std::future::ready(Ok(Some(nev![id]))))
+        } else {
+            Box::pin(std::future::ready(Err(MockError)))
+        }
+    });
+    // Heartbeat may fire while the instance is active, but the drain
+    // cycle can complete before the first tick — optional expectation.
+    backend
+        .expect_refresh_pinnings()
+        .times(0..)
+        .returning(move |_, _, _| {
+            Box::pin(std::future::ready(Ok(nev![PinningStatus {
+                instance_id: id,
+                pinning: Some(pinning.clone()),
+            }])))
+        });
+    // Eviction releases the pinning.
+    backend
+        .expect_release_pinnings()
+        .with(predicate::eq(node_id), predicate::eq(nev![id]))
+        .return_once(move |_, _| Box::pin(std::future::ready(Ok(()))));
+
+    let backend = Arc::new(backend);
+
+    let (pinned_tx, mut pinned_rx) =
+        mpsc::channel::<nonempty_collections::NEVec<PinnedHandle<u64>>>(1);
+
+    // Spawn a helper to receive the pinned handle and drop it,
+    // triggering eviction in the maintenance loop.
+    let handle_dropper = tokio::spawn(async move {
+        let handles = pinned_rx
+            .recv()
+            .await
+            .expect("should receive pinned handle");
+        drop(handles);
+    });
+
+    let outcome = tokio::time::timeout(
+        Duration::from_secs(5),
+        run(Params {
+            shutdown_token: CancellationToken::new(),
+            force_shutdown_token: CancellationToken::new(),
+            backend: Arc::clone(&backend),
+            node_id,
+            pinned_tx,
+            max_pinned: test_max_concurrent(),
+            pinning_ttl: test_pinning_ttl(),
+            pinning_heartbeat: short_heartbeat(),
+        }),
+    )
+    .await
+    .expect("run should exit after maintenance drains");
+
+    // Ensure the handle was received and dropped.
+    handle_dropper.await.expect("handle dropper panicked");
+
+    // Explicit: release_pinnings was called (and completed) before run() returned.
+    let mut mock = Arc::into_inner(backend)
+        .unwrap_or_else(|| panic!("backend should be exclusively owned after run() drops its Arc"));
+    mock.checkpoint();
+
+    match outcome.poll_error {
+        Some(_) => {} // expected — poll errored
+        other => panic!("expected Poll error on poll_error, got {other:?}"),
+    }
+}
+
+/// After the poll loop dies, the maintenance loop must still execute
+/// heartbeats for in-flight instances. Three heartbeats are observed:
+/// 1. Before poll error — proves heartbeats work normally.
+/// 2. After signalling poll error — may race with termination; discarded.
+/// 3. After poll is definitively dead — this is the proof.
+#[tokio::test]
+async fn maintenance_heartbeats_after_poll_is_dead() {
+    let id = 1u64;
+    let node_id = test_node_id();
+    let pinning = test_pinning(node_id, 1);
+
+    // mpsc instead of Notify so every heartbeat is queued — no lost wakeups
+    // when multiple heartbeats fire between consumer polls.
+    let (heartbeat_tx, mut heartbeat_rx) = mpsc::unbounded_channel();
+    // Async mutex so the monitor can signal poll termination without
+    // atomics. try_lock() lets the mock check synchronously.
+    let poll_error = Arc::new(tokio::sync::Mutex::new(false));
+
+    let mut backend = MockBackend::new();
+    let mut poll_calls = 0;
+    {
+        let poll_error = Arc::clone(&poll_error);
+        backend.expect_poll_unlocked().returning(move |_, _, _| {
+            poll_calls += 1;
+            if poll_calls == 1 {
+                // First call: hand out an instance so maintenance has
+                // something to heartbeat.
+                return Box::pin(std::future::ready(Ok(Some(nev![id]))));
+            }
+            let poll_error = Arc::clone(&poll_error);
+            Box::pin(async move {
+                if *poll_error.lock().await {
+                    // After the monitor signals, fail so the poll loop dies.
+                    return Err(MockError);
+                }
+                // Yield so the single-threaded runtime can schedule
+                // spawned tasks between polls.
+                tokio::task::yield_now().await;
+                Ok(None)
+            })
+        });
+    }
+    {
+        let heartbeat_tx = heartbeat_tx.clone();
+        backend
+            .expect_refresh_pinnings()
+            .times(..)
+            .returning(move |_, _, _| {
+                // Record every heartbeat so the monitor can count them.
+                heartbeat_tx.send(()).ok();
+                Box::pin(std::future::ready(Ok(nev![PinningStatus {
+                    instance_id: id,
+                    pinning: Some(pinning.clone()),
+                }])))
+            });
+    }
+    backend
+        .expect_release_pinnings()
+        .with(predicate::eq(node_id), predicate::eq(nev![id]))
+        .return_once(move |_, _| Box::pin(std::future::ready(Ok(()))));
+
+    let backend = Arc::new(backend);
+
+    let (pinned_tx, mut pinned_rx) =
+        mpsc::channel::<nonempty_collections::NEVec<PinnedHandle<u64>>>(1);
+
+    let heartbeat = Duration::from_millis(10);
+
+    // The monitor owns the pinned handle — it holds the instance
+    // in-flight while counting three heartbeats, then drops the handle
+    // to trigger eviction so maintenance can drain and run() can exit.
+    let monitor = tokio::spawn(async move {
+        let handles = pinned_rx
+            .recv()
+            .await
+            .expect("should receive pinned handle");
+
+        heartbeat_rx.recv().await.expect("first heartbeat");
+        *poll_error.lock().await = true;
+        heartbeat_rx.recv().await.expect("second heartbeat");
+        heartbeat_rx.recv().await.expect("third heartbeat — proof");
+
+        drop(handles);
+    });
+
+    let outcome = tokio::time::timeout(
+        Duration::from_secs(5),
+        run(Params {
+            shutdown_token: CancellationToken::new(),
+            force_shutdown_token: CancellationToken::new(),
+            backend: Arc::clone(&backend),
+            node_id,
+            pinned_tx,
+            max_pinned: test_max_concurrent(),
+            pinning_ttl: test_pinning_ttl(),
+            pinning_heartbeat: NonZeroDuration::new(heartbeat).unwrap(),
+        }),
+    )
+    .await
+    .expect("run should exit after maintenance drains");
+
+    monitor.await.expect("monitor panicked");
+
+    // Explicit: release_pinnings was called (and completed) before run() returned.
+    let mut mock = Arc::into_inner(backend)
+        .unwrap_or_else(|| panic!("backend should be exclusively owned after run() drops its Arc"));
+    mock.checkpoint();
+
+    match outcome.poll_error {
+        Some(_) => {} // expected
+        other => panic!("expected Poll error on poll_error, got {other:?}"),
+    }
+}


### PR DESCRIPTION
This PR adds the workload pinning subsystem.

In comparison to the old implementation, within the new architecture this subsystem partially replaces the instance queue and locks - while not including any of the actual execution state (i.e. graphs in the old implementation or VM snapshots in the new implementation).

The workload can be anything, but in the current design it is intended to be used for managing the VM runtimes scheduling on the pool of executor nodes (in concrete terms - the `start-workers` instances).

The benefit of this approach is that it decouples the slow and costly operations on the big blobs from the more lightweight data that we can poll often (i.e. the queue and the locking status of a particular workload - or, more concretely - a instance of a VM).

---

This implementation expresses the interaction between the internal control loops in a tight type-safe manner, and also exposes underlying error conditions for explicit error handling.

---

The test coverage is good, and we explicitly cover tricky edge cases, like the behaviour of one loop when the other crashes.