### PR TITLE
Add conversions machinery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4440,6 +4440,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "waymark-convert-core"
+version = "0.1.0"
+
+[[package]]
 name = "waymark-core-backend"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5676,6 +5676,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "waymark-vm-value-convert-core"
+version = "0.1.0"
+dependencies = [
+ "thiserror",
+ "waymark-vm-runtime-promise-core",
+]
+
+[[package]]
 name = "waymark-webapp-backend"
 version = "0.1.0"
 dependencies = [

--- a/crates/lib/convert-core/Cargo.toml
+++ b/crates/lib/convert-core/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "waymark-convert-core"
+edition = "2024"
+version.workspace = true
+publish.workspace = true
+
+[dependencies]

--- a/crates/lib/convert-core/src/lib.rs
+++ b/crates/lib/convert-core/src/lib.rs
@@ -1,0 +1,45 @@
+//! Core conversion traits.
+
+#![warn(missing_docs)]
+
+/// Fallible conversion from one type to another.
+pub trait TryConvert<From, To> {
+    /// The error type returned when conversion fails.
+    type Error;
+
+    /// Convert `from` into `To`, or return an error.
+    fn try_convert(from: From) -> Result<To, Self::Error>;
+}
+
+/// Conversion from one type to another.
+pub trait Convert<From, To>: TryConvert<From, To, Error = core::convert::Infallible> {
+    /// Convert `from` into `To`.
+    fn convert(from: From) -> To;
+}
+
+impl<Converter, From, To> Convert<From, To> for Converter
+where
+    Converter: TryConvert<From, To, Error = core::convert::Infallible>,
+{
+    fn convert(from: From) -> To {
+        let Ok(to) = Converter::try_convert(from);
+        to
+    }
+}
+
+/// The error type produced by a converter for a given source and target type.
+pub type ConvertErrorFor<Converter, From, To> = <Converter as TryConvert<From, To>>::Error;
+
+/// A converter based on [`core::convert::TryFrom`].
+pub struct StdConverter;
+
+impl<From, To> TryConvert<From, To> for StdConverter
+where
+    To: core::convert::TryFrom<From>,
+{
+    type Error = <To as core::convert::TryFrom<From>>::Error;
+
+    fn try_convert(from: From) -> Result<To, Self::Error> {
+        from.try_into()
+    }
+}

--- a/crates/lib/vm-value-convert-core/Cargo.toml
+++ b/crates/lib/vm-value-convert-core/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "waymark-vm-value-convert-core"
+version.workspace = true
+publish.workspace = true
+edition = "2024"
+
+[dependencies]
+waymark-vm-runtime-promise-core = { workspace = true }
+
+thiserror = { workspace = true }
+
+[lib]
+doctest = false

--- a/crates/lib/vm-value-convert-core/src/lib.rs
+++ b/crates/lib/vm-value-convert-core/src/lib.rs
@@ -1,0 +1,8 @@
+//! Core error type shared across VM-value converter crates.
+
+#![warn(missing_docs)]
+
+/// Error returned when attempting to convert a pending promise value.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[error("cannot convert pending promise {0:?}")]
+pub struct PendingPromiseError(pub waymark_vm_runtime_promise_core::PromiseStateId);


### PR DESCRIPTION
This PR adds a common trait and generally composable system of conversions.

It's like `From`/`Into`, but bound to a third-party converter type as opposed to a source or the target of the conversion.

This gives us the ability to have multiple converters for the same type pairs which do different things - something that really comes in handy given that we have different representations for essentially the same data encoded for actions calls, workflow completions and workflow initializations.