### PR TITLE
Implement effect counting at vm-runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5304,6 +5304,7 @@ dependencies = [
  "waymark-vm-interpreter-fullset",
  "waymark-vm-runtime",
  "waymark-vm-runtime-core",
+ "waymark-vm-runtime-effect",
 ]
 
 [[package]]
@@ -5356,6 +5357,7 @@ dependencies = [
  "waymark-vm-interpreter",
  "waymark-vm-runtime",
  "waymark-vm-runtime-core",
+ "waymark-vm-runtime-effect",
  "waymark-vm-runtime-exception",
  "waymark-vm-runtime-promise-core",
  "waymark-vm-runtime-test",
@@ -5511,6 +5513,7 @@ dependencies = [
  "waymark-vm-executable",
  "waymark-vm-interpreter",
  "waymark-vm-runtime-core",
+ "waymark-vm-runtime-effect",
  "waymark-vm-runtime-exception",
  "waymark-vm-runtime-promise-core",
  "waymark-vm-runtime-test",
@@ -5525,10 +5528,18 @@ dependencies = [
  "thiserror",
  "waymark-typed-vec-serde",
  "waymark-vm-exception-handler",
+ "waymark-vm-runtime-effect",
  "waymark-vm-runtime-exception",
  "waymark-vm-runtime-promise-core",
  "waymark-vm-runtime-promise-value",
  "waymark-vm-runtime-value",
+]
+
+[[package]]
+name = "waymark-vm-runtime-effect"
+version = "0.1.0"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,6 +93,7 @@ waymark-vm-interpreter-pureset = { path = "crates/lib/vm-interpreter-pureset" }
 waymark-vm-interpreter-utils = { path = "crates/lib/vm-interpreter-utils" }
 waymark-vm-runtime = { path = "crates/lib/vm-runtime" }
 waymark-vm-runtime-core = { path = "crates/lib/vm-runtime-core" }
+waymark-vm-runtime-effect = { path = "crates/lib/vm-runtime-effect" }
 waymark-vm-runtime-exception = { path = "crates/lib/vm-runtime-exception" }
 waymark-vm-runtime-promise-core = { path = "crates/lib/vm-runtime-promise-core" }
 waymark-vm-runtime-promise-value = { path = "crates/lib/vm-runtime-promise-value" }

--- a/crates/bin/vm-cli/src/run.rs
+++ b/crates/bin/vm-cli/src/run.rs
@@ -54,11 +54,11 @@ pub async fn run(
     tasks.spawn({
         async move {
             loop {
-                let Some(effect) = effects_rx.recv().await else {
+                let Some(emitted_effect) = effects_rx.recv().await else {
                     break;
                 };
 
-                match effect {
+                match emitted_effect.effect {
                     waymark_vm_interpreter_fullset::Effect::CoreSet(effect) => match effect {
                         waymark_vm_interpreter_coreset::Effect::Complete(value) => {
                             completion_tx.send(Ok(value)).unwrap();
@@ -76,6 +76,7 @@ pub async fn run(
                             args,
                         } => {
                             tracing::info!(
+                                effect_number = %emitted_effect.number,
                                 ?action_ref,
                                 ?promise_state_id,
                                 ?args,
@@ -89,6 +90,7 @@ pub async fn run(
 
                                     let value = integration::SampleReadyValue::Int(42);
                                     tracing::info!(
+                                        effect_number = %emitted_effect.number,
                                         ?action_ref,
                                         ?promise_state_id,
                                         ?args,
@@ -109,7 +111,12 @@ pub async fn run(
                             promise_state_id,
                             duration,
                         } => {
-                            tracing::info!(?promise_state_id, ?duration, "sleep received");
+                            tracing::info!(
+                                effect_number = %emitted_effect.number,
+                                ?promise_state_id,
+                                ?duration,
+                                "sleep received"
+                            );
 
                             tokio::spawn({
                                 let promise_resolutions_tx = promise_resolutions_tx.clone();
@@ -117,7 +124,12 @@ pub async fn run(
                                     tokio::time::sleep(duration.get()).await;
 
                                     let value = integration::SampleReadyValue::None;
-                                    tracing::info!(?promise_state_id, ?value, "resolving sleep");
+                                    tracing::info!(
+                                        effect_number = %emitted_effect.number,
+                                        ?promise_state_id,
+                                        ?value,
+                                        "resolving sleep"
+                                    );
                                     promise_resolutions_tx
                                         .send((
                                             promise_state_id,

--- a/crates/lib/vm-compiler-for-ast-old/Cargo.toml
+++ b/crates/lib/vm-compiler-for-ast-old/Cargo.toml
@@ -31,6 +31,7 @@ waymark-vm-interpreter-coreset = { workspace = true }
 waymark-vm-interpreter-extcallset = { workspace = true }
 waymark-vm-interpreter-fullset = { workspace = true }
 waymark-vm-runtime = { workspace = true }
+waymark-vm-runtime-effect = { workspace = true }
 
 async-walkdir = { workspace = true }
 futures-util = { workspace = true }

--- a/crates/lib/vm-compiler-for-ast-old/tests/integration.rs
+++ b/crates/lib/vm-compiler-for-ast-old/tests/integration.rs
@@ -16,17 +16,23 @@ use waymark_vm_bytecode_core::{FunctionId, InstructionId, StateId};
 use waymark_vm_compiler_for_ast_old_test_support::{TestActionRef, TestReadyValue, TestValue};
 use waymark_vm_interpreter_fullset::Effect;
 
-fn completed_int(effect: Effect<TestReadyValue, TestActionRef, TestReadyValue>) -> i64 {
-    match completed_value(effect) {
+fn completed_int(
+    emitted_effect: waymark_vm_runtime_effect::EmittedEffect<
+        Effect<TestReadyValue, TestActionRef, TestReadyValue>,
+    >,
+) -> i64 {
+    match completed_value(emitted_effect) {
         TestReadyValue::Int(value) => value,
         other => panic!("unexpected runtime effect: {other:?}"),
     }
 }
 
 fn completed_value(
-    effect: Effect<TestReadyValue, TestActionRef, TestReadyValue>,
+    emitted_effect: waymark_vm_runtime_effect::EmittedEffect<
+        Effect<TestReadyValue, TestActionRef, TestReadyValue>,
+    >,
 ) -> TestReadyValue {
-    match effect {
+    match emitted_effect.effect {
         Effect::CoreSet(waymark_vm_interpreter_coreset::Effect::Complete(value)) => value,
         other => panic!("unexpected runtime effect: {other:?}"),
     }
@@ -51,9 +57,9 @@ fn compiles_assignments_and_addition_to_completion() {
     let executable = compile_program(&program);
     let mut runtime = runtime(executable);
 
-    let effect = runtime.run().expect("program should complete");
+    let emitted_effect = runtime.run().expect("program should complete");
 
-    match effect {
+    match emitted_effect.effect {
         Effect::CoreSet(waymark_vm_interpreter_coreset::Effect::Complete(TestReadyValue::Int(
             value,
         ))) => assert_eq!(value, 5),
@@ -368,9 +374,9 @@ fn compiles_user_function_calls() {
     let executable = compile_program(&program);
     let mut runtime = runtime(executable);
 
-    let effect = runtime.run().expect("program should complete");
+    let emitted_effect = runtime.run().expect("program should complete");
 
-    match effect {
+    match emitted_effect.effect {
         Effect::CoreSet(waymark_vm_interpreter_coreset::Effect::Complete(TestReadyValue::Int(
             value,
         ))) => assert_eq!(value, 42),
@@ -392,9 +398,9 @@ fn compiles_action_calls_into_extcalls() {
     let executable = compile_program(&program);
     let mut runtime = runtime(executable);
 
-    let effect = runtime.run().expect("program should emit an extcall");
+    let emitted_effect = runtime.run().expect("program should emit an extcall");
 
-    let promise_state_id = match effect {
+    let promise_state_id = match emitted_effect.effect {
         Effect::ExtCallSet(waymark_vm_interpreter_extcallset::Effect::ActionCall {
             promise_state_id,
             action_ref,
@@ -411,11 +417,11 @@ fn compiles_action_calls_into_extcalls() {
         .resolve_promise(promise_state_id, TestReadyValue::Int(42))
         .expect("extcall promise should resolve");
 
-    let effect = runtime
+    let emitted_effect = runtime
         .run()
         .expect("program should complete after resolution");
 
-    match effect {
+    match emitted_effect.effect {
         Effect::CoreSet(waymark_vm_interpreter_coreset::Effect::Complete(TestReadyValue::Int(
             value,
         ))) => assert_eq!(value, 42),
@@ -607,7 +613,9 @@ fn compiles_sleep_statements_into_resumable_sleep_effects() {
     let executable = compile_program(&program);
     let mut runtime = runtime(executable);
 
-    let promise_state_id = match runtime.run().expect("program should emit a sleep effect") {
+    let emitted_effect = runtime.run().expect("program should emit a sleep effect");
+
+    let promise_state_id = match emitted_effect.effect {
         Effect::ExtCallSet(waymark_vm_interpreter_extcallset::Effect::Sleep {
             promise_state_id,
             duration,
@@ -716,10 +724,10 @@ fn compiles_parallel_action_blocks_with_multiple_outstanding_extcalls() {
     let executable = compile_program(&program);
     let mut runtime = runtime(executable);
 
-    let first_promise = match runtime
+    let emitted_effect = runtime
         .run()
-        .expect("first run should emit the first extcall")
-    {
+        .expect("first run should emit the first extcall");
+    let first_promise = match emitted_effect.effect {
         Effect::ExtCallSet(waymark_vm_interpreter_extcallset::Effect::ActionCall {
             promise_state_id,
             action_ref,
@@ -732,10 +740,10 @@ fn compiles_parallel_action_blocks_with_multiple_outstanding_extcalls() {
         other => panic!("unexpected first runtime effect: {other:?}"),
     };
 
-    let second_promise = match runtime
+    let emitted_effect = runtime
         .run()
-        .expect("second run should emit the second extcall")
-    {
+        .expect("second run should emit the second extcall");
+    let second_promise = match emitted_effect.effect {
         Effect::ExtCallSet(waymark_vm_interpreter_extcallset::Effect::ActionCall {
             promise_state_id,
             action_ref,
@@ -755,11 +763,11 @@ fn compiles_parallel_action_blocks_with_multiple_outstanding_extcalls() {
         .resolve_promise(first_promise, TestReadyValue::Int(10))
         .expect("first extcall promise should resolve");
 
-    let effect = runtime
+    let emitted_effect = runtime
         .run()
         .expect("program should complete after resolving both extcalls");
 
-    match effect {
+    match emitted_effect.effect {
         Effect::CoreSet(waymark_vm_interpreter_coreset::Effect::Complete(TestReadyValue::Int(
             value,
         ))) => assert_eq!(value, 7),
@@ -798,11 +806,12 @@ fn compiles_spread_expressions_to_completion() {
     let mut pending_promises = Vec::new();
 
     for input in [1, 2, 3] {
-        let promise = match runtime.run().unwrap_or_else(|error| {
+        let emitted_effect = runtime.run().unwrap_or_else(|error| {
             panic!(
                 "spread action for {input} should start before earlier promises resolve: {error:?}"
             )
-        }) {
+        });
+        let promise = match emitted_effect.effect {
             Effect::ExtCallSet(waymark_vm_interpreter_extcallset::Effect::ActionCall {
                 promise_state_id,
                 action_ref,
@@ -865,10 +874,10 @@ fn compiles_mixed_parallel_blocks_with_leading_action_before_awaiting() {
     let executable = compile_program(&program);
     let mut runtime = runtime(executable);
 
-    let first_promise = match runtime
+    let emitted_effect = runtime
         .run()
-        .expect("first run should emit the first extcall")
-    {
+        .expect("first run should emit the first extcall");
+    let first_promise = match emitted_effect.effect {
         Effect::ExtCallSet(waymark_vm_interpreter_extcallset::Effect::ActionCall {
             promise_state_id,
             action_ref,
@@ -881,10 +890,10 @@ fn compiles_mixed_parallel_blocks_with_leading_action_before_awaiting() {
         other => panic!("unexpected first runtime effect: {other:?}"),
     };
 
-    let second_promise = match runtime
+    let emitted_effect = runtime
         .run()
-        .expect("second run should emit the second extcall before awaiting the first")
-    {
+        .expect("second run should emit the second extcall before awaiting the first");
+    let second_promise = match emitted_effect.effect {
         Effect::ExtCallSet(waymark_vm_interpreter_extcallset::Effect::ActionCall {
             promise_state_id,
             action_ref,
@@ -904,11 +913,11 @@ fn compiles_mixed_parallel_blocks_with_leading_action_before_awaiting() {
         .resolve_promise(first_promise, TestReadyValue::Int(10))
         .expect("first extcall promise should resolve");
 
-    let effect = runtime
+    let emitted_effect = runtime
         .run()
         .expect("program should complete after resolving both extcalls");
 
-    match effect {
+    match emitted_effect.effect {
         Effect::CoreSet(waymark_vm_interpreter_coreset::Effect::Complete(TestReadyValue::Int(
             value,
         ))) => assert_eq!(value, 7),
@@ -927,7 +936,7 @@ fn compiles_empty_parallel_blocks_as_noops() {
     let executable = compile_program(&program);
     let mut runtime = runtime(executable);
 
-    let effect = runtime.run().expect("program should complete");
+    let effect = runtime.run().expect("program should complete").effect;
 
     match effect {
         Effect::CoreSet(waymark_vm_interpreter_coreset::Effect::Complete(TestReadyValue::Int(
@@ -972,7 +981,8 @@ fn compiles_parallel_expressions_into_positional_assignments() {
     let executable = compile_program(&program);
     let mut runtime = runtime(executable);
 
-    let promise_state_id = match runtime.run().expect("program should emit an extcall") {
+    let emitted_effect = runtime.run().expect("program should emit an extcall");
+    let promise_state_id = match emitted_effect.effect {
         Effect::ExtCallSet(waymark_vm_interpreter_extcallset::Effect::ActionCall {
             promise_state_id,
             action_ref,
@@ -989,11 +999,11 @@ fn compiles_parallel_expressions_into_positional_assignments() {
         .resolve_promise(promise_state_id, TestReadyValue::Int(5))
         .expect("extcall promise should resolve");
 
-    let effect = runtime
+    let emitted_effect = runtime
         .run()
         .expect("program should complete after resolving the parallel expression");
 
-    match effect {
+    match emitted_effect.effect {
         Effect::CoreSet(waymark_vm_interpreter_coreset::Effect::Complete(TestReadyValue::Int(
             value,
         ))) => assert_eq!(value, 9),
@@ -1037,10 +1047,10 @@ fn compiles_mixed_parallel_expressions_with_leading_action_before_awaiting() {
     let executable = compile_program(&program);
     let mut runtime = runtime(executable);
 
-    let first_promise = match runtime
+    let emitted_effect = runtime
         .run()
-        .expect("first run should emit the first extcall")
-    {
+        .expect("first run should emit the first extcall");
+    let first_promise = match emitted_effect.effect {
         Effect::ExtCallSet(waymark_vm_interpreter_extcallset::Effect::ActionCall {
             promise_state_id,
             action_ref,
@@ -1053,10 +1063,10 @@ fn compiles_mixed_parallel_expressions_with_leading_action_before_awaiting() {
         other => panic!("unexpected first runtime effect: {other:?}"),
     };
 
-    let second_promise = match runtime
+    let emitted_effect = runtime
         .run()
-        .expect("second run should emit the second extcall before awaiting the first")
-    {
+        .expect("second run should emit the second extcall before awaiting the first");
+    let second_promise = match emitted_effect.effect {
         Effect::ExtCallSet(waymark_vm_interpreter_extcallset::Effect::ActionCall {
             promise_state_id,
             action_ref,
@@ -1076,11 +1086,11 @@ fn compiles_mixed_parallel_expressions_with_leading_action_before_awaiting() {
         .resolve_promise(first_promise, TestReadyValue::Int(10))
         .expect("first extcall promise should resolve");
 
-    let effect = runtime
+    let emitted_effect = runtime
         .run()
         .expect("program should complete after resolving both extcalls");
 
-    match effect {
+    match emitted_effect.effect {
         Effect::CoreSet(waymark_vm_interpreter_coreset::Effect::Complete(TestReadyValue::Int(
             value,
         ))) => assert_eq!(value, 43),
@@ -1119,7 +1129,8 @@ fn compiles_parallel_expressions_into_aggregate_lists() {
     let executable = compile_program(&program);
     let mut runtime = runtime(executable);
 
-    let promise_state_id = match runtime.run().expect("program should emit an extcall") {
+    let emitted_effect = runtime.run().expect("program should emit an extcall");
+    let promise_state_id = match emitted_effect.effect {
         Effect::ExtCallSet(waymark_vm_interpreter_extcallset::Effect::ActionCall {
             promise_state_id,
             action_ref,
@@ -1136,11 +1147,11 @@ fn compiles_parallel_expressions_into_aggregate_lists() {
         .resolve_promise(promise_state_id, TestReadyValue::Int(5))
         .expect("extcall promise should resolve");
 
-    let effect = runtime
+    let emitted_effect = runtime
         .run()
         .expect("program should complete after resolving the parallel expression");
 
-    match effect {
+    match emitted_effect.effect {
         Effect::CoreSet(waymark_vm_interpreter_coreset::Effect::Complete(
             TestReadyValue::List(values),
         )) => assert_eq!(
@@ -1178,10 +1189,10 @@ fn compiles_parallel_expression_results_by_call_position() {
     let executable = compile_program(&program);
     let mut runtime = runtime(executable);
 
-    let first_promise = match runtime
+    let emitted_effect = runtime
         .run()
-        .expect("first run should emit the first extcall")
-    {
+        .expect("first run should emit the first extcall");
+    let first_promise = match emitted_effect.effect {
         Effect::ExtCallSet(waymark_vm_interpreter_extcallset::Effect::ActionCall {
             promise_state_id,
             action_ref,
@@ -1194,10 +1205,10 @@ fn compiles_parallel_expression_results_by_call_position() {
         other => panic!("unexpected first runtime effect: {other:?}"),
     };
 
-    let second_promise = match runtime
+    let emitted_effect = runtime
         .run()
-        .expect("second run should emit the second extcall")
-    {
+        .expect("second run should emit the second extcall");
+    let second_promise = match emitted_effect.effect {
         Effect::ExtCallSet(waymark_vm_interpreter_extcallset::Effect::ActionCall {
             promise_state_id,
             action_ref,
@@ -1217,11 +1228,11 @@ fn compiles_parallel_expression_results_by_call_position() {
         .resolve_promise(first_promise, TestReadyValue::Int(10))
         .expect("first extcall promise should resolve");
 
-    let effect = runtime
+    let emitted_effect = runtime
         .run()
         .expect("program should complete after resolving both parallel expression calls");
 
-    match effect {
+    match emitted_effect.effect {
         Effect::CoreSet(waymark_vm_interpreter_coreset::Effect::Complete(TestReadyValue::Int(
             value,
         ))) => assert_eq!(value, 30),

--- a/crates/lib/vm-driver/Cargo.toml
+++ b/crates/lib/vm-driver/Cargo.toml
@@ -9,6 +9,7 @@ waymark-vm-executable = { workspace = true }
 waymark-vm-interpreter = { workspace = true }
 waymark-vm-runtime = { workspace = true }
 waymark-vm-runtime-core = { workspace = true }
+waymark-vm-runtime-effect = { workspace = true }
 waymark-vm-runtime-exception = { workspace = true }
 waymark-vm-runtime-promise-core = { workspace = true }
 

--- a/crates/lib/vm-driver/src/lib.rs
+++ b/crates/lib/vm-driver/src/lib.rs
@@ -48,7 +48,8 @@ where
     pub runtime: Runtime<Executable, Interpreter, Value>,
 
     /// Channel used to publish effects emitted by the runtime.
-    pub effects_tx: tokio::sync::mpsc::Sender<Interpreter::Effect>,
+    pub effects_tx:
+        tokio::sync::mpsc::Sender<waymark_vm_runtime_effect::EmittedEffect<Interpreter::Effect>>,
 
     /// Channel used to receive promise resolutions for pending promises.
     pub promise_resolutions_rx:
@@ -97,9 +98,10 @@ where
 
     loop {
         match runtime.run() {
-            Ok(effect) => {
-                tracing::info!(?effect, "effect");
-                if effects_tx.send(effect).await.is_err() {
+            Ok(emitted_effect) => {
+                let waymark_vm_runtime_effect::EmittedEffect { effect, number } = &emitted_effect;
+                tracing::info!(?effect, %number, "effect");
+                if effects_tx.send(emitted_effect).await.is_err() {
                     return Err(Error::EffectSenderClosed);
                 }
             }

--- a/crates/lib/vm-driver/tests/integration.rs
+++ b/crates/lib/vm-driver/tests/integration.rs
@@ -21,7 +21,13 @@ async fn forwards_emitted_effects_to_the_effect_channel() {
         promise_resolutions_rx,
     }));
 
-    assert_eq!(effects_rx.recv().await, Some(TestEffect::Message("tick")));
+    assert_eq!(
+        effects_rx.recv().await,
+        Some(waymark_vm_runtime_effect::EmittedEffect {
+            effect: TestEffect::Message("tick"),
+            number: waymark_vm_runtime_effect::EffectNumber(0),
+        })
+    );
     drop(promise_resolutions_tx);
 
     assert!(matches!(
@@ -60,7 +66,10 @@ async fn resumes_waiting_promises_and_forwards_the_resolved_effect() {
 
     assert_eq!(
         effects_rx.recv().await,
-        Some(TestEffect::Value(TestReadyValue::Int(41)))
+        Some(waymark_vm_runtime_effect::EmittedEffect {
+            effect: TestEffect::Value(TestReadyValue::Int(41)),
+            number: waymark_vm_runtime_effect::EffectNumber(0),
+        })
     );
     drop(promise_resolutions_tx);
 
@@ -251,10 +260,13 @@ async fn resumes_waiting_promises_with_exception_errors() {
 
     assert_eq!(
         effects_rx.recv().await,
-        Some(TestEffect::UnhandledException(Exception {
-            type_id: "ValueError".to_owned(),
-            details: TestReadyValue::Int(41),
-        }))
+        Some(waymark_vm_runtime_effect::EmittedEffect {
+            effect: TestEffect::UnhandledException(Exception {
+                type_id: "ValueError".to_owned(),
+                details: TestReadyValue::Int(41),
+            }),
+            number: waymark_vm_runtime_effect::EffectNumber(0),
+        })
     );
     drop(promise_resolutions_tx);
 

--- a/crates/lib/vm-interpreter-coreset/tests/call_await/mod.rs
+++ b/crates/lib/vm-interpreter-coreset/tests/call_await/mod.rs
@@ -33,11 +33,11 @@ fn runtime_executes_call_await_and_return_to_completion() {
 
     let mut runtime = new_runtime_with_args(executable, vec![TestReadyValue::Int(7)]);
 
-    let effect = runtime
+    let emitted_effect = runtime
         .run()
         .expect("call/await/return program should complete");
 
-    match effect {
+    match emitted_effect.effect {
         Effect::Complete(value) => assert_eq!(value, TestReadyValue::Int(7)),
         Effect::UnhandledException(exception) => {
             panic!("program should complete successfully, got {exception:?}")

--- a/crates/lib/vm-interpreter-coreset/tests/jump/mod.rs
+++ b/crates/lib/vm-interpreter-coreset/tests/jump/mod.rs
@@ -28,9 +28,9 @@ fn runtime_follows_jump_and_jump_if_before_returning() {
         vec![TestReadyValue::Int(1), TestReadyValue::Int(9)],
     );
 
-    let effect = runtime.run().expect("jump program should complete");
+    let emitted_effect = runtime.run().expect("jump program should complete");
 
-    match effect {
+    match emitted_effect.effect {
         Effect::Complete(value) => assert_eq!(value, TestReadyValue::Int(9)),
         Effect::UnhandledException(exception) => {
             panic!("jump program should not raise an exception: {exception:?}")

--- a/crates/lib/vm-interpreter-coreset/tests/raise/mod.rs
+++ b/crates/lib/vm-interpreter-coreset/tests/raise/mod.rs
@@ -22,11 +22,11 @@ fn runtime_raises_exception_values_from_registers() {
 
     let mut runtime = new_runtime_with_args(executable, vec![raised]);
 
-    let effect = runtime
+    let emitted_effect = runtime
         .run()
         .expect("raise program should emit an unhandled exception");
 
-    match effect {
+    match emitted_effect.effect {
         Effect::UnhandledException(Exception { type_id, details }) => {
             assert_eq!(type_id, "ValueError");
             assert_eq!(details, TestReadyValue::Int(7));
@@ -82,11 +82,11 @@ fn bubble_exception_handles_same_frame_exceptions_with_local_handlers() {
 
     let mut runtime = new_runtime_with_args(executable, vec![raised]);
 
-    let effect = runtime
+    let emitted_effect = runtime
         .run()
         .expect("local handler should catch the raised exception");
 
-    match effect {
+    match emitted_effect.effect {
         Effect::Complete(TestReadyValue::Exception(exception)) => {
             assert_eq!(exception.type_id, "ValueError");
             assert_eq!(exception.details, TestValue::Ready(TestReadyValue::Int(7)));

--- a/crates/lib/vm-interpreter-extcallset/tests/action_call/mod.rs
+++ b/crates/lib/vm-interpreter-extcallset/tests/action_call/mod.rs
@@ -29,13 +29,14 @@ fn runtime_emits_an_action_call_and_queues_the_resumed_frame() {
         vec![TestReadyValue(41)],
     );
 
+    let emitted_effect = runtime
+        .run()
+        .expect("first run should emit the action call");
     let TestEffect::ExtCallSet(Effect::ActionCall {
         promise_state_id,
         action_ref,
         args,
-    }) = runtime
-        .run()
-        .expect("first run should emit the action call")
+    }) = emitted_effect.effect
     else {
         panic!("first run should emit an action call");
     };
@@ -43,10 +44,10 @@ fn runtime_emits_an_action_call_and_queues_the_resumed_frame() {
     assert_eq!(action_ref, 7);
     assert_eq!(args, vec![41]);
 
-    let TestEffect::PendingPromiseStateId(resumed_promise_state_id) = runtime
+    let emitted_effect = runtime
         .run()
-        .expect("second run should execute the resumed frame")
-    else {
+        .expect("second run should execute the resumed frame");
+    let TestEffect::PendingPromiseStateId(resumed_promise_state_id) = emitted_effect.effect else {
         panic!("second run should inspect the resumed pending promise");
     };
 

--- a/crates/lib/vm-interpreter-extcallset/tests/sleep/mod.rs
+++ b/crates/lib/vm-interpreter-extcallset/tests/sleep/mod.rs
@@ -29,22 +29,23 @@ fn runtime_emits_a_sleep_effect_and_queues_the_resumed_frame() {
         vec![TestReadyValue(5)],
     );
 
+    let emitted_effect = runtime
+        .run()
+        .expect("first run should emit the sleep effect");
     let TestEffect::ExtCallSet(Effect::Sleep {
         promise_state_id,
         duration,
-    }) = runtime
-        .run()
-        .expect("first run should emit the sleep effect")
+    }) = emitted_effect.effect
     else {
         panic!("first run should emit a sleep effect");
     };
 
     assert_eq!(duration, NonZeroDuration::from_secs(5).unwrap());
 
-    let TestEffect::PendingPromiseStateId(resumed_promise_state_id) = runtime
+    let emitted_effect = runtime
         .run()
-        .expect("second run should execute the resumed frame")
-    else {
+        .expect("second run should execute the resumed frame");
+    let TestEffect::PendingPromiseStateId(resumed_promise_state_id) = emitted_effect.effect else {
         panic!("second run should inspect the resumed pending promise");
     };
 

--- a/crates/lib/vm-interpreter-fullset/tests/extcall/mod.rs
+++ b/crates/lib/vm-interpreter-fullset/tests/extcall/mod.rs
@@ -56,11 +56,11 @@ fn runtime_resumes_extcalls_and_finishes_with_pure_work() {
 
     let mut runtime = new_runtime_with_args(executable, vec![TestReadyValue::Int(41)]);
 
-    let effect = runtime
+    let emitted_effect = runtime
         .run()
         .expect("first run should emit the action call");
 
-    let promise_state_id = match effect {
+    let promise_state_id = match emitted_effect.effect {
         Effect::ExtCallSet(waymark_vm_interpreter_extcallset::Effect::ActionCall {
             promise_state_id,
             action_ref,
@@ -86,11 +86,11 @@ fn runtime_resumes_extcalls_and_finishes_with_pure_work() {
         .resolve_promise(promise_state_id, TestReadyValue::Int(41))
         .expect("action call promise should resolve cleanly");
 
-    let effect = runtime
+    let emitted_effect = runtime
         .run()
         .expect("second run should finish after resuming the action call");
 
-    match effect {
+    match emitted_effect.effect {
         Effect::CoreSet(waymark_vm_interpreter_coreset::Effect::Complete(value)) => {
             assert_eq!(value, TestReadyValue::Int(42));
         }

--- a/crates/lib/vm-interpreter-fullset/tests/sleep/mod.rs
+++ b/crates/lib/vm-interpreter-fullset/tests/sleep/mod.rs
@@ -50,11 +50,11 @@ fn runtime_resumes_sleep_effects_and_finishes_with_pure_work() {
 
     let mut runtime = new_runtime(executable);
 
-    let effect = runtime
+    let emitted_effect = runtime
         .run()
         .expect("first run should emit the sleep effect");
 
-    let promise_state_id = match effect {
+    let promise_state_id = match emitted_effect.effect {
         Effect::ExtCallSet(waymark_vm_interpreter_extcallset::Effect::Sleep {
             promise_state_id,
             duration,
@@ -78,11 +78,11 @@ fn runtime_resumes_sleep_effects_and_finishes_with_pure_work() {
         .resolve_promise(promise_state_id, TestReadyValue::Int(0))
         .expect("sleep promise should resolve cleanly");
 
-    let effect = runtime
+    let emitted_effect = runtime
         .run()
         .expect("second run should finish after resuming sleep");
 
-    match effect {
+    match emitted_effect.effect {
         Effect::CoreSet(waymark_vm_interpreter_coreset::Effect::Complete(value)) => {
             assert_eq!(value, TestReadyValue::Int(7));
         }

--- a/crates/lib/vm-interpreter-fullset/tests/state_entry/mod.rs
+++ b/crates/lib/vm-interpreter-fullset/tests/state_entry/mod.rs
@@ -100,13 +100,14 @@ fn pending_exceptions_are_consumed_before_execute_dispatch() {
     )
     .expect("function 0 should exist");
 
+    let emitted_effect = runtime
+        .run()
+        .expect("first run should suspend on the action call");
     let waymark_vm_interpreter_fullset::Effect::ExtCallSet(
         waymark_vm_interpreter_extcallset::Effect::ActionCall {
             promise_state_id, ..
         },
-    ) = runtime
-        .run()
-        .expect("first run should suspend on the action call")
+    ) = emitted_effect.effect
     else {
         panic!("first run should emit an action call");
     };
@@ -121,11 +122,11 @@ fn pending_exceptions_are_consumed_before_execute_dispatch() {
         )
         .expect("action-call promise should resolve exceptionally");
 
-    let effect = runtime
+    let emitted_effect = runtime
         .run()
         .expect("state entry should bubble the pending exception before execute dispatch");
 
-    match effect {
+    match emitted_effect.effect {
         waymark_vm_interpreter_fullset::Effect::CoreSet(
             waymark_vm_interpreter_coreset::Effect::UnhandledException(Exception {
                 type_id,

--- a/crates/lib/vm-interpreter-fullset/tests/synchronous/mod.rs
+++ b/crates/lib/vm-interpreter-fullset/tests/synchronous/mod.rs
@@ -38,11 +38,11 @@ fn runtime_executes_pure_and_core_instructions_to_completion() {
 
     let mut runtime = new_runtime(executable);
 
-    let effect = runtime
+    let emitted_effect = runtime
         .run()
         .expect("mixed fullset program should complete successfully");
 
-    match effect {
+    match emitted_effect.effect {
         Effect::CoreSet(waymark_vm_interpreter_coreset::Effect::Complete(value)) => {
             assert_eq!(value, TestReadyValue::Int(5));
         }

--- a/crates/lib/vm-interpreter-pureset/tests/support/mod.rs
+++ b/crates/lib/vm-interpreter-pureset/tests/support/mod.rs
@@ -379,5 +379,5 @@ pub fn run(regs: usize, instrs: Vec<RuntimeInstruction>) -> Result<TestValue, Ru
     let exec = executable(vec![function::<RuntimeInstruction>(regs, vec![instrs])]);
     let mut runtime = Runtime::with_conventional_entrypoint(RuntimeInterpreter::default(), exec)
         .expect("function 0 should exist");
-    runtime.run()
+    runtime.run().map(|emitted_effect| emitted_effect.effect)
 }

--- a/crates/lib/vm-runtime-core/Cargo.toml
+++ b/crates/lib/vm-runtime-core/Cargo.toml
@@ -7,6 +7,7 @@ publish.workspace = true
 [dependencies]
 waymark-typed-vec-serde = { workspace = true, optional = true }
 waymark-vm-exception-handler = { workspace = true }
+waymark-vm-runtime-effect = { workspace = true }
 waymark-vm-runtime-exception = { workspace = true }
 waymark-vm-runtime-promise-core = { workspace = true }
 
@@ -21,6 +22,7 @@ serde = [
   "dep:serde",
   "dep:waymark-typed-vec-serde",
   "waymark-vm-exception-handler/serde",
+  "waymark-vm-runtime-effect/serde",
   "waymark-vm-runtime-exception/serde",
   "waymark-vm-runtime-promise-core/serde",
 ]

--- a/crates/lib/vm-runtime-core/src/runtime_state.rs
+++ b/crates/lib/vm-runtime-core/src/runtime_state.rs
@@ -1,5 +1,6 @@
 use std::collections::VecDeque;
 
+use waymark_vm_runtime_effect::EffectNumber;
 use waymark_vm_runtime_promise_core::PromiseStateId;
 
 use crate::{Frame, PromiseStates, RejectPromiseError, ResolvePromiseError};
@@ -29,6 +30,11 @@ pub struct RuntimeState<FunctionId, StateId, Value> {
     // a full garbage-collector by holding the promises in a weak-rc-map
     // or something like that.
     pub promise_states: PromiseStates<FunctionId, StateId, Value>,
+
+    /// Sequential counter of effects produced by this runtime.
+    ///
+    /// Incremented each time the runtime emits an effect.
+    pub effect_counter: EffectNumber,
 }
 
 impl<FunctionId, StateId, Value> RuntimeState<FunctionId, StateId, Value>
@@ -80,6 +86,7 @@ where
 mod tests {
     use std::collections::VecDeque;
 
+    use waymark_vm_runtime_effect::EffectNumber;
     use waymark_vm_runtime_exception::Exception;
     use waymark_vm_runtime_promise_value::PromiseValue;
 
@@ -133,6 +140,7 @@ mod tests {
         let mut runtime = RuntimeState {
             ready: VecDeque::new(),
             promise_states,
+            effect_counter: EffectNumber(0),
         };
 
         runtime
@@ -182,6 +190,7 @@ mod tests {
         let mut runtime = RuntimeState {
             ready: VecDeque::new(),
             promise_states,
+            effect_counter: EffectNumber(0),
         };
 
         let err = runtime
@@ -223,6 +232,7 @@ mod tests {
         let mut runtime = RuntimeState {
             ready: VecDeque::new(),
             promise_states,
+            effect_counter: EffectNumber(0),
         };
 
         let exception = Exception {
@@ -264,6 +274,7 @@ mod tests {
         let mut runtime = RuntimeState {
             ready: VecDeque::new(),
             promise_states,
+            effect_counter: EffectNumber(0),
         };
 
         runtime

--- a/crates/lib/vm-runtime-effect/Cargo.toml
+++ b/crates/lib/vm-runtime-effect/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "waymark-vm-runtime-effect"
+edition = "2024"
+version.workspace = true
+publish.workspace = true
+
+[dependencies]
+serde = { workspace = true, optional = true, features = ["derive"] }
+
+[features]
+default = []
+
+serde = ["dep:serde"]
+
+[lib]
+doctest = false

--- a/crates/lib/vm-runtime-effect/src/lib.rs
+++ b/crates/lib/vm-runtime-effect/src/lib.rs
@@ -1,0 +1,18 @@
+//! Core types for runtime operations support for VM effects.
+
+#![warn(missing_docs)]
+
+mod number;
+
+pub use crate::number::EffectNumber;
+
+/// An effect emitted by the runtime, paired with its zero-based sequence
+/// number.
+#[derive(Debug, PartialEq, Eq)]
+pub struct EmittedEffect<Effect> {
+    /// The effect emitted by the interpreter.
+    pub effect: Effect,
+
+    /// The zero-based sequence number of this effect.
+    pub number: EffectNumber,
+}

--- a/crates/lib/vm-runtime-effect/src/number.rs
+++ b/crates/lib/vm-runtime-effect/src/number.rs
@@ -1,0 +1,15 @@
+/// The zero-based sequence number of an effect emitted by the runtime.
+///
+/// Each time the VM runtime produces an effect, the counter is
+/// incremented. This number is embedded in [`super::EmittedEffect`] so
+/// consumers can track ordering.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
+pub struct EffectNumber(pub usize);
+
+impl std::fmt::Display for EffectNumber {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(&self.0, f)
+    }
+}

--- a/crates/lib/vm-runtime-test/src/lib.rs
+++ b/crates/lib/vm-runtime-test/src/lib.rs
@@ -52,6 +52,11 @@ pub enum TestInstruction {
     },
     EmitRegister(RegisterId),
     EmitException,
+    EnqueueFrame {
+        func: FunctionId,
+        state: StateId,
+        num_regs: usize,
+    },
     EnqueueFrameAndExit {
         func: FunctionId,
         state: StateId,
@@ -181,6 +186,22 @@ impl Interpreter for TestInterpreter {
                 Ok(ExecutionOutcome::ExitFrameWithEffect(
                     TestEffect::UnhandledException(Exception { type_id, details }),
                 ))
+            }
+            TestInstruction::EnqueueFrame {
+                func,
+                state: next_state,
+                num_regs,
+            } => {
+                let FullRuntimeView { state, .. } = runtime;
+                state.ready.push_back(Frame {
+                    func,
+                    state: next_state,
+                    regs: Registers::new(num_regs),
+                    exception: None,
+                    exception_handler_blocks: ExceptionHandlers::new(),
+                    kind: FrameKind::TopLevel,
+                });
+                Ok(ExecutionOutcome::Continue(frame))
             }
             TestInstruction::EnqueueFrameAndExit {
                 func,

--- a/crates/lib/vm-runtime/Cargo.toml
+++ b/crates/lib/vm-runtime/Cargo.toml
@@ -8,6 +8,7 @@ publish.workspace = true
 waymark-vm-executable = { workspace = true }
 waymark-vm-interpreter = { workspace = true }
 waymark-vm-runtime-core = { workspace = true, features = ["serde"] }
+waymark-vm-runtime-effect = { workspace = true, features = ["serde"] }
 waymark-vm-runtime-exception = { workspace = true }
 waymark-vm-runtime-promise-core = { workspace = true }
 

--- a/crates/lib/vm-runtime/src/lib.rs
+++ b/crates/lib/vm-runtime/src/lib.rs
@@ -112,6 +112,7 @@ where
         let state = RuntimeState {
             ready,
             promise_states: PromiseStates::new(),
+            effect_counter: waymark_vm_runtime_effect::EffectNumber(0),
         };
 
         Ok(Self {
@@ -168,7 +169,16 @@ where
     Value: core::fmt::Debug,
 {
     /// Run the VM steps until the next event is encountered.
-    pub fn run(&mut self) -> Result<Interpreter::Effect, RunError<Interpreter::Error>> {
+    ///
+    /// Returns the emitted effect paired with its zero-based sequence number.
+    /// The counter is embedded in the runtime snapshot so numbering survives
+    /// revivals.
+    pub fn run(
+        &mut self,
+    ) -> Result<
+        waymark_vm_runtime_effect::EmittedEffect<Interpreter::Effect>,
+        RunError<Interpreter::Error>,
+    > {
         loop {
             let Some(frame) = self.state.ready.pop_front() else {
                 // No frames but also no valid exit either,
@@ -182,7 +192,11 @@ where
                 step::StepOutcome::Yield => continue,
             };
 
-            return Ok(effect);
+            let number = self.state.effect_counter;
+            self.state.effect_counter =
+                waymark_vm_runtime_effect::EffectNumber(self.state.effect_counter.0 + 1);
+
+            return Ok(waymark_vm_runtime_effect::EmittedEffect { effect, number });
         }
     }
 }

--- a/crates/lib/vm-runtime/tests/integration.rs
+++ b/crates/lib/vm-runtime/tests/integration.rs
@@ -2,6 +2,7 @@ use waymark_vm_runtime::{CallSpec, RunError};
 use waymark_vm_runtime_core::{
     CaptureRuntimeView, FullRuntimeView, RegisterId, ResolvePromiseError,
 };
+use waymark_vm_runtime_effect::EffectNumber;
 use waymark_vm_runtime_exception::Exception;
 use waymark_vm_runtime_promise_core::PromiseStateId;
 use waymark_vm_runtime_test::{
@@ -82,8 +83,9 @@ fn with_custom_entrypoint_uses_requested_function_and_ready_arguments() {
         },
     );
 
+    let emitted_effect = runtime.run().expect("custom entrypoint should emit");
     assert_eq!(
-        runtime.run().expect("custom entrypoint should emit"),
+        emitted_effect.effect,
         TestEffect::Value(TestReadyValue::Int(9))
     );
 }
@@ -118,10 +120,8 @@ fn run_skips_yielded_frames_until_an_effect_is_emitted() {
         function(0, vec![vec![TestInstruction::Emit("next")]]),
     ]));
 
-    assert_eq!(
-        runtime.run().expect("queued frame should emit"),
-        TestEffect::Message("next")
-    );
+    let emitted_effect = runtime.run().expect("queued frame should emit");
+    assert_eq!(emitted_effect.effect, TestEffect::Message("next"));
 }
 
 #[test]
@@ -180,8 +180,9 @@ fn resolve_promise_resumes_a_suspended_frame_and_emits_the_resolved_value() {
         .resolve_promise(PromiseStateId(0), TestReadyValue::Int(41))
         .expect("prepared promise should resolve");
 
+    let emitted_effect = runtime.run().expect("resumed frame should emit");
     assert_eq!(
-        runtime.run().expect("resumed frame should emit"),
+        emitted_effect.effect,
         TestEffect::Value(TestReadyValue::Int(41))
     );
 }
@@ -214,8 +215,9 @@ fn resolve_promise_rejects_unknown_promise_ids_without_disturbing_waiting_work()
         .resolve_promise(PromiseStateId(0), TestReadyValue::Int(41))
         .expect("the waiting promise should still resolve cleanly");
 
+    let emitted_effect = runtime.run().expect("resumed frame should still emit");
     assert_eq!(
-        runtime.run().expect("resumed frame should still emit"),
+        emitted_effect.effect,
         TestEffect::Value(TestReadyValue::Int(41))
     );
 }
@@ -248,10 +250,11 @@ fn resolve_promise_preserves_the_first_value_when_duplicate_resolution_occurs() 
     };
 
     assert_eq!(err.new_value, TestReadyValue::Int(11));
+    let emitted_effect = runtime
+        .run()
+        .expect("resumed frame should keep the first value");
     assert_eq!(
-        runtime
-            .run()
-            .expect("resumed frame should keep the first value"),
+        emitted_effect.effect,
         TestEffect::Value(TestReadyValue::Int(7))
     );
 }
@@ -281,10 +284,11 @@ fn reject_promise_bubbles_uncaught_exceptions() {
         )
         .expect("exceptional promise result should resolve");
 
+    let emitted_effect = runtime
+        .run()
+        .expect("resumed frame should emit the raised exception");
     assert_eq!(
-        runtime
-            .run()
-            .expect("resumed frame should emit the raised exception"),
+        emitted_effect.effect,
         TestEffect::UnhandledException(Exception {
             type_id: "ValueError".to_owned(),
             details: TestReadyValue::Int(41),
@@ -309,12 +313,10 @@ fn state_entry_hook_can_exit_before_instruction_dispatch() {
     )
     .expect("entrypoint should exist");
 
-    assert_eq!(
-        runtime
-            .run()
-            .expect("state-entry hook should emit before dispatch"),
-        TestEffect::Message("hook")
-    );
+    let emitted_effect = runtime
+        .run()
+        .expect("state-entry hook should emit before dispatch");
+    assert_eq!(emitted_effect.effect, TestEffect::Message("hook"));
 }
 
 #[test]
@@ -353,12 +355,10 @@ fn state_entry_hook_can_redirect_exceptional_resumes_when_the_interpreter_wants(
         )
         .expect("exceptional promise result should resolve");
 
-    assert_eq!(
-        runtime
-            .run()
-            .expect("state-entry hook should redirect into the handler state"),
-        TestEffect::Message("handled")
-    );
+    let emitted_effect = runtime
+        .run()
+        .expect("state-entry hook should redirect into the handler state");
+    assert_eq!(emitted_effect.effect, TestEffect::Message("handled"));
 }
 
 #[test]
@@ -402,8 +402,9 @@ fn snapshot_suspended_and_from_snapshot_preserves_suspended_promises() {
         .resolve_promise(PromiseStateId(0), TestReadyValue::Int(42))
         .expect("promise should resolve after restore");
 
+    let emitted_effect = restored.run().expect("restored runtime should emit");
     assert_eq!(
-        restored.run().expect("restored runtime should emit"),
+        emitted_effect.effect,
         TestEffect::Value(TestReadyValue::Int(42))
     );
 }
@@ -454,10 +455,11 @@ fn snapshot_suspended_and_from_snapshot_preserves_rejected_promises() {
         )
         .expect("promise should reject after restore");
 
+    let emitted_effect = restored
+        .run()
+        .expect("restored runtime should emit exception");
     assert_eq!(
-        restored
-            .run()
-            .expect("restored runtime should emit exception"),
+        emitted_effect.effect,
         TestEffect::UnhandledException(Exception {
             type_id: "ValueError".to_owned(),
             details: TestReadyValue::Int(41),
@@ -488,8 +490,149 @@ fn allow_live_snapshots_runtime_with_ready_frames() {
     )
     .expect("live snapshot should restore");
 
+    let emitted_effect = restored.run().expect("restored runtime should emit");
+    assert_eq!(emitted_effect.effect, TestEffect::Message("still-alive"));
+}
+
+// ---------------------------------------------------------------------------
+// Effect counting
+// ---------------------------------------------------------------------------
+
+#[test]
+fn effect_numbers_start_at_zero() {
+    let mut runtime = runtime(executable(vec![function(
+        0,
+        vec![vec![TestInstruction::Emit("first")]],
+    )]));
+
+    let emitted_effect = runtime.run().expect("first effect should be emitted");
+    assert_eq!(emitted_effect.number, EffectNumber(0));
+    assert_eq!(emitted_effect.effect, TestEffect::Message("first"));
+}
+
+#[test]
+fn effect_numbers_increment_sequentially() {
+    // Emit three effects across successive run() calls and verify
+    // that the effect number increments 0 → 1 → 2 each time.
+    let mut runtime = runtime(executable(vec![function(
+        0,
+        vec![
+            vec![
+                TestInstruction::EnqueueFrame {
+                    func: FunctionId(0),
+                    state: StateId(1),
+                    num_regs: 0,
+                },
+                TestInstruction::Emit("first"),
+            ],
+            vec![
+                TestInstruction::EnqueueFrame {
+                    func: FunctionId(0),
+                    state: StateId(2),
+                    num_regs: 0,
+                },
+                TestInstruction::Emit("second"),
+            ],
+            vec![TestInstruction::Emit("third")],
+        ],
+    )]));
+
+    let first = runtime.run().expect("first emit should succeed");
+    assert_eq!(first.number, EffectNumber(0));
+    assert_eq!(first.effect, TestEffect::Message("first"));
+
+    let second = runtime.run().expect("second emit should succeed");
+    assert_eq!(second.number, EffectNumber(1));
+    assert_eq!(second.effect, TestEffect::Message("second"));
+
+    let third = runtime.run().expect("third emit should succeed");
+    assert_eq!(third.number, EffectNumber(2));
+    assert_eq!(third.effect, TestEffect::Message("third"));
+
+    // No more frames after the third emission.
+    assert!(matches!(runtime.run(), Err(RunError::NoReadyFrame)));
+}
+
+#[test]
+fn effect_counter_survives_snapshot_roundtrip() {
+    // Emit two effects to bump the counter past the default (0), then
+    // suspend so we can snapshot a runtime whose counter is ≥ 2.
+    // After restore the resumed emit must carry the continuing number.
+    let make_executable = || {
+        executable(vec![function(
+            1,
+            vec![
+                // Enqueue the next frame then emit an effect.
+                // After the emit the frame exits but the enqueued frame
+                // will be picked up by the next run() call.
+                vec![
+                    TestInstruction::EnqueueFrame {
+                        func: FunctionId(0),
+                        state: StateId(1),
+                        num_regs: 1,
+                    },
+                    TestInstruction::Emit("first"),
+                ],
+                // Same pattern: enqueue the suspending frame, then emit.
+                vec![
+                    TestInstruction::EnqueueFrame {
+                        func: FunctionId(0),
+                        state: StateId(2),
+                        num_regs: 1,
+                    },
+                    TestInstruction::Emit("second"),
+                ],
+                // Now suspend. The counter is 2.
+                vec![TestInstruction::Suspend {
+                    dst: RegisterId(0),
+                    resume: StateId(3),
+                }],
+                // After resolve, emit the resolved value with the
+                // continuing effect number.
+                vec![TestInstruction::EmitRegister(RegisterId(0))],
+            ],
+        )])
+    };
+
+    let mut runtime = waymark_vm_runtime::Runtime::with_conventional_entrypoint(
+        TestInterpreter,
+        make_executable(),
+    )
+    .expect("entrypoint should exist");
+
+    // First effect bumps counter 0 → 1.
+    let emitted_first = runtime.run().expect("first emit should succeed");
+    assert_eq!(emitted_first.number, EffectNumber(0));
+    assert_eq!(emitted_first.effect, TestEffect::Message("first"));
+
+    // Second effect bumps counter 1 → 2.
+    let emitted_second = runtime.run().expect("second emit should succeed");
+    assert_eq!(emitted_second.number, EffectNumber(1));
+    assert_eq!(emitted_second.effect, TestEffect::Message("second"));
+
+    // Now the suspending frame runs → counter stays at 2.
+    assert!(matches!(runtime.run(), Err(RunError::NoReadyFrame)));
+
+    // Snapshot while suspended (counter is 2).
+    let mut buf = Vec::new();
+    runtime
+        .snapshot(&mut rmp_serde::Serializer::new(&mut buf))
+        .expect("suspended runtime should snapshot");
+
+    // Restore and resolve the suspend → emits with the continuing
+    // number that was stored in the snapshot.
+    let mut de = rmp_serde::Deserializer::new(&buf[..]);
+    let mut restored =
+        waymark_vm_runtime::Runtime::from_snapshot(TestInterpreter, make_executable(), &mut de)
+            .expect("snapshot should restore");
+
+    restored
+        .resolve_promise(PromiseStateId(0), TestReadyValue::Int(20))
+        .expect("promise should resolve after restore");
+    let emitted_effect = restored.run().expect("emit after restore");
+    assert_eq!(emitted_effect.number, EffectNumber(2));
     assert_eq!(
-        restored.run().expect("restored runtime should emit"),
-        TestEffect::Message("still-alive")
+        emitted_effect.effect,
+        TestEffect::Value(TestReadyValue::Int(20))
     );
 }

--- a/crates/lib/vm-value/tests/action_call_exception.rs
+++ b/crates/lib/vm-value/tests/action_call_exception.rs
@@ -205,13 +205,14 @@ fn action_call_can_resume_with_an_exception_error() {
     )
     .expect("function 0 should exist");
 
+    let emitted_effect = runtime
+        .run()
+        .expect("first run should emit the action call");
     let TestEffect::ExtCallSet(waymark_vm_interpreter_extcallset::Effect::ActionCall {
         promise_state_id,
         action_ref,
         args,
-    }) = runtime
-        .run()
-        .expect("first run should emit the action call")
+    }) = emitted_effect.effect
     else {
         panic!("first run should emit an action call");
     };
@@ -229,13 +230,14 @@ fn action_call_can_resume_with_an_exception_error() {
         )
         .expect("action call promise should reject cleanly");
 
+    let emitted_effect = runtime.run().expect("rejected action call should surface");
     assert!(matches!(
-        runtime.run(),
-        Ok(TestEffect::CoreSet(
+        emitted_effect.effect,
+        TestEffect::CoreSet(
             waymark_vm_interpreter_coreset::Effect::UnhandledException(Exception {
                 type_id,
                 details: ReadyValue::String(details),
             })
-        )) if type_id == "ValueError" && details == "boom"
+        ) if type_id == "ValueError" && details == "boom"
     ));
 }


### PR DESCRIPTION
This PR adds effects numbering to the runtime.

The core idea is each emitted effect is be sequentially numbered. The execution and effect production is deterministic, and thus this numbering can be useful for correlation and de-duplication of the effects.