### PR TITLE
Fix cargo shear

### DIFF
--- a/crates/lib/vm-bytecode/Cargo.toml
+++ b/crates/lib/vm-bytecode/Cargo.toml
@@ -4,6 +4,9 @@ edition = "2024"
 version.workspace = true
 publish.workspace = true
 
+[package.metadata.cargo-shear]
+ignored = ["waymark-typed-vec-serde"]
+
 [dependencies]
 waymark-vm-bytecode-core = { workspace = true }
 waymark-vm-executable = { workspace = true }

--- a/crates/lib/vm-runtime-core/Cargo.toml
+++ b/crates/lib/vm-runtime-core/Cargo.toml
@@ -4,6 +4,9 @@ edition = "2024"
 version.workspace = true
 publish.workspace = true
 
+[package.metadata.cargo-shear]
+ignored = ["waymark-typed-vec-serde"]
+
 [dependencies]
 waymark-typed-vec-serde = { workspace = true, optional = true }
 waymark-vm-exception-handler = { workspace = true }


### PR DESCRIPTION
This PR correct the warnings at cargo shear.

They don't trigger CI errors, but they show up and clutter the output. There is no option to force them to make the `cargo shear` command to return non-zero exit code afaik, so we should create an issue.