### PR TITLE
Add vm-value-convert-json

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5684,6 +5684,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "waymark-vm-value-convert-json"
+version = "0.1.0"
+dependencies = [
+ "indexmap 2.13.0",
+ "serde_json",
+ "typed_floats",
+ "waymark-convert-core",
+ "waymark-vm-runtime-exception",
+ "waymark-vm-value",
+ "waymark-vm-value-convert-core",
+]
+
+[[package]]
 name = "waymark-webapp-backend"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ waymark-backend-postgres-migrations = { path = "crates/lib/backend-postgres-migr
 waymark-backends-core = { path = "crates/lib/backends-core" }
 waymark-blocking-future = { path = "crates/lib/blocking-future" }
 waymark-config = { path = "crates/lib/config" }
+waymark-convert-core = { path = "crates/lib/convert-core" }
 waymark-core-backend = { path = "crates/lib/core-backend" }
 waymark-core-backend-metadata = { path = "crates/lib/core-backend-metadata" }
 waymark-dag = { path = "crates/lib/dag" }
@@ -103,6 +104,7 @@ waymark-vm-runtime-promise-value = { path = "crates/lib/vm-runtime-promise-value
 waymark-vm-runtime-test = { path = "crates/lib/vm-runtime-test" }
 waymark-vm-runtime-value = { path = "crates/lib/vm-runtime-value" }
 waymark-vm-value = { path = "crates/lib/vm-value" }
+waymark-vm-value-convert-core = { path = "crates/lib/vm-value-convert-core" }
 waymark-webapp-backend = { path = "crates/lib/webapp-backend" }
 waymark-webapp-bringup = { path = "crates/lib/webapp-bringup" }
 waymark-webapp-config = { path = "crates/lib/webapp-config" }

--- a/crates/lib/vm-value-convert-json/Cargo.toml
+++ b/crates/lib/vm-value-convert-json/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "waymark-vm-value-convert-json"
+edition = "2024"
+version.workspace = true
+publish.workspace = true
+
+[dependencies]
+waymark-convert-core = { workspace = true }
+waymark-vm-runtime-exception = { workspace = true }
+waymark-vm-value = { workspace = true }
+waymark-vm-value-convert-core = { workspace = true }
+
+indexmap = { workspace = true }
+serde_json = { workspace = true }
+typed_floats = { workspace = true }

--- a/crates/lib/vm-value-convert-json/src/lib.rs
+++ b/crates/lib/vm-value-convert-json/src/lib.rs
@@ -1,0 +1,175 @@
+//! [`Convert`](waymark_convert_core::Convert) implementations between JSON
+//! and VM value types.
+
+#![warn(missing_docs)]
+
+use std::convert::Infallible;
+
+use indexmap::IndexMap;
+use typed_floats::NonNaNFinite;
+use waymark_convert_core::{Convert, TryConvert};
+use waymark_vm_runtime_exception::Exception;
+use waymark_vm_value::{ReadyValue, Value};
+
+pub use waymark_vm_value_convert_core::PendingPromiseError;
+
+/// Stateless converter with all JSON-to-VM [`Convert`] impls.
+pub struct Converter;
+
+impl TryConvert<serde_json::Value, ReadyValue> for Converter {
+    type Error = Infallible;
+
+    fn try_convert(value: serde_json::Value) -> Result<ReadyValue, Self::Error> {
+        Ok(match value {
+            serde_json::Value::Null => ReadyValue::None,
+            serde_json::Value::Bool(b) => ReadyValue::Bool(b),
+            serde_json::Value::Number(n) => {
+                if let Some(i) = n.as_i64() {
+                    ReadyValue::Int(i)
+                } else if let Some(f) = n.as_f64() {
+                    match NonNaNFinite::try_from(f) {
+                        Ok(finite) => ReadyValue::Float(finite),
+                        Err(_) => ReadyValue::None,
+                    }
+                } else {
+                    ReadyValue::None
+                }
+            }
+            serde_json::Value::String(s) => ReadyValue::String(s),
+            serde_json::Value::Array(items) => ReadyValue::List(
+                items
+                    .into_iter()
+                    .map(<Converter as Convert<_, ReadyValue>>::convert)
+                    .map(Value::Ready)
+                    .collect(),
+            ),
+            serde_json::Value::Object(entries) => {
+                let mut map = IndexMap::new();
+                for (k, v) in entries {
+                    map.insert(
+                        k,
+                        Value::Ready(<Converter as Convert<_, ReadyValue>>::convert(v)),
+                    );
+                }
+                ReadyValue::Dict(map)
+            }
+        })
+    }
+}
+
+impl TryConvert<serde_json::Value, Value> for Converter {
+    type Error = Infallible;
+
+    fn try_convert(value: serde_json::Value) -> Result<Value, Self::Error> {
+        Ok(Value::Ready(
+            <Converter as TryConvert<_, ReadyValue>>::try_convert(value)?,
+        ))
+    }
+}
+
+impl<Details> TryConvert<serde_json::Value, Exception<Details>> for Converter
+where
+    Converter: TryConvert<serde_json::Value, Details>,
+{
+    type Error = <Converter as TryConvert<serde_json::Value, Details>>::Error;
+
+    fn try_convert(value: serde_json::Value) -> Result<Exception<Details>, Self::Error> {
+        let type_id = value
+            .get("type")
+            .and_then(|v| v.as_str())
+            .map(String::from)
+            .unwrap_or_else(|| "UndeclaredException".into());
+
+        let details = value
+            .get("message")
+            .cloned()
+            .unwrap_or(serde_json::Value::Null);
+        let details = <Converter as TryConvert<_, Details>>::try_convert(details)?;
+
+        Ok(Exception { type_id, details })
+    }
+}
+
+/// Identity pass-through for JSON values (useful when the caller
+/// already has the JSON representation).
+impl TryConvert<serde_json::Value, serde_json::Value> for Converter {
+    type Error = Infallible;
+
+    fn try_convert(value: serde_json::Value) -> Result<serde_json::Value, Self::Error> {
+        Ok(value)
+    }
+}
+
+/// Serialize a ready value back to JSON (for action-call arguments).
+///
+/// Implemented manually to avoid depending on serde's `Serialize` impl
+/// being active — the conversion is direct via pattern matching.
+impl TryConvert<ReadyValue, serde_json::Value> for Converter {
+    type Error = PendingPromiseError;
+
+    fn try_convert(value: ReadyValue) -> Result<serde_json::Value, Self::Error> {
+        Ok(match value {
+            ReadyValue::Int(i) => serde_json::Value::Number(i.into()),
+            ReadyValue::Float(f) => {
+                let n = serde_json::Number::from_f64(f.get())
+                    .unwrap_or_else(|| serde_json::Number::from(0));
+                serde_json::Value::Number(n)
+            }
+            ReadyValue::Bool(b) => serde_json::Value::Bool(b),
+            ReadyValue::String(s) => serde_json::Value::String(s),
+            ReadyValue::None => serde_json::Value::Null,
+            ReadyValue::List(items) => serde_json::Value::Array(
+                items
+                    .into_iter()
+                    .map(<Converter as TryConvert<_, serde_json::Value>>::try_convert)
+                    .collect::<Result<_, _>>()?,
+            ),
+            ReadyValue::Dict(entries) => serde_json::Value::Object(
+                entries
+                    .into_iter()
+                    .map(|(k, v)| {
+                        Ok((
+                            k,
+                            <Converter as TryConvert<_, serde_json::Value>>::try_convert(v)?,
+                        ))
+                    })
+                    .collect::<Result<_, _>>()?,
+            ),
+            ReadyValue::Exception(exc) => {
+                <Converter as TryConvert<_, serde_json::Value>>::try_convert(*exc)?
+            }
+        })
+    }
+}
+
+/// Convert a [`Value`] to JSON, erroring on [`Value::Pending`].
+impl TryConvert<Value, serde_json::Value> for Converter {
+    type Error = PendingPromiseError;
+
+    fn try_convert(value: Value) -> Result<serde_json::Value, Self::Error> {
+        match value {
+            Value::Ready(v) => <Converter as TryConvert<_, serde_json::Value>>::try_convert(v),
+            Value::Pending(id) => Err(PendingPromiseError(id)),
+        }
+    }
+}
+
+/// Convert an [`Exception`] to JSON.
+///
+/// Produces `{"type": "<type_id>", "message": <details>}`.
+impl<Details> TryConvert<Exception<Details>, serde_json::Value> for Converter
+where
+    Converter: TryConvert<Details, serde_json::Value>,
+{
+    type Error = <Converter as TryConvert<Details, serde_json::Value>>::Error;
+
+    fn try_convert(exc: Exception<Details>) -> Result<serde_json::Value, Self::Error> {
+        let mut map = serde_json::Map::new();
+        map.insert("type".into(), serde_json::Value::String(exc.type_id));
+        map.insert(
+            "message".into(),
+            <Converter as TryConvert<_, serde_json::Value>>::try_convert(exc.details)?,
+        );
+        Ok(serde_json::Value::Object(map))
+    }
+}


### PR DESCRIPTION
This PR introduces custom (i.e. non-`serde`-`derive`) conversions of the `vm-value` to `serde_json::Value`.

We keep a custom and separate implementation because we have some legacy `proto` conversions that depend and go though the `serde_json` as an intermediate layer before being converted to/from the transport-layer protobuf; the conversion is non-trivial and can have subtle differences.

This is intended to be used at the boundaries where we have to convert the value to/from to the transport layer. For internal representations (i.e. state snapshots) we use a different machinery (serde & codec providers).

---

Since we ultimately have the JSON as barely an intermediate representation, we  will eventually get rid of this conversion in favor of encoding values directly into the transport format (i.e. without going though the JSON).