### PR TITLE
State managers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5219,6 +5219,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "waymark-state-manager"
+version = "0.1.0"
+dependencies = [
+ "dashmap 6.2.1",
+ "tokio",
+ "tracing",
+ "waymark-nonzero-duration",
+ "waymark-state-manager-core",
+]
+
+[[package]]
+name = "waymark-state-manager-core"
+version = "0.1.0"
+
+[[package]]
 name = "waymark-support-integration"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5234,6 +5234,21 @@ name = "waymark-state-manager-core"
 version = "0.1.0"
 
 [[package]]
+name = "waymark-state-vm-executables"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "thiserror",
+ "waymark-state-manager-core",
+ "waymark-state-vm-executables-backend",
+ "waymark-vm-codec-core",
+]
+
+[[package]]
+name = "waymark-state-vm-executables-backend"
+version = "0.1.0"
+
+[[package]]
 name = "waymark-state-vm-runtimes"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5234,6 +5234,38 @@ name = "waymark-state-manager-core"
 version = "0.1.0"
 
 [[package]]
+name = "waymark-state-vm-runtimes"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "waymark-state-manager",
+ "waymark-state-manager-core",
+ "waymark-state-vm-runtimes-backend",
+ "waymark-state-vm-runtimes-core",
+ "waymark-vm-codec-core",
+ "waymark-vm-driver",
+ "waymark-vm-driver-core",
+ "waymark-vm-driver-thread",
+ "waymark-vm-executable",
+ "waymark-vm-interpreter",
+ "waymark-vm-runtime",
+ "waymark-vm-runtime-core",
+ "waymark-vm-runtime-promise-core",
+]
+
+[[package]]
+name = "waymark-state-vm-runtimes-backend"
+version = "0.1.0"
+
+[[package]]
+name = "waymark-state-vm-runtimes-core"
+version = "0.1.0"
+
+[[package]]
 name = "waymark-support-integration"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,10 @@ waymark-scheduler-loop-core = { path = "crates/lib/scheduler-loop-core" }
 waymark-secret-string = { path = "crates/lib/secret-string" }
 waymark-sleep-reconciler = { path = "crates/lib/sleep-reconciler" }
 waymark-smoke-sources = { path = "crates/lib/smoke-sources" }
+waymark-state-manager = { path = "crates/lib/state-manager" }
 waymark-state-manager-core = { path = "crates/lib/state-manager-core" }
+waymark-state-vm-runtimes-backend = { path = "crates/lib/state-vm-runtimes-backend" }
+waymark-state-vm-runtimes-core = { path = "crates/lib/state-vm-runtimes-core" }
 waymark-support-integration = { path = "crates/lib/support-integration" }
 waymark-support-test = { path = "crates/lib/support-test" }
 waymark-support-test-python = { path = "crates/lib/support-test-python" }
@@ -90,6 +93,7 @@ waymark-vm-compiler-for-ast-old-core = { path = "crates/lib/vm-compiler-for-ast-
 waymark-vm-compiler-for-ast-old-test-support = { path = "crates/lib/vm-compiler-for-ast-old-test-support" }
 waymark-vm-driver = { path = "crates/lib/vm-driver" }
 waymark-vm-driver-core = { path = "crates/lib/vm-driver-core" }
+waymark-vm-driver-thread = { path = "crates/lib/vm-driver-thread" }
 waymark-vm-exception-handler = { path = "crates/lib/vm-exception-handler" }
 waymark-vm-executable = { path = "crates/lib/vm-executable" }
 waymark-vm-instructions-coreset = { path = "crates/lib/vm-instructions-coreset" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ waymark-sleep-reconciler = { path = "crates/lib/sleep-reconciler" }
 waymark-smoke-sources = { path = "crates/lib/smoke-sources" }
 waymark-state-manager = { path = "crates/lib/state-manager" }
 waymark-state-manager-core = { path = "crates/lib/state-manager-core" }
+waymark-state-vm-executables-backend = { path = "crates/lib/state-vm-executables-backend" }
 waymark-state-vm-runtimes-backend = { path = "crates/lib/state-vm-runtimes-backend" }
 waymark-state-vm-runtimes-core = { path = "crates/lib/state-vm-runtimes-core" }
 waymark-support-integration = { path = "crates/lib/support-integration" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ waymark-scheduler-loop-core = { path = "crates/lib/scheduler-loop-core" }
 waymark-secret-string = { path = "crates/lib/secret-string" }
 waymark-sleep-reconciler = { path = "crates/lib/sleep-reconciler" }
 waymark-smoke-sources = { path = "crates/lib/smoke-sources" }
+waymark-state-manager-core = { path = "crates/lib/state-manager-core" }
 waymark-support-integration = { path = "crates/lib/support-integration" }
 waymark-support-test = { path = "crates/lib/support-test" }
 waymark-support-test-python = { path = "crates/lib/support-test-python" }

--- a/crates/lib/state-manager-core/Cargo.toml
+++ b/crates/lib/state-manager-core/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "waymark-state-manager-core"
+edition = "2024"
+version.workspace = true
+publish.workspace = true
+
+[dependencies]

--- a/crates/lib/state-manager-core/src/lib.rs
+++ b/crates/lib/state-manager-core/src/lib.rs
@@ -1,0 +1,10 @@
+pub trait Factory {
+    type Key;
+    type Value;
+    type Error;
+
+    fn produce<'a>(
+        &'a self,
+        key: &'a Self::Key,
+    ) -> impl Future<Output = Result<Self::Value, Self::Error>> + Send + 'a;
+}

--- a/crates/lib/state-manager/Cargo.toml
+++ b/crates/lib/state-manager/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "waymark-state-manager"
+edition = "2024"
+version.workspace = true
+publish.workspace = true
+
+[dependencies]
+waymark-nonzero-duration = { workspace = true }
+waymark-state-manager-core = { workspace = true }
+
+dashmap = { workspace = true }
+tokio = { workspace = true, features = ["sync"] }
+tracing = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time", "sync"] }

--- a/crates/lib/state-manager/src/guard.rs
+++ b/crates/lib/state-manager/src/guard.rs
@@ -1,0 +1,71 @@
+//! The ref-count [`Guard`] for entries in [`State`](crate::State).
+
+use core::hash::Hash;
+use std::sync::Weak;
+
+use crate::storage::Maps;
+
+/// Owns one reference to an entry in the state.
+///
+/// A `Guard` is created by [`State::get`](crate::State::get) the moment it
+/// acquires an entry's reference — before the factory runs — and its [`Drop`]
+/// releases that reference.  This makes the acquire and its release a single
+/// unit regardless of how `get` ends:
+///
+/// * the `get` future is cancelled at its `.await`, or the factory errors:
+///   the `Guard` is dropped directly and the reference is released;
+/// * `get` succeeds: the `Guard` is moved into the returned
+///   [`Handle`](crate::Handle), and the reference is released when the last
+///   handle is dropped.
+pub(crate) struct Guard<Key, Value>
+where
+    Key: Eq + Hash,
+{
+    maps: Weak<Maps<Key, Value>>,
+
+    /// The guarded key.
+    ///
+    /// SAFETY: safety invariants depend on this field, which is why it is
+    /// private to this module — nothing outside can take or replace it.  It is
+    /// `Some` for the whole life of the guard and is taken only in [`Drop`] (so
+    /// the key can be moved into the storage without cloning).
+    key: Option<Key>,
+}
+
+impl<Key, Value> Guard<Key, Value>
+where
+    Key: Eq + Hash,
+{
+    /// Create a guard owning the caller's freshly-acquired reference to `key`.
+    pub(crate) fn new(maps: Weak<Maps<Key, Value>>, key: Key) -> Self {
+        Self {
+            maps,
+            key: Some(key),
+        }
+    }
+
+    /// The key of the entry whose reference this guard owns.
+    pub(crate) fn key(&self) -> &Key {
+        // SAFETY: `key` is `Some` for the whole life of the guard — it is taken
+        // only in `Drop`, during which no `&self` method can run.
+        unsafe { self.key.as_ref().unwrap_unchecked() }
+    }
+}
+
+impl<Key, Value> Drop for Guard<Key, Value>
+where
+    Key: Eq + Hash,
+{
+    fn drop(&mut self) {
+        let Some(maps) = self.maps.upgrade() else {
+            // Maps are gone; nothing to release.
+            return;
+        };
+
+        // SAFETY: `key` is `Some` for the whole life of the guard, is taken
+        // only here, and `drop` runs at most once.
+        let key = unsafe { self.key.take().unwrap_unchecked() };
+
+        maps.release(key);
+    }
+}

--- a/crates/lib/state-manager/src/handle.rs
+++ b/crates/lib/state-manager/src/handle.rs
@@ -1,0 +1,53 @@
+//! Handles to entries in [`State`](crate::State).
+
+use core::hash::Hash;
+
+use crate::guard::Guard;
+
+/// A handle to an entry in the state.
+///
+/// See [`State::get`](crate::State::get).
+#[must_use]
+pub struct Handle<Key, Value>
+where
+    Key: Eq + Hash,
+{
+    /// Owns this handle's reference to the entry; its [`Drop`] releases the
+    /// reference (and marks the entry for eviction, or removes it, when this
+    /// was the last handle).
+    guard: Guard<Key, Value>,
+
+    /// The value.
+    value: Value,
+}
+
+impl<Key, Value> Handle<Key, Value>
+where
+    Key: Eq + Hash,
+{
+    /// Wrap a produced `value` together with the `guard` owning its reference.
+    pub(crate) fn new(guard: Guard<Key, Value>, value: Value) -> Self {
+        Self { guard, value }
+    }
+
+    /// Return a ref to the key for this entry.
+    pub fn key(this: &Self) -> &Key {
+        this.guard.key()
+    }
+
+    /// Return a ref to the value for this entry.
+    pub fn value(this: &Self) -> &Value {
+        &this.value
+    }
+}
+
+impl<Key, Value> std::ops::Deref for Handle<Key, Value>
+where
+    Key: Eq + Hash,
+{
+    type Target = Value;
+
+    fn deref(&self) -> &Self::Target {
+        &self.value
+    }
+}

--- a/crates/lib/state-manager/src/lib.rs
+++ b/crates/lib/state-manager/src/lib.rs
@@ -1,0 +1,93 @@
+//! Generic state manager with delayed eviction control.
+//!
+//! See [`State`] and [`Sweeper`].
+
+#![warn(missing_docs)]
+
+mod guard;
+mod handle;
+pub mod provider;
+mod storage;
+mod sweeper;
+
+pub use self::handle::Handle;
+pub use self::provider::Provider;
+pub use self::sweeper::Sweeper;
+
+use core::hash::Hash;
+use std::sync::Arc;
+
+use waymark_nonzero_duration::NonZeroDuration;
+
+use self::guard::Guard;
+use self::storage::Maps;
+
+/// The state that holds `Key`/`Value` pairs.
+///
+/// `Value`s are only exposed as read-only to the consumers.
+///
+/// After the last [`Handle`] to a value is dropped, the value is guaranteed
+/// to remain in the state for a specified retention period, after which
+/// the [`Sweeper`] can pick it up and clear it out.
+///
+/// If the value is not in the state (either it has never been there, or it
+/// was unused and got removed) - a new value is created when obtaining
+/// a [`Handle`]; see [`State::get`].
+pub struct State<Key, Value, Factory> {
+    /// The underlying state maps.
+    maps: Arc<Maps<Key, Value>>,
+
+    /// A factory used to produce the values for this state manager.
+    factory: Factory,
+}
+
+impl<Key, Value, Factory> State<Key, Value, Factory>
+where
+    Key: Eq + Hash,
+{
+    /// Create a new [`State`] and [`Sweeper`] with the specified
+    /// `retention` and `factory`.
+    pub fn new(retention: NonZeroDuration, factory: Factory) -> (Self, Sweeper<Key, Value>) {
+        let maps = Arc::new(Maps::new());
+
+        let sweeper = Sweeper::new(retention, Arc::downgrade(&maps));
+
+        let state = Self { maps, factory };
+
+        (state, sweeper)
+    }
+}
+
+impl<Key, Value, Factory> State<Key, Value, Factory>
+where
+    Key: Eq + Hash + Clone,
+    Factory: waymark_state_manager_core::Factory<Key = Key, Value = Value>,
+    Value: Clone,
+{
+    /// Get or create a new value in the store, and return a [`Handle`] to it.
+    ///
+    /// [`Handle`] provides read-only access to the value, and while
+    /// the [`Handle`] is held the entry will not be removed from the store.
+    ///
+    /// After the last [`Handle`] to the entry is dropped, it is marked for
+    /// eviction, and (unless another [`Handle`] to it is obtained) will
+    /// be removed from the store by the [`Sweeper`] after the corresponding
+    /// retention period.
+    pub async fn get(&self, key: Key) -> Result<Handle<Key, Value>, Factory::Error> {
+        let oncecell = self.maps.acquire(&key);
+
+        // The reference acquired above is owned by `guard` from here on. If the
+        // factory errors or this future is cancelled at the `.await` below,
+        // dropping `guard` releases the reference; on success `guard` moves
+        // into the returned `Handle` and releases it when the last handle is
+        // dropped.
+        let guard = Guard::new(Arc::downgrade(&self.maps), key);
+
+        let value = oncecell
+            .get_or_try_init(|| self.factory.produce(guard.key()))
+            .await?
+            .clone();
+
+        Ok(Handle::new(guard, value))
+    }
+}

--- a/crates/lib/state-manager/src/provider.rs
+++ b/crates/lib/state-manager/src/provider.rs
@@ -1,0 +1,63 @@
+//! The [`Provider`] trait - an abstraction over the state manager's
+//! [`get`](State::get) semantics.
+//!
+//! Consumers can bound on `Provider<Key = ..., Value = ...>` without
+//! knowing about [`Factory`](waymark_state_manager_core::Factory) or other
+//! implementation details.
+
+use core::hash::Hash;
+use std::sync::Arc;
+
+use crate::{Handle, State};
+
+/// Abstract provider of key-value pairs that returns [`Handle`]s.
+///
+/// This trait lets consumers declare only their required `Key` and `Value`
+/// types without knowing about [`Factory`](waymark_state_manager_core::Factory),
+/// [`State`], or other implementation details.
+pub trait Provider {
+    /// The key type.
+    type Key: Eq + Hash;
+
+    /// The value type.
+    type Value;
+
+    /// The error returned when provisioning fails.
+    type Error;
+
+    /// Get or create a value for the given key, returning a [`Handle`]
+    /// that keeps the entry alive.
+    fn get(
+        &self,
+        key: Self::Key,
+    ) -> impl Future<Output = Result<Handle<Self::Key, Self::Value>, Self::Error>> + Send + '_;
+}
+
+impl<Key, Value, Factory> Provider for State<Key, Value, Factory>
+where
+    Key: Eq + Hash + Clone + Send + Sync,
+    Factory: waymark_state_manager_core::Factory<Key = Key, Value = Value> + Sync,
+    Value: Clone + Send + Sync,
+{
+    type Key = Key;
+    type Value = Value;
+    type Error = Factory::Error;
+
+    async fn get(&self, key: Self::Key) -> Result<Handle<Self::Key, Self::Value>, Self::Error> {
+        State::get(self, key).await
+    }
+}
+
+impl<T> Provider for Arc<T>
+where
+    T: Provider + Send + Sync,
+    <T as Provider>::Key: Send,
+{
+    type Key = T::Key;
+    type Value = T::Value;
+    type Error = T::Error;
+
+    async fn get(&self, key: Self::Key) -> Result<Handle<Self::Key, Self::Value>, Self::Error> {
+        T::get(self, key).await
+    }
+}

--- a/crates/lib/state-manager/src/storage.rs
+++ b/crates/lib/state-manager/src/storage.rs
@@ -1,0 +1,201 @@
+//! Internal keyed storage for [`State`](crate::State).
+//!
+//! [`Maps`] owns the entry table and the pending-eviction index, and is the
+//! only place that mutates an entry's ref-count and orphan timestamp.  The
+//! invariants those carry — a ref-count that only ever moves through paired
+//! [`acquire`](Maps::acquire)/[`release`](Maps::release) calls, and an
+//! `orphaned_since` set exactly when the last reference is released — are
+//! therefore established and checked here rather than spread across the crate.
+
+use core::hash::Hash;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use dashmap::DashMap;
+
+/// The underlying state maps.
+///
+/// Entries' ref-counts and orphan timestamps are mutated only through
+/// [`acquire`](Maps::acquire)/[`release`](Maps::release)/[`sweep`](Maps::sweep);
+/// the fields are private to this module so nothing else can bypass them.
+/// The crate's white-box tests live in a submodule here, so they retain
+/// access without any of that reaching production code.
+pub(crate) struct Maps<Key, Value> {
+    /// A map of keys to value-entries.
+    entries: DashMap<Key, Entry<Value>>,
+
+    /// The pending evictions map.
+    pending_evictions: DashMap<Key, Instant>,
+}
+
+/// A single stored value together with its liveness bookkeeping.
+struct Entry<Value> {
+    value: Arc<tokio::sync::OnceCell<Value>>,
+    refs: usize,
+
+    /// Timestamp of when `refs` last dropped to zero.
+    ///
+    /// `None` while at least one reference is held.  Set when the last
+    /// reference is released and cleared by [`Maps::acquire`].  Used inside
+    /// [`Maps::sweep`]'s `remove_if` to make the retention check atomic with
+    /// the ref-count, eliminating a cross-map race between `pending_evictions`
+    /// and `entries`.
+    orphaned_since: Option<Instant>,
+}
+
+impl<Key, Value> Maps<Key, Value>
+where
+    Key: Eq + Hash,
+{
+    /// Create an empty set of maps.
+    pub(crate) fn new() -> Self {
+        Self {
+            entries: DashMap::new(),
+            pending_evictions: DashMap::new(),
+        }
+    }
+
+    /// Acquire a reference to the entry for `key`, creating it if absent.
+    ///
+    /// Bumps the ref-count, clears any orphan timestamp, drops any pending
+    /// eviction, and returns the `OnceCell` the caller should initialize.
+    /// Every successful call must be paired with exactly one [`release`] once
+    /// the reference is no longer needed.
+    ///
+    /// [`release`]: Maps::release
+    pub(crate) fn acquire(&self, key: &Key) -> Arc<tokio::sync::OnceCell<Value>>
+    where
+        Key: Clone,
+    {
+        let oncecell = {
+            let mut entry = self.entries.entry(key.clone()).or_insert_with(|| Entry {
+                value: Arc::new(tokio::sync::OnceCell::new()),
+                refs: 0,
+                orphaned_since: None,
+            });
+            entry.refs += 1;
+            entry.orphaned_since = None;
+            Arc::clone(&entry.value)
+            // Shard lock released here.
+        };
+
+        self.pending_evictions.remove(key);
+
+        oncecell
+    }
+
+    /// Release one reference previously taken via [`acquire`](Maps::acquire).
+    ///
+    /// If this was the last reference, the entry is either removed (when the
+    /// value was never produced) or marked for delayed eviction (when it
+    /// holds a value the [`sweep`](Maps::sweep) should retain).
+    pub(crate) fn release(&self, key: Key) {
+        let now = Instant::now();
+
+        let dashmap::Entry::Occupied(mut occupied) = self.entries.entry(key) else {
+            // The entry is gone already; nothing to release.
+            return;
+        };
+
+        let entry = occupied.get_mut();
+
+        let Some(new_refs) = entry.refs.checked_sub(1) else {
+            unreachable!("refs underflow"); // should be impossible
+        };
+        entry.refs = new_refs;
+
+        if new_refs != 0 {
+            // Other references remain — nothing to do.
+            return;
+        }
+
+        if entry.value.get().is_none() {
+            // Last reference and the value was never produced — remove the
+            // entry so it leaves nothing behind.  Atomic with the decrement
+            // above (same shard lock), so a concurrent `acquire` either sees
+            // the entry with our reference still counted or not at all.
+            occupied.remove();
+            return;
+        }
+
+        // Last reference and the value exists — mark for delayed eviction so
+        // the sweeper retains it.  Stamp both maps with the same instant so
+        // the sweep's two gates agree on when the entry became orphaned.
+        entry.orphaned_since = Some(now);
+
+        // Consumes the entry and releases the shard lock.  A concurrent
+        // `acquire` may revive the entry before the insert below lands,
+        // leaving a stale pending eviction behind — harmless, as the sweep
+        // re-checks `refs` and `orphaned_since` against `entries` before
+        // evicting anything.
+        let key = occupied.into_key();
+
+        // If there was another entry in the pending evictions map due
+        // to some sort of a race - the last one wins, so overwrite the
+        // preexisting one to delay the eviction further.
+        let previous = self.pending_evictions.insert(key, now);
+
+        if previous.is_some() {
+            // Found a race! Nothing special to do really, but we'll
+            // log it just in case - if users see a lot of these it
+            // would warrant an investigation, as we should be able to
+            // make this even safer and more reliable. Or it could be
+            // caused by a newly introduced bug.
+            tracing::warn!(
+                "detected race at state handle drop; \
+                this is probably safe as it anticipated in the design - \
+                but still logged cause it should be rare and notable \
+                occurrence"
+            );
+        }
+    }
+
+    /// Evict every entry orphaned for longer than `retention`, passing each
+    /// evicted key and value to `on_eviction`.
+    pub(crate) fn sweep(
+        &self,
+        retention: Duration,
+        mut on_eviction: impl FnMut(Key, Arc<tokio::sync::OnceCell<Value>>),
+    ) where
+        Key: Clone,
+    {
+        let now = Instant::now();
+
+        // Empty until something has actually expired — the common sweep
+        // outcome is no evictions, which this way costs no allocation.
+        let mut cleanup_queue = Vec::new();
+        self.pending_evictions.retain(|key, orphaned_since| {
+            let retain = now.duration_since(*orphaned_since) <= retention;
+            if !retain {
+                cleanup_queue.push((*key).clone());
+            }
+            retain
+        });
+
+        for key in cleanup_queue {
+            let Some((key, entry)) = self.entries.remove_if(&key, |_, entry| {
+                entry.refs == 0
+                    && entry
+                        .orphaned_since
+                        .is_some_and(|t| now.duration_since(t) > retention)
+            }) else {
+                // The entry either has non-zero refs (still held), has been
+                // re-acquired and re-dropped with a fresh `orphaned_since`
+                // (retention not yet elapsed), or was already evicted by a
+                // prior sweep.  In all cases it is harmless to skip.
+                //
+                // The `orphaned_since` gate inside `remove_if` closes the race
+                // where a handle is acquired and dropped mid-sweep: `retain`
+                // strips the stale key from `pending_evictions`, but
+                // `remove_if` sees the fresh `orphaned_since` and refuses to
+                // evict until the full retention has elapsed.
+                continue;
+            };
+
+            on_eviction(key, entry.value);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/lib/state-manager/src/storage/tests.rs
+++ b/crates/lib/state-manager/src/storage/tests.rs
@@ -1,0 +1,240 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+use core::hash::Hash;
+
+use waymark_nonzero_duration::NonZeroDuration;
+
+use super::{Entry, Maps};
+use crate::State;
+
+fn retention_10ms() -> NonZeroDuration {
+    NonZeroDuration::from_millis(10).expect("10ms is non-zero")
+}
+
+/// White-box helpers used by the tests to set up and inspect internal state.
+///
+/// These live here (rather than behind `#[cfg(test)]` in `storage`) so no test
+/// scaffolding leaks into the production modules.
+impl<Key, Value> Maps<Key, Value>
+where
+    Key: Eq + Hash,
+{
+    /// Insert an entry holding an uninitialized value with the given
+    /// ref-count, to simulate other holders.
+    ///
+    /// The fabricated refs have no owning `Guard`s, so the key must not be
+    /// touched by an in-flight `get` — a stale guard releasing against a
+    /// replaced entry would corrupt the ref-count.  Refuses to replace an
+    /// existing entry for that reason.
+    fn insert_uninitialized_for_test(&self, key: Key, refs: usize) {
+        let previous = self.entries.insert(
+            key,
+            Entry {
+                value: std::sync::Arc::new(tokio::sync::OnceCell::new()),
+                refs,
+                orphaned_since: None,
+            },
+        );
+        assert!(
+            previous.is_none(),
+            "test helper must not replace an existing entry"
+        );
+    }
+
+    /// The ref-count of the entry for `key`, or `None` if the entry is absent.
+    fn refs_of(&self, key: &Key) -> Option<usize> {
+        self.entries.get(key).map(|entry| entry.refs)
+    }
+
+    /// Whether `key` currently has a pending eviction scheduled.
+    fn is_pending_eviction(&self, key: &Key) -> bool {
+        self.pending_evictions.contains_key(key)
+    }
+}
+
+// ------------------------------------------------------------------
+// Factory failure when other refs exist
+// ------------------------------------------------------------------
+
+/// A factory that fails once for each key, then succeeds.
+struct FlakyFactory {
+    failures: dashmap::DashMap<u64, usize>,
+}
+
+impl waymark_state_manager_core::Factory for FlakyFactory {
+    type Key = u64;
+    type Value = u64;
+    type Error = &'static str;
+
+    async fn produce(&self, key: &Self::Key) -> Result<Self::Value, Self::Error> {
+        let mut count = self.failures.entry(*key).or_insert(0);
+        *count += 1;
+        if *count == 1 {
+            Err("factory failed")
+        } else {
+            Ok(*key * 10)
+        }
+    }
+}
+
+/// When the factory fails but another holder keeps the entry alive
+/// (refs > 1), cleanup must decrement refs back to the original count
+/// rather than removing the entry.  This path cannot be tested via
+/// integration because a failing factory never produces a Handle.
+#[tokio::test]
+async fn factory_failure_keeps_entry_when_other_handle_exists() {
+    let factory = FlakyFactory {
+        failures: dashmap::DashMap::new(),
+    };
+    let (state, _sweeper) = State::<u64, u64, _>::new(retention_10ms(), factory);
+
+    // Pre-populate an entry with refs=2 to simulate another holder keeping
+    // the entry alive.
+    state.maps.insert_uninitialized_for_test(2, 2);
+
+    let result = state.get(2).await;
+    assert!(result.is_err());
+    assert_eq!(result.err().unwrap(), "factory failed");
+
+    assert_eq!(
+        state.maps.refs_of(&2),
+        Some(2),
+        "refs should be back to original count (other refs held)"
+    );
+}
+
+// ------------------------------------------------------------------
+// Cancellation safety of `get`
+// ------------------------------------------------------------------
+
+/// A factory that pauses at a gate until signalled, then fails.
+struct GateFactory {
+    started: Arc<AtomicBool>,
+    gate: Arc<tokio::sync::Notify>,
+}
+
+impl waymark_state_manager_core::Factory for GateFactory {
+    type Key = u64;
+    type Value = u64;
+    type Error = &'static str;
+
+    async fn produce(&self, _key: &Self::Key) -> Result<Self::Value, Self::Error> {
+        self.started.store(true, Ordering::SeqCst);
+        self.gate.notified().await;
+        Err("gated failure")
+    }
+}
+
+/// When the `get` future is dropped while the factory is still producing
+/// (e.g. a `timeout` fires, or a `select!` branch loses), the ref bump the
+/// call performed before awaiting must be undone.  Otherwise `refs` never
+/// returns to zero, `orphaned_since` is never set, and the `Sweeper` can
+/// never evict the entry — a permanent leak.
+#[tokio::test]
+async fn cancelled_get_does_not_leak_ref() {
+    let started = Arc::new(AtomicBool::new(false));
+    // Never signalled in this test: the factory stays parked, so the only
+    // way `get` returns is by being cancelled.
+    let gate = Arc::new(tokio::sync::Notify::new());
+
+    let factory = GateFactory {
+        started: started.clone(),
+        gate: gate.clone(),
+    };
+    let (state, _sweeper) = State::<u64, u64, _>::new(retention_10ms(), factory);
+    let state = Arc::new(state);
+
+    // Drive `get` on a task so we can cancel it by aborting.
+    let state_clone = Arc::clone(&state);
+    let handle = tokio::spawn(async move { state_clone.get(7).await });
+
+    // Wait until the factory is entered — the ref has been bumped and the
+    // future is now parked at the `get_or_try_init` await.
+    while !started.load(Ordering::SeqCst) {
+        tokio::time::sleep(Duration::from_millis(1)).await;
+    }
+
+    // The entry exists with the bumped ref while the factory runs.
+    assert_eq!(
+        state.maps.refs_of(&7),
+        Some(1),
+        "ref should be bumped while the factory produces"
+    );
+
+    // Cancel the `get` future mid-produce.
+    handle.abort();
+    let _ = handle.await;
+
+    // The guard must have undone the bump; as the only ref, the entry is
+    // removed entirely so a later `get` starts fresh.
+    assert_eq!(
+        state.maps.refs_of(&7),
+        None,
+        "cancelled get must not leak the entry"
+    );
+    assert!(
+        !state.maps.is_pending_eviction(&7),
+        "cancelled get must not leave a pending eviction"
+    );
+}
+
+/// A cancelled `get` on an entry another holder keeps alive (refs > 1) must
+/// decrement the ref back rather than removing the shared entry.
+#[tokio::test]
+async fn cancelled_get_keeps_entry_when_other_handle_exists() {
+    let started = Arc::new(AtomicBool::new(false));
+    let gate = Arc::new(tokio::sync::Notify::new());
+
+    let factory = GateFactory {
+        started: started.clone(),
+        gate: gate.clone(),
+    };
+    let (state, _sweeper) = State::<u64, u64, _>::new(retention_10ms(), factory);
+    let state = Arc::new(state);
+
+    // A first `get` parked at the factory's gate acts as the other holder:
+    // it owns a real guard-backed reference for as long as it stays parked.
+    let state_clone = Arc::clone(&state);
+    let holder = tokio::spawn(async move { state_clone.get(8).await });
+
+    while !started.load(Ordering::SeqCst) {
+        tokio::time::sleep(Duration::from_millis(1)).await;
+    }
+    assert_eq!(
+        state.maps.refs_of(&8),
+        Some(1),
+        "holder should own one ref while parked in the factory"
+    );
+
+    // The second `get` bumps the ref-count and parks awaiting the same
+    // `OnceCell` (the holder's factory call is already in flight).
+    let state_clone = Arc::clone(&state);
+    let handle = tokio::spawn(async move { state_clone.get(8).await });
+
+    while state.maps.refs_of(&8) != Some(2) {
+        tokio::time::sleep(Duration::from_millis(1)).await;
+    }
+
+    handle.abort();
+    let _ = handle.await;
+
+    assert_eq!(
+        state.maps.refs_of(&8),
+        Some(1),
+        "cancelled get must decrement back to the other holder's ref"
+    );
+
+    // Release the holder through the gate — its factory fails, `get` returns
+    // the error, and the guard releases the last ref on the way out.
+    gate.notify_one();
+    let holder_result = holder.await.expect("holder task must not panic");
+    assert_eq!(holder_result.err(), Some("gated failure"));
+
+    assert_eq!(
+        state.maps.refs_of(&8),
+        None,
+        "releasing the last ref must remove the never-produced entry"
+    );
+}

--- a/crates/lib/state-manager/src/sweeper.rs
+++ b/crates/lib/state-manager/src/sweeper.rs
@@ -1,0 +1,57 @@
+//! The [`Sweeper`] that evicts stale entries from [`State`](crate::State).
+
+use core::hash::Hash;
+use std::sync::{Arc, Weak};
+
+use waymark_nonzero_duration::NonZeroDuration;
+
+use crate::storage::Maps;
+
+/// The sweeper for a particular state that performs the eviction of stale
+/// entries.
+pub struct Sweeper<Key, Value> {
+    retention: NonZeroDuration,
+    maps: Weak<Maps<Key, Value>>,
+}
+
+impl<Key, Value> Sweeper<Key, Value> {
+    /// Create a sweeper over `maps` with the given `retention`.
+    pub(crate) fn new(retention: NonZeroDuration, maps: Weak<Maps<Key, Value>>) -> Self {
+        Self { retention, maps }
+    }
+
+    /// Returns whether this [`Sweeper`]'s associated [`State`](crate::State)
+    /// still exists.
+    ///
+    /// Returns `false` if the [`State`](crate::State) has been dropped.
+    pub fn associated_state_exists(&self) -> bool {
+        self.maps.strong_count() > 0
+    }
+}
+
+impl<Key, Value> Sweeper<Key, Value>
+where
+    Key: Eq + Hash + Clone,
+{
+    /// Perform one sweep on the pending evictions map, evicting all the
+    /// entries that have not been held on to via a
+    /// [`Handle`](crate::Handle) for longer than the configured retention
+    /// duration.
+    ///
+    /// Passes the evicted entries to the `on_eviction` callback.
+    pub fn sweep_with_handler(
+        &mut self,
+        on_eviction: impl FnMut(Key, Arc<tokio::sync::OnceCell<Value>>),
+    ) {
+        let Some(maps) = self.maps.upgrade() else {
+            return;
+        };
+
+        maps.sweep(self.retention.get(), on_eviction);
+    }
+
+    /// Like [`Sweeper::sweep_with_handler`] but discards the evicted entries.
+    pub fn sweep(&mut self) {
+        self.sweep_with_handler(|_, _| {});
+    }
+}

--- a/crates/lib/state-manager/tests/integration.rs
+++ b/crates/lib/state-manager/tests/integration.rs
@@ -1,0 +1,603 @@
+use std::convert::Infallible;
+use std::hash::Hash;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+
+use waymark_nonzero_duration::NonZeroDuration;
+use waymark_state_manager::{Handle, State};
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+/// A `Factory` that returns a fixed value and counts invocations.
+struct CountingFactory<K, V> {
+    value: V,
+    call_count: Arc<AtomicUsize>,
+    _phantom: std::marker::PhantomData<K>,
+}
+
+impl<K, V> waymark_state_manager_core::Factory for CountingFactory<K, V>
+where
+    K: Hash + Eq + Sync,
+    V: Clone + Sync + Send,
+{
+    type Key = K;
+    type Value = V;
+    type Error = Infallible;
+
+    async fn produce(&self, _key: &Self::Key) -> Result<Self::Value, Self::Error> {
+        self.call_count.fetch_add(1, Ordering::Relaxed);
+        Ok(self.value.clone())
+    }
+}
+
+/// A `Factory` that produces `key * 10` for `u64` keys.
+struct MultiplyFactory {
+    call_count: Arc<AtomicUsize>,
+}
+
+impl waymark_state_manager_core::Factory for MultiplyFactory {
+    type Key = u64;
+    type Value = u64;
+    type Error = Infallible;
+
+    async fn produce(&self, key: &Self::Key) -> Result<Self::Value, Self::Error> {
+        self.call_count.fetch_add(1, Ordering::Relaxed);
+        Ok(key * 10)
+    }
+}
+
+/// A `Factory` that prepends "value-for-" to string keys.
+struct PrefixFactory {
+    call_count: Arc<AtomicUsize>,
+}
+
+impl waymark_state_manager_core::Factory for PrefixFactory {
+    type Key = String;
+    type Value = String;
+    type Error = Infallible;
+
+    async fn produce(&self, key: &Self::Key) -> Result<Self::Value, Self::Error> {
+        self.call_count.fetch_add(1, Ordering::Relaxed);
+        Ok(format!("value-for-{key}"))
+    }
+}
+
+/// A value that tracks how many times it has been dropped.
+#[derive(Clone)]
+struct DropCounter {
+    drops: Arc<AtomicUsize>,
+}
+
+impl DropCounter {
+    fn new(drops: Arc<AtomicUsize>) -> Self {
+        Self { drops }
+    }
+}
+
+impl Drop for DropCounter {
+    fn drop(&mut self) {
+        self.drops.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+/// A `Factory` that produces [`DropCounter`] values.
+struct DropCounterFactory {
+    drops: Arc<AtomicUsize>,
+}
+
+impl waymark_state_manager_core::Factory for DropCounterFactory {
+    type Key = u64;
+    type Value = DropCounter;
+    type Error = Infallible;
+
+    async fn produce(&self, _key: &Self::Key) -> Result<Self::Value, Self::Error> {
+        Ok(DropCounter::new(self.drops.clone()))
+    }
+}
+
+fn retention_10ms() -> NonZeroDuration {
+    NonZeroDuration::from_millis(10).expect("10ms is non-zero")
+}
+
+fn retention_1s() -> NonZeroDuration {
+    NonZeroDuration::from_secs(1).expect("1s is non-zero")
+}
+
+// ---------------------------------------------------------------------------
+// Basic Handle lifecycle
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn get_and_deref() {
+    let call_count = Arc::new(AtomicUsize::new(0));
+    let factory = CountingFactory {
+        value: "hello".to_string(),
+        call_count: call_count.clone(),
+        _phantom: std::marker::PhantomData,
+    };
+    let (state, _sweeper) = State::<u64, String, _>::new(retention_1s(), factory);
+
+    let handle = state.get(42).await.unwrap();
+    assert_eq!(*handle, "hello");
+    assert_eq!(call_count.load(Ordering::Relaxed), 1);
+}
+
+#[tokio::test]
+async fn handle_key_access() {
+    let call_count = Arc::new(AtomicUsize::new(0));
+    let factory = CountingFactory {
+        value: 100u64,
+        call_count: call_count.clone(),
+        _phantom: std::marker::PhantomData,
+    };
+    let (state, _sweeper) = State::<u64, u64, _>::new(retention_1s(), factory);
+
+    let handle = state.get(99).await.unwrap();
+    assert_eq!(*Handle::key(&handle), 99);
+    assert_eq!(*handle, 100);
+}
+
+#[tokio::test]
+async fn factory_called_only_once_for_same_key() {
+    let call_count = Arc::new(AtomicUsize::new(0));
+    let factory = CountingFactory {
+        value: 42u64,
+        call_count: call_count.clone(),
+        _phantom: std::marker::PhantomData,
+    };
+    let (state, _sweeper) = State::<u64, u64, _>::new(retention_1s(), factory);
+
+    let _h1 = state.get(1).await.unwrap();
+    let _h2 = state.get(1).await.unwrap();
+
+    assert_eq!(call_count.load(Ordering::Relaxed), 1);
+}
+
+#[tokio::test]
+async fn factory_receives_key() {
+    let call_count = Arc::new(AtomicUsize::new(0));
+    let factory = PrefixFactory {
+        call_count: call_count.clone(),
+    };
+    let (state, _sweeper) = State::<String, String, _>::new(retention_1s(), factory);
+
+    let handle = state.get("my-key".to_string()).await.unwrap();
+    assert_eq!(*handle, "value-for-my-key");
+}
+
+// ---------------------------------------------------------------------------
+// Eviction
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn sweep_evicts_after_retention() {
+    let drops = Arc::new(AtomicUsize::new(0));
+    let factory = DropCounterFactory {
+        drops: drops.clone(),
+    };
+    let (state, mut sweeper) = State::<u64, DropCounter, _>::new(retention_10ms(), factory);
+
+    {
+        let _handle = state.get(1).await.unwrap();
+    }
+    sweeper.sweep();
+
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    let evicted = Arc::new(AtomicUsize::new(0));
+    let evicted_clone = evicted.clone();
+    sweeper.sweep_with_handler(move |key, cell| {
+        assert_eq!(key, 1);
+        let _value = cell.get().expect("OnceCell should be initialised");
+        evicted_clone.fetch_add(1, Ordering::Relaxed);
+    });
+    assert_eq!(evicted.load(Ordering::Relaxed), 1);
+}
+
+#[tokio::test]
+async fn sweep_skips_when_handle_still_held() {
+    let drops = Arc::new(AtomicUsize::new(0));
+    let factory = DropCounterFactory {
+        drops: drops.clone(),
+    };
+    let (state, mut sweeper) = State::<u64, DropCounter, _>::new(retention_10ms(), factory);
+
+    let _handle = state.get(1).await.unwrap();
+
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    let evicted = Arc::new(AtomicUsize::new(0));
+    let evicted_clone = evicted.clone();
+    sweeper.sweep_with_handler(move |_key, _cell| {
+        evicted_clone.fetch_add(1, Ordering::Relaxed);
+    });
+    assert_eq!(evicted.load(Ordering::Relaxed), 0);
+}
+
+// ---------------------------------------------------------------------------
+// Multiple handles
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn multiple_handles_delay_eviction_until_all_dropped() {
+    let drops = Arc::new(AtomicUsize::new(0));
+    let factory = DropCounterFactory {
+        drops: drops.clone(),
+    };
+    let (state, mut sweeper) = State::<u64, DropCounter, _>::new(retention_10ms(), factory);
+
+    let h1 = state.get(1).await.unwrap();
+    let _h2 = state.get(1).await.unwrap();
+
+    drop(h1);
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    let evicted = Arc::new(AtomicUsize::new(0));
+    let evicted_clone = evicted.clone();
+    sweeper.sweep_with_handler(move |_key, _cell| {
+        evicted_clone.fetch_add(1, Ordering::Relaxed);
+    });
+    assert_eq!(evicted.load(Ordering::Relaxed), 0);
+
+    drop(_h2);
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    let evicted = Arc::new(AtomicUsize::new(0));
+    let evicted_clone = evicted.clone();
+    sweeper.sweep_with_handler(move |key, cell| {
+        assert_eq!(key, 1);
+        let _value = cell.get().expect("OnceCell should be initialised");
+        evicted_clone.fetch_add(1, Ordering::Relaxed);
+    });
+    assert_eq!(evicted.load(Ordering::Relaxed), 1);
+}
+
+// ---------------------------------------------------------------------------
+// Concurrent access
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn concurrent_get_same_key() {
+    let call_count = Arc::new(AtomicUsize::new(0));
+    let factory = CountingFactory {
+        value: 42u64,
+        call_count: call_count.clone(),
+        _phantom: std::marker::PhantomData,
+    };
+    let (state, _sweeper) = State::<u64, u64, _>::new(retention_1s(), factory);
+    let state = Arc::new(state);
+
+    let mut handles = Vec::new();
+    for _ in 0..10 {
+        let state = state.clone();
+        let task = tokio::task::spawn(async move {
+            let h = state.get(1).await.unwrap();
+            *h
+        });
+        handles.push(task);
+    }
+
+    for handle in handles {
+        let value = handle.await.unwrap();
+        assert_eq!(value, 42);
+    }
+    assert_eq!(call_count.load(Ordering::Relaxed), 1);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn concurrent_get_different_keys() {
+    let call_count = Arc::new(AtomicUsize::new(0));
+    let factory = MultiplyFactory {
+        call_count: call_count.clone(),
+    };
+    let (state, _sweeper) = State::<u64, u64, _>::new(retention_1s(), factory);
+    let state = Arc::new(state);
+
+    let mut handles = Vec::new();
+    for i in 0..10 {
+        let state = state.clone();
+        let task = tokio::task::spawn(async move {
+            let h = state.get(i).await.unwrap();
+            *h
+        });
+        handles.push(task);
+    }
+
+    for (i, handle) in handles.into_iter().enumerate() {
+        let value = handle.await.unwrap();
+        assert_eq!(value, (i as u64) * 10);
+    }
+    assert_eq!(call_count.load(Ordering::Relaxed), 10);
+}
+
+// ---------------------------------------------------------------------------
+// Edge cases
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn empty_sweep_does_nothing() {
+    let call_count = Arc::new(AtomicUsize::new(0));
+    let factory = CountingFactory {
+        value: "unused".to_string(),
+        call_count,
+        _phantom: std::marker::PhantomData::<String>,
+    };
+    let (_state, mut sweeper) = State::<String, String, _>::new(retention_1s(), factory);
+    sweeper.sweep();
+}
+
+#[tokio::test]
+async fn sweep_after_state_dropped() {
+    let call_count = Arc::new(AtomicUsize::new(0));
+    let factory = CountingFactory {
+        value: "value".to_string(),
+        call_count,
+        _phantom: std::marker::PhantomData,
+    };
+    let (state, mut sweeper) = State::<u64, String, _>::new(retention_1s(), factory);
+
+    {
+        let _handle = state.get(1).await.unwrap();
+    }
+    drop(state);
+    sweeper.sweep();
+}
+
+#[tokio::test]
+async fn get_after_handle_drop_before_sweep() {
+    let call_count = Arc::new(AtomicUsize::new(0));
+    let factory = CountingFactory {
+        value: 100u64,
+        call_count: call_count.clone(),
+        _phantom: std::marker::PhantomData,
+    };
+    let (state, mut sweeper) = State::<u64, u64, _>::new(retention_10ms(), factory);
+
+    {
+        let _h = state.get(1).await.unwrap();
+    }
+
+    let h2 = state.get(1).await.unwrap();
+    assert_eq!(*h2, 100);
+    assert_eq!(call_count.load(Ordering::Relaxed), 1);
+
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    let evicted = Arc::new(AtomicUsize::new(0));
+    let evicted_clone = evicted.clone();
+    sweeper.sweep_with_handler(move |_key, _cell| {
+        evicted_clone.fetch_add(1, Ordering::Relaxed);
+    });
+    assert_eq!(evicted.load(Ordering::Relaxed), 0);
+}
+
+#[tokio::test]
+async fn retention_window_resets_on_reacquire() {
+    // Verify that the retention timer is measured from the *last* drop,
+    // not the first.  This guards against the cross-map race where
+    // `pending_evictions` and `entries` timestamps diverge during a
+    // mid-sweep get+drop cycle.
+
+    let factory = CountingFactory {
+        value: 100u64,
+        call_count: Arc::new(AtomicUsize::new(0)),
+        _phantom: std::marker::PhantomData,
+    };
+    let (state, mut sweeper) = State::<u64, u64, _>::new(retention_10ms(), factory);
+
+    // First handle: acquire and drop.
+    {
+        let _h = state.get(1).await.unwrap();
+    }
+
+    // Wait half the retention window.
+    tokio::time::sleep(Duration::from_millis(5)).await;
+
+    // Re-acquire and drop — this should reset the timer.
+    {
+        let _h = state.get(1).await.unwrap();
+    }
+
+    // Wait just past the *original* drop's retention window,
+    // but still within the *second* drop's retention window.
+    tokio::time::sleep(Duration::from_millis(7)).await;
+
+    // The entry should NOT be evicted because only ~7ms have passed
+    // since the last drop, not the full 10ms retention.
+    let evicted = Arc::new(AtomicUsize::new(0));
+    let evicted_clone = evicted.clone();
+    sweeper.sweep_with_handler(move |_key, _cell| {
+        evicted_clone.fetch_add(1, Ordering::Relaxed);
+    });
+    assert_eq!(evicted.load(Ordering::Relaxed), 0);
+
+    // Wait the remainder of the retention window.
+    tokio::time::sleep(Duration::from_millis(10)).await;
+
+    // Now the entry should be evicted.
+    let evicted = Arc::new(AtomicUsize::new(0));
+    let evicted_clone = evicted.clone();
+    sweeper.sweep_with_handler(move |key, cell| {
+        assert_eq!(key, 1);
+        let _value = cell.get().expect("OnceCell should be initialised");
+        evicted_clone.fetch_add(1, Ordering::Relaxed);
+    });
+    assert_eq!(evicted.load(Ordering::Relaxed), 1);
+}
+
+// ---------------------------------------------------------------------------
+// Multiple keys
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn sweep_evicts_multiple_stale_entries() {
+    let call_count = Arc::new(AtomicUsize::new(0));
+    let factory = MultiplyFactory {
+        call_count: call_count.clone(),
+    };
+    let (state, mut sweeper) = State::<u64, u64, _>::new(retention_10ms(), factory);
+
+    for i in 0..5 {
+        let _h = state.get(i).await.unwrap();
+    }
+
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    let evicted = Arc::new(AtomicUsize::new(0));
+    let evicted_clone = evicted.clone();
+    sweeper.sweep_with_handler(move |key, cell| {
+        let value = *cell.get().expect("OnceCell should be initialised");
+        assert_eq!(value, key * 10);
+        evicted_clone.fetch_add(1, Ordering::Relaxed);
+    });
+    assert_eq!(evicted.load(Ordering::Relaxed), 5);
+}
+
+#[tokio::test]
+async fn sweep_evicts_only_stale_entries() {
+    let call_count = Arc::new(AtomicUsize::new(0));
+    let factory = CountingFactory {
+        value: 100u64,
+        call_count: call_count.clone(),
+        _phantom: std::marker::PhantomData,
+    };
+    let (state, mut sweeper) = State::<u64, u64, _>::new(retention_10ms(), factory);
+
+    {
+        let _h1 = state.get(1).await.unwrap();
+    }
+
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    let _h2 = state.get(2).await.unwrap();
+
+    let evicted = Arc::new(AtomicUsize::new(0));
+    let evicted_clone = evicted.clone();
+    sweeper.sweep_with_handler(move |key, _cell| {
+        assert_eq!(key, 1);
+        evicted_clone.fetch_add(1, Ordering::Relaxed);
+    });
+    assert_eq!(evicted.load(Ordering::Relaxed), 1);
+}
+
+// ---------------------------------------------------------------------------
+// Factory failure
+// ---------------------------------------------------------------------------
+
+/// A `Factory` that fails on the first `N` calls for each key, then succeeds.
+struct FlakyFactory {
+    failures_per_key: usize,
+    call_counts: Arc<dashmap::DashMap<u64, usize>>,
+}
+
+impl FlakyFactory {
+    fn new(failures_per_key: usize) -> Self {
+        Self {
+            failures_per_key,
+            call_counts: Arc::new(dashmap::DashMap::new()),
+        }
+    }
+}
+
+impl waymark_state_manager_core::Factory for FlakyFactory {
+    type Key = u64;
+    type Value = u64;
+    type Error = &'static str;
+
+    async fn produce(&self, key: &Self::Key) -> Result<Self::Value, Self::Error> {
+        let mut count = self.call_counts.entry(*key).or_insert(0);
+        if *count < self.failures_per_key {
+            *count += 1;
+            Err("factory failed")
+        } else {
+            *count += 1;
+            Ok(*key * 10)
+        }
+    }
+}
+
+#[tokio::test]
+async fn factory_failure_does_not_leak_kv_pair() {
+    let factory = FlakyFactory::new(1);
+    let (state, mut sweeper) = State::<u64, u64, _>::new(retention_10ms(), factory);
+
+    // First call fails — no Handle is returned.
+    let result = state.get(1).await;
+    assert!(result.is_err(), "first call should fail");
+    assert_eq!(result.err().unwrap(), "factory failed");
+
+    // Second call succeeds.
+    let handle = state.get(1).await.unwrap();
+    assert_eq!(*handle, 10);
+
+    // Drop the handle so the entry becomes eligible for eviction.
+    drop(handle);
+
+    // Wait past the retention window.
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    // The entry should be evicted (refs should have reached 0).
+    // If the failed call leaked a ref, the entry would linger forever.
+    let evicted = Arc::new(AtomicUsize::new(0));
+    let evicted_clone = evicted.clone();
+    sweeper.sweep_with_handler(move |key, cell| {
+        assert_eq!(key, 1);
+        let value = *cell.get().expect("OnceCell should be initialised");
+        assert_eq!(value, 10);
+        evicted_clone.fetch_add(1, Ordering::Relaxed);
+    });
+    assert_eq!(evicted.load(Ordering::Relaxed), 1);
+}
+
+// ---------------------------------------------------------------------------
+// Sweeper introspection
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn associated_state_exists() {
+    let call_count = Arc::new(AtomicUsize::new(0));
+    let factory = CountingFactory {
+        value: 0u64,
+        call_count,
+        _phantom: std::marker::PhantomData::<u64>,
+    };
+    let (state, sweeper) = State::<u64, u64, _>::new(retention_1s(), factory);
+    assert!(sweeper.associated_state_exists());
+    drop(state);
+    assert!(!sweeper.associated_state_exists());
+}
+
+// ---------------------------------------------------------------------------
+// OnceCell guarantees
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn once_cell_guarantees_single_init() {
+    let call_count = Arc::new(AtomicUsize::new(0));
+    let factory = CountingFactory {
+        value: 42u64,
+        call_count: call_count.clone(),
+        _phantom: std::marker::PhantomData,
+    };
+    let (state, _sweeper) = State::<u64, u64, _>::new(retention_1s(), factory);
+    let state = Arc::new(state);
+
+    let mut handles = Vec::new();
+    for _ in 0..20 {
+        let state = state.clone();
+        let task = tokio::task::spawn(async move {
+            let h = state.get(1).await.unwrap();
+            *h
+        });
+        handles.push(task);
+    }
+
+    for handle in handles {
+        let value = handle.await.unwrap();
+        assert_eq!(value, 42);
+    }
+    assert_eq!(call_count.load(Ordering::Relaxed), 1);
+}

--- a/crates/lib/state-vm-executables-backend/Cargo.toml
+++ b/crates/lib/state-vm-executables-backend/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "waymark-state-vm-executables-backend"
+edition = "2024"
+version.workspace = true
+publish.workspace = true
+
+[dependencies]

--- a/crates/lib/state-vm-executables-backend/src/lib.rs
+++ b/crates/lib/state-vm-executables-backend/src/lib.rs
@@ -1,0 +1,22 @@
+//! Persistence operations for VM executables (bytecode).
+
+#![warn(missing_docs)]
+
+/// Common base: every executable backend is associated with an executable
+/// identifier type.
+pub trait HasExecutableId {
+    /// The executable identifier type.
+    type ExecutableId;
+}
+
+/// Load a previously-stored executable.
+pub trait LoadExecutable: HasExecutableId {
+    /// Error type for load operations.
+    type Error: std::fmt::Debug;
+
+    /// Load a previously-stored executable.
+    fn load_executable<'a>(
+        &'a self,
+        id: &'a Self::ExecutableId,
+    ) -> impl Future<Output = Result<Vec<u8>, Self::Error>> + Send + 'a;
+}

--- a/crates/lib/state-vm-executables/Cargo.toml
+++ b/crates/lib/state-vm-executables/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "waymark-state-vm-executables"
+edition = "2024"
+version.workspace = true
+publish.workspace = true
+
+[dependencies]
+waymark-state-manager-core = { workspace = true }
+waymark-state-vm-executables-backend = { workspace = true }
+waymark-vm-codec-core = { workspace = true }
+
+serde = { workspace = true }
+thiserror = { workspace = true }

--- a/crates/lib/state-vm-executables/src/lib.rs
+++ b/crates/lib/state-vm-executables/src/lib.rs
@@ -1,0 +1,78 @@
+//! Executable loading and retrieval, backed by
+//! [`waymark_state_vm_executables_backend`].
+//!
+//! Provides an [`ExecutablesFactory`] that implements
+//! [`waymark_state_manager_core::Factory`] to load VM executables
+//! from a backend on demand.
+
+#![warn(missing_docs)]
+
+use std::hash::Hash;
+use std::marker::PhantomData;
+use std::sync::Arc;
+
+/// Errors returned by [`ExecutablesFactory`].
+#[derive(Debug, thiserror::Error)]
+pub enum LoadError<BackendError, CodecError> {
+    /// The backend failed to load the executable bytes.
+    #[error("backend load error: {0}")]
+    Backend(#[source] BackendError),
+
+    /// The codec failed to deserialize the executable.
+    #[error("deserialize error: {0}")]
+    Deserialize(#[source] CodecError),
+}
+
+/// A [`Factory`](waymark_state_manager_core::Factory) that loads VM executables
+/// from a [`waymark_state_vm_executables_backend::LoadExecutable`] backend,
+/// deserializing them with the given [`Codec`].
+pub struct ExecutablesFactory<Backend, Codec, Executable> {
+    backend: Arc<Backend>,
+    codec: Arc<Codec>,
+    _phantom: PhantomData<Executable>,
+}
+
+impl<Backend, Codec, Executable> ExecutablesFactory<Backend, Codec, Executable> {
+    /// Create a new executables factory wrapping the given backend and codec.
+    pub fn new(backend: Arc<Backend>, codec: Arc<Codec>) -> Self {
+        Self {
+            backend,
+            codec,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<Backend, Codec, Executable> waymark_state_manager_core::Factory
+    for ExecutablesFactory<Backend, Codec, Executable>
+where
+    Backend: waymark_state_vm_executables_backend::LoadExecutable,
+    Backend: Send + Sync + 'static,
+    Backend::ExecutableId: Hash + Eq + Send + Sync,
+    <Backend as waymark_state_vm_executables_backend::LoadExecutable>::Error: Send + 'static,
+    Codec: waymark_vm_codec_core::DeserializerProvider,
+    Codec: Send + Sync + 'static,
+    Codec::Error: Send + 'static,
+    Executable: for<'de> serde::Deserialize<'de>,
+    Executable: Send + Sync + 'static,
+{
+    type Key = Backend::ExecutableId;
+    type Value = Arc<Executable>;
+    type Error = LoadError<
+        <Backend as waymark_state_vm_executables_backend::LoadExecutable>::Error,
+        Codec::Error,
+    >;
+
+    async fn produce(&self, key: &Self::Key) -> Result<Self::Value, Self::Error> {
+        let bytes = self
+            .backend
+            .load_executable(key)
+            .await
+            .map_err(LoadError::Backend)?;
+        let value = self
+            .codec
+            .with_deserializer(&bytes, |de| serde::Deserialize::deserialize(de))
+            .map_err(LoadError::Deserialize)?;
+        Ok(Arc::new(value))
+    }
+}

--- a/crates/lib/state-vm-runtimes-backend/Cargo.toml
+++ b/crates/lib/state-vm-runtimes-backend/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "waymark-state-vm-runtimes-backend"
+edition = "2024"
+version.workspace = true
+publish.workspace = true
+
+[dependencies]

--- a/crates/lib/state-vm-runtimes-backend/src/lib.rs
+++ b/crates/lib/state-vm-runtimes-backend/src/lib.rs
@@ -1,0 +1,66 @@
+//! Persistence operations for VM runtimes state management.
+
+#![warn(missing_docs)]
+
+/// Common base: every snapshot backend is associated with a VM identifier type.
+pub trait HasVmId {
+    /// The VM identifier type.
+    type VmId;
+}
+
+/// Common base: every snapshot backend is associated with an executable
+/// identifier type.
+pub trait HasExecutableId {
+    /// The executable identifier type.
+    type ExecutableId;
+}
+
+/// Persist a snapshot for a VM.
+///
+/// Called from a driver thread — implementations may block.
+pub trait StoreSnapshot: HasVmId {
+    /// Error type for store operations.
+    type Error: std::fmt::Debug;
+
+    /// Persist a snapshot for the given VM.
+    fn store_snapshot<'a>(
+        &'a self,
+        vm_id: &'a Self::VmId,
+        data: &'a [u8],
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send + 'a;
+}
+
+/// Payload returned by [`LoadForRevive`], containing both the serialized
+/// snapshot and the id of the executable needed to revive the VM.
+#[derive(Debug, Clone)]
+pub struct RevivePayload<ExecutableId> {
+    /// The serialized VM runtime snapshot.
+    pub snapshot: Vec<u8>,
+
+    /// The id of the bytecode executable that the VM was running.
+    pub executable_id: ExecutableId,
+}
+
+/// Load a previously-stored snapshot and the associated executable id
+/// for reviving a VM.
+pub trait LoadForRevive: HasVmId + HasExecutableId {
+    /// Error type for load operations.
+    type Error: std::fmt::Debug;
+
+    /// Load a previously-stored snapshot for the given VM, returning both
+    /// the snapshot bytes and the id of the executable needed to revive it.
+    fn load_for_revive<'a>(
+        &'a self,
+        vm_id: &'a Self::VmId,
+    ) -> impl std::future::Future<Output = Result<RevivePayload<Self::ExecutableId>, Self::Error>>
+    + Send
+    + 'a;
+}
+
+/// Convenience trait: a backend that supports both store and load.
+///
+/// Blanket-implemented for any type that implements both [`StoreSnapshot`]
+/// and [`LoadForRevive`].
+pub trait VmRuntimesStateBackend: StoreSnapshot + LoadForRevive {}
+
+impl<T> VmRuntimesStateBackend for T where T: StoreSnapshot + LoadForRevive {}

--- a/crates/lib/state-vm-runtimes-core/Cargo.toml
+++ b/crates/lib/state-vm-runtimes-core/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "waymark-state-vm-runtimes-core"
+edition = "2024"
+version.workspace = true
+publish.workspace = true
+
+[dependencies]

--- a/crates/lib/state-vm-runtimes-core/src/lib.rs
+++ b/crates/lib/state-vm-runtimes-core/src/lib.rs
@@ -1,0 +1,98 @@
+//! Core traits for the state-vm-runtimes subsystem.
+//!
+//! Provides the [`EffectorProvider`] and [`InterpreterProvider`] traits —
+//! abstractions for creating per-VM effectors and interpreters.
+
+#![warn(missing_docs)]
+
+/// Provides an effector for a given VM.
+///
+/// The effector is the composite handler that the VM driver uses to process
+/// interpreter effects and settle promises. Since effectors are typically
+/// bound to a specific VM identity and backend, this trait allows creating
+/// them on demand when a VM is revived, rather than requiring a single
+/// shared effector at factory construction time.
+pub trait EffectorProvider {
+    /// The VM identifier type.
+    type VmId;
+
+    /// The effector type produced by this provider.
+    type Effector;
+
+    /// Provide an effector for the given VM.
+    fn provide_effector(&self, vm_id: &Self::VmId) -> Self::Effector;
+}
+
+/// Provides an interpreter for a given VM.
+pub trait InterpreterProvider {
+    /// The VM identifier type.
+    type VmId;
+
+    /// The interpreter type produced by this provider.
+    type Interpreter;
+
+    /// Provide an interpreter for the given VM.
+    fn provide_interpreter(&self, vm_id: &Self::VmId) -> Self::Interpreter;
+}
+
+/// An [`InterpreterProvider`] that always returns a default-constructed
+/// interpreter, ignoring the VM identifier.
+///
+/// Useful for stateless interpreters that implement [`Default`].
+pub struct DefaultInterpreterProvider<Interpreter, VmId> {
+    _phantom: core::marker::PhantomData<(Interpreter, VmId)>,
+}
+
+impl<Interpreter, VmId> DefaultInterpreterProvider<Interpreter, VmId> {
+    /// Create a new default interpreter provider.
+    pub fn new() -> Self {
+        Self {
+            _phantom: core::marker::PhantomData,
+        }
+    }
+}
+
+impl<Interpreter, VmId> Default for DefaultInterpreterProvider<Interpreter, VmId> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<Interpreter: Default, VmId> InterpreterProvider
+    for DefaultInterpreterProvider<Interpreter, VmId>
+{
+    type VmId = VmId;
+    type Interpreter = Interpreter;
+
+    fn provide_interpreter(&self, _vm_id: &Self::VmId) -> Self::Interpreter {
+        Interpreter::default()
+    }
+}
+
+/// An [`EffectorProvider`] that wraps a closure.
+pub struct FnEffectorProvider<F, VmId> {
+    f: F,
+    phantom_data: std::marker::PhantomData<fn(&VmId)>,
+}
+
+impl<F, VmId> FnEffectorProvider<F, VmId> {
+    /// Create a new [`FnEffectorProvider`] from a given `f`.
+    pub fn new(f: F) -> Self {
+        Self {
+            f,
+            phantom_data: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<F, VmId, Effector> EffectorProvider for FnEffectorProvider<F, VmId>
+where
+    F: Fn(&VmId) -> Effector,
+{
+    type VmId = VmId;
+    type Effector = Effector;
+
+    fn provide_effector(&self, vm_id: &Self::VmId) -> Self::Effector {
+        (self.f)(vm_id)
+    }
+}

--- a/crates/lib/state-vm-runtimes/Cargo.toml
+++ b/crates/lib/state-vm-runtimes/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "waymark-state-vm-runtimes"
+edition = "2024"
+version.workspace = true
+publish.workspace = true
+
+[dependencies]
+waymark-state-manager = { workspace = true }
+waymark-state-manager-core = { workspace = true }
+waymark-state-vm-runtimes-backend = { workspace = true }
+waymark-state-vm-runtimes-core = { workspace = true }
+waymark-vm-codec-core = { workspace = true }
+waymark-vm-driver = { workspace = true }
+waymark-vm-driver-core = { workspace = true }
+waymark-vm-driver-thread = { workspace = true }
+waymark-vm-executable = { workspace = true }
+waymark-vm-interpreter = { workspace = true }
+waymark-vm-runtime = { workspace = true }
+waymark-vm-runtime-core = { workspace = true }
+waymark-vm-runtime-promise-core = { workspace = true }
+
+serde = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["sync", "macros", "rt", "time"] }
+tokio-util = { workspace = true }
+tracing = { workspace = true }

--- a/crates/lib/state-vm-runtimes/src/lib.rs
+++ b/crates/lib/state-vm-runtimes/src/lib.rs
@@ -1,0 +1,236 @@
+//! Multi-VM runtime manager, backed by [`waymark_state_manager::State`].
+//!
+//! This crate manages multiple [`waymark_vm_runtime::Runtime`] instances,
+//! driving each one's execution loop, routing extcall effects and promise
+//! settlements, and coordinating persistence via a backend.
+//!
+//! The state-manager provides concurrent access and automatic cleanup
+//! through ref-counted [`Handle`](waymark_state_manager::Handle)s. When
+//! the last handle to a VM is dropped, the entry is marked for eviction
+//! and eventually swept (which drops the [`Spawned`], aborting the
+//! underlying driver thread).
+
+#![warn(missing_docs)]
+
+mod snapshot_adapter;
+mod spawner;
+
+pub use self::spawner::Spawned;
+
+use std::hash::Hash;
+use std::marker::PhantomData;
+use std::sync::Arc;
+
+/// Error from [`SpawningFactory::produce`].
+#[derive(Debug, thiserror::Error)]
+pub enum SpawningError<LoadError, ExecutableProviderError, DeserializeError>
+where
+    DeserializeError: std::error::Error + 'static,
+{
+    /// Failed to load the persisted snapshot.
+    #[error("load: {0}")]
+    Load(#[source] LoadError),
+
+    /// Failed to load the bytecode executable.
+    #[error("executable provider: {0}")]
+    ExecutableProvider(#[source] ExecutableProviderError),
+
+    /// Failed to deserialize the snapshot.
+    #[error("deserialization failed: {0}")]
+    Deserialization(#[source] DeserializeError),
+}
+
+/// A [`waymark_state_manager_core::Factory`] that revives VMs from persisted
+/// snapshots.
+pub struct SpawningFactory<
+    Backend,
+    Codec,
+    ExecutableProvider,
+    InterpreterProvider,
+    EffectorProvider,
+    Value,
+> {
+    backend: Arc<Backend>,
+    codec: Arc<Codec>,
+    executable_provider: ExecutableProvider,
+    interpreter_provider: InterpreterProvider,
+    effector_provider: EffectorProvider,
+    _phantom_data: PhantomData<Value>,
+}
+
+impl<Backend, Codec, ExecutableProvider, InterpreterProvider, EffectorProvider, Value>
+    SpawningFactory<
+        Backend,
+        Codec,
+        ExecutableProvider,
+        InterpreterProvider,
+        EffectorProvider,
+        Value,
+    >
+{
+    /// Create a new spawning factory.
+    pub fn new(
+        backend: Arc<Backend>,
+        codec: Arc<Codec>,
+        executable_provider: ExecutableProvider,
+        interpreter_provider: InterpreterProvider,
+        effector_provider: EffectorProvider,
+    ) -> Self {
+        Self {
+            backend,
+            codec,
+            executable_provider,
+            interpreter_provider,
+            effector_provider,
+            _phantom_data: PhantomData,
+        }
+    }
+}
+
+impl<Backend, Codec, ExecutableProvider, InterpreterProvider, EffectorProvider, Value>
+    waymark_state_manager_core::Factory
+    for SpawningFactory<
+        Backend,
+        Codec,
+        ExecutableProvider,
+        InterpreterProvider,
+        EffectorProvider,
+        Value,
+    >
+where
+    Backend: waymark_state_vm_runtimes_backend::HasVmId,
+    Backend::VmId: Hash + Eq + Clone + Send + Sync + core::fmt::Debug + 'static,
+    Backend: waymark_state_vm_runtimes_backend::StoreSnapshot,
+    Backend: waymark_state_vm_runtimes_backend::LoadForRevive,
+    Backend: Send + Sync + 'static,
+    <Backend as waymark_state_vm_runtimes_backend::StoreSnapshot>::Error:
+        std::fmt::Debug + Send + 'static,
+    <Backend as waymark_state_vm_runtimes_backend::LoadForRevive>::Error:
+        std::fmt::Debug + Send + 'static,
+    Codec: waymark_vm_codec_core::SerializerProvider<Ok = ()>,
+    Codec: waymark_vm_codec_core::DeserializerProvider,
+    Codec: Send + Sync + 'static,
+    <Codec as waymark_vm_codec_core::SerializerProvider>::Error: Send + 'static,
+    <Codec as waymark_vm_codec_core::DeserializerProvider>::Error:
+        std::error::Error + Send + 'static,
+    Backend: waymark_state_vm_runtimes_backend::HasExecutableId,
+    <Backend as waymark_state_vm_runtimes_backend::HasExecutableId>::ExecutableId:
+        Eq + Hash + Clone + Send + Sync,
+    ExecutableProvider: waymark_state_manager::provider::Provider<
+        Key = <Backend as waymark_state_vm_runtimes_backend::HasExecutableId>::ExecutableId,
+    >,
+    ExecutableProvider: Send + Sync + 'static,
+    ExecutableProvider::Error: Send + 'static,
+    ExecutableProvider::Value:
+        waymark_vm_executable::InstructionsProvider + Send + Sync + 'static + Clone,
+    <ExecutableProvider::Value as waymark_vm_executable::Functions>::FunctionId: Copy + Send,
+    <ExecutableProvider::Value as waymark_vm_executable::Functions>::FunctionId:
+        serde::Serialize,
+    <ExecutableProvider::Value as waymark_vm_executable::Functions>::FunctionId:
+        for<'a> serde::Deserialize<'a>,
+    <ExecutableProvider::Value as waymark_vm_executable::FunctionStates>::StateId:
+        Copy + PartialEq + Send,
+    <ExecutableProvider::Value as waymark_vm_executable::FunctionStates>::StateId:
+        serde::Serialize,
+    <ExecutableProvider::Value as waymark_vm_executable::FunctionStates>::StateId:
+        for<'a> serde::Deserialize<'a>,
+    ExecutableProvider::Value: waymark_vm_executable::FunctionStates + Send,
+    InterpreterProvider: waymark_state_vm_runtimes_core::InterpreterProvider<
+        VmId = Backend::VmId,
+    >,
+    InterpreterProvider: Send + Sync + 'static,
+    InterpreterProvider::Interpreter: waymark_vm_interpreter::Interpreter<
+            Frame = waymark_vm_runtime::FrameFor<ExecutableProvider::Value, Value>,
+            Instruction = <ExecutableProvider::Value as waymark_vm_executable::InstructionsProvider>::Instruction,
+        >,
+    InterpreterProvider::Interpreter: Send + 'static,
+    InterpreterProvider::Interpreter: for<'r> waymark_vm_runtime_core::CaptureRuntimeView<
+            ExecutableProvider::Value,
+            <ExecutableProvider::Value as waymark_vm_executable::Functions>::FunctionId,
+            <ExecutableProvider::Value as waymark_vm_executable::FunctionStates>::StateId,
+            Value,
+            RuntimeView<'r> = <InterpreterProvider::Interpreter as waymark_vm_interpreter::Interpreter>::RuntimeView<'r>,
+        >,
+    EffectorProvider: waymark_state_vm_runtimes_core::EffectorProvider<
+        VmId = Backend::VmId,
+    >,
+    EffectorProvider: Send + Sync + 'static,
+    EffectorProvider::Effector: waymark_vm_driver_core::EffectHandler<
+            Effect = <InterpreterProvider::Interpreter as waymark_vm_interpreter::Interpreter>::Effect,
+        > + waymark_vm_driver_core::PromiseSettler<Value = Value::ReadyValue, Ack: Send>
+        + Send
+        + Sync
+        + 'static,
+    Value: Clone + Send + Sync + 'static,
+    Value: serde::Serialize + for<'a> serde::Deserialize<'a>,
+    Value: waymark_vm_runtime_promise_core::Resolvable + core::fmt::Debug,
+    Value::ReadyValue: core::fmt::Debug + Send,
+    <InterpreterProvider::Interpreter as waymark_vm_interpreter::Interpreter>::Error:
+        core::fmt::Debug + Send,
+    <InterpreterProvider::Interpreter as waymark_vm_interpreter::Interpreter>::Effect:
+        core::fmt::Debug + Send,
+    <InterpreterProvider::Interpreter as waymark_vm_interpreter::Interpreter>::Instruction:
+        core::fmt::Debug,
+    <EffectorProvider::Effector as waymark_vm_driver_core::EffectHandler>::Error:
+        Send + 'static,
+    <EffectorProvider::Effector as waymark_vm_driver_core::PromiseSettler>::Error:
+        Send + 'static,
+{
+    type Key = Backend::VmId;
+    type Value = Arc<Spawned>;
+    type Error = SpawningError<
+        <Backend as waymark_state_vm_runtimes_backend::LoadForRevive>::Error,
+        ExecutableProvider::Error,
+        <Codec as waymark_vm_codec_core::DeserializerProvider>::Error,
+    >;
+
+    #[tracing::instrument(skip_all, fields(vm_id = ?key))]
+    async fn produce(&self, key: &Self::Key) -> Result<Self::Value, Self::Error> {
+        let revive_payload = self
+            .backend
+            .load_for_revive(key)
+            .await
+            .map_err(SpawningError::Load)?;
+
+
+        let waymark_state_vm_runtimes_backend::RevivePayload { snapshot, executable_id } = revive_payload;
+
+        let executable_handle = self
+            .executable_provider
+            .get(executable_id)
+            .await
+            .map_err(SpawningError::ExecutableProvider)?;
+
+        let executable = (*executable_handle).clone();
+
+        let interpreter = self.interpreter_provider.provide_interpreter(key);
+
+        let runtime = self.codec.with_deserializer(&snapshot, |de| {
+            waymark_vm_runtime::Runtime::from_snapshot(
+                interpreter,
+                executable,
+                de,
+            )
+        }).map_err(SpawningError::Deserialization)?;
+
+
+        let snapshotter = snapshot_adapter::SnapshotAdapter {
+            vm_id: key.clone(),
+            backend: Arc::clone(&self.backend),
+        };
+
+        let span = tracing::info_span!("drive_runtime", ?key);
+        let _guard = span.enter();
+
+        let spawned = spawner::spawn(
+            Arc::clone(&self.codec),
+            runtime,
+            self.effector_provider.provide_effector(key),
+            snapshotter,
+            vec![Box::new(executable_handle)],
+        )
+        .await;
+
+        Ok(Arc::new(spawned))
+    }
+}

--- a/crates/lib/state-vm-runtimes/src/snapshot_adapter.rs
+++ b/crates/lib/state-vm-runtimes/src/snapshot_adapter.rs
@@ -1,0 +1,20 @@
+use std::sync::Arc;
+
+/// Adapter that binds a VM id to a shared backend.
+pub(crate) struct SnapshotAdapter<VmId, Backend> {
+    pub vm_id: VmId,
+    pub backend: Arc<Backend>,
+}
+
+impl<VmId, Backend> waymark_vm_driver_core::SnapshotPersister for SnapshotAdapter<VmId, Backend>
+where
+    Backend: waymark_state_vm_runtimes_backend::StoreSnapshot<VmId = VmId> + Send + Sync,
+    <Backend as waymark_state_vm_runtimes_backend::StoreSnapshot>::Error: std::fmt::Debug,
+    VmId: Sync,
+{
+    type Error = <Backend as waymark_state_vm_runtimes_backend::StoreSnapshot>::Error;
+
+    async fn persist_snapshot<'a>(&'a self, data: &'a [u8]) -> Result<(), Self::Error> {
+        self.backend.store_snapshot(&self.vm_id, data).await
+    }
+}

--- a/crates/lib/state-vm-runtimes/src/spawner.rs
+++ b/crates/lib/state-vm-runtimes/src/spawner.rs
@@ -1,0 +1,158 @@
+//! VM driver thread spawning.
+
+use std::sync::Arc;
+
+use tokio_util::sync::CancellationToken;
+use tracing::Instrument as _;
+
+/// A spawned VM handle that exposes the access to the VM.
+#[must_use = "driver thread is aborted when this handle is dropped"]
+pub struct Spawned {
+    /// Gracefully cancels the driver loop.
+    driver_loop_cancel: CancellationToken,
+
+    /// A handle to allow joining on the driver completion task.
+    ///
+    /// That's the one that waits for the driver to complete.
+    driver_completion_task: Option<tokio::task::JoinHandle<()>>,
+
+    /// Cancelled when the driver thread exits (the VM is evicted).
+    driver_evicted: CancellationToken,
+
+    /// Opaque handles kept alive while this VM is running.
+    #[allow(
+        unused,
+        reason = "these handles are kept around for the drop semantics, \
+                    they don't actually have to be used"
+    )]
+    keepalive_handles: Vec<Box<dyn Send + Sync>>,
+}
+
+impl Spawned {
+    /// Returns a future that resolves when the VM driver thread exits
+    /// (the VM is evicted).
+    pub fn evicted(&self) -> impl std::future::Future<Output = ()> + '_ {
+        self.driver_evicted.cancelled()
+    }
+
+    /// Trigger the graceful eviction of the VM.
+    ///
+    /// The VM driver loop is cancelled (not the loop future itself, but
+    /// the token), and will stop the execution when the loop picks
+    /// the cancellation up.
+    pub fn trigger_eviction(&self) {
+        self.driver_loop_cancel.cancel();
+    }
+
+    /// Gracefully shut down the VM, waiting for the driver thread to exit.
+    ///
+    /// # Cancellation safety
+    ///
+    /// This method is cancellation-safe. If the future is dropped, the
+    /// shutdown signal has already been sent (via the cancellation token)
+    /// before any `.await` point. The driver thread will continue shutting
+    /// down asynchronously.
+    pub async fn shutdown(mut self) {
+        self.driver_loop_cancel.cancel();
+
+        let completion_task = self.driver_completion_task.take().unwrap();
+
+        let completion_result = completion_task.await;
+
+        match completion_result {
+            Ok(()) => {}                         // fallthrough to disable abort-on-drop
+            Err(err) if err.is_cancelled() => {} // fallthrough to disable abort-on-drop
+            Err(err) => std::panic::resume_unwind(err.into_panic()), // unwind and trigger abort-on-drop
+        }
+    }
+}
+
+impl Drop for Spawned {
+    fn drop(&mut self) {
+        self.driver_loop_cancel.cancel();
+    }
+}
+
+/// Spawn a new VM runtime on a dedicated OS thread.
+#[tracing::instrument(skip_all)]
+pub(crate) async fn spawn<Codec, Executable, Interpreter, Value, Effector, Persister>(
+    codec: Arc<Codec>,
+    runtime: waymark_vm_runtime::Runtime<Executable, Interpreter, Value>,
+    effector: Effector,
+    persister: Persister,
+    keepalive_handles: Vec<Box<dyn Send + Sync>>,
+) -> Spawned
+where
+    Codec: waymark_vm_codec_core::SerializerProvider<Ok = ()>,
+    Codec: Send + Sync + 'static,
+    <Codec as waymark_vm_codec_core::SerializerProvider>::Error: Send,
+    Effector: waymark_vm_driver_core::EffectHandler<Effect = Interpreter::Effect>,
+    Effector: waymark_vm_driver_core::PromiseSettler<Value = Value::ReadyValue, Ack: Send>,
+    Effector: Send + 'static,
+    Executable: waymark_vm_executable::InstructionsProvider + Send + 'static,
+    Executable::FunctionId: Copy + Send,
+    Executable::FunctionId: serde::Serialize,
+    Executable::StateId: Copy + PartialEq + Send,
+    Executable::StateId: serde::Serialize,
+    Executable: waymark_vm_executable::FunctionStates + Send,
+    Interpreter: waymark_vm_interpreter::Interpreter<
+            Frame = waymark_vm_runtime::FrameFor<Executable, Value>,
+            Instruction = Executable::Instruction,
+        >,
+    Interpreter: Send + 'static,
+    Interpreter: for<'r> waymark_vm_runtime_core::CaptureRuntimeView<
+            Executable,
+            Executable::FunctionId,
+            Executable::StateId,
+            Value,
+            RuntimeView<'r> = <Interpreter as waymark_vm_interpreter::Interpreter>::RuntimeView<'r>,
+        >,
+    Value: Clone + Send + 'static,
+    Value: serde::Serialize,
+    Value: waymark_vm_runtime_promise_core::Resolvable,
+    Interpreter::Error: core::fmt::Debug + Send,
+    Interpreter::Effect: core::fmt::Debug + Send,
+    Interpreter::Instruction: core::fmt::Debug,
+    Value: core::fmt::Debug,
+    Value::ReadyValue: core::fmt::Debug + Send,
+    Persister: waymark_vm_driver_core::SnapshotPersister + Send + 'static,
+    Persister::Error: Send,
+    <Effector as waymark_vm_driver_core::EffectHandler>::Error: Send,
+    <Effector as waymark_vm_driver_core::PromiseSettler>::Error: Send,
+{
+    let cancel = CancellationToken::new();
+    let driver_evicted = CancellationToken::new();
+    let driver = waymark_vm_driver_thread::spawn(waymark_vm_driver::Params {
+        runtime,
+        effector,
+        persister,
+        codec,
+        cancel: cancel.clone(),
+    });
+
+    let completion = tokio::spawn({
+        let driver_evicted = driver_evicted.clone();
+        {
+            async move {
+                let _driver_evicted = driver_evicted.drop_guard();
+                let Err(error) = driver.await;
+                match error {
+                    waymark_vm_driver_thread::Error::Driver(error) => {
+                        tracing::error!(?error, "vm driver terminated");
+                    }
+                    waymark_vm_driver_thread::Error::Thread(error) => {
+                        tracing::error!(?error, "vm thread panicked");
+                    }
+                }
+            }
+        }
+        .in_current_span()
+    });
+
+    Spawned {
+        driver_loop_cancel: cancel,
+        driver_completion_task: Some(completion),
+        driver_evicted,
+        keepalive_handles,
+    }
+}


### PR DESCRIPTION
Goes in after #445.

---

This PR adds state managers - a new subsystem that is designed to keep the in-memory objects live while they are used or for a specified liveness period after they are not.

This was originally called "cache", but the "state manager" captures the semantics better.

The subsystem is designed to operate on the "live" objects as opposed to bytes, hence why cache in the naming was discouraged.

---

The state manager itself acts as main the holder of the main volume of complexities; it is well-tested and optimized. The other crates are thin layers that integrate on top, providing the business logic.

The idea is simple - we have an map that keep the values around for the certain keys; the values, when obtained, give out a handle - which, when expires, starts the eviction timer. When the time comes to evict the entry, unless it was obtained again and there's another active handle, we drop the key/value from the map; it can be reconstructed again if needed by fetching it again.