### PR TITLE
Add workflow-service-vm-runtimes-backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6191,6 +6191,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "waymark-workflow-service-vm-runtimes-backend"
+version = "0.1.0"
+dependencies = [
+ "nonempty-collections",
+]
+
+[[package]]
 name = "waymark-workload-pinning-backend"
 version = "0.1.0"
 dependencies = [

--- a/crates/lib/workflow-service-vm-runtimes-backend/Cargo.toml
+++ b/crates/lib/workflow-service-vm-runtimes-backend/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "waymark-workflow-service-vm-runtimes-backend"
+version.workspace = true
+publish.workspace = true
+edition = "2024"
+
+[dependencies]
+nonempty-collections = { workspace = true }

--- a/crates/lib/workflow-service-vm-runtimes-backend/src/common.rs
+++ b/crates/lib/workflow-service-vm-runtimes-backend/src/common.rs
@@ -1,0 +1,15 @@
+//! Shared identifier traits for workflow-service backends.
+
+/// Common base: every workflow-service backend is associated with a VM
+/// identifier type.
+pub trait HasVmId {
+    /// The VM / workflow identifier type.
+    type VmId;
+}
+
+/// Associates the backend with an executable (workflow version) identifier
+/// type.
+pub trait HasExecutableId {
+    /// The executable / workflow version identifier type.
+    type ExecutableId;
+}

--- a/crates/lib/workflow-service-vm-runtimes-backend/src/find_existing_vm_runtimes.rs
+++ b/crates/lib/workflow-service-vm-runtimes-backend/src/find_existing_vm_runtimes.rs
@@ -1,0 +1,31 @@
+//! Batch existence query for registered VM runtimes.
+
+use nonempty_collections::NESlice;
+
+use super::common::HasVmId;
+
+/// Backend capability for checking which VM runtimes are registered.
+///
+/// This is the read-side counterpart to
+/// [`RegisterVmRuntime`](super::RegisterVmRuntime): it answers "which of these
+/// VM runtimes exist?" against the same registration state, without touching
+/// the registration write path.
+pub trait FindExistingVmRuntimes: HasVmId {
+    /// The error type for the query.
+    type Error: core::fmt::Debug;
+
+    /// Return the subset of `vm_ids` that have a registered VM runtime.
+    ///
+    /// The result may be empty (none are registered), may be smaller than the
+    /// input, and its order is unspecified.
+    ///
+    /// Takes a borrowed [`NESlice`] — a concrete type — rather than a generic
+    /// iterator. A generic parameter (named or `impl Trait`) would be captured
+    /// by the `impl Future` return and trip rust-lang/rust#100013 when the
+    /// future is awaited through an `#[async_trait]` consumer; a slice also
+    /// binds directly to the `= ANY($1)` query with no intermediate allocation.
+    fn find_existing_vm_runtimes<'a>(
+        &'a self,
+        vm_ids: NESlice<'a, Self::VmId>,
+    ) -> impl Future<Output = Result<Vec<Self::VmId>, Self::Error>> + Send + 'a;
+}

--- a/crates/lib/workflow-service-vm-runtimes-backend/src/lib.rs
+++ b/crates/lib/workflow-service-vm-runtimes-backend/src/lib.rs
@@ -1,0 +1,17 @@
+//! Backend traits for the workflow service.
+//!
+//! Defines the contracts for registering a VM runtime — inserting the
+//! initial snapshot and workload pinning rows for a workflow instance.
+
+#![warn(missing_docs)]
+
+/// Shared identifier traits (`HasVmId`, `HasExecutableId`).
+pub mod common;
+/// Batch existence query for registered VM runtimes.
+pub mod find_existing_vm_runtimes;
+/// VM runtime registration trait and error classification.
+pub mod register_vm_runtime;
+
+pub use self::common::{HasExecutableId, HasVmId};
+pub use self::find_existing_vm_runtimes::FindExistingVmRuntimes;
+pub use self::register_vm_runtime::RegisterVmRuntime;

--- a/crates/lib/workflow-service-vm-runtimes-backend/src/register_vm_runtime.rs
+++ b/crates/lib/workflow-service-vm-runtimes-backend/src/register_vm_runtime.rs
@@ -1,0 +1,44 @@
+//! VM runtime registration trait and error classification.
+
+use super::common::{HasExecutableId, HasVmId};
+
+/// Backend capability for registering VM runtimes.
+pub trait RegisterVmRuntime: HasVmId + HasExecutableId {
+    /// The error type for service operations.
+    type Error: Error + std::fmt::Debug;
+
+    /// Register a VM runtime with its associated executable and initial
+    /// snapshot.
+    ///
+    /// Creates a row in the snapshot table and a matching row in the
+    /// workload pinning table. Returns an error if this VM is already
+    /// registered.
+    fn register_vm_runtime(
+        &self,
+        vm_id: &Self::VmId,
+        executable_id: &Self::ExecutableId,
+        snapshot: &[u8],
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send;
+}
+
+/// Classification interface for VM runtime registration errors.
+pub trait Error {
+    /// Classify this error into a stable [`ErrorKind`].
+    fn kind(&self) -> ErrorKind;
+}
+
+/// Stable categories for VM runtime registration failures.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ErrorKind {
+    /// A VM runtime is already registered for this VM id.
+    AlreadyRegistered,
+
+    /// An internal backend failure (database, serialization, etc.).
+    Internal,
+}
+
+impl Error for core::convert::Infallible {
+    fn kind(&self) -> ErrorKind {
+        match *self {}
+    }
+}


### PR DESCRIPTION
Goes in after #446.

---

This is a small PR that add a `workflow-service-vm-runtimes-backend` crate - a backend for a crate called `workflow-service-vm-runtimes`; the backend is added before the notion of the crate itself because what follows is the postgres backend implementation, and this backend is an important part of the integration to work properly.

---

The logic is as follows: `workflow-service-vm-runtimes` crate is a service that various parts of the code can use to create a new VM and write it to the database for processing. It makes things easy and avoids code duplication.

The corresponding `workflow-service-vm-runtimes-backend` encapsulates the capability to add the workflow to the database.

There is also a `state-vm-runtimes-backend` - the counterpart that encapsulates the capability to resume the execution of a runtime that has been recorded by the `workflow-service-vm-runtimes-backend` - and to write the snapshot of the vm runtime state into the database.

---

The immediate follow-up of this PR is to provide the postgres backend implementations for all these traits.