### PR TITLE
Implement vm-runtimes and workload pinning backends for postgres

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4420,6 +4420,7 @@ dependencies = [
  "waymark-webapp-core",
  "waymark-worker-status-backend",
  "waymark-workflow-registry-backend",
+ "waymark-workflow-service-vm-runtimes-backend",
  "waymark-workload-pinning-backend",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4420,6 +4420,7 @@ dependencies = [
  "waymark-webapp-core",
  "waymark-worker-status-backend",
  "waymark-workflow-registry-backend",
+ "waymark-workload-pinning-backend",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4413,6 +4413,7 @@ dependencies = [
  "waymark-scheduler-backend",
  "waymark-scheduler-core",
  "waymark-secret-string",
+ "waymark-state-vm-runtimes-backend",
  "waymark-support-test",
  "waymark-timed-future",
  "waymark-webapp-backend",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,6 +140,7 @@ waymark-worker-status-backend = { path = "crates/lib/worker-status-backend" }
 waymark-worker-status-core = { path = "crates/lib/worker-status-core" }
 waymark-worker-status-reporter = { path = "crates/lib/worker-status-reporter" }
 waymark-workflow-registry-backend = { path = "crates/lib/workflow-registry-backend" }
+waymark-workflow-service-vm-runtimes-backend = { path = "crates/lib/workflow-service-vm-runtimes-backend" }
 waymark-workload-pinning-backend = { path = "crates/lib/workload-pinning-backend" }
 
 anyhow = "1"

--- a/crates/lib/backend-postgres-migrations/migrations/0012_vm_runtime_snapshots.sql
+++ b/crates/lib/backend-postgres-migrations/migrations/0012_vm_runtime_snapshots.sql
@@ -1,0 +1,9 @@
+-- VM runtime snapshot persistence.
+
+CREATE TABLE vm_runtime_snapshots (
+    vm_id UUID PRIMARY KEY,
+    executable_id UUID NOT NULL,
+    snapshot BYTEA NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);

--- a/crates/lib/backend-postgres-migrations/migrations/0013_workload_pinnings.sql
+++ b/crates/lib/backend-postgres-migrations/migrations/0013_workload_pinnings.sql
@@ -1,0 +1,15 @@
+-- Workload pinning: tracks which node owns VM runtime instances.
+-- Every row in vm_runtime_snapshots has a matching row here.
+
+CREATE TABLE workload_pinnings (
+    instance_id UUID PRIMARY KEY REFERENCES vm_runtime_snapshots(vm_id) ON DELETE CASCADE,
+    node_id UUID,
+    expires_at TIMESTAMPTZ,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    -- A pinning's owner and its lease expiry are set and cleared together:
+    -- claimed rows have both, unclaimed rows have neither. A row with only one
+    -- set would match neither the poll nor the refresh predicate and become
+    -- permanently unclaimable.
+    CONSTRAINT workload_pinnings_node_expiry_paired
+        CHECK ((node_id IS NULL) = (expires_at IS NULL))
+);

--- a/crates/lib/backend-postgres/Cargo.toml
+++ b/crates/lib/backend-postgres/Cargo.toml
@@ -24,6 +24,7 @@ waymark-runner-state = { workspace = true }
 waymark-scheduler-backend = { workspace = true }
 waymark-scheduler-core = { workspace = true }
 waymark-secret-string = { workspace = true }
+waymark-state-vm-runtimes-backend = { workspace = true }
 waymark-timed-future = { workspace = true }
 waymark-webapp-backend = { workspace = true }
 waymark-webapp-core = { workspace = true }

--- a/crates/lib/backend-postgres/Cargo.toml
+++ b/crates/lib/backend-postgres/Cargo.toml
@@ -30,6 +30,7 @@ waymark-webapp-backend = { workspace = true }
 waymark-webapp-core = { workspace = true }
 waymark-worker-status-backend = { workspace = true }
 waymark-workflow-registry-backend = { workspace = true }
+waymark-workflow-service-vm-runtimes-backend = { workspace = true }
 waymark-workload-pinning-backend = { workspace = true }
 
 chrono = { workspace = true }

--- a/crates/lib/backend-postgres/Cargo.toml
+++ b/crates/lib/backend-postgres/Cargo.toml
@@ -30,6 +30,7 @@ waymark-webapp-backend = { workspace = true }
 waymark-webapp-core = { workspace = true }
 waymark-worker-status-backend = { workspace = true }
 waymark-workflow-registry-backend = { workspace = true }
+waymark-workload-pinning-backend = { workspace = true }
 
 chrono = { workspace = true }
 function_name = { workspace = true }

--- a/crates/lib/backend-postgres/src/lib.rs
+++ b/crates/lib/backend-postgres/src/lib.rs
@@ -7,6 +7,7 @@ mod registry;
 mod scheduler;
 #[cfg(test)]
 mod test_helpers;
+mod vm_runtimes;
 mod webapp;
 
 use std::collections::HashMap;

--- a/crates/lib/backend-postgres/src/lib.rs
+++ b/crates/lib/backend-postgres/src/lib.rs
@@ -9,6 +9,7 @@ mod scheduler;
 mod test_helpers;
 mod vm_runtimes;
 mod webapp;
+mod workload_pinning;
 
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};

--- a/crates/lib/backend-postgres/src/lib.rs
+++ b/crates/lib/backend-postgres/src/lib.rs
@@ -9,6 +9,7 @@ mod scheduler;
 mod test_helpers;
 mod vm_runtimes;
 mod webapp;
+mod workflow_service_vm_runtimes;
 mod workload_pinning;
 
 use std::collections::HashMap;

--- a/crates/lib/backend-postgres/src/test_helpers.rs
+++ b/crates/lib/backend-postgres/src/test_helpers.rs
@@ -1,12 +1,30 @@
 use sqlx::PgPool;
 
 use super::PostgresBackend;
+use waymark_ids::{InstanceId, WorkflowVersionId};
 use waymark_support_test::postgres_setup;
+use waymark_workflow_service_vm_runtimes_backend::RegisterVmRuntime;
 
 pub(super) async fn setup_backend() -> PostgresBackend {
     let pool = postgres_setup().await;
     reset_database(&pool).await;
     PostgresBackend::new(pool)
+}
+
+/// Snapshot bytes written by [`register_test_vm`].
+pub(super) const TEST_VM_SNAPSHOT: &[u8] = b"test-snapshot";
+
+/// Register a VM runtime (its snapshot and workload pinning rows) through the
+/// production [`RegisterVmRuntime`] path and return its identifiers, so tests
+/// share exactly the registration behavior they exercise.
+pub(super) async fn register_test_vm(backend: &PostgresBackend) -> (InstanceId, WorkflowVersionId) {
+    let vm_id = InstanceId::new_uuid_v4();
+    let executable_id = WorkflowVersionId::new_uuid_v4();
+    backend
+        .register_vm_runtime(&vm_id, &executable_id, TEST_VM_SNAPSHOT)
+        .await
+        .expect("register test vm");
+    (vm_id, executable_id)
 }
 
 pub(super) async fn reset_database(pool: &PgPool) {

--- a/crates/lib/backend-postgres/src/test_helpers.rs
+++ b/crates/lib/backend-postgres/src/test_helpers.rs
@@ -18,7 +18,8 @@ pub(super) async fn reset_database(pool: &PgPool) {
                  workflow_versions,
                  workflow_schedules,
                  worker_status,
-                 vm_runtime_snapshots
+                 vm_runtime_snapshots,
+                 workload_pinnings
         RESTART IDENTITY CASCADE
         "#,
     )

--- a/crates/lib/backend-postgres/src/test_helpers.rs
+++ b/crates/lib/backend-postgres/src/test_helpers.rs
@@ -17,7 +17,8 @@ pub(super) async fn reset_database(pool: &PgPool) {
                  runner_instances,
                  workflow_versions,
                  workflow_schedules,
-                 worker_status
+                 worker_status,
+                 vm_runtime_snapshots
         RESTART IDENTITY CASCADE
         "#,
     )

--- a/crates/lib/backend-postgres/src/vm_runtimes/error.rs
+++ b/crates/lib/backend-postgres/src/vm_runtimes/error.rs
@@ -1,0 +1,28 @@
+//! Error types for the state-vm-runtimes postgres backend.
+
+/// Error returned by [`super::PostgresBackend`] when storing a VM snapshot.
+#[derive(Debug, thiserror::Error)]
+pub enum StoreSnapshotError {
+    /// The underlying database operation failed.
+    #[error("sqlx: {0}")]
+    Sqlx(#[source] sqlx::Error),
+
+    /// The VM has not been registered yet. Register it via
+    /// [`waymark_workflow_service_vm_runtimes_backend::RegisterVmRuntime::register_vm_runtime`]
+    /// first.
+    #[error("vm runtime not registered: {0}")]
+    NotRegistered(waymark_ids::InstanceId),
+}
+
+/// Error returned by [`super::PostgresBackend`] when loading a VM snapshot
+/// for revival.
+#[derive(Debug, thiserror::Error)]
+pub enum LoadForReviveError {
+    /// The underlying database operation failed.
+    #[error("sqlx: {0}")]
+    Sqlx(#[source] sqlx::Error),
+
+    /// No snapshot exists for the given VM.
+    #[error("vm runtime not found: {0}")]
+    NotFound(waymark_ids::InstanceId),
+}

--- a/crates/lib/backend-postgres/src/vm_runtimes/mod.rs
+++ b/crates/lib/backend-postgres/src/vm_runtimes/mod.rs
@@ -1,0 +1,93 @@
+//! Postgres backend for VM runtime snapshot persistence.
+
+pub mod error;
+
+#[cfg(test)]
+mod tests;
+
+use sqlx::Row;
+use waymark_ids::{InstanceId, WorkflowVersionId};
+use waymark_observability::obs;
+use waymark_timed_future::TimedFutureExt as _;
+
+use crate::PostgresBackend;
+
+impl waymark_state_vm_runtimes_backend::HasVmId for PostgresBackend {
+    type VmId = InstanceId;
+}
+
+impl waymark_state_vm_runtimes_backend::HasExecutableId for PostgresBackend {
+    type ExecutableId = WorkflowVersionId;
+}
+
+impl waymark_state_vm_runtimes_backend::StoreSnapshot for PostgresBackend {
+    type Error = error::StoreSnapshotError;
+
+    #[obs]
+    #[function_name::named]
+    async fn store_snapshot<'a>(
+        &'a self,
+        vm_id: &'a InstanceId,
+        data: &'a [u8],
+    ) -> Result<(), Self::Error> {
+        Self::count_query(&self.query_counts, "update:vm_runtime_snapshots_snapshot");
+        let result = sqlx::query(
+            r#"
+            UPDATE vm_runtime_snapshots
+            SET snapshot = $2, updated_at = NOW()
+            WHERE vm_id = $1
+            "#,
+        )
+        .bind(vm_id)
+        .bind(data)
+        .execute(&self.pool)
+        .timed(crate::query_timing_histogram!(
+            "update:vm_runtime_snapshots_snapshot"
+        ))
+        .await
+        .map_err(error::StoreSnapshotError::Sqlx)?;
+
+        if result.rows_affected() == 0 {
+            return Err(error::StoreSnapshotError::NotRegistered(*vm_id));
+        }
+
+        Ok(())
+    }
+}
+
+impl waymark_state_vm_runtimes_backend::LoadForRevive for PostgresBackend {
+    type Error = error::LoadForReviveError;
+
+    #[obs]
+    #[function_name::named]
+    async fn load_for_revive<'a>(
+        &'a self,
+        vm_id: &'a InstanceId,
+    ) -> Result<waymark_state_vm_runtimes_backend::RevivePayload<WorkflowVersionId>, Self::Error>
+    {
+        Self::count_query(&self.query_counts, "select:vm_runtime_snapshots_for_revive");
+        let row = sqlx::query(
+            r#"
+            SELECT snapshot, executable_id
+            FROM vm_runtime_snapshots
+            WHERE vm_id = $1
+            "#,
+        )
+        .bind(vm_id)
+        .fetch_optional(&self.pool)
+        .timed(crate::query_timing_histogram!(
+            "select:vm_runtime_snapshots_for_revive"
+        ))
+        .await
+        .map_err(error::LoadForReviveError::Sqlx)?
+        .ok_or(error::LoadForReviveError::NotFound(*vm_id))?;
+
+        let snapshot: Vec<u8> = row.get("snapshot");
+        let executable_id: WorkflowVersionId = row.get("executable_id");
+
+        Ok(waymark_state_vm_runtimes_backend::RevivePayload {
+            snapshot,
+            executable_id,
+        })
+    }
+}

--- a/crates/lib/backend-postgres/src/vm_runtimes/tests.rs
+++ b/crates/lib/backend-postgres/src/vm_runtimes/tests.rs
@@ -1,0 +1,83 @@
+use serial_test::serial;
+
+use super::super::test_helpers::setup_backend;
+use waymark_ids::{InstanceId, WorkflowVersionId};
+
+#[serial(postgres)]
+#[tokio::test]
+async fn store_and_load_snapshot_happy_path() {
+    let backend = setup_backend().await;
+    let vm_id = InstanceId::new_uuid_v4();
+    let executable_id = WorkflowVersionId::new_uuid_v4();
+    let initial_snapshot = b"initial-snapshot";
+    let updated_snapshot = b"updated-snapshot";
+
+    // Insert the initial snapshot and workload pinning rows directly
+    // for precise control over the test scenario.
+    sqlx::query(
+        "INSERT INTO vm_runtime_snapshots (vm_id, executable_id, snapshot) VALUES ($1, $2, $3)",
+    )
+    .bind(vm_id)
+    .bind(executable_id)
+    .bind(initial_snapshot)
+    .execute(backend.pool())
+    .await
+    .expect("insert vm runtime snapshot");
+
+    sqlx::query("INSERT INTO workload_pinnings (instance_id) VALUES ($1)")
+        .bind(vm_id)
+        .execute(backend.pool())
+        .await
+        .expect("insert workload pinning");
+
+    let payload =
+        waymark_state_vm_runtimes_backend::LoadForRevive::load_for_revive(&backend, &vm_id)
+            .await
+            .expect("load for revive");
+    assert_eq!(payload.snapshot, initial_snapshot);
+    assert_eq!(payload.executable_id, executable_id);
+
+    waymark_state_vm_runtimes_backend::StoreSnapshot::store_snapshot(
+        &backend,
+        &vm_id,
+        updated_snapshot,
+    )
+    .await
+    .expect("store snapshot");
+
+    let payload =
+        waymark_state_vm_runtimes_backend::LoadForRevive::load_for_revive(&backend, &vm_id)
+            .await
+            .expect("load for revive");
+    assert_eq!(payload.snapshot, updated_snapshot);
+    assert_eq!(payload.executable_id, executable_id);
+}
+
+#[serial(postgres)]
+#[tokio::test]
+async fn store_snapshot_before_register_returns_error() {
+    let backend = setup_backend().await;
+    let vm_id = InstanceId::new_uuid_v4();
+
+    let result =
+        waymark_state_vm_runtimes_backend::StoreSnapshot::store_snapshot(&backend, &vm_id, b"data")
+            .await;
+    assert!(matches!(
+        result,
+        Err(super::error::StoreSnapshotError::NotRegistered(_))
+    ));
+}
+
+#[serial(postgres)]
+#[tokio::test]
+async fn load_for_revive_unknown_vm_returns_error() {
+    let backend = setup_backend().await;
+    let vm_id = InstanceId::new_uuid_v4();
+
+    let result =
+        waymark_state_vm_runtimes_backend::LoadForRevive::load_for_revive(&backend, &vm_id).await;
+    assert!(matches!(
+        result,
+        Err(super::error::LoadForReviveError::NotFound(_))
+    ));
+}

--- a/crates/lib/backend-postgres/src/vm_runtimes/tests.rs
+++ b/crates/lib/backend-postgres/src/vm_runtimes/tests.rs
@@ -1,40 +1,20 @@
 use serial_test::serial;
 
-use super::super::test_helpers::setup_backend;
-use waymark_ids::{InstanceId, WorkflowVersionId};
+use super::super::test_helpers::{TEST_VM_SNAPSHOT, register_test_vm, setup_backend};
+use waymark_ids::InstanceId;
 
 #[serial(postgres)]
 #[tokio::test]
 async fn store_and_load_snapshot_happy_path() {
     let backend = setup_backend().await;
-    let vm_id = InstanceId::new_uuid_v4();
-    let executable_id = WorkflowVersionId::new_uuid_v4();
-    let initial_snapshot = b"initial-snapshot";
+    let (vm_id, executable_id) = register_test_vm(&backend).await;
     let updated_snapshot = b"updated-snapshot";
-
-    // Insert the initial snapshot and workload pinning rows directly
-    // for precise control over the test scenario.
-    sqlx::query(
-        "INSERT INTO vm_runtime_snapshots (vm_id, executable_id, snapshot) VALUES ($1, $2, $3)",
-    )
-    .bind(vm_id)
-    .bind(executable_id)
-    .bind(initial_snapshot)
-    .execute(backend.pool())
-    .await
-    .expect("insert vm runtime snapshot");
-
-    sqlx::query("INSERT INTO workload_pinnings (instance_id) VALUES ($1)")
-        .bind(vm_id)
-        .execute(backend.pool())
-        .await
-        .expect("insert workload pinning");
 
     let payload =
         waymark_state_vm_runtimes_backend::LoadForRevive::load_for_revive(&backend, &vm_id)
             .await
             .expect("load for revive");
-    assert_eq!(payload.snapshot, initial_snapshot);
+    assert_eq!(payload.snapshot, TEST_VM_SNAPSHOT);
     assert_eq!(payload.executable_id, executable_id);
 
     waymark_state_vm_runtimes_backend::StoreSnapshot::store_snapshot(

--- a/crates/lib/backend-postgres/src/workflow_service_vm_runtimes/error.rs
+++ b/crates/lib/backend-postgres/src/workflow_service_vm_runtimes/error.rs
@@ -1,0 +1,37 @@
+//! Error types for the workflow-service postgres backend.
+
+use waymark_ids::InstanceId;
+use waymark_workflow_service_vm_runtimes_backend::register_vm_runtime;
+
+/// Error returned by [`super::PostgresBackend`] when registering a VM runtime
+/// via the trait.
+#[derive(Debug, thiserror::Error)]
+pub enum RegisterVmRuntimeError {
+    /// The underlying database operation failed.
+    #[error("sqlx: {0}")]
+    Sqlx(#[source] sqlx::Error),
+
+    /// A runtime is already registered for this VM.
+    #[error("vm runtime already registered: {0}")]
+    AlreadyExists(InstanceId),
+}
+
+impl waymark_workflow_service_vm_runtimes_backend::register_vm_runtime::Error
+    for RegisterVmRuntimeError
+{
+    fn kind(&self) -> register_vm_runtime::ErrorKind {
+        match self {
+            Self::Sqlx(_) => register_vm_runtime::ErrorKind::Internal,
+            Self::AlreadyExists(_) => register_vm_runtime::ErrorKind::AlreadyRegistered,
+        }
+    }
+}
+
+/// Error returned by [`super::PostgresBackend`] when querying which VM
+/// runtimes are registered.
+#[derive(Debug, thiserror::Error)]
+pub enum FindExistingVmRuntimesError {
+    /// The underlying database operation failed.
+    #[error("sqlx: {0}")]
+    Sqlx(#[source] sqlx::Error),
+}

--- a/crates/lib/backend-postgres/src/workflow_service_vm_runtimes/mod.rs
+++ b/crates/lib/backend-postgres/src/workflow_service_vm_runtimes/mod.rs
@@ -1,0 +1,112 @@
+//! Postgres backend for the workflow service.
+//!
+//! Implements [`waymark_workflow_service_vm_runtimes_backend::RegisterVmRuntime`]
+//! and [`waymark_workflow_service_vm_runtimes_backend::FindExistingVmRuntimes`]
+//! for [`crate::PostgresBackend`].
+
+pub mod error;
+
+#[cfg(test)]
+mod tests;
+
+use nonempty_collections::NESlice;
+use sqlx::Row as _;
+use waymark_ids::{InstanceId, WorkflowVersionId};
+use waymark_observability::obs;
+use waymark_timed_future::TimedFutureExt as _;
+
+use crate::PostgresBackend;
+
+impl waymark_workflow_service_vm_runtimes_backend::HasVmId for PostgresBackend {
+    type VmId = InstanceId;
+}
+
+impl waymark_workflow_service_vm_runtimes_backend::HasExecutableId for PostgresBackend {
+    type ExecutableId = WorkflowVersionId;
+}
+
+impl waymark_workflow_service_vm_runtimes_backend::RegisterVmRuntime for PostgresBackend {
+    type Error = error::RegisterVmRuntimeError;
+
+    #[obs]
+    #[function_name::named]
+    async fn register_vm_runtime(
+        &self,
+        vm_id: &Self::VmId,
+        executable_id: &Self::ExecutableId,
+        snapshot: &[u8],
+    ) -> Result<(), Self::Error> {
+        Self::count_query(&self.query_counts, "insert:vm_runtime_snapshots_register");
+        let mut tx = self
+            .pool
+            .begin()
+            .await
+            .map_err(error::RegisterVmRuntimeError::Sqlx)?;
+
+        let result = sqlx::query(
+            r#"
+            INSERT INTO vm_runtime_snapshots (vm_id, executable_id, snapshot)
+            VALUES ($1, $2, $3)
+            ON CONFLICT (vm_id) DO NOTHING
+            "#,
+        )
+        .bind(vm_id)
+        .bind(executable_id)
+        .bind(snapshot)
+        .execute(&mut *tx)
+        .timed(crate::query_timing_histogram!(
+            "insert:vm_runtime_snapshots_register"
+        ))
+        .await
+        .map_err(error::RegisterVmRuntimeError::Sqlx)?;
+
+        if result.rows_affected() == 0 {
+            return Err(error::RegisterVmRuntimeError::AlreadyExists(*vm_id));
+        }
+
+        sqlx::query(
+            r#"
+            INSERT INTO workload_pinnings (instance_id)
+            VALUES ($1)
+            "#,
+        )
+        .bind(vm_id)
+        .execute(&mut *tx)
+        .await
+        .map_err(error::RegisterVmRuntimeError::Sqlx)?;
+
+        tx.commit()
+            .await
+            .map_err(error::RegisterVmRuntimeError::Sqlx)?;
+        Ok(())
+    }
+}
+
+impl waymark_workflow_service_vm_runtimes_backend::FindExistingVmRuntimes for PostgresBackend {
+    type Error = error::FindExistingVmRuntimesError;
+
+    #[obs]
+    #[function_name::named]
+    async fn find_existing_vm_runtimes<'a>(
+        &'a self,
+        vm_ids: NESlice<'a, Self::VmId>,
+    ) -> Result<Vec<Self::VmId>, Self::Error> {
+        Self::count_query(&self.query_counts, "select:vm_runtime_snapshots_existing");
+        let rows = sqlx::query(
+            r#"
+            SELECT vm_id
+            FROM vm_runtime_snapshots
+            WHERE vm_id = ANY($1)
+            "#,
+        )
+        .bind(vm_ids.as_ref())
+        .fetch_all(&self.pool)
+        .timed(crate::query_timing_histogram!(
+            "select:vm_runtime_snapshots_existing"
+        ))
+        .await
+        .map_err(error::FindExistingVmRuntimesError::Sqlx)?;
+
+        Ok(rows.iter().map(|row| row.get("vm_id")).collect())
+    }
+}

--- a/crates/lib/backend-postgres/src/workflow_service_vm_runtimes/tests.rs
+++ b/crates/lib/backend-postgres/src/workflow_service_vm_runtimes/tests.rs
@@ -1,0 +1,65 @@
+use nonempty_collections::NESlice;
+use serial_test::serial;
+
+use super::super::test_helpers::setup_backend;
+use waymark_ids::{InstanceId, WorkflowVersionId};
+use waymark_workflow_service_vm_runtimes_backend::{FindExistingVmRuntimes, RegisterVmRuntime};
+
+#[serial(postgres)]
+#[tokio::test]
+async fn register_duplicate_vm_returns_error() {
+    let backend = setup_backend().await;
+    let vm_id = InstanceId::new_uuid_v4();
+    let executable_id = WorkflowVersionId::new_uuid_v4();
+
+    backend
+        .register_vm_runtime(&vm_id, &executable_id, b"first")
+        .await
+        .expect("first register");
+
+    let result =
+        RegisterVmRuntime::register_vm_runtime(&backend, &vm_id, &executable_id, b"second").await;
+    assert!(matches!(
+        result,
+        Err(super::error::RegisterVmRuntimeError::AlreadyExists(_))
+    ));
+}
+
+#[serial(postgres)]
+#[tokio::test]
+async fn find_existing_vm_runtimes_returns_only_registered() {
+    let backend = setup_backend().await;
+    let executable_id = WorkflowVersionId::new_uuid_v4();
+
+    let registered = InstanceId::new_uuid_v4();
+    let unregistered = InstanceId::new_uuid_v4();
+
+    backend
+        .register_vm_runtime(&registered, &executable_id, b"snapshot")
+        .await
+        .expect("register");
+
+    let existing = backend
+        .find_existing_vm_runtimes(
+            NESlice::try_from_slice(&[registered, unregistered]).expect("non-empty"),
+        )
+        .await
+        .expect("find existing");
+
+    assert_eq!(existing, vec![registered]);
+}
+
+#[serial(postgres)]
+#[tokio::test]
+async fn find_existing_vm_runtimes_empty_when_none_registered() {
+    let backend = setup_backend().await;
+
+    let existing = backend
+        .find_existing_vm_runtimes(
+            NESlice::try_from_slice(&[InstanceId::new_uuid_v4()]).expect("non-empty"),
+        )
+        .await
+        .expect("find existing");
+
+    assert!(existing.is_empty());
+}

--- a/crates/lib/backend-postgres/src/workload_pinning/error.rs
+++ b/crates/lib/backend-postgres/src/workload_pinning/error.rs
@@ -1,0 +1,25 @@
+//! Error types for the workload-pinning postgres backend.
+
+/// Error returned by [`super::PostgresBackend`] when polling for unpinned instances.
+#[derive(Debug, thiserror::Error)]
+pub enum PollError {
+    /// The underlying database operation failed.
+    #[error("sqlx: {0}")]
+    Sqlx(#[source] sqlx::Error),
+}
+
+/// Error returned by [`super::PostgresBackend`] when refreshing pinnings.
+#[derive(Debug, thiserror::Error)]
+pub enum RefreshError {
+    /// The underlying database operation failed.
+    #[error("sqlx: {0}")]
+    Sqlx(#[source] sqlx::Error),
+}
+
+/// Error returned by [`super::PostgresBackend`] when releasing pinnings.
+#[derive(Debug, thiserror::Error)]
+pub enum ReleaseError {
+    /// The underlying database operation failed.
+    #[error("sqlx: {0}")]
+    Sqlx(#[source] sqlx::Error),
+}

--- a/crates/lib/backend-postgres/src/workload_pinning/mod.rs
+++ b/crates/lib/backend-postgres/src/workload_pinning/mod.rs
@@ -1,0 +1,187 @@
+//! Postgres backend for workload pinning.
+//!
+//! Implements [`waymark_workload_pinning_backend::Backend`] so that the
+//! workload pinning manager can claim, refresh, and release instance
+//! pinnings via Postgres.
+
+pub mod error;
+
+#[cfg(test)]
+mod tests;
+
+use std::num::NonZeroUsize;
+
+use chrono::{DateTime, Utc};
+use nonempty_collections::{
+    IntoIteratorExt as _, IntoNonEmptyIterator as _, NEVec, NonEmptyIterator as _,
+};
+use sqlx::Row;
+use waymark_ids::InstanceId;
+use waymark_observability::obs;
+use waymark_timed_future::TimedFutureExt as _;
+use waymark_workload_pinning_backend::{Pinning, PinningStatus};
+
+use crate::PostgresBackend;
+
+impl waymark_workload_pinning_backend::HasTimestamp for PostgresBackend {
+    type Timestamp = DateTime<Utc>;
+}
+
+impl waymark_workload_pinning_backend::HasNodeId for PostgresBackend {
+    type NodeId = uuid::Uuid;
+}
+
+impl waymark_workload_pinning_backend::HasInstanceId for PostgresBackend {
+    type InstanceId = InstanceId;
+}
+
+impl waymark_workload_pinning_backend::PollUnpinnedInstances for PostgresBackend {
+    type Error = error::PollError;
+
+    #[obs]
+    #[function_name::named]
+    async fn poll_unlocked(
+        &self,
+        now: Self::Timestamp,
+        pinning: Pinning<Self::NodeId, Self::Timestamp>,
+        max_items: NonZeroUsize,
+    ) -> Result<Option<NEVec<Self::InstanceId>>, Self::Error> {
+        Self::count_query(&self.query_counts, "update:workload_pinnings_poll");
+        let rows = sqlx::query(
+            r#"
+            UPDATE workload_pinnings
+            SET node_id = $3, expires_at = $4, updated_at = NOW()
+            WHERE instance_id IN (
+                SELECT instance_id
+                FROM workload_pinnings
+                WHERE node_id IS NULL OR expires_at <= $1
+                ORDER BY updated_at
+                LIMIT $2
+                FOR UPDATE SKIP LOCKED
+            )
+            RETURNING instance_id
+            "#,
+        )
+        .bind(now)
+        .bind(max_items.get() as i64)
+        .bind(pinning.node_id)
+        .bind(pinning.expires_at)
+        .fetch_all(&self.pool)
+        .timed(crate::query_timing_histogram!(
+            "update:workload_pinnings_poll"
+        ))
+        .await
+        .map_err(error::PollError::Sqlx)?;
+
+        let Some(rows) = rows.try_into_nonempty_iter() else {
+            return Ok(None);
+        };
+
+        Ok(Some(rows.map(|row| row.get("instance_id")).collect()))
+    }
+}
+
+impl waymark_workload_pinning_backend::KeepaliveInstancePinnings for PostgresBackend {
+    type Error = error::RefreshError;
+
+    #[obs]
+    #[function_name::named]
+    fn refresh_pinnings<'a>(
+        &'a self,
+        // TODO: the trait should be updated to drop this param
+        _now: Self::Timestamp,
+        pinning: Pinning<Self::NodeId, Self::Timestamp>,
+        instance_ids: impl nonempty_collections::IntoNonEmptyIterator<Item = Self::InstanceId> + 'a,
+    ) -> impl Future<
+        Output = Result<
+            NEVec<PinningStatus<Self::InstanceId, Pinning<Self::NodeId, Self::Timestamp>>>,
+            Self::Error,
+        >,
+    > + Send
+    + 'a {
+        let ids: NEVec<InstanceId> = instance_ids.into_nonempty_iter().collect();
+        async move {
+            Self::count_query(&self.query_counts, "update:workload_pinnings_refresh");
+            // Re-fence every row still owned by this node, even if it has
+            // already lapsed past `expires_at`. Ownership (`node_id`) is the
+            // source of truth: a steal by another node rewrites `node_id` and a
+            // release nulls it, so either makes this UPDATE match zero rows and
+            // report the pinning as lost. Row-level locking serializes a
+            // concurrent poll-steal against this refresh, so whichever commits
+            // first wins deterministically. Guarding on `expires_at > now` here
+            // would instead drop a still-owned pinning that nobody contested
+            // just because a heartbeat landed late.
+            let rows = sqlx::query(
+                r#"
+                UPDATE workload_pinnings
+                SET expires_at = $3, updated_at = NOW()
+                WHERE node_id = $1 AND instance_id = ANY($2)
+                RETURNING instance_id
+                "#,
+            )
+            .bind(pinning.node_id)
+            .bind(ids.as_ref())
+            .bind(pinning.expires_at)
+            .fetch_all(&self.pool)
+            .timed(crate::query_timing_histogram!(
+                "update:workload_pinnings_refresh"
+            ))
+            .await
+            .map_err(error::RefreshError::Sqlx)?;
+
+            let refreshed: std::collections::HashSet<InstanceId> =
+                rows.iter().map(|row| row.get("instance_id")).collect();
+
+            let statuses = ids
+                .into_nonempty_iter()
+                .map(|id| PinningStatus {
+                    instance_id: id,
+                    pinning: if refreshed.contains(&id) {
+                        Some(Pinning {
+                            node_id: pinning.node_id,
+                            expires_at: pinning.expires_at,
+                        })
+                    } else {
+                        None
+                    },
+                })
+                .collect();
+
+            Ok(statuses)
+        }
+    }
+}
+
+impl waymark_workload_pinning_backend::ReleasePinnings for PostgresBackend {
+    type Error = error::ReleaseError;
+
+    #[obs]
+    #[function_name::named]
+    fn release_pinnings<'a>(
+        &'a self,
+        node_id: Self::NodeId,
+        instance_ids: impl nonempty_collections::IntoNonEmptyIterator<Item = Self::InstanceId> + 'a,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send + 'a {
+        let ids: Vec<InstanceId> = instance_ids.into_iter().collect();
+        async move {
+            Self::count_query(&self.query_counts, "update:workload_pinnings_release");
+            sqlx::query(
+                r#"
+                UPDATE workload_pinnings
+                SET node_id = NULL, expires_at = NULL, updated_at = NOW()
+                WHERE node_id = $1 AND instance_id = ANY($2)
+                "#,
+            )
+            .bind(node_id)
+            .bind(&ids)
+            .execute(&self.pool)
+            .timed(crate::query_timing_histogram!(
+                "update:workload_pinnings_release"
+            ))
+            .await
+            .map_err(error::ReleaseError::Sqlx)?;
+
+            Ok(())
+        }
+    }
+}

--- a/crates/lib/backend-postgres/src/workload_pinning/tests.rs
+++ b/crates/lib/backend-postgres/src/workload_pinning/tests.rs
@@ -1,0 +1,382 @@
+use std::num::NonZeroUsize;
+
+use chrono::Duration;
+use serial_test::serial;
+use uuid::Uuid;
+use waymark_ids::{InstanceId, WorkflowVersionId};
+
+use super::super::test_helpers::setup_backend;
+
+fn test_now() -> chrono::DateTime<chrono::Utc> {
+    chrono::Utc::now()
+}
+
+fn test_pinning(
+    node_id: Uuid,
+) -> waymark_workload_pinning_backend::Pinning<Uuid, chrono::DateTime<chrono::Utc>> {
+    waymark_workload_pinning_backend::Pinning {
+        node_id,
+        expires_at: test_now() + Duration::seconds(30),
+    }
+}
+
+fn test_max_items() -> NonZeroUsize {
+    NonZeroUsize::new(10).expect("10 > 0")
+}
+
+async fn register_test_vm(backend: &super::PostgresBackend) -> (InstanceId, WorkflowVersionId) {
+    let vm_id = InstanceId::new_uuid_v4();
+    let executable_id = WorkflowVersionId::new_uuid_v4();
+
+    sqlx::query(
+        "INSERT INTO vm_runtime_snapshots (vm_id, executable_id, snapshot) VALUES ($1, $2, $3)",
+    )
+    .bind(vm_id)
+    .bind(executable_id)
+    .bind(b"test-snapshot")
+    .execute(backend.pool())
+    .await
+    .expect("insert vm runtime snapshot");
+
+    sqlx::query("INSERT INTO workload_pinnings (instance_id) VALUES ($1)")
+        .bind(vm_id)
+        .execute(backend.pool())
+        .await
+        .expect("insert workload pinning");
+
+    (vm_id, executable_id)
+}
+
+#[serial(postgres)]
+#[tokio::test]
+async fn poll_claims_newly_registered_vm() {
+    let backend = setup_backend().await;
+    let (vm_id, _executable_id) = register_test_vm(&backend).await;
+
+    let result = waymark_workload_pinning_backend::PollUnpinnedInstances::poll_unlocked(
+        &backend,
+        test_now(),
+        test_pinning(Uuid::new_v4()),
+        test_max_items(),
+    )
+    .await
+    .expect("poll unlocked")
+    .expect("instances available");
+
+    let ids: Vec<InstanceId> = result.into_iter().collect();
+    assert_eq!(ids, vec![vm_id]);
+}
+
+#[serial(postgres)]
+#[tokio::test]
+async fn poll_skips_already_pinned_vm() {
+    let backend = setup_backend().await;
+    let (_vm_id, _executable_id) = register_test_vm(&backend).await;
+
+    // First poll claims the VM.
+    let result = waymark_workload_pinning_backend::PollUnpinnedInstances::poll_unlocked(
+        &backend,
+        test_now(),
+        test_pinning(Uuid::new_v4()),
+        test_max_items(),
+    )
+    .await
+    .expect("first poll")
+    .expect("instances available");
+    assert_eq!(result.len().get(), 1);
+
+    // Second poll should find nothing.
+    let result = waymark_workload_pinning_backend::PollUnpinnedInstances::poll_unlocked(
+        &backend,
+        test_now(),
+        test_pinning(Uuid::new_v4()),
+        test_max_items(),
+    )
+    .await;
+    assert!(matches!(result, Ok(None)));
+}
+
+#[serial(postgres)]
+#[tokio::test]
+async fn poll_picks_up_expired_pinning() {
+    let backend = setup_backend().await;
+    let node_id = Uuid::new_v4();
+    let (vm_id, _executable_id) = register_test_vm(&backend).await;
+
+    // Claim with a short expiry.
+    let short_pinning = waymark_workload_pinning_backend::Pinning {
+        node_id,
+        expires_at: test_now() - Duration::seconds(1),
+    };
+    waymark_workload_pinning_backend::PollUnpinnedInstances::poll_unlocked(
+        &backend,
+        test_now(),
+        short_pinning,
+        test_max_items(),
+    )
+    .await
+    .expect("claim with short expiry")
+    .expect("instances available");
+
+    // Now poll — the expired pinning should be picked up.
+    let result = waymark_workload_pinning_backend::PollUnpinnedInstances::poll_unlocked(
+        &backend,
+        test_now(),
+        test_pinning(node_id),
+        test_max_items(),
+    )
+    .await
+    .expect("poll after expiry")
+    .expect("instances available");
+    let ids: Vec<InstanceId> = result.into_iter().collect();
+    assert_eq!(ids, vec![vm_id]);
+}
+
+#[serial(postgres)]
+#[tokio::test]
+async fn refresh_updates_expiry() {
+    let backend = setup_backend().await;
+    let node_id = Uuid::new_v4();
+    let (vm_id, _executable_id) = register_test_vm(&backend).await;
+
+    // Claim the VM.
+    let original_pinning = waymark_workload_pinning_backend::Pinning {
+        node_id,
+        expires_at: test_now() + Duration::seconds(10),
+    };
+    waymark_workload_pinning_backend::PollUnpinnedInstances::poll_unlocked(
+        &backend,
+        test_now(),
+        original_pinning,
+        test_max_items(),
+    )
+    .await
+    .expect("claim vm")
+    .expect("instances available");
+
+    // Refresh with a later expiry.
+    let new_pinning = waymark_workload_pinning_backend::Pinning {
+        node_id,
+        expires_at: test_now() + Duration::seconds(60),
+    };
+    let statuses = waymark_workload_pinning_backend::KeepaliveInstancePinnings::refresh_pinnings(
+        &backend,
+        test_now(),
+        new_pinning,
+        nonempty_collections::NEVec::new(vm_id),
+    )
+    .await
+    .expect("refresh pinnings");
+
+    assert_eq!(statuses.len().get(), 1);
+    assert!(statuses.first().pinning.is_some());
+}
+
+#[serial(postgres)]
+#[tokio::test]
+async fn refresh_re_fences_expired_but_still_owned_pinning() {
+    let backend = setup_backend().await;
+    let node_id = Uuid::new_v4();
+    let (vm_id, _executable_id) = register_test_vm(&backend).await;
+
+    // Claim the VM with an already-lapsed expiry, but let nobody steal it —
+    // the pinning is expired yet still owned by this node.
+    let expired_pinning = waymark_workload_pinning_backend::Pinning {
+        node_id,
+        expires_at: test_now() - Duration::seconds(1),
+    };
+    waymark_workload_pinning_backend::PollUnpinnedInstances::poll_unlocked(
+        &backend,
+        test_now(),
+        expired_pinning,
+        test_max_items(),
+    )
+    .await
+    .expect("claim vm")
+    .expect("instances available");
+
+    // A late heartbeat must still be able to re-fence it, since ownership was
+    // never contested.
+    let renewed_pinning = waymark_workload_pinning_backend::Pinning {
+        node_id,
+        expires_at: test_now() + Duration::seconds(60),
+    };
+    let statuses = waymark_workload_pinning_backend::KeepaliveInstancePinnings::refresh_pinnings(
+        &backend,
+        test_now(),
+        renewed_pinning,
+        nonempty_collections::NEVec::new(vm_id),
+    )
+    .await
+    .expect("refresh pinnings");
+    assert!(statuses.first().pinning.is_some());
+
+    // Re-fenced with the future expiry, so a subsequent poll can no longer
+    // claim it.
+    let poll = waymark_workload_pinning_backend::PollUnpinnedInstances::poll_unlocked(
+        &backend,
+        test_now(),
+        test_pinning(Uuid::new_v4()),
+        test_max_items(),
+    )
+    .await;
+    assert!(matches!(poll, Ok(None)));
+}
+
+#[serial(postgres)]
+#[tokio::test]
+async fn refresh_returns_none_for_lost_pinning() {
+    let backend = setup_backend().await;
+    let node_a = Uuid::new_v4();
+    let node_b = Uuid::new_v4();
+    let (vm_id, _executable_id) = register_test_vm(&backend).await;
+
+    // Node A claims the VM with a short expiry.
+    let short_pinning = waymark_workload_pinning_backend::Pinning {
+        node_id: node_a,
+        expires_at: test_now() - Duration::seconds(1),
+    };
+    waymark_workload_pinning_backend::PollUnpinnedInstances::poll_unlocked(
+        &backend,
+        test_now(),
+        short_pinning,
+        test_max_items(),
+    )
+    .await
+    .expect("node a claim")
+    .expect("instances available");
+
+    // Node B steals it.
+    waymark_workload_pinning_backend::PollUnpinnedInstances::poll_unlocked(
+        &backend,
+        test_now(),
+        test_pinning(node_b),
+        test_max_items(),
+    )
+    .await
+    .expect("node b claim")
+    .expect("instances available");
+
+    // Node A tries to refresh — should get None.
+    let statuses = waymark_workload_pinning_backend::KeepaliveInstancePinnings::refresh_pinnings(
+        &backend,
+        test_now(),
+        test_pinning(node_a),
+        nonempty_collections::NEVec::new(vm_id),
+    )
+    .await
+    .expect("refresh pinnings");
+    assert!(statuses.first().pinning.is_none());
+}
+
+#[serial(postgres)]
+#[tokio::test]
+async fn refresh_returns_mixed_statuses_for_refreshed_and_lost() {
+    let backend = setup_backend().await;
+    let node_id = Uuid::new_v4();
+    let (vm_a, _executable_a) = register_test_vm(&backend).await;
+    let (vm_b, _executable_b) = register_test_vm(&backend).await;
+
+    // Claim both VMs.
+    waymark_workload_pinning_backend::PollUnpinnedInstances::poll_unlocked(
+        &backend,
+        test_now(),
+        test_pinning(node_id),
+        NonZeroUsize::new(5).unwrap(),
+    )
+    .await
+    .expect("claim both vms")
+    .expect("instances available");
+
+    // Release vm_b so it loses its pinning.
+    waymark_workload_pinning_backend::ReleasePinnings::release_pinnings(
+        &backend,
+        node_id,
+        nonempty_collections::NEVec::new(vm_b),
+    )
+    .await
+    .expect("release vm_b");
+
+    // Refresh both — vm_a should stay pinned, vm_b should be None.
+    let mut ids = nonempty_collections::NEVec::new(vm_a);
+    ids.push(vm_b);
+    let statuses = waymark_workload_pinning_backend::KeepaliveInstancePinnings::refresh_pinnings(
+        &backend,
+        test_now(),
+        test_pinning(node_id),
+        ids,
+    )
+    .await
+    .expect("refresh pinnings");
+
+    assert_eq!(statuses.len().get(), 2);
+    let by_id: std::collections::HashMap<_, _> = statuses
+        .into_iter()
+        .map(|s| (s.instance_id, s.pinning))
+        .collect();
+    assert!(by_id[&vm_a].is_some());
+    assert!(by_id[&vm_b].is_none());
+}
+
+#[serial(postgres)]
+#[tokio::test]
+async fn release_clears_pinning() {
+    let backend = setup_backend().await;
+    let node_id = Uuid::new_v4();
+    let (vm_id, _executable_id) = register_test_vm(&backend).await;
+
+    // Claim the VM.
+    waymark_workload_pinning_backend::PollUnpinnedInstances::poll_unlocked(
+        &backend,
+        test_now(),
+        test_pinning(node_id),
+        test_max_items(),
+    )
+    .await
+    .expect("claim vm")
+    .expect("instances available");
+
+    // Release it.
+    waymark_workload_pinning_backend::ReleasePinnings::release_pinnings(
+        &backend,
+        node_id,
+        nonempty_collections::NEVec::new(vm_id),
+    )
+    .await
+    .expect("release pinning");
+
+    // Poll again — should pick it up since it's released.
+    let result = waymark_workload_pinning_backend::PollUnpinnedInstances::poll_unlocked(
+        &backend,
+        test_now(),
+        test_pinning(node_id),
+        test_max_items(),
+    )
+    .await
+    .expect("poll after release")
+    .expect("instances available");
+    let ids: Vec<InstanceId> = result.into_iter().collect();
+    assert_eq!(ids, vec![vm_id]);
+}
+
+#[serial(postgres)]
+#[tokio::test]
+async fn deregister_removes_vm_from_poll() {
+    let backend = setup_backend().await;
+    let (vm_id, _executable_id) = register_test_vm(&backend).await;
+
+    sqlx::query("DELETE FROM vm_runtime_snapshots WHERE vm_id = $1")
+        .bind(vm_id)
+        .execute(backend.pool())
+        .await
+        .expect("delete vm runtime snapshot");
+
+    let result = waymark_workload_pinning_backend::PollUnpinnedInstances::poll_unlocked(
+        &backend,
+        test_now(),
+        test_pinning(Uuid::new_v4()),
+        test_max_items(),
+    )
+    .await;
+    assert!(matches!(result, Ok(None)));
+}

--- a/crates/lib/backend-postgres/src/workload_pinning/tests.rs
+++ b/crates/lib/backend-postgres/src/workload_pinning/tests.rs
@@ -3,9 +3,9 @@ use std::num::NonZeroUsize;
 use chrono::Duration;
 use serial_test::serial;
 use uuid::Uuid;
-use waymark_ids::{InstanceId, WorkflowVersionId};
+use waymark_ids::InstanceId;
 
-use super::super::test_helpers::setup_backend;
+use super::super::test_helpers::{register_test_vm, setup_backend};
 
 fn test_now() -> chrono::DateTime<chrono::Utc> {
     chrono::Utc::now()
@@ -22,29 +22,6 @@ fn test_pinning(
 
 fn test_max_items() -> NonZeroUsize {
     NonZeroUsize::new(10).expect("10 > 0")
-}
-
-async fn register_test_vm(backend: &super::PostgresBackend) -> (InstanceId, WorkflowVersionId) {
-    let vm_id = InstanceId::new_uuid_v4();
-    let executable_id = WorkflowVersionId::new_uuid_v4();
-
-    sqlx::query(
-        "INSERT INTO vm_runtime_snapshots (vm_id, executable_id, snapshot) VALUES ($1, $2, $3)",
-    )
-    .bind(vm_id)
-    .bind(executable_id)
-    .bind(b"test-snapshot")
-    .execute(backend.pool())
-    .await
-    .expect("insert vm runtime snapshot");
-
-    sqlx::query("INSERT INTO workload_pinnings (instance_id) VALUES ($1)")
-        .bind(vm_id)
-        .execute(backend.pool())
-        .await
-        .expect("insert workload pinning");
-
-    (vm_id, executable_id)
 }
 
 #[serial(postgres)]


### PR DESCRIPTION
Goes in after #447.

---

This PR implements a full backend for workload pinnings and vm runtimes - both for submitting the initial workload into the pipeline, and for "revival" of the vm after it has been evicted.

---

As with the overall architecture, the database model in denormalized a bit to provide a better layout for our operations. Polling happens only on the workload pinnings, and they don't have any heavy columns - like the snapshot blobs.