### PR TITLE
Add execution-driver crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4624,6 +4624,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "waymark-execution-driver"
+version = "0.1.0"
+dependencies = [
+ "nonempty-collections",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "waymark-state-manager",
+ "waymark-state-manager-core",
+ "waymark-state-vm-runtimes",
+ "waymark-workload-pinning-manager",
+]
+
+[[package]]
 name = "waymark-extcall-reconciler"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ waymark-smoke-sources = { path = "crates/lib/smoke-sources" }
 waymark-state-manager = { path = "crates/lib/state-manager" }
 waymark-state-manager-core = { path = "crates/lib/state-manager-core" }
 waymark-state-vm-executables-backend = { path = "crates/lib/state-vm-executables-backend" }
+waymark-state-vm-runtimes = { path = "crates/lib/state-vm-runtimes" }
 waymark-state-vm-runtimes-backend = { path = "crates/lib/state-vm-runtimes-backend" }
 waymark-state-vm-runtimes-core = { path = "crates/lib/state-vm-runtimes-core" }
 waymark-support-integration = { path = "crates/lib/support-integration" }
@@ -142,6 +143,7 @@ waymark-worker-status-reporter = { path = "crates/lib/worker-status-reporter" }
 waymark-workflow-registry-backend = { path = "crates/lib/workflow-registry-backend" }
 waymark-workflow-service-vm-runtimes-backend = { path = "crates/lib/workflow-service-vm-runtimes-backend" }
 waymark-workload-pinning-backend = { path = "crates/lib/workload-pinning-backend" }
+waymark-workload-pinning-manager = { path = "crates/lib/workload-pinning-manager" }
 
 anyhow = "1"
 async-stream = "0.3"

--- a/crates/lib/execution-driver/Cargo.toml
+++ b/crates/lib/execution-driver/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "waymark-execution-driver"
+edition = "2024"
+version.workspace = true
+publish.workspace = true
+
+[dependencies]
+waymark-state-manager = { workspace = true }
+waymark-state-manager-core = { workspace = true }
+waymark-state-vm-runtimes = { workspace = true }
+waymark-workload-pinning-manager = { workspace = true }
+
+nonempty-collections = { workspace = true }
+tokio = { workspace = true, features = ["sync", "macros", "rt"] }
+tokio-util = { workspace = true }
+tracing = { workspace = true }
+
+[lib]
+doctest = false

--- a/crates/lib/execution-driver/src/lib.rs
+++ b/crates/lib/execution-driver/src/lib.rs
@@ -1,0 +1,115 @@
+//! Execution driver — bridges the workload-pinning manager and the
+//! state-vm-runtimes systems.
+//!
+//! [`run`] subscribes to batches of
+//! [`waymark_workload_pinning_manager::PinnedHandle`]s dispatched by the
+//! workload pinning manager's poll loop, revives (or retrieves) each VM
+//! via [`waymark_state_manager::State`], and unpins them when the VM
+//! driver exits or on global shutdown.
+
+#![warn(missing_docs)]
+
+use std::hash::Hash;
+use std::sync::Arc;
+
+use nonempty_collections::NEVec;
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+use tracing::Instrument as _;
+
+/// Run the execution driver loop — receives batches of pinned handles from
+/// the workload pinning manager, activates each VM, and keeps them alive
+/// while the spawned runtime drives to completion.
+///
+/// Returns when the [`CancellationToken`] fires or the pinning channel closes.
+#[tracing::instrument(skip_all)]
+pub async fn run<Factory>(
+    mut pinned_rx: mpsc::Receiver<
+        NEVec<waymark_workload_pinning_manager::PinnedHandle<Factory::Key>>,
+    >,
+    state: Arc<
+        waymark_state_manager::State<
+            Factory::Key,
+            Arc<waymark_state_vm_runtimes::Spawned>,
+            Factory,
+        >,
+    >,
+    shutdown_token: CancellationToken,
+) where
+    Factory: waymark_state_manager_core::Factory<Value = Arc<waymark_state_vm_runtimes::Spawned>>
+        + Send
+        + Sync
+        + 'static,
+    Factory::Key: Eq + Hash + Clone + std::fmt::Debug + Send + Sync + 'static,
+    Factory::Error: std::fmt::Debug,
+{
+    let shutdown = shutdown_token.clone().cancelled_owned();
+    let mut shutdown = std::pin::pin!(shutdown);
+
+    loop {
+        let batch = tokio::select! {
+            _ = &mut shutdown => {
+                tracing::info!("execution driver shutting down");
+                break;
+            }
+            Some(batch) = pinned_rx.recv() => batch,
+            else => {
+                tracing::info!("pinned channel closed");
+                break;
+            }
+        };
+
+        for pinned in batch {
+            let state = Arc::clone(&state);
+            let shutdown = shutdown_token.child_token();
+            tokio::spawn(drive_one(pinned, state, shutdown).in_current_span());
+        }
+    }
+}
+
+/// Revive a pinned VM from its snapshot, then hold both handles alive until
+/// the VM driver exits or global shutdown fires. Dropping the handles on
+/// return releases the pinning and decrements the state-manager refcount.
+#[tracing::instrument(skip_all, fields(instance_id = ?pinned.id()))]
+async fn drive_one<Factory>(
+    pinned: waymark_workload_pinning_manager::PinnedHandle<Factory::Key>,
+    state: Arc<
+        waymark_state_manager::State<
+            Factory::Key,
+            Arc<waymark_state_vm_runtimes::Spawned>,
+            Factory,
+        >,
+    >,
+    shutdown: CancellationToken,
+) where
+    Factory: waymark_state_manager_core::Factory<Value = Arc<waymark_state_vm_runtimes::Spawned>>
+        + Send
+        + Sync
+        + 'static,
+    Factory::Key: Eq + Hash + Clone + std::fmt::Debug + Send + Sync + 'static,
+    Factory::Error: std::fmt::Debug,
+{
+    let vm = match state.get(pinned.id().clone()).await {
+        Ok(vm) => vm,
+        Err(error) => {
+            tracing::error!(?error, "failed to revive VM");
+            return;
+        }
+    };
+
+    tracing::debug!("VM running");
+
+    tokio::select! {
+        _ = vm.evicted() => {
+            tracing::debug!("VM evicted, unpinning");
+        }
+        _ = shutdown.cancelled() => {
+            tracing::debug!("shutting down: evicting VM and unpinning");
+            vm.trigger_eviction();
+            vm.evicted().await;
+        }
+    }
+
+    // `vm` drops before `pinned` on scope exit; the pin is held until the VM
+    // driver has fully exited.
+}


### PR DESCRIPTION
Goes in after #448.

---

This PR holds the actual "runloop" of the new implementation; it is super simpler, since all the complexity is abstracted under the hood; yet, nonetheless, it is important to do right.

The current logic is simple: when we receive a new workload pinning we get a VM for it and start driving it. Once the VM is evicted - this can only happen when the VM errors out, possible because there's no more work to do - the workload pinning is released. The shutdown triggers eviction first, and then waits for the eviction and only then releases the workload pinning.

---

There is some more work to be done here: the scheduling; as in, some vms are schedulable (ready to progress) and some are not (waiting for promise resolutions); the unschedulable ones can be pinned, but will be evicted - so we *shouldn't* pin them; so there should be another layer of logic somewhere that would handle the scheduling; possibly in the extcall reconciler. Overall the logic is simple: when we have no work for a vm, we mark it as unschedulable; when we have some promise that can be resolved in a vm - we mark it schedulable again. Simplest way is to remove or re-add an entry at the workload pinnings.