### PR TITLE
Add system-vm crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5339,6 +5339,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "waymark-system-vm"
+version = "0.1.0"
+dependencies = [
+ "static_assertions",
+ "waymark-action-core",
+ "waymark-vm-ast-old",
+ "waymark-vm-bytecode",
+ "waymark-vm-bytecode-core",
+ "waymark-vm-compiler-for-ast-old-action-ref",
+ "waymark-vm-compiler-for-ast-old-const-value",
+ "waymark-vm-compiler-for-ast-old-core",
+ "waymark-vm-instructions-coreset",
+ "waymark-vm-instructions-extcallset",
+ "waymark-vm-instructions-fullset",
+ "waymark-vm-instructions-pureset",
+ "waymark-vm-interpreter-fullset",
+ "waymark-vm-runtime",
+ "waymark-vm-runtime-core",
+ "waymark-vm-value",
+]
+
+[[package]]
 name = "waymark-tick-loop"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,7 @@ waymark-vm-bytecode-fmt = { path = "crates/lib/vm-bytecode-fmt" }
 waymark-vm-codec-core = { path = "crates/lib/vm-codec-core" }
 waymark-vm-codec-rmp = { path = "crates/lib/vm-codec-rmp" }
 waymark-vm-compiler-for-ast-old = { path = "crates/lib/vm-compiler-for-ast-old" }
+waymark-vm-compiler-for-ast-old-action-ref = { path = "crates/lib/vm-compiler-for-ast-old-action-ref" }
 waymark-vm-compiler-for-ast-old-const-value = { path = "crates/lib/vm-compiler-for-ast-old-const-value" }
 waymark-vm-compiler-for-ast-old-core = { path = "crates/lib/vm-compiler-for-ast-old-core" }
 waymark-vm-compiler-for-ast-old-test-support = { path = "crates/lib/vm-compiler-for-ast-old-test-support" }

--- a/crates/lib/system-vm/Cargo.toml
+++ b/crates/lib/system-vm/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "waymark-system-vm"
+edition = "2024"
+version.workspace = true
+publish.workspace = true
+
+[features]
+serde = [
+  "waymark-action-core/serde",
+  "waymark-vm-bytecode/serde",
+  "waymark-vm-bytecode-core/serde",
+  "waymark-vm-compiler-for-ast-old-const-value/serde",
+  "waymark-vm-instructions-fullset/serde",
+  "waymark-vm-runtime-core/serde",
+  "waymark-vm-value/serde",
+]
+
+[dependencies]
+waymark-action-core = { workspace = true }
+waymark-vm-ast-old = { workspace = true }
+waymark-vm-bytecode = { workspace = true }
+waymark-vm-bytecode-core = { workspace = true }
+waymark-vm-compiler-for-ast-old-action-ref = { workspace = true }
+waymark-vm-compiler-for-ast-old-const-value = { workspace = true }
+waymark-vm-compiler-for-ast-old-core = { workspace = true }
+waymark-vm-instructions-coreset = { workspace = true }
+waymark-vm-instructions-extcallset = { workspace = true }
+waymark-vm-instructions-fullset = { workspace = true }
+waymark-vm-instructions-pureset = { workspace = true }
+waymark-vm-interpreter-fullset = { workspace = true }
+waymark-vm-runtime = { workspace = true }
+waymark-vm-runtime-core = { workspace = true }
+waymark-vm-value = { workspace = true }
+
+[dev-dependencies]
+static_assertions = { workspace = true }

--- a/crates/lib/system-vm/src/lib.rs
+++ b/crates/lib/system-vm/src/lib.rs
@@ -1,0 +1,69 @@
+//! A crate that assembles various waymark VM types and traits into
+//! a single and coherent system of interconntected types.
+
+use std::sync::Arc;
+
+pub use waymark_vm_compiler_for_ast_old_const_value::ConstValue;
+pub use waymark_vm_value::{ReadyValue, Value};
+
+#[cfg(test)]
+static_assertions::assert_impl_all!(Value: waymark_vm_interpreter_fullset::Value);
+
+pub type InstructionSet = waymark_vm_instructions_fullset::FullSet<Spec>;
+
+pub type Executable = waymark_vm_bytecode::Executable<InstructionSet>;
+
+pub type Interpreter =
+    waymark_vm_interpreter_fullset::FullSetInterpreter<Spec, Arc<Executable>, Value>;
+
+pub type Runtime = waymark_vm_runtime::Runtime<Arc<Executable>, Interpreter, Value>;
+
+pub type CallSpec = waymark_vm_runtime::CallSpec<waymark_vm_bytecode_core::FunctionId, Value>;
+
+#[derive(Debug)]
+pub struct Spec;
+
+pub struct Lowering;
+
+impl waymark_vm_instructions_coreset::Spec for Spec {
+    type RegisterId = waymark_vm_runtime_core::RegisterId;
+    type FunctionId = waymark_vm_bytecode_core::FunctionId;
+    type StateId = waymark_vm_bytecode_core::StateId;
+}
+
+impl waymark_vm_instructions_extcallset::Spec for Spec {
+    type RegisterId = waymark_vm_runtime_core::RegisterId;
+    type StateId = waymark_vm_bytecode_core::StateId;
+    type ActionRef = waymark_action_core::ActionRef;
+}
+
+impl waymark_vm_instructions_pureset::Spec for Spec {
+    type RegisterId = waymark_vm_runtime_core::RegisterId;
+    type ConstValue = ConstValue;
+}
+
+impl<Spec> waymark_vm_compiler_for_ast_old_core::lowering::ExtCallSet<Spec> for Lowering
+where
+    Spec: waymark_vm_instructions_extcallset::Spec<ActionRef = waymark_action_core::ActionRef>,
+{
+    type ActionError = core::convert::Infallible;
+
+    fn lower_action(
+        call: &waymark_vm_ast_old::ActionCall,
+    ) -> Result<Spec::ActionRef, Self::ActionError> {
+        Ok(waymark_vm_compiler_for_ast_old_action_ref::lower_action_ref(call))
+    }
+}
+
+impl<Spec> waymark_vm_compiler_for_ast_old_core::lowering::PureSet<Spec> for Lowering
+where
+    Spec: waymark_vm_instructions_pureset::Spec<ConstValue = ConstValue>,
+{
+    type LiteralError = waymark_vm_compiler_for_ast_old_const_value::LoweringError;
+
+    fn lower_literal(
+        literal: &waymark_vm_ast_old::Literal,
+    ) -> Result<Spec::ConstValue, Self::LiteralError> {
+        ConstValue::lower(literal)
+    }
+}


### PR DESCRIPTION
This PR goes in after #449.


---

This PR adds a system-vm crate.

The naming here has a prefix of `system-` prefix, where this particular thing is a `vm` - meaning this is a crate that organizes all independent VM parts into a single concrete system.

Crates can be logically divided into two kinds: the abstract ones - the ones that operate on generics with trait bounds, and the concrete ones - the ones that depend on concrete types and don't bother with generics/bounds. Subsystems are typically abstract, while executables and bringup logic is concrete.

This crate a *utility* crate for the concrete crates that holds the common types. This is sort-of a placeholder design, since we might have more than one actual "VM system"s: current one is just called that, but it is, implicitly, specifically for Python and with old-ast / IR machinery. There could be other implementations - for instance TypeScript might have a separate crate of this nature. Or might not have - hard to tell currently.

But, anyhow, this is the crate the binds all the parts together.