### PR TITLE
Add fullset-effect-handler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4680,6 +4680,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "waymark-fullset-effect-handler"
+version = "0.1.0"
+dependencies = [
+ "thiserror",
+ "waymark-vm-driver-core",
+ "waymark-vm-interpreter-coreset",
+ "waymark-vm-interpreter-extcallset",
+ "waymark-vm-interpreter-fullset",
+ "waymark-vm-runtime-effect",
+]
+
+[[package]]
 name = "waymark-fuzzer"
 version = "0.1.0"
 dependencies = [

--- a/crates/lib/fullset-effect-handler/Cargo.toml
+++ b/crates/lib/fullset-effect-handler/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "waymark-fullset-effect-handler"
+edition = "2024"
+version.workspace = true
+publish.workspace = true
+
+[dependencies]
+waymark-vm-driver-core = { workspace = true }
+waymark-vm-interpreter-coreset = { workspace = true }
+waymark-vm-interpreter-extcallset = { workspace = true }
+waymark-vm-interpreter-fullset = { workspace = true }
+waymark-vm-runtime-effect = { workspace = true }
+
+thiserror = { workspace = true }

--- a/crates/lib/fullset-effect-handler/src/lib.rs
+++ b/crates/lib/fullset-effect-handler/src/lib.rs
@@ -1,0 +1,64 @@
+//! Effect handler for the fullset interpreter.
+
+/// Handles effects emitted by the VM driver for the fullset interpreter.
+pub struct EffectHandler<CoreEffectHandler, ExtcallEffectHandler> {
+    /// Handles core effects
+    pub core: CoreEffectHandler,
+
+    /// Handles extcall effects.
+    pub extcall: ExtcallEffectHandler,
+}
+
+/// Error returned when handling a fullset effect fails.
+#[derive(Debug, thiserror::Error)]
+pub enum Error<CoreError, ExtcallError> {
+    #[error("coreset effect: {0}")]
+    Core(CoreError),
+
+    #[error("extcallset effect: {0}")]
+    Extcall(ExtcallError),
+}
+
+impl<CoreEffectHandler, ExtcallEffectHandler, Value, ActionRef, ActionCallArgument>
+    waymark_vm_driver_core::EffectHandler for EffectHandler<CoreEffectHandler, ExtcallEffectHandler>
+where
+    CoreEffectHandler: waymark_vm_driver_core::EffectHandler<
+            Effect = waymark_vm_interpreter_coreset::Effect<Value>,
+        >,
+    CoreEffectHandler: Send,
+    ExtcallEffectHandler: waymark_vm_driver_core::EffectHandler<
+            Effect = waymark_vm_interpreter_extcallset::Effect<ActionRef, ActionCallArgument>,
+        >,
+    ExtcallEffectHandler: Send,
+    Value: Send + 'static,
+    ActionRef: Send + 'static,
+    ActionCallArgument: Send + 'static,
+{
+    type Effect = waymark_vm_interpreter_fullset::Effect<Value, ActionRef, ActionCallArgument>;
+    type Error = Error<CoreEffectHandler::Error, ExtcallEffectHandler::Error>;
+
+    async fn handle_effect(
+        &mut self,
+        emitted_effect: waymark_vm_runtime_effect::EmittedEffect<Self::Effect>,
+    ) -> Result<(), Self::Error> {
+        let waymark_vm_runtime_effect::EmittedEffect { effect, number } = emitted_effect;
+        match effect {
+            waymark_vm_interpreter_fullset::Effect::CoreSet(core_effect) => self
+                .core
+                .handle_effect(waymark_vm_runtime_effect::EmittedEffect {
+                    effect: core_effect,
+                    number,
+                })
+                .await
+                .map_err(Error::Core),
+            waymark_vm_interpreter_fullset::Effect::ExtCallSet(extcall_effect) => self
+                .extcall
+                .handle_effect(waymark_vm_runtime_effect::EmittedEffect {
+                    effect: extcall_effect,
+                    number,
+                })
+                .await
+                .map_err(Error::Extcall),
+        }
+    }
+}


### PR DESCRIPTION
Goes in after #456

This PR adds a generic `fullset-effect-handler`.

This is a very simple generic struct to allow flexible combining of lower-level building blocks and delegate the core and extcall effects handling to the corresponding composed handlers.