### PR TITLE
Add transient workflows completions machinery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6264,10 +6264,39 @@ name = "waymark-workflow-completion-backend"
 version = "0.1.0"
 
 [[package]]
+name = "waymark-workflow-completion-convert-proto"
+version = "0.1.0"
+dependencies = [
+ "serde_json",
+ "waymark-convert-core",
+ "waymark-message-conversions",
+ "waymark-proto",
+ "waymark-vm-runtime-exception",
+ "waymark-vm-value",
+ "waymark-vm-value-convert-core",
+ "waymark-vm-value-convert-json",
+ "waymark-workflow-completion-core",
+]
+
+[[package]]
 name = "waymark-workflow-completion-core"
 version = "0.1.0"
 dependencies = [
  "waymark-vm-runtime-exception",
+]
+
+[[package]]
+name = "waymark-workflow-initialization-convert-proto"
+version = "0.1.0"
+dependencies = [
+ "index_type",
+ "thiserror",
+ "waymark-action-runtime-convert",
+ "waymark-convert-core",
+ "waymark-proto",
+ "waymark-vm-compiler-metadata",
+ "waymark-vm-runtime",
+ "waymark-vm-value",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6286,6 +6286,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "waymark-workflow-completion-direct"
+version = "0.1.0"
+dependencies = [
+ "thiserror",
+ "tokio",
+ "tracing",
+ "waymark-vm-driver-core",
+ "waymark-vm-interpreter-coreset",
+ "waymark-vm-runtime-effect",
+ "waymark-vm-runtime-exception",
+ "waymark-workflow-completion-core",
+]
+
+[[package]]
 name = "waymark-workflow-initialization-convert-proto"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,6 +143,7 @@ waymark-worker-status-backend = { path = "crates/lib/worker-status-backend" }
 waymark-worker-status-core = { path = "crates/lib/worker-status-core" }
 waymark-worker-status-reporter = { path = "crates/lib/worker-status-reporter" }
 waymark-workflow-completion-backend = { path = "crates/lib/workflow-completion-backend" }
+waymark-workflow-completion-core = { path = "crates/lib/workflow-completion-core" }
 waymark-workflow-registry-backend = { path = "crates/lib/workflow-registry-backend" }
 waymark-workflow-service-vm-runtimes-backend = { path = "crates/lib/workflow-service-vm-runtimes-backend" }
 waymark-workload-pinning-backend = { path = "crates/lib/workload-pinning-backend" }

--- a/crates/lib/workflow-completion-convert-proto/Cargo.toml
+++ b/crates/lib/workflow-completion-convert-proto/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "waymark-workflow-completion-convert-proto"
+version.workspace = true
+publish.workspace = true
+edition = "2024"
+
+[dependencies]
+waymark-convert-core = { workspace = true }
+waymark-message-conversions = { workspace = true }
+waymark-proto = { workspace = true }
+waymark-vm-runtime-exception = { workspace = true }
+waymark-vm-value = { workspace = true }
+waymark-vm-value-convert-core = { workspace = true }
+waymark-vm-value-convert-json = { workspace = true }
+waymark-workflow-completion-core = { workspace = true }
+
+serde_json = { workspace = true }
+
+[lib]
+doctest = false

--- a/crates/lib/workflow-completion-convert-proto/src/lib.rs
+++ b/crates/lib/workflow-completion-convert-proto/src/lib.rs
@@ -1,0 +1,117 @@
+//! Workflow-completion result serialisation.
+//!
+//! Converts VM runtime values into the
+//! [`WorkflowArguments`](waymark_proto::messages::WorkflowArguments)
+//! format that the Python client expects for workflow completion results.
+
+#![warn(missing_docs)]
+
+use waymark_convert_core::TryConvert;
+use waymark_vm_value_convert_core::PendingPromiseError;
+use waymark_workflow_completion_core::Outcome;
+
+/// Converter for workflow-completion results.
+///
+/// Completion results are wrapped in a
+/// [`BaseModelWorkflowArgument`](waymark_proto::messages::BaseModelWorkflowArgument)
+/// (`WorkflowNodeResult`) rather than plain primitive/dict/list values.
+pub struct Converter;
+
+impl TryConvert<Outcome<waymark_vm_value::ReadyValue>, waymark_proto::messages::WorkflowArguments>
+    for Converter
+{
+    type Error = PendingPromiseError;
+
+    fn try_convert(
+        outcome: Outcome<waymark_vm_value::ReadyValue>,
+    ) -> Result<waymark_proto::messages::WorkflowArguments, PendingPromiseError> {
+        match outcome {
+            Outcome::Completion(value) => Converter::try_convert(value),
+            Outcome::Exception(exception) => Converter::try_convert(exception),
+        }
+    }
+}
+
+impl TryConvert<waymark_vm_value::ReadyValue, waymark_proto::messages::WorkflowArguments>
+    for Converter
+{
+    type Error = PendingPromiseError;
+
+    fn try_convert(
+        value: waymark_vm_value::ReadyValue,
+    ) -> Result<waymark_proto::messages::WorkflowArguments, PendingPromiseError> {
+        let json = waymark_vm_value_convert_json::Converter::try_convert(value)?;
+        Ok(completion_workflow_arguments(json))
+    }
+}
+
+impl
+    TryConvert<
+        waymark_vm_runtime_exception::Exception<waymark_vm_value::ReadyValue>,
+        waymark_proto::messages::WorkflowArguments,
+    > for Converter
+{
+    type Error = PendingPromiseError;
+
+    fn try_convert(
+        exception: waymark_vm_runtime_exception::Exception<waymark_vm_value::ReadyValue>,
+    ) -> Result<waymark_proto::messages::WorkflowArguments, PendingPromiseError> {
+        let error_json = waymark_vm_value_convert_json::Converter::try_convert(exception)?;
+        Ok(exception_workflow_arguments(error_json))
+    }
+}
+
+fn exception_workflow_arguments(
+    error_json: serde_json::Value,
+) -> waymark_proto::messages::WorkflowArguments {
+    use waymark_proto::messages::{WorkflowArgument, WorkflowArguments};
+
+    WorkflowArguments {
+        arguments: vec![WorkflowArgument {
+            key: "error".to_string(),
+            value: Some(waymark_message_conversions::json_to_workflow_argument_value(&error_json)),
+        }],
+    }
+}
+
+fn completion_workflow_arguments(
+    json: serde_json::Value,
+) -> waymark_proto::messages::WorkflowArguments {
+    use waymark_proto::messages::{
+        BaseModelWorkflowArgument, WorkflowArgument, WorkflowArguments, WorkflowDictArgument,
+        workflow_argument_value::Kind,
+    };
+
+    let variables_value = match &json {
+        serde_json::Value::Object(_) => json.clone(),
+        other => {
+            let mut map = serde_json::Map::new();
+            map.insert("result".to_string(), other.clone());
+            serde_json::Value::Object(map)
+        }
+    };
+
+    let variables_arg =
+        waymark_message_conversions::json_to_workflow_argument_value(&variables_value);
+    let dict = WorkflowDictArgument {
+        entries: vec![WorkflowArgument {
+            key: "variables".to_string(),
+            value: Some(variables_arg),
+        }],
+    };
+
+    let result_value = waymark_proto::messages::WorkflowArgumentValue {
+        kind: Some(Kind::Basemodel(BaseModelWorkflowArgument {
+            module: "waymark.workflow_runtime".to_string(),
+            name: "WorkflowNodeResult".to_string(),
+            data: Some(dict),
+        })),
+    };
+
+    WorkflowArguments {
+        arguments: vec![WorkflowArgument {
+            key: "result".to_string(),
+            value: Some(result_value),
+        }],
+    }
+}

--- a/crates/lib/workflow-completion-convert-proto/tests/integration.rs
+++ b/crates/lib/workflow-completion-convert-proto/tests/integration.rs
@@ -1,0 +1,89 @@
+//! Happy-path coverage for the workflow-completion result converter.
+
+use waymark_convert_core::TryConvert;
+use waymark_workflow_completion_convert_proto::Converter;
+use waymark_workflow_completion_core::Outcome;
+
+#[test]
+fn completion_wraps_primitive_in_workflow_node_result() {
+    use waymark_proto::messages::{
+        primitive_workflow_argument::Kind as PrimitiveKind, workflow_argument_value::Kind,
+    };
+
+    let outcome = Outcome::Completion(waymark_vm_value::ReadyValue::Int(42));
+    let args = Converter::try_convert(outcome).expect("conversion is infallible for ready ints");
+
+    assert_eq!(args.arguments.len(), 1);
+    let result_arg = &args.arguments[0];
+    assert_eq!(result_arg.key, "result");
+
+    let Some(Kind::Basemodel(basemodel)) = result_arg
+        .value
+        .as_ref()
+        .and_then(|value| value.kind.as_ref())
+    else {
+        panic!("expected a BaseModel-wrapped result, got {result_arg:?}");
+    };
+    assert_eq!(basemodel.module, "waymark.workflow_runtime");
+    assert_eq!(basemodel.name, "WorkflowNodeResult");
+
+    let variables = &basemodel
+        .data
+        .as_ref()
+        .expect("basemodel carries a dict")
+        .entries;
+    assert_eq!(variables.len(), 1);
+    assert_eq!(variables[0].key, "variables");
+
+    // A non-object completion value is nested under a `result` key.
+    let Some(Kind::DictValue(dict)) = variables[0]
+        .value
+        .as_ref()
+        .and_then(|value| value.kind.as_ref())
+    else {
+        panic!("expected variables to be a dict");
+    };
+    assert_eq!(dict.entries.len(), 1);
+    assert_eq!(dict.entries[0].key, "result");
+
+    let Some(Kind::Primitive(primitive)) = dict.entries[0]
+        .value
+        .as_ref()
+        .and_then(|value| value.kind.as_ref())
+    else {
+        panic!("expected the wrapped result to be a primitive");
+    };
+    assert_eq!(primitive.kind, Some(PrimitiveKind::IntValue(42)));
+}
+
+#[test]
+fn exception_outcome_produces_single_error_argument() {
+    use waymark_proto::messages::workflow_argument_value::Kind;
+
+    let exception = waymark_vm_runtime_exception::Exception {
+        type_id: "ValueError".to_string(),
+        details: waymark_vm_value::ReadyValue::String("boom".to_string()),
+    };
+    let args = Converter::try_convert(Outcome::Exception(exception))
+        .expect("conversion is infallible for ready exceptions");
+
+    assert_eq!(args.arguments.len(), 1);
+    let error_arg = &args.arguments[0];
+    assert_eq!(error_arg.key, "error");
+
+    // The error payload is serialised as `{"type": ..., "message": ...}`.
+    let Some(Kind::DictValue(dict)) = error_arg
+        .value
+        .as_ref()
+        .and_then(|value| value.kind.as_ref())
+    else {
+        panic!("expected the error payload to be a dict, got {error_arg:?}");
+    };
+    let keys: Vec<&str> = dict
+        .entries
+        .iter()
+        .map(|entry| entry.key.as_str())
+        .collect();
+    assert!(keys.contains(&"type"), "missing type key in {keys:?}");
+    assert!(keys.contains(&"message"), "missing message key in {keys:?}");
+}

--- a/crates/lib/workflow-completion-direct/Cargo.toml
+++ b/crates/lib/workflow-completion-direct/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "waymark-workflow-completion-direct"
+edition = "2024"
+version.workspace = true
+publish.workspace = true
+
+[dependencies]
+waymark-vm-driver-core = { workspace = true }
+waymark-vm-interpreter-coreset = { workspace = true }
+waymark-vm-runtime-effect = { workspace = true }
+waymark-vm-runtime-exception = { workspace = true }
+waymark-workflow-completion-core = { workspace = true }
+
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["sync"] }
+tracing = { workspace = true }
+
+[lib]
+doctest = false

--- a/crates/lib/workflow-completion-direct/src/lib.rs
+++ b/crates/lib/workflow-completion-direct/src/lib.rs
@@ -1,0 +1,82 @@
+//! Backend-free workflow completion handler that sends the outcome
+//! directly through a [`tokio::sync::oneshot`] channel.
+//!
+//! This is an alternative to
+//! [`waymark_workflow_completion::EffectHandler`] for transient /
+//! in-memory execution where no durable persistence is needed and the
+//! caller wants to await the result directly rather than polling a
+//! backend.
+//!
+//! Unlike the persisting handler, the outcome is delivered as a typed value
+//! rather than serialized bytes: producer and consumer live in the same
+//! process, so there is nothing to serialize for, and the caller can convert
+//! the value directly.
+
+#![warn(missing_docs)]
+
+use tokio::sync::oneshot;
+use waymark_vm_interpreter_coreset::Effect as CoreSetEffect;
+use waymark_vm_runtime_exception::Exception;
+use waymark_workflow_completion_core::Outcome;
+
+/// An [`waymark_vm_driver_core::EffectHandler`] that sends the workflow
+/// outcome directly through a [`tokio::sync::oneshot`] channel instead of
+/// persisting to a backend.
+///
+/// This is useful for transient / in-memory execution where no durable
+/// persistence is needed and the caller wants to await the result directly
+/// rather than polling a backend.
+pub struct DirectHandler<ReadyValue> {
+    sender: Option<oneshot::Sender<Outcome<ReadyValue>>>,
+}
+
+impl<ReadyValue> DirectHandler<ReadyValue> {
+    /// Create a new handler that will send the outcome through `sender`.
+    pub fn new(sender: oneshot::Sender<Outcome<ReadyValue>>) -> Self {
+        Self {
+            sender: Some(sender),
+        }
+    }
+}
+
+/// Error returned by [`DirectHandler::handle_effect`].
+#[derive(Debug, thiserror::Error)]
+pub enum DirectHandleEffectError {
+    /// `handle_effect` was invoked again after the outcome was already sent.
+    #[error("outcome was already sent")]
+    AlreadyCompleted,
+}
+
+impl<ReadyValue> waymark_vm_driver_core::EffectHandler for DirectHandler<ReadyValue>
+where
+    ReadyValue: Send,
+    Exception<ReadyValue>: Send,
+{
+    type Effect = CoreSetEffect<ReadyValue>;
+    type Error = DirectHandleEffectError;
+
+    async fn handle_effect(
+        &mut self,
+        emitted_effect: waymark_vm_runtime_effect::EmittedEffect<Self::Effect>,
+    ) -> Result<(), Self::Error> {
+        let outcome = match emitted_effect.effect {
+            CoreSetEffect::Complete(value) => {
+                tracing::info!("workflow completed successfully");
+                Outcome::Completion(value)
+            }
+            CoreSetEffect::UnhandledException(exception) => {
+                tracing::info!(
+                    exception_type = %exception.type_id,
+                    "workflow terminated with unhandled exception",
+                );
+                Outcome::Exception(exception)
+            }
+        };
+        let sender = self
+            .sender
+            .take()
+            .ok_or(DirectHandleEffectError::AlreadyCompleted)?;
+        let _ = sender.send(outcome);
+        Ok(())
+    }
+}

--- a/crates/lib/workflow-initialization-convert-proto/Cargo.toml
+++ b/crates/lib/workflow-initialization-convert-proto/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "waymark-workflow-initialization-convert-proto"
+version.workspace = true
+publish.workspace = true
+edition = "2024"
+
+[dependencies]
+waymark-action-runtime-convert = { workspace = true }
+waymark-convert-core = { workspace = true }
+waymark-proto = { workspace = true }
+waymark-vm-compiler-metadata = { workspace = true }
+waymark-vm-runtime = { workspace = true }
+waymark-vm-value = { workspace = true }
+
+index_type = { workspace = true }
+thiserror = { workspace = true }
+
+[lib]
+doctest = false

--- a/crates/lib/workflow-initialization-convert-proto/src/lib.rs
+++ b/crates/lib/workflow-initialization-convert-proto/src/lib.rs
@@ -1,0 +1,201 @@
+//! [`Convert`](waymark_convert_core::Convert) implementation for turning a
+//! [`proto::WorkflowRegistration::initial_context`] into positional
+//! entry-function arguments.
+//!
+//! The Python side sends workflow arguments as a
+//! [`proto::WorkflowArguments`] map.  This converter pairs that map with
+//! the entry function's ordered input names (from the AST) and produces a
+//! `Vec<`[`waymark_vm_value::Value`]`>` ready for
+//! [`waymark_vm_runtime::Runtime::with_custom_entrypoint`].
+
+#![warn(missing_docs)]
+
+use waymark_convert_core::{Convert, TryConvert};
+
+/// Error returned when an `initial_context` is required but missing.
+#[derive(Debug, thiserror::Error)]
+#[error("entry function expects {entry_input_names:?} but no initial_context was provided")]
+pub struct MissingInitialContextError {
+    /// The expected input names.
+    pub entry_input_names: Vec<String>,
+}
+
+/// Stateless converter that builds positional entry-function arguments from
+/// a keyword-argument map and the function's declared input names.
+///
+/// Values are converted from proto to VM via
+/// [`waymark_extcall_convert_proto::Converter`].
+///
+/// The conversion is infallible — callers should use
+/// [`Convert::convert`](waymark_convert_core::Convert::convert).
+/// Missing keys default to
+/// [`waymark_vm_value::Value::Ready(ReadyValue::None)`].
+pub struct InitialContextConverter;
+
+impl
+    TryConvert<
+        (
+            Option<&waymark_proto::messages::WorkflowArguments>,
+            &[String],
+        ),
+        Vec<waymark_vm_value::Value>,
+    > for InitialContextConverter
+{
+    type Error = MissingInitialContextError;
+
+    fn try_convert(
+        (initial_context, input_names): (
+            Option<&waymark_proto::messages::WorkflowArguments>,
+            &[String],
+        ),
+    ) -> Result<Vec<waymark_vm_value::Value>, Self::Error> {
+        let Some(ctx) = initial_context else {
+            if input_names.is_empty() {
+                return Ok(Vec::new());
+            }
+            return Err(MissingInitialContextError {
+                entry_input_names: input_names.to_vec(),
+            });
+        };
+        Ok(InitialContextConverter::convert((ctx, input_names)))
+    }
+}
+
+impl
+    TryConvert<
+        (&waymark_proto::messages::WorkflowArguments, &[String]),
+        Vec<waymark_vm_value::Value>,
+    > for InitialContextConverter
+{
+    type Error = core::convert::Infallible;
+
+    fn try_convert(
+        (initial_context, input_names): (&waymark_proto::messages::WorkflowArguments, &[String]),
+    ) -> Result<Vec<waymark_vm_value::Value>, Self::Error> {
+        let args_dict = waymark_action_runtime_convert::Converter::convert(initial_context);
+        let waymark_vm_value::ReadyValue::Dict(args_map) = args_dict else {
+            // Should never happen — Converter always produces a Dict for
+            // WorkflowArguments.
+            return Ok(vec![
+                waymark_vm_value::Value::Ready(
+                    waymark_vm_value::ReadyValue::None
+                );
+                input_names.len()
+            ]);
+        };
+
+        let positional: Vec<_> = input_names
+            .iter()
+            .map(|name| {
+                args_map
+                    .get(name)
+                    .cloned()
+                    .unwrap_or(waymark_vm_value::Value::Ready(
+                        waymark_vm_value::ReadyValue::None,
+                    ))
+            })
+            .collect();
+
+        Ok(positional)
+    }
+}
+
+impl<FunctionId>
+    TryConvert<
+        (
+            Option<&waymark_proto::messages::WorkflowArguments>,
+            &[String],
+            FunctionId,
+        ),
+        waymark_vm_runtime::CallSpec<FunctionId, waymark_vm_value::Value>,
+    > for InitialContextConverter
+{
+    type Error = MissingInitialContextError;
+
+    fn try_convert(
+        (initial_context, input_names, func): (
+            Option<&waymark_proto::messages::WorkflowArguments>,
+            &[String],
+            FunctionId,
+        ),
+    ) -> Result<waymark_vm_runtime::CallSpec<FunctionId, waymark_vm_value::Value>, Self::Error>
+    {
+        let args = Self::try_convert((initial_context, input_names))?;
+        Ok(waymark_vm_runtime::CallSpec { func, args })
+    }
+}
+
+impl<FunctionId>
+    TryConvert<
+        (
+            Option<&waymark_proto::messages::WorkflowArguments>,
+            &[String],
+        ),
+        waymark_vm_runtime::CallSpec<FunctionId, waymark_vm_value::Value>,
+    > for InitialContextConverter
+where
+    FunctionId: Default,
+{
+    type Error = MissingInitialContextError;
+
+    fn try_convert(
+        (initial_context, input_names): (
+            Option<&waymark_proto::messages::WorkflowArguments>,
+            &[String],
+        ),
+    ) -> Result<waymark_vm_runtime::CallSpec<FunctionId, waymark_vm_value::Value>, Self::Error>
+    {
+        Self::try_convert((initial_context, input_names, FunctionId::default()))
+    }
+}
+
+impl<FunctionId>
+    TryConvert<
+        (
+            Option<&waymark_proto::messages::WorkflowArguments>,
+            &waymark_vm_compiler_metadata::Metadata<FunctionId>,
+            FunctionId,
+        ),
+        waymark_vm_runtime::CallSpec<FunctionId, waymark_vm_value::Value>,
+    > for InitialContextConverter
+where
+    FunctionId: index_type::IndexType,
+{
+    type Error = MissingInitialContextError;
+
+    fn try_convert(
+        (initial_context, metadata, func): (
+            Option<&waymark_proto::messages::WorkflowArguments>,
+            &waymark_vm_compiler_metadata::Metadata<FunctionId>,
+            FunctionId,
+        ),
+    ) -> Result<waymark_vm_runtime::CallSpec<FunctionId, waymark_vm_value::Value>, Self::Error>
+    {
+        let entry_input_names = metadata.input_names(func).unwrap_or_default();
+        Self::try_convert((initial_context, entry_input_names, func))
+    }
+}
+
+impl<FunctionId>
+    TryConvert<
+        (
+            Option<&waymark_proto::messages::WorkflowArguments>,
+            &waymark_vm_compiler_metadata::Metadata<FunctionId>,
+        ),
+        waymark_vm_runtime::CallSpec<FunctionId, waymark_vm_value::Value>,
+    > for InitialContextConverter
+where
+    FunctionId: Default + index_type::IndexType,
+{
+    type Error = MissingInitialContextError;
+
+    fn try_convert(
+        (initial_context, metadata): (
+            Option<&waymark_proto::messages::WorkflowArguments>,
+            &waymark_vm_compiler_metadata::Metadata<FunctionId>,
+        ),
+    ) -> Result<waymark_vm_runtime::CallSpec<FunctionId, waymark_vm_value::Value>, Self::Error>
+    {
+        Self::try_convert((initial_context, metadata, FunctionId::default()))
+    }
+}

--- a/crates/lib/workflow-initialization-convert-proto/tests/integration.rs
+++ b/crates/lib/workflow-initialization-convert-proto/tests/integration.rs
@@ -1,0 +1,54 @@
+//! Happy-path coverage for the initial-context converter.
+
+use waymark_convert_core::Convert;
+use waymark_workflow_initialization_convert_proto::InitialContextConverter;
+
+fn int_arg(key: &str, value: i64) -> waymark_proto::messages::WorkflowArgument {
+    use waymark_proto::messages::{
+        PrimitiveWorkflowArgument, WorkflowArgument, WorkflowArgumentValue,
+        primitive_workflow_argument::Kind as PrimitiveKind, workflow_argument_value::Kind,
+    };
+
+    WorkflowArgument {
+        key: key.to_string(),
+        value: Some(WorkflowArgumentValue {
+            kind: Some(Kind::Primitive(PrimitiveWorkflowArgument {
+                kind: Some(PrimitiveKind::IntValue(value)),
+            })),
+        }),
+    }
+}
+
+fn ready_int(value: i64) -> waymark_vm_value::Value {
+    waymark_vm_value::Value::Ready(waymark_vm_value::ReadyValue::Int(value))
+}
+
+#[test]
+fn positional_args_follow_input_name_order() {
+    let arguments = waymark_proto::messages::WorkflowArguments {
+        arguments: vec![int_arg("x", 1), int_arg("y", 2)],
+    };
+    let input_names = vec!["y".to_string(), "x".to_string()];
+
+    let positional = InitialContextConverter::convert((&arguments, input_names.as_slice()));
+
+    assert_eq!(positional, vec![ready_int(2), ready_int(1)]);
+}
+
+#[test]
+fn missing_keys_default_to_none() {
+    let arguments = waymark_proto::messages::WorkflowArguments {
+        arguments: vec![int_arg("present", 7)],
+    };
+    let input_names = vec!["present".to_string(), "absent".to_string()];
+
+    let positional = InitialContextConverter::convert((&arguments, input_names.as_slice()));
+
+    assert_eq!(
+        positional,
+        vec![
+            ready_int(7),
+            waymark_vm_value::Value::Ready(waymark_vm_value::ReadyValue::None),
+        ],
+    );
+}


### PR DESCRIPTION
Goes in after #454.

---

This PR adds transient completions machinery - tailored for the streaming gRPC service `execute_workflow` call.