### PR TITLE
Add compiler metadata machinery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5595,6 +5595,7 @@ dependencies = [
  "waymark-vm-ast-old",
  "waymark-vm-bytecode",
  "waymark-vm-bytecode-core",
+ "waymark-vm-compiler-metadata",
  "waymark-vm-instructions-coreset",
  "waymark-vm-instructions-extcallset",
  "waymark-vm-instructions-fullset",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5618,6 +5618,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "waymark-vm-compiler-metadata"
+version = "0.1.0"
+dependencies = [
+ "index_type",
+ "indexmap 2.13.0",
+ "serde",
+ "waymark-typed-vec-serde",
+]
+
+[[package]]
 name = "waymark-vm-driver"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,6 +94,7 @@ waymark-vm-compiler-for-ast-old-action-ref = { path = "crates/lib/vm-compiler-fo
 waymark-vm-compiler-for-ast-old-const-value = { path = "crates/lib/vm-compiler-for-ast-old-const-value" }
 waymark-vm-compiler-for-ast-old-core = { path = "crates/lib/vm-compiler-for-ast-old-core" }
 waymark-vm-compiler-for-ast-old-test-support = { path = "crates/lib/vm-compiler-for-ast-old-test-support" }
+waymark-vm-compiler-metadata = { path = "crates/lib/vm-compiler-metadata" }
 waymark-vm-driver = { path = "crates/lib/vm-driver" }
 waymark-vm-driver-core = { path = "crates/lib/vm-driver-core" }
 waymark-vm-driver-thread = { path = "crates/lib/vm-driver-thread" }

--- a/crates/lib/vm-compiler-for-ast-old-core/Cargo.toml
+++ b/crates/lib/vm-compiler-for-ast-old-core/Cargo.toml
@@ -8,6 +8,7 @@ publish.workspace = true
 waymark-vm-ast-old = { workspace = true }
 waymark-vm-bytecode = { workspace = true }
 waymark-vm-bytecode-core = { workspace = true }
+waymark-vm-compiler-metadata = { workspace = true }
 waymark-vm-instructions-coreset = { workspace = true }
 waymark-vm-instructions-extcallset = { workspace = true }
 waymark-vm-instructions-fullset = { workspace = true }

--- a/crates/lib/vm-compiler-for-ast-old-core/src/lib.rs
+++ b/crates/lib/vm-compiler-for-ast-old-core/src/lib.rs
@@ -42,3 +42,7 @@ pub type InstructionFor<Spec> = waymark_vm_instructions_fullset::FullSet<Spec>;
 
 /// Convenience alias for an executable produced by an AST-old compiler.
 pub type ExecutableFor<Spec> = waymark_vm_bytecode::Executable<InstructionFor<Spec>>;
+
+/// Convenience alias for [`Metadata`](waymark_vm_compiler_metadata::Metadata)
+/// using this compiler's [`FunctionId`](waymark_vm_bytecode_core::FunctionId).
+pub type Metadata = waymark_vm_compiler_metadata::Metadata<waymark_vm_bytecode_core::FunctionId>;

--- a/crates/lib/vm-compiler-for-ast-old/src/lib.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/lib.rs
@@ -2,9 +2,9 @@
 //! [`waymark_vm_bytecode`] using [`waymark_vm_instructions_fullset`].
 //!
 //! [`compile`] is the crate entry point. It resolves user-defined functions in
-//! source order, lowers each function body independently, and returns a
-//! [`waymark_vm_bytecode::Executable`] parameterized by a
-//! [`waymark_vm_compiler_for_ast_old_core::lowering::FullSet`] implementation.
+//! source order, lowers each function body independently, and returns a tuple
+//! of the [`waymark_vm_bytecode::Executable`] and [`Metadata`] about the
+//! program's functions.
 //!
 //! The current compiler intentionally implements only the subset that can be
 //! represented by the existing VM instruction set: literals, variables,
@@ -36,7 +36,33 @@ use self::utils::*;
 mod tests;
 
 use index_type::typed_vec::TypedVec;
-use waymark_vm_compiler_for_ast_old_core::{ExecutableFor, lowering};
+use waymark_vm_compiler_for_ast_old_core::{ExecutableFor, Metadata, lowering};
+
+/// Build [`Metadata`] from an AST program.
+fn metadata_from_ast_program(program: &waymark_vm_ast_old::Program) -> Metadata {
+    let function_inputs = program
+        .functions
+        .iter()
+        .map(|f| f.value.io.value.inputs.clone())
+        .collect();
+
+    let function_ids = program
+        .functions
+        .iter()
+        .enumerate()
+        .map(|(i, f)| {
+            (
+                f.value.name.clone(),
+                waymark_vm_bytecode_core::FunctionId(i),
+            )
+        })
+        .collect();
+
+    Metadata {
+        function_inputs,
+        function_ids,
+    }
+}
 
 /// Errors that can occur while compiling AST into bytecode.
 #[derive(Debug, thiserror::Error)]
@@ -61,11 +87,34 @@ pub type CompileErrorFor<Spec, Lowering> = CompileError<
 /// Functions keep their source order. That means function `0` in the resulting
 /// executable is the first entry from `program.functions`.
 ///
+/// For the [`Metadata`] (function input names, etc.) use
+/// [`compile_with_metadata`].
+///
 /// Unsupported AST constructs return [`CompileError`] instead of partial or
 /// lossy bytecode.
 pub fn compile<Spec, Lowering>(
     program: &waymark_vm_ast_old::Program,
 ) -> Result<ExecutableFor<Spec>, CompileErrorFor<Spec, Lowering>>
+where
+    Spec: waymark_vm_compiler_for_ast_old_core::SpecRequirements,
+    Lowering: waymark_vm_compiler_for_ast_old_core::lowering::FullSet<Spec>,
+{
+    compile_with_metadata::<Spec, Lowering>(program).map(|(executable, _)| executable)
+}
+
+/// Compile an old AST program into VM bytecode with [`Metadata`].
+///
+/// Functions keep their source order. That means function `0` in the resulting
+/// executable is the first entry from `program.functions`.
+///
+/// Returns a tuple of the [`ExecutableFor`] bytecode and the program
+/// [`Metadata`] (function input names, etc.).
+///
+/// Unsupported AST constructs return [`CompileError`] instead of partial or
+/// lossy bytecode.
+pub fn compile_with_metadata<Spec, Lowering>(
+    program: &waymark_vm_ast_old::Program,
+) -> Result<(ExecutableFor<Spec>, Metadata), CompileErrorFor<Spec, Lowering>>
 where
     Spec: waymark_vm_compiler_for_ast_old_core::SpecRequirements,
     Lowering: waymark_vm_compiler_for_ast_old_core::lowering::FullSet<Spec>,
@@ -79,5 +128,8 @@ where
         functions.push(compiler.compile(function)?);
     }
 
-    Ok(waymark_vm_bytecode::Executable { functions })
+    let executable = waymark_vm_bytecode::Executable { functions };
+    let metadata = metadata_from_ast_program(program);
+
+    Ok((executable, metadata))
 }

--- a/crates/lib/vm-compiler-metadata/Cargo.toml
+++ b/crates/lib/vm-compiler-metadata/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "waymark-vm-compiler-metadata"
+version.workspace = true
+publish.workspace = true
+edition = "2024"
+
+[dependencies]
+waymark-typed-vec-serde = { workspace = true, optional = true }
+
+index_type = { workspace = true }
+indexmap = { workspace = true }
+serde = { workspace = true, optional = true, features = ["derive"] }
+
+[features]
+serde = ["dep:serde", "dep:waymark-typed-vec-serde", "indexmap/serde"]
+
+[lib]
+doctest = false

--- a/crates/lib/vm-compiler-metadata/src/lib.rs
+++ b/crates/lib/vm-compiler-metadata/src/lib.rs
@@ -1,0 +1,63 @@
+//! Compiler metadata: [`Metadata`] about compiled programs.
+//!
+//! This crate defines the [`Metadata`] type produced alongside compiled
+//! bytecode.  It carries information about the original AST functions that
+//! is not represented in the bytecode itself but is needed at runtime.
+
+#![warn(missing_docs)]
+
+use index_type::typed_vec::TypedVec;
+
+/// Program metadata produced alongside the compiled bytecode.
+///
+/// Carries information about the original AST functions that is not
+/// represented in the bytecode itself but is needed at runtime (e.g.,
+/// entry-function argument names for building `CallSpec`s).
+///
+/// The `FunctionId` type parameter is the compiler's function-identifier
+/// type (e.g. [`waymark_vm_bytecode_core::FunctionId`]).
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(bound(
+        serialize = "FunctionId: serde::Serialize",
+        deserialize = "FunctionId: serde::Deserialize<'de>",
+    ))
+)]
+pub struct Metadata<FunctionId>
+where
+    FunctionId: index_type::IndexType,
+{
+    /// Input parameter names for each function, indexed by `FunctionId`
+    /// (matching source order in the AST program).
+    #[cfg_attr(feature = "serde", serde(with = "waymark_typed_vec_serde"))]
+    pub function_inputs: TypedVec<FunctionId, Vec<String>>,
+
+    /// Maps each function name to its `FunctionId`.
+    pub function_ids: indexmap::IndexMap<String, FunctionId>,
+}
+
+impl<FunctionId> Metadata<FunctionId>
+where
+    FunctionId: index_type::IndexType,
+{
+    /// Return the input names for the function with the given ID, or
+    /// `None` if the function ID is out of range.
+    pub fn input_names(&self, function_id: FunctionId) -> Option<&[String]> {
+        self.function_inputs.get(function_id).map(Vec::as_slice)
+    }
+}
+
+impl<FunctionId> Metadata<FunctionId>
+where
+    FunctionId: index_type::IndexType + core::hash::Hash,
+{
+    /// Look up a function's `FunctionId` by name.
+    pub fn function_id(&self, name: &str) -> Option<FunctionId>
+    where
+        FunctionId: Copy,
+    {
+        self.function_ids.get(name).copied()
+    }
+}


### PR DESCRIPTION
Goes in after #452.

This PR adds compiler metadata and the facilities for convenient VM runtime call specification based using the human-readable function identifiers as opposed to the function ids in the bytecode.

Users will expect some means to map the function name to the function index after the compilation, and would most likely want those ways to be compiler-independent; this is essentially a simple system to do so.