### PR TITLE
Add service for VM runtimes managements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6323,6 +6323,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "waymark-workflow-service-vm-runtimes"
+version = "0.1.0"
+dependencies = [
+ "nonempty-collections",
+ "serde",
+ "thiserror",
+ "tokio",
+ "waymark-vm-codec-core",
+ "waymark-workflow-completion-backend",
+ "waymark-workflow-completion-core",
+ "waymark-workflow-service-vm-runtimes-backend",
+]
+
+[[package]]
 name = "waymark-workflow-service-vm-runtimes-backend"
 version = "0.1.0"
 dependencies = [

--- a/crates/lib/workflow-completion-core/Cargo.toml
+++ b/crates/lib/workflow-completion-core/Cargo.toml
@@ -4,6 +4,11 @@ edition = "2024"
 version.workspace = true
 publish.workspace = true
 
+[features]
+default = []
+
+serde = ["waymark-vm-runtime-exception/serde"]
+
 [dependencies]
 waymark-vm-runtime-exception = { workspace = true }
 

--- a/crates/lib/workflow-service-vm-runtimes/Cargo.toml
+++ b/crates/lib/workflow-service-vm-runtimes/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "waymark-workflow-service-vm-runtimes"
+version.workspace = true
+publish.workspace = true
+edition = "2024"
+
+[dependencies]
+waymark-vm-codec-core = { workspace = true }
+waymark-workflow-completion-backend = { workspace = true }
+waymark-workflow-completion-core = { workspace = true, features = ["serde"] }
+waymark-workflow-service-vm-runtimes-backend = { workspace = true }
+
+nonempty-collections = { workspace = true }
+serde = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["time"] }

--- a/crates/lib/workflow-service-vm-runtimes/src/lib.rs
+++ b/crates/lib/workflow-service-vm-runtimes/src/lib.rs
@@ -1,0 +1,189 @@
+//! Workflow service — encapsulates creating workflows and polling for
+//! their outcomes.
+
+#![warn(missing_docs)]
+
+use std::{marker::PhantomData, time::Duration};
+
+use waymark_vm_codec_core::{DeserializerProvider, SerializerProvider};
+
+use waymark_workflow_completion_core::Outcome;
+
+/// Errors returned by [`RegistrationService::register_vm`].
+#[derive(Debug, thiserror::Error)]
+pub enum RegisterVmError<RegistrationError, CodecError> {
+    /// The runtime snapshot serialization failed.
+    #[error("serialize runtime snapshot: {0:?}")]
+    Serialize(CodecError),
+
+    /// The VM runtime registration failed.
+    #[error("register vm runtime: {0:?}")]
+    Registration(RegistrationError),
+}
+
+/// Errors returned by [`OutcomePollingService::wait_for_outcome`].
+#[derive(Debug, thiserror::Error)]
+pub enum WaitForOutcomeError<PollError, ExistsError, CodecError> {
+    /// The outcome poll failed.
+    #[error("poll outcome: {0:?}")]
+    Poll(PollError),
+
+    /// The registered-runtime existence check failed.
+    #[error("find existing vm runtime: {0:?}")]
+    Exists(ExistsError),
+
+    /// No VM runtime was ever registered for the requested id.
+    #[error("no vm runtime registered for the requested id")]
+    NotFound,
+
+    /// The outcome deserialization failed.
+    #[error("deserialize outcome: {0:?}")]
+    Deserialize(CodecError),
+}
+
+/// High-level service for registering workflow VMs.
+pub struct RegistrationService<Backend, Codec> {
+    backend: Backend,
+    codec: Codec,
+}
+
+impl<Backend, Codec> RegistrationService<Backend, Codec> {
+    /// Create a new workflow service wrapping the given backend and codec.
+    pub fn new(backend: Backend, codec: Codec) -> Self {
+        Self { backend, codec }
+    }
+}
+
+impl<Backend, Codec> RegistrationService<Backend, Codec>
+where
+    Backend: waymark_workflow_service_vm_runtimes_backend::RegisterVmRuntime,
+    Codec: SerializerProvider,
+{
+    /// Register a VM runtime by serializing it into a snapshot.
+    pub async fn register_vm(
+        &self,
+        vm_id: Backend::VmId,
+        executable_id: Backend::ExecutableId,
+        snapshot_provider: impl for<'buf> FnOnce(
+            Codec::Serializer<'buf>,
+        )
+            -> Result<(), <Codec as SerializerProvider>::Error>,
+    ) -> Result<
+        (),
+        RegisterVmError<
+            <Backend as waymark_workflow_service_vm_runtimes_backend::RegisterVmRuntime>::Error,
+            <Codec as SerializerProvider>::Error,
+        >,
+    > {
+        let mut snapshot = Vec::new();
+        self.codec
+            .with_serializer(&mut snapshot, snapshot_provider)
+            .map_err(RegisterVmError::Serialize)?;
+        self.backend
+            .register_vm_runtime(&vm_id, &executable_id, &snapshot)
+            .await
+            .map_err(RegisterVmError::Registration)
+    }
+}
+
+/// High-level service for polling workflow outcomes.
+pub struct OutcomePollingService<Backend, Codec, Value> {
+    backend: Backend,
+    codec: Codec,
+    phantom_data: PhantomData<Value>,
+}
+
+impl<Backend, Codec, Value> OutcomePollingService<Backend, Codec, Value> {
+    /// Create a new outcome polling service wrapping the given backend and
+    /// codec.
+    pub fn new(backend: Backend, codec: Codec) -> Self {
+        Self {
+            backend,
+            codec,
+            phantom_data: PhantomData,
+        }
+    }
+}
+
+impl<Backend, Codec, Value> OutcomePollingService<Backend, Codec, Value>
+where
+    Backend: waymark_workflow_completion_backend::PollOutcome,
+    Backend: waymark_workflow_service_vm_runtimes_backend::FindExistingVmRuntimes<
+            VmId = <Backend as waymark_workflow_completion_backend::HasVmId>::VmId,
+        >,
+    Codec: DeserializerProvider,
+    Value: for<'de> serde::Deserialize<'de>,
+{
+    /// Poll for the outcome of a workflow instance.
+    ///
+    /// Blocks until an outcome is recorded or the caller cancels. Returns
+    /// [`WaitForOutcomeError::NotFound`] if no VM runtime was ever registered
+    /// for `vm_id` — the existence check runs at most once, only when the first
+    /// poll finds no outcome, so the steady-state poll loop stays a
+    /// single-table query.
+    pub async fn wait_for_outcome(
+        &self,
+        vm_id: &<Backend as waymark_workflow_completion_backend::HasVmId>::VmId,
+        poll_interval: Duration,
+    ) -> Result<
+        Outcome<Value>,
+        WaitForOutcomeError<
+            <Backend as waymark_workflow_completion_backend::PollOutcome>::Error,
+            <Backend as waymark_workflow_service_vm_runtimes_backend::FindExistingVmRuntimes>::Error,
+            <Codec as DeserializerProvider>::Error,
+        >,
+    >{
+        let mut checked = false;
+        loop {
+            match self.backend.poll_outcome(vm_id).await {
+                Ok(Some(raw)) => {
+                    return decode(&self.codec, raw).map_err(WaitForOutcomeError::Deserialize);
+                }
+                Ok(None) => {
+                    if !checked {
+                        let vm_ids = nonempty_collections::NESlice::try_from_slice(
+                            std::slice::from_ref(vm_id),
+                        )
+                        .expect("from_ref yields a one-element, non-empty slice");
+                        let existing = self
+                            .backend
+                            .find_existing_vm_runtimes(vm_ids)
+                            .await
+                            .map_err(WaitForOutcomeError::Exists)?;
+                        if existing.is_empty() {
+                            return Err(WaitForOutcomeError::NotFound);
+                        }
+                        checked = true;
+                    }
+                    tokio::time::sleep(poll_interval).await;
+                    continue;
+                }
+                Err(err) => {
+                    return Err(WaitForOutcomeError::Poll(err));
+                }
+            }
+        }
+    }
+}
+
+fn decode<Codec, Value>(
+    codec: &Codec,
+    raw: waymark_workflow_completion_backend::Outcome,
+) -> Result<Outcome<Value>, Codec::Error>
+where
+    Codec: DeserializerProvider,
+    Value: for<'de> serde::Deserialize<'de>,
+{
+    match raw {
+        waymark_workflow_completion_backend::Outcome::Completion(bytes) => {
+            let value =
+                codec.with_deserializer(&bytes, |de| serde::Deserialize::deserialize(de))?;
+            Ok(Outcome::Completion(value))
+        }
+        waymark_workflow_completion_backend::Outcome::Exception(bytes) => {
+            let exception =
+                codec.with_deserializer(&bytes, |de| serde::Deserialize::deserialize(de))?;
+            Ok(Outcome::Exception(exception))
+        }
+    }
+}


### PR DESCRIPTION
Goes in after #455.

---

This PR adds a convenience workflow-service for operations with VM runtimes.

This is supposed to be a single entrypoint for places that need to have high-level operations the VM runtimes - like registering them, spawning them, etc. To be used in the bridge.