### PR TITLE
Add executables management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6323,6 +6323,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "waymark-workflow-service-vm-executables"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "thiserror",
+ "waymark-vm-ast-old",
+ "waymark-vm-codec-core",
+ "waymark-vm-compiler-for-ast-old",
+ "waymark-vm-compiler-for-ast-old-core",
+ "waymark-workflow-service-vm-executables-backend",
+]
+
+[[package]]
+name = "waymark-workflow-service-vm-executables-backend"
+version = "0.1.0"
+
+[[package]]
 name = "waymark-workflow-service-vm-runtimes"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4421,6 +4421,7 @@ dependencies = [
  "waymark-worker-status-backend",
  "waymark-workflow-completion-backend",
  "waymark-workflow-registry-backend",
+ "waymark-workflow-service-vm-executables-backend",
  "waymark-workflow-service-vm-runtimes-backend",
  "waymark-workload-pinning-backend",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4413,6 +4413,7 @@ dependencies = [
  "waymark-scheduler-backend",
  "waymark-scheduler-core",
  "waymark-secret-string",
+ "waymark-state-vm-executables-backend",
  "waymark-state-vm-runtimes-backend",
  "waymark-support-test",
  "waymark-timed-future",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -145,6 +145,7 @@ waymark-worker-status-reporter = { path = "crates/lib/worker-status-reporter" }
 waymark-workflow-completion-backend = { path = "crates/lib/workflow-completion-backend" }
 waymark-workflow-completion-core = { path = "crates/lib/workflow-completion-core" }
 waymark-workflow-registry-backend = { path = "crates/lib/workflow-registry-backend" }
+waymark-workflow-service-vm-executables-backend = { path = "crates/lib/workflow-service-vm-executables-backend" }
 waymark-workflow-service-vm-runtimes-backend = { path = "crates/lib/workflow-service-vm-runtimes-backend" }
 waymark-workload-pinning-backend = { path = "crates/lib/workload-pinning-backend" }
 waymark-workload-pinning-manager = { path = "crates/lib/workload-pinning-manager" }

--- a/crates/lib/backend-postgres-migrations/migrations/0015_vm_executables.sql
+++ b/crates/lib/backend-postgres-migrations/migrations/0015_vm_executables.sql
@@ -1,0 +1,10 @@
+-- Persist compiled VM executables (bytecode), deduplicated by (name, version).
+
+CREATE TABLE vm_executables (
+    id UUID PRIMARY KEY,
+    name TEXT NOT NULL,
+    version TEXT NOT NULL,
+    bytecode BYTEA NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (name, version)
+);

--- a/crates/lib/backend-postgres/Cargo.toml
+++ b/crates/lib/backend-postgres/Cargo.toml
@@ -24,6 +24,7 @@ waymark-runner-state = { workspace = true }
 waymark-scheduler-backend = { workspace = true }
 waymark-scheduler-core = { workspace = true }
 waymark-secret-string = { workspace = true }
+waymark-state-vm-executables-backend = { workspace = true }
 waymark-state-vm-runtimes-backend = { workspace = true }
 waymark-timed-future = { workspace = true }
 waymark-webapp-backend = { workspace = true }

--- a/crates/lib/backend-postgres/Cargo.toml
+++ b/crates/lib/backend-postgres/Cargo.toml
@@ -31,6 +31,7 @@ waymark-webapp-core = { workspace = true }
 waymark-worker-status-backend = { workspace = true }
 waymark-workflow-completion-backend = { workspace = true }
 waymark-workflow-registry-backend = { workspace = true }
+waymark-workflow-service-vm-executables-backend = { workspace = true }
 waymark-workflow-service-vm-runtimes-backend = { workspace = true }
 waymark-workload-pinning-backend = { workspace = true }
 

--- a/crates/lib/backend-postgres/src/lib.rs
+++ b/crates/lib/backend-postgres/src/lib.rs
@@ -5,6 +5,7 @@ mod core;
 mod macros;
 mod registry;
 mod scheduler;
+mod state_vm_executables;
 #[cfg(test)]
 mod test_helpers;
 mod vm_runtimes;

--- a/crates/lib/backend-postgres/src/lib.rs
+++ b/crates/lib/backend-postgres/src/lib.rs
@@ -10,6 +10,7 @@ mod test_helpers;
 mod vm_runtimes;
 mod webapp;
 mod workflow_completion;
+mod workflow_service_vm_executables;
 mod workflow_service_vm_runtimes;
 mod workload_pinning;
 

--- a/crates/lib/backend-postgres/src/state_vm_executables/error.rs
+++ b/crates/lib/backend-postgres/src/state_vm_executables/error.rs
@@ -1,0 +1,15 @@
+//! Error types for the state-vm-executables postgres backend.
+
+use waymark_ids::WorkflowVersionId;
+
+/// Error returned when loading a compiled executable.
+#[derive(Debug, thiserror::Error)]
+pub enum LoadError {
+    /// The underlying database operation failed.
+    #[error("sqlx: {0}")]
+    Sqlx(#[from] sqlx::Error),
+
+    /// No executable found with the given id.
+    #[error("executable not found: {0}")]
+    NotFound(WorkflowVersionId),
+}

--- a/crates/lib/backend-postgres/src/state_vm_executables/mod.rs
+++ b/crates/lib/backend-postgres/src/state_vm_executables/mod.rs
@@ -1,0 +1,44 @@
+//! Postgres backend for VM executable loading.
+//!
+//! Implements [`waymark_state_vm_executables_backend::LoadExecutable`]
+//! for [`crate::PostgresBackend`].
+
+pub mod error;
+
+#[cfg(test)]
+mod tests;
+
+use sqlx::Row;
+use waymark_ids::WorkflowVersionId;
+use waymark_observability::obs;
+
+use crate::PostgresBackend;
+
+impl waymark_state_vm_executables_backend::HasExecutableId for PostgresBackend {
+    type ExecutableId = WorkflowVersionId;
+}
+
+impl waymark_state_vm_executables_backend::LoadExecutable for PostgresBackend {
+    type Error = error::LoadError;
+
+    #[obs]
+    #[function_name::named]
+    async fn load_executable<'a>(
+        &'a self,
+        id: &'a Self::ExecutableId,
+    ) -> Result<Vec<u8>, Self::Error> {
+        Self::count_query(&self.query_counts, "select:vm_executables_by_id");
+        let row = sqlx::query(
+            r#"
+            SELECT bytecode FROM vm_executables
+            WHERE id = $1
+            "#,
+        )
+        .bind(id)
+        .fetch_optional(&self.pool)
+        .await?
+        .ok_or(error::LoadError::NotFound(*id))?;
+
+        Ok(row.get("bytecode"))
+    }
+}

--- a/crates/lib/backend-postgres/src/state_vm_executables/tests.rs
+++ b/crates/lib/backend-postgres/src/state_vm_executables/tests.rs
@@ -1,0 +1,32 @@
+use serial_test::serial;
+use waymark_state_vm_executables_backend::LoadExecutable as _;
+use waymark_workflow_service_vm_executables_backend::UpsertExecutable as _;
+
+use crate::test_helpers::setup_backend;
+
+#[serial(postgres)]
+#[tokio::test]
+async fn load_missing_executable_returns_not_found() {
+    let backend = setup_backend().await;
+    let id = waymark_ids::WorkflowVersionId::new_uuid_v4();
+
+    let result = backend.load_executable(&id).await;
+
+    assert!(matches!(result, Err(super::error::LoadError::NotFound(_))));
+}
+
+#[serial(postgres)]
+#[tokio::test]
+async fn load_after_upsert_returns_bytes() {
+    let backend = setup_backend().await;
+    let bytes = b"test bytecode";
+
+    let id = backend
+        .upsert_executable("test_wf", "v1", bytes)
+        .await
+        .expect("upsert");
+
+    let loaded = backend.load_executable(&id).await.expect("load");
+
+    assert_eq!(loaded, bytes);
+}

--- a/crates/lib/backend-postgres/src/test_helpers.rs
+++ b/crates/lib/backend-postgres/src/test_helpers.rs
@@ -33,11 +33,12 @@ pub(super) async fn reset_database(pool: &PgPool) {
         TRUNCATE runner_actions_done,
                  queued_instances,
                  runner_instances,
-                 workflow_versions,
-                 workflow_schedules,
-                 worker_status,
+                 vm_executables,
                  vm_runtime_snapshots,
-                 workload_pinnings
+                 workflow_schedules,
+                 workflow_versions,
+                 workload_pinnings,
+                 worker_status
         RESTART IDENTITY CASCADE
         "#,
     )

--- a/crates/lib/backend-postgres/src/workflow_service_vm_executables/error.rs
+++ b/crates/lib/backend-postgres/src/workflow_service_vm_executables/error.rs
@@ -1,0 +1,22 @@
+//! Error types for the workflow-service-vm-executables postgres backend.
+
+/// Error returned when storing a compiled executable.
+#[derive(Debug, thiserror::Error)]
+pub enum UpsertError {
+    /// The underlying database operation failed.
+    #[error("sqlx: {0}")]
+    Sqlx(#[from] sqlx::Error),
+
+    /// A conflicting executable already exists.
+    #[error("executable conflict")]
+    Conflict,
+}
+
+impl waymark_workflow_service_vm_executables_backend::Error for UpsertError {
+    fn kind(&self) -> waymark_workflow_service_vm_executables_backend::ErrorKind {
+        match self {
+            Self::Sqlx(_) => waymark_workflow_service_vm_executables_backend::ErrorKind::Internal,
+            Self::Conflict => waymark_workflow_service_vm_executables_backend::ErrorKind::Conflict,
+        }
+    }
+}

--- a/crates/lib/backend-postgres/src/workflow_service_vm_executables/mod.rs
+++ b/crates/lib/backend-postgres/src/workflow_service_vm_executables/mod.rs
@@ -1,0 +1,69 @@
+//! Postgres backend for the workflow service VM executables.
+//!
+//! Implements [`waymark_workflow_service_vm_executables_backend::UpsertExecutable`]
+//! for [`crate::PostgresBackend`].
+
+pub mod error;
+
+#[cfg(test)]
+mod tests;
+
+use sqlx::Row;
+use waymark_ids::WorkflowVersionId;
+use waymark_observability::obs;
+
+use crate::PostgresBackend;
+
+impl waymark_workflow_service_vm_executables_backend::HasExecutableId for PostgresBackend {
+    type ExecutableId = WorkflowVersionId;
+}
+
+impl waymark_workflow_service_vm_executables_backend::UpsertExecutable for PostgresBackend {
+    type Error = error::UpsertError;
+
+    #[obs]
+    #[function_name::named]
+    async fn upsert_executable<'a>(
+        &'a self,
+        name: &'a str,
+        version: &'a str,
+        bytes: &'a [u8],
+    ) -> Result<Self::ExecutableId, Self::Error> {
+        let id = WorkflowVersionId::new_uuid_v4();
+        Self::count_query(&self.query_counts, "upsert:vm_executables");
+
+        // `DO UPDATE` with a no-op set (rather than `DO NOTHING`) guarantees a
+        // row is always returned. Under READ COMMITTED, `DO NOTHING` can detect
+        // a conflict against a concurrently-committed duplicate that a
+        // same-statement `SELECT` — bound to the statement snapshot — can't yet
+        // see, yielding zero rows. `DO UPDATE` re-reads and locks the
+        // conflicting row, so `RETURNING` always produces exactly one row.
+        //
+        // The set is a no-op, so the row's stored bytecode is preserved. The
+        // `bytecode = $4` comparison runs server-side so the (potentially large)
+        // blob never travels back — we only need to know whether it matches. For
+        // a fresh insert the stored bytecode is the one we just wrote, so
+        // `matches` is trivially true.
+        let row = sqlx::query(
+            r#"
+            INSERT INTO vm_executables (id, name, version, bytecode)
+            VALUES ($1, $2, $3, $4)
+            ON CONFLICT (name, version) DO UPDATE SET name = EXCLUDED.name
+            RETURNING id, bytecode = $4 AS matches
+            "#,
+        )
+        .bind(id)
+        .bind(name)
+        .bind(version)
+        .bind(bytes)
+        .fetch_one(&self.pool)
+        .await?;
+
+        if row.get::<bool, _>("matches") {
+            let returned_id: WorkflowVersionId = row.get("id");
+            Ok(returned_id)
+        } else {
+            Err(error::UpsertError::Conflict)
+        }
+    }
+}

--- a/crates/lib/backend-postgres/src/workflow_service_vm_executables/tests.rs
+++ b/crates/lib/backend-postgres/src/workflow_service_vm_executables/tests.rs
@@ -1,0 +1,91 @@
+use serial_test::serial;
+use waymark_workflow_service_vm_executables_backend::Error;
+use waymark_workflow_service_vm_executables_backend::UpsertExecutable as _;
+
+use crate::test_helpers::setup_backend;
+
+#[serial(postgres)]
+#[tokio::test]
+async fn upsert_new_executable_returns_id() {
+    let backend = setup_backend().await;
+
+    let id = backend
+        .upsert_executable("test_wf", "v1", b"bytecode")
+        .await
+        .expect("first upsert");
+
+    // Verify the returned id is valid (not nil UUID).
+    assert_ne!(id.to_string(), "00000000-0000-0000-0000-000000000000");
+}
+
+#[serial(postgres)]
+#[tokio::test]
+async fn upsert_same_bytecode_returns_existing_id() {
+    let backend = setup_backend().await;
+
+    let first_id = backend
+        .upsert_executable("test_wf", "v1", b"bytecode")
+        .await
+        .expect("first upsert");
+
+    let second_id = backend
+        .upsert_executable("test_wf", "v1", b"bytecode")
+        .await
+        .expect("second upsert");
+
+    assert_eq!(first_id, second_id);
+}
+
+#[serial(postgres)]
+#[tokio::test]
+async fn upsert_different_bytecode_returns_conflict() {
+    let backend = setup_backend().await;
+
+    backend
+        .upsert_executable("test_wf", "v1", b"first")
+        .await
+        .expect("first upsert");
+
+    let result = backend.upsert_executable("test_wf", "v1", b"second").await;
+
+    assert!(matches!(
+        result,
+        Err(ref e) if matches!(e.kind(), waymark_workflow_service_vm_executables_backend::ErrorKind::Conflict)
+    ));
+}
+
+#[serial(postgres)]
+#[tokio::test]
+async fn upsert_different_names_are_independent() {
+    let backend = setup_backend().await;
+
+    let id_a = backend
+        .upsert_executable("wf_a", "v1", b"bytes")
+        .await
+        .expect("upsert wf_a");
+
+    let id_b = backend
+        .upsert_executable("wf_b", "v1", b"bytes")
+        .await
+        .expect("upsert wf_b");
+
+    assert_ne!(id_a, id_b);
+}
+
+#[serial(postgres)]
+#[tokio::test]
+async fn upsert_different_versions_are_independent() {
+    let backend = setup_backend().await;
+
+    let id_v1 = backend
+        .upsert_executable("test_wf", "v1", b"bytes")
+        .await
+        .expect("upsert v1");
+
+    let id_v2 = backend
+        .upsert_executable("test_wf", "v2", b"bytes")
+        .await
+        .expect("upsert v2");
+
+    assert_ne!(id_v1, id_v2);
+}

--- a/crates/lib/workflow-service-vm-executables-backend/Cargo.toml
+++ b/crates/lib/workflow-service-vm-executables-backend/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "waymark-workflow-service-vm-executables-backend"
+edition = "2024"
+version.workspace = true
+publish.workspace = true
+
+[dependencies]

--- a/crates/lib/workflow-service-vm-executables-backend/src/lib.rs
+++ b/crates/lib/workflow-service-vm-executables-backend/src/lib.rs
@@ -1,0 +1,15 @@
+//! Backend traits for the workflow service VM compiler.
+//!
+//! Defines the contract for storing compiled VM executables.
+
+#![warn(missing_docs)]
+
+pub mod upsert_executable;
+
+pub use self::upsert_executable::{Error, ErrorKind, UpsertExecutable};
+
+/// Associates the backend with an executable identifier type.
+pub trait HasExecutableId {
+    /// The executable / workflow version identifier type.
+    type ExecutableId;
+}

--- a/crates/lib/workflow-service-vm-executables-backend/src/upsert_executable.rs
+++ b/crates/lib/workflow-service-vm-executables-backend/src/upsert_executable.rs
@@ -1,0 +1,45 @@
+//! VM executable upsert trait and error classification.
+
+use super::HasExecutableId;
+
+/// Backend capability for atomically inserting an executable with
+/// deduplication by `(name, version)`.
+///
+/// If an executable with the same name and version already exists and
+/// has the same bytecode, returns the existing id. If the bytecode
+/// differs, returns an error with [`ErrorKind::Conflict`].
+pub trait UpsertExecutable: HasExecutableId {
+    /// The error type for store operations.
+    type Error: Error + std::fmt::Debug;
+
+    /// Atomically upsert an executable, deduplicating by `(name, version)`.
+    fn upsert_executable<'a>(
+        &'a self,
+        name: &'a str,
+        version: &'a str,
+        bytes: &'a [u8],
+    ) -> impl Future<Output = Result<Self::ExecutableId, Self::Error>> + Send + 'a;
+}
+
+/// Classification interface for [`UpsertExecutable`] backend errors.
+pub trait Error {
+    /// Classify this error into a stable [`ErrorKind`].
+    fn kind(&self) -> ErrorKind;
+}
+
+/// Stable categories for [`UpsertExecutable`] backend failures.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ErrorKind {
+    /// An executable with this name and version already exists but with
+    /// different bytecode.
+    Conflict,
+
+    /// An internal backend failure occurred.
+    Internal,
+}
+
+impl Error for core::convert::Infallible {
+    fn kind(&self) -> ErrorKind {
+        match *self {}
+    }
+}

--- a/crates/lib/workflow-service-vm-executables/Cargo.toml
+++ b/crates/lib/workflow-service-vm-executables/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "waymark-workflow-service-vm-executables"
+version.workspace = true
+publish.workspace = true
+edition = "2024"
+
+[dependencies]
+waymark-vm-ast-old = { workspace = true }
+waymark-vm-codec-core = { workspace = true }
+waymark-vm-compiler-for-ast-old = { workspace = true }
+waymark-vm-compiler-for-ast-old-core = { workspace = true }
+waymark-workflow-service-vm-executables-backend = { workspace = true }
+
+serde = { workspace = true }
+thiserror = { workspace = true }

--- a/crates/lib/workflow-service-vm-executables/src/lib.rs
+++ b/crates/lib/workflow-service-vm-executables/src/lib.rs
@@ -1,0 +1,97 @@
+//! VM compiler service — compiles ast-old programs and stores the
+//! resulting bytecode via a
+//! [`waymark_workflow_service_vm_executables_backend::UpsertExecutable`] backend.
+
+#![warn(missing_docs)]
+
+use std::marker::PhantomData;
+
+use serde::Serialize;
+
+/// Errors returned by [`ExecutablesService::compile_and_store`].
+#[derive(Debug, thiserror::Error)]
+pub enum CompileAndStoreError<CompileError, SerializeError, StoreError> {
+    /// The compilation failed.
+    #[error("compilation: {0}")]
+    Compile(#[source] CompileError),
+
+    /// The bytecode serialization failed.
+    #[error("serialize bytecode: {0:?}")]
+    Serialize(#[source] SerializeError),
+
+    /// The backend store operation failed.
+    #[error("store bytecode: {0:?}")]
+    Store(#[source] StoreError),
+}
+
+/// Service that compiles ast-old programs to bytecode and stores them.
+pub struct ExecutablesService<Backend, Codec, Spec, Lowering> {
+    backend: Backend,
+    codec: Codec,
+    _phantom: PhantomData<(Spec, Lowering)>,
+}
+
+impl<Backend, Codec, Spec, Lowering> ExecutablesService<Backend, Codec, Spec, Lowering> {
+    /// Create a new compiler service wrapping the given backend and codec.
+    pub fn new(backend: Backend, codec: Codec) -> Self {
+        Self {
+            backend,
+            codec,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<Backend, Codec, Spec, Lowering> ExecutablesService<Backend, Codec, Spec, Lowering>
+where
+    Backend: waymark_workflow_service_vm_executables_backend::UpsertExecutable,
+    Backend: Send + Sync + 'static,
+    Backend::ExecutableId: Send + Sync,
+    Codec: waymark_vm_codec_core::SerializerProvider,
+    Codec: Send + Sync + 'static,
+    Spec: waymark_vm_compiler_for_ast_old_core::SpecRequirements + Sync,
+    Lowering: waymark_vm_compiler_for_ast_old_core::lowering::FullSet<Spec> + Sync,
+    waymark_vm_compiler_for_ast_old::CompileErrorFor<Spec, Lowering>: Send,
+    waymark_vm_compiler_for_ast_old_core::ExecutableFor<Spec>: serde::Serialize,
+{
+    /// Compile an ast-old program and atomically store it with deduplication.
+    ///
+    /// Returns the stored executable's ID, the compiled executable itself, and
+    /// the program [`Metadata`](waymark_vm_compiler_for_ast_old_core::Metadata).
+    /// Handing back the in-memory executable lets the caller build runtimes
+    /// without re-fetching and re-deserializing what was just stored.
+    pub async fn compile_and_store(
+        &self,
+        name: &str,
+        version: &str,
+        program: &waymark_vm_ast_old::Program,
+    ) -> Result<
+        (
+            Backend::ExecutableId,
+            waymark_vm_compiler_for_ast_old_core::ExecutableFor<Spec>,
+            waymark_vm_compiler_for_ast_old_core::Metadata,
+        ),
+        CompileAndStoreError<
+            waymark_vm_compiler_for_ast_old::CompileErrorFor<Spec, Lowering>,
+            Codec::Error,
+            Backend::Error,
+        >,
+    > {
+        let (executable, metadata) =
+            waymark_vm_compiler_for_ast_old::compile_with_metadata::<Spec, Lowering>(program)
+                .map_err(CompileAndStoreError::Compile)?;
+
+        let mut bytes = Vec::new();
+        self.codec
+            .with_serializer(&mut bytes, |ser| executable.serialize(ser))
+            .map_err(CompileAndStoreError::Serialize)?;
+
+        let id = self
+            .backend
+            .upsert_executable(name, version, &bytes)
+            .await
+            .map_err(CompileAndStoreError::Store)?;
+
+        Ok((id, executable, metadata))
+    }
+}


### PR DESCRIPTION
Goes in after #457.

---

This PR adds state manager, backends and workflow-service for executables management.

The workflow-service is a high-level entrypoint for operations with executables (e.g. compilation and registration). State management is rather simple, since the entrypoints are kept in a pre-validated compiled form in the database and we just need to deserialize them.