### PR TITLE
Small refactor to the extcall-reconciler-core traits and more documentation for the vm-driver promise settler

### DIFF
--- a/crates/lib/action-reconciler/src/lib.rs
+++ b/crates/lib/action-reconciler/src/lib.rs
@@ -166,21 +166,23 @@ where
     }
 }
 
-impl<Provider> waymark_extcall_reconciler_core::ActionPromiseSettler for Poller<Provider>
+impl<Provider> waymark_extcall_reconciler_core::SettlerAck for Poller<Provider> {
+    type Ack = Ack;
+}
+
+impl<Provider, UnifiedAck> waymark_extcall_reconciler_core::ActionPromiseSettler<UnifiedAck>
+    for Poller<Provider>
 where
     Provider: waymark_action_runtime_core::ActionCallCompletionsProvider + Send + Sync,
     Provider::Metadata: ActionCallCorrelated,
+    UnifiedAck: From<Ack>,
 {
     type Value = Provider::Value;
     type Error = Provider::Error;
-    type Ack = Ack;
 
-    async fn poll_action_settlements<UnifiedAck>(
+    async fn poll_action_settlements(
         &mut self,
-    ) -> Result<NEVec<PromiseSettlement<Self::Value, UnifiedAck>>, Self::Error>
-    where
-        UnifiedAck: From<Self::Ack>,
-    {
+    ) -> Result<NEVec<PromiseSettlement<Self::Value, UnifiedAck>>, Self::Error> {
         self.poll::<UnifiedAck>().await
     }
 }

--- a/crates/lib/extcall-reconciler-core/src/lib.rs
+++ b/crates/lib/extcall-reconciler-core/src/lib.rs
@@ -67,39 +67,47 @@ pub trait SleepEffectHandler {
     ) -> impl std::future::Future<Output = Result<(), Self::Error>> + Send;
 }
 
+/// Exposes the acknowledgement type a settler produces natively, independent
+/// of the unified ack it is ultimately polled into.
+///
+/// Kept as a separate, non-generic trait so that `Self::Ack` can be named
+/// without committing to (and cyclically depending on) a particular
+/// unified-ack type parameter.
+pub trait SettlerAck {
+    /// The acknowledgement type produced by this settler.
+    type Ack;
+}
+
 /// Produces promise settlements from completed action calls.
-pub trait ActionPromiseSettler {
+pub trait ActionPromiseSettler<UnifiedAck>: SettlerAck
+where
+    UnifiedAck: From<Self::Ack>,
+{
     /// The type of a successful action result value.
     type Value;
 
     /// The error type returned when polling for action settlements fails.
     type Error: std::fmt::Debug;
 
-    /// The acknowledgement type produced by this settler.
-    type Ack;
-
     /// Poll for the next batch of action-completion settlements.
-    fn poll_action_settlements<UnifiedAck>(
+    fn poll_action_settlements(
         &mut self,
     ) -> impl Future<Output = Result<NEVec<PromiseSettlement<Self::Value, UnifiedAck>>, Self::Error>>
-    + Send
-    where
-        UnifiedAck: From<Self::Ack>;
+    + Send;
 }
 
 /// Produces promise settlements from elapsed sleeps.
-pub trait SleepPromiseSettler {
-    /// The acknowledgement type produced by this settler.
-    type Ack;
-
+pub trait SleepPromiseSettler<UnifiedAck>: SettlerAck
+where
+    UnifiedAck: From<Self::Ack>,
+{
     /// The error type returned when polling for sleep settlements fails.
     type Error: std::fmt::Debug;
 
     /// Poll for the next batch of elapsed-sleep settlements.
-    fn poll_sleep_settlements<UnifiedAck, Value>(
+    fn poll_sleep_settlements<Value>(
         &mut self,
     ) -> impl Future<Output = Result<NEVec<PromiseSettlement<Value, UnifiedAck>>, Self::Error>> + Send
     where
-        Value: From<()>,
-        UnifiedAck: From<Self::Ack>;
+        Value: From<()>;
 }

--- a/crates/lib/extcall-reconciler/src/lib.rs
+++ b/crates/lib/extcall-reconciler/src/lib.rs
@@ -133,12 +133,24 @@ where
 impl<ActionSettler, SleepSettler> waymark_vm_driver_core::PromiseSettler
     for PromiseSettler<ActionSettler, SleepSettler>
 where
-    ActionSettler: waymark_extcall_reconciler_core::ActionPromiseSettler + Send,
+    ActionSettler: waymark_extcall_reconciler_core::SettlerAck + Send,
+    SleepSettler: waymark_extcall_reconciler_core::SettlerAck + Send,
+    ActionSettler: waymark_extcall_reconciler_core::ActionPromiseSettler<
+            Ack<
+                <ActionSettler as waymark_extcall_reconciler_core::SettlerAck>::Ack,
+                <SleepSettler as waymark_extcall_reconciler_core::SettlerAck>::Ack,
+            >,
+        >,
+    SleepSettler: waymark_extcall_reconciler_core::SleepPromiseSettler<
+            Ack<
+                <ActionSettler as waymark_extcall_reconciler_core::SettlerAck>::Ack,
+                <SleepSettler as waymark_extcall_reconciler_core::SettlerAck>::Ack,
+            >,
+        >,
     ActionSettler::Ack: PromiseSettlementAck,
     ActionSettler::Value: From<()>,
-    Ack<ActionSettler::Ack, SleepSettler::Ack>: From<ActionSettler::Ack>,
-    SleepSettler: waymark_extcall_reconciler_core::SleepPromiseSettler + Send,
     SleepSettler::Ack: PromiseSettlementAck,
+    Ack<ActionSettler::Ack, SleepSettler::Ack>: From<ActionSettler::Ack>,
     Ack<ActionSettler::Ack, SleepSettler::Ack>: From<SleepSettler::Ack>,
 {
     type Value = ActionSettler::Value;
@@ -150,10 +162,10 @@ where
         _waiting_ids: NEVec<PromiseStateId>,
     ) -> Result<NEVec<PromiseSettlement<Self::Value, Self::Ack>>, Self::Error> {
         tokio::select! {
-            settlements = self.sleep.poll_sleep_settlements::<Self::Ack, Self::Value>() => {
+            settlements = self.sleep.poll_sleep_settlements::<Self::Value>() => {
                 settlements.map_err(GetPromiseSettlementsError::Sleep)
             }
-            settlements = self.action.poll_action_settlements::<Self::Ack>() => {
+            settlements = self.action.poll_action_settlements() => {
                 settlements.map_err(GetPromiseSettlementsError::Action)
             }
         }

--- a/crates/lib/sleep-reconciler/src/lib.rs
+++ b/crates/lib/sleep-reconciler/src/lib.rs
@@ -140,18 +140,22 @@ pub enum PollSleepError {
     ChannelClosed,
 }
 
-impl waymark_extcall_reconciler_core::SleepPromiseSettler for Poller {
+impl waymark_extcall_reconciler_core::SettlerAck for Poller {
     type Ack = Ack;
+}
 
+impl<UnifiedAck> waymark_extcall_reconciler_core::SleepPromiseSettler<UnifiedAck> for Poller
+where
+    UnifiedAck: From<Ack>,
+{
     /// The error type returned when polling for sleep settlements fails.
     type Error = PollSleepError;
 
-    async fn poll_sleep_settlements<UnifiedAck, Value>(
+    async fn poll_sleep_settlements<Value>(
         &mut self,
     ) -> Result<NEVec<PromiseSettlement<Value, UnifiedAck>>, Self::Error>
     where
         Value: From<()>,
-        UnifiedAck: From<Self::Ack>,
     {
         self.poll::<Value, UnifiedAck>()
             .await

--- a/crates/lib/vm-driver-core/src/promise_settler.rs
+++ b/crates/lib/vm-driver-core/src/promise_settler.rs
@@ -18,9 +18,11 @@ pub struct PromiseSettlement<Value, Ack> {
 
     /// Opaque acknowledgement handle.
     ///
-    /// Call [`PromiseSettlementAck::acknowledge_settlement`] after the
-    /// settlement has been applied *and* the resulting VM state has been
-    /// persisted, so the settler can reclaim resources or confirm delivery.
+    /// [`acknowledge_promise_settlement`](PromiseSettlementAck::acknowledge_promise_settlement)
+    /// is called after the settlement has been applied *and* the resulting
+    /// VM state has been persisted, so the settler can reclaim resources or
+    /// confirm delivery. Dropping this handle without acknowledging is a
+    /// negative acknowledgement (Nack) — see [`PromiseSettlementAck`].
     pub ack: Ack,
 }
 
@@ -76,11 +78,43 @@ pub trait PromiseSettler {
 /// Acknowledges that a promise settlement has been durably consumed.
 ///
 /// After the driver applies a settlement and persists the resulting VM
-/// state it calls [`acknowledge_promise_settlement`] on each
-/// [`PromiseSettlement::ack`] in the batch.  This lets the settler
+/// state it calls [`acknowledge_promise_settlement`](PromiseSettlementAck::acknowledge_promise_settlement)
+/// on each [`PromiseSettlement::ack`] in the batch.  This lets the settler
 /// reclaim resources, notify upstream systems, or confirm delivery.
+///
+/// # Acknowledgement is synchronous but may defer its work
+///
+/// [`acknowledge_promise_settlement`](PromiseSettlementAck::acknowledge_promise_settlement)
+/// is deliberately **synchronous** and must not block the driver: it runs
+/// on the driver's hot path between snapshot persistence and the next VM
+/// step, and the VM must not wait on any upstream acknowledgement I/O.
+///
+/// Implementations that need to perform work (e.g. deleting a queue row or
+/// notifying an upstream system) must **defer** it — hand the work off to a
+/// background task, channel, or batch — and return immediately. Deferral is
+/// safe because settlement delivery is idempotent: if a deferred
+/// acknowledgement is lost, the settlement is simply redelivered and applied
+/// again, and repeating an already-applied resolution is a no-op that can be
+/// safely ignored (see [`PromiseSettler`]'s cancellation contract).
+///
+/// # Dropping without acknowledging is a Nack
+///
+/// The ack handle carries **negative acknowledgement on `Drop`**: if an
+/// [`Ack`](PromiseSettlement::ack) is dropped without
+/// [`acknowledge_promise_settlement`](PromiseSettlementAck::acknowledge_promise_settlement)
+/// having been called, that signals the settlement was *not* durably
+/// consumed and must be redelivered. The core relies on this — the driver
+/// only calls `acknowledge_promise_settlement` after the resulting VM state
+/// has been persisted, so an ack dropped on any earlier error or
+/// cancellation path correctly Nacks the settlement. Implementations that
+/// want Nack-on-failure semantics should encode them in the ack's `Drop`
+/// impl (e.g. leave the queue row in place unless explicitly acknowledged).
 pub trait PromiseSettlementAck {
     /// Acknowledge that the settlement has been durably applied.
+    ///
+    /// Must not block: defer any real work to the background. See the
+    /// [trait docs](PromiseSettlementAck) for the deferral and Drop-Nack
+    /// contract.
     fn acknowledge_promise_settlement(self);
 }
 


### PR DESCRIPTION
Goes in after #467.

---

A bulk of small unrelated things.