### PR TITLE
Expose the driver error to the execution-runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4737,6 +4737,8 @@ dependencies = [
  "waymark-state-manager",
  "waymark-state-manager-core",
  "waymark-state-vm-runtimes",
+ "waymark-vm-driver",
+ "waymark-vm-driver-thread",
  "waymark-workload-pinning-manager",
 ]
 

--- a/crates/lib/execution-driver/Cargo.toml
+++ b/crates/lib/execution-driver/Cargo.toml
@@ -8,6 +8,8 @@ publish.workspace = true
 waymark-state-manager = { workspace = true }
 waymark-state-manager-core = { workspace = true }
 waymark-state-vm-runtimes = { workspace = true }
+waymark-vm-driver = { workspace = true }
+waymark-vm-driver-thread = { workspace = true }
 waymark-workload-pinning-manager = { workspace = true }
 
 nonempty-collections = { workspace = true }

--- a/crates/lib/execution-driver/src/lib.rs
+++ b/crates/lib/execution-driver/src/lib.rs
@@ -16,6 +16,52 @@ use nonempty_collections::NEVec;
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 use tracing::Instrument as _;
+use waymark_state_vm_runtimes::Evicted;
+
+/// The exit error of the VMs the execution driver drives.
+type DriverErrorFor<
+    Value,
+    ExecutionError,
+    SnapshotSerializationError,
+    SnapshotPersistenceError,
+    EffectHandlingError,
+    GettingPromiseSettlementsError,
+> = waymark_vm_driver_thread::Error<
+    waymark_vm_driver::Error<
+        Value,
+        ExecutionError,
+        SnapshotSerializationError,
+        SnapshotPersistenceError,
+        EffectHandlingError,
+        GettingPromiseSettlementsError,
+    >,
+>;
+
+/// The state manager the execution driver operates on.
+type StateFor<
+    Factory,
+    Value,
+    ExecutionError,
+    SnapshotSerializationError,
+    SnapshotPersistenceError,
+    EffectHandlingError,
+    GettingPromiseSettlementsError,
+> = waymark_state_manager::State<
+    <Factory as waymark_state_manager_core::Factory>::Key,
+    Arc<
+        waymark_state_vm_runtimes::Spawned<
+            DriverErrorFor<
+                Value,
+                ExecutionError,
+                SnapshotSerializationError,
+                SnapshotPersistenceError,
+                EffectHandlingError,
+                GettingPromiseSettlementsError,
+            >,
+        >,
+    >,
+    Factory,
+>;
 
 /// Run the execution driver loop — receives batches of pinned handles from
 /// the workload pinning manager, activates each VM, and keeps them alive
@@ -23,27 +69,55 @@ use tracing::Instrument as _;
 ///
 /// Returns when the [`CancellationToken`] fires or the pinning channel closes.
 #[tracing::instrument(skip_all)]
-pub async fn run<Factory, DriverError>(
+pub async fn run<
+    Factory,
+    Value,
+    ExecutionError,
+    SnapshotSerializationError,
+    SnapshotPersistenceError,
+    EffectHandlingError,
+    GettingPromiseSettlementsError,
+>(
     mut pinned_rx: mpsc::Receiver<
         NEVec<waymark_workload_pinning_manager::PinnedHandle<Factory::Key>>,
     >,
     state: Arc<
-        waymark_state_manager::State<
-            Factory::Key,
-            Arc<waymark_state_vm_runtimes::Spawned<DriverError>>,
+        StateFor<
             Factory,
+            Value,
+            ExecutionError,
+            SnapshotSerializationError,
+            SnapshotPersistenceError,
+            EffectHandlingError,
+            GettingPromiseSettlementsError,
         >,
     >,
     shutdown_token: CancellationToken,
 ) where
     Factory: waymark_state_manager_core::Factory<
-            Value = Arc<waymark_state_vm_runtimes::Spawned<DriverError>>,
+            Value = Arc<
+                waymark_state_vm_runtimes::Spawned<
+                    DriverErrorFor<
+                        Value,
+                        ExecutionError,
+                        SnapshotSerializationError,
+                        SnapshotPersistenceError,
+                        EffectHandlingError,
+                        GettingPromiseSettlementsError,
+                    >,
+                >,
+            >,
         > + Send
         + Sync
         + 'static,
     Factory::Key: Eq + Hash + Clone + std::fmt::Debug + Send + Sync + 'static,
     Factory::Error: std::fmt::Debug,
-    DriverError: Send + 'static,
+    Value: Send + 'static,
+    ExecutionError: Send + 'static,
+    SnapshotSerializationError: Send + 'static,
+    SnapshotPersistenceError: Send + 'static,
+    EffectHandlingError: Send + 'static,
+    GettingPromiseSettlementsError: Send + 'static,
 {
     let shutdown = shutdown_token.clone().cancelled_owned();
     let mut shutdown = std::pin::pin!(shutdown);
@@ -73,25 +147,53 @@ pub async fn run<Factory, DriverError>(
 /// the VM driver exits or global shutdown fires. Dropping the handles on
 /// return releases the pinning and decrements the state-manager refcount.
 #[tracing::instrument(skip_all, fields(instance_id = ?pinned.id()))]
-async fn drive_one<Factory, DriverError>(
+async fn drive_one<
+    Factory,
+    Value,
+    ExecutionError,
+    SnapshotSerializationError,
+    SnapshotPersistenceError,
+    EffectHandlingError,
+    GettingPromiseSettlementsError,
+>(
     pinned: waymark_workload_pinning_manager::PinnedHandle<Factory::Key>,
     state: Arc<
-        waymark_state_manager::State<
-            Factory::Key,
-            Arc<waymark_state_vm_runtimes::Spawned<DriverError>>,
+        StateFor<
             Factory,
+            Value,
+            ExecutionError,
+            SnapshotSerializationError,
+            SnapshotPersistenceError,
+            EffectHandlingError,
+            GettingPromiseSettlementsError,
         >,
     >,
     shutdown: CancellationToken,
 ) where
     Factory: waymark_state_manager_core::Factory<
-            Value = Arc<waymark_state_vm_runtimes::Spawned<DriverError>>,
+            Value = Arc<
+                waymark_state_vm_runtimes::Spawned<
+                    DriverErrorFor<
+                        Value,
+                        ExecutionError,
+                        SnapshotSerializationError,
+                        SnapshotPersistenceError,
+                        EffectHandlingError,
+                        GettingPromiseSettlementsError,
+                    >,
+                >,
+            >,
         > + Send
         + Sync
         + 'static,
     Factory::Key: Eq + Hash + Clone + std::fmt::Debug + Send + Sync + 'static,
     Factory::Error: std::fmt::Debug,
-    DriverError: Send + 'static,
+    Value: Send + 'static,
+    ExecutionError: Send + 'static,
+    SnapshotSerializationError: Send + 'static,
+    SnapshotPersistenceError: Send + 'static,
+    EffectHandlingError: Send + 'static,
+    GettingPromiseSettlementsError: Send + 'static,
 {
     let vm = match state.get(pinned.id().clone()).await {
         Ok(vm) => vm,
@@ -103,14 +205,26 @@ async fn drive_one<Factory, DriverError>(
 
     tracing::debug!("VM running");
 
-    tokio::select! {
-        _ = vm.evicted() => {
-            tracing::debug!("VM evicted, unpinning");
-        }
+    let evicted = tokio::select! {
+        evicted = vm.evicted() => evicted,
         _ = shutdown.cancelled() => {
-            tracing::debug!("shutting down: evicting VM and unpinning");
+            tracing::debug!("shutting down: evicting VM");
             vm.trigger_eviction();
-            let _ = vm.evicted().await;
+            vm.evicted().await
+        }
+    };
+
+    match evicted {
+        Evicted::DriverError(waymark_vm_driver_thread::Error::Driver(
+            waymark_vm_driver::Error::NoReadyFramesOrWaitingPromises,
+        )) => {
+            // TODO: park the workload via the pinned handle once the
+            // workload-pinning manager grows the park operation; the pin
+            // is lifted for now.
+            tracing::debug!("VM evicted, park requested, unpinning");
+        }
+        Evicted::DriverError(_) | Evicted::HandledElsewhere => {
+            tracing::debug!("VM evicted, unpinning");
         }
     }
 

--- a/crates/lib/execution-driver/src/lib.rs
+++ b/crates/lib/execution-driver/src/lib.rs
@@ -23,25 +23,27 @@ use tracing::Instrument as _;
 ///
 /// Returns when the [`CancellationToken`] fires or the pinning channel closes.
 #[tracing::instrument(skip_all)]
-pub async fn run<Factory>(
+pub async fn run<Factory, DriverError>(
     mut pinned_rx: mpsc::Receiver<
         NEVec<waymark_workload_pinning_manager::PinnedHandle<Factory::Key>>,
     >,
     state: Arc<
         waymark_state_manager::State<
             Factory::Key,
-            Arc<waymark_state_vm_runtimes::Spawned>,
+            Arc<waymark_state_vm_runtimes::Spawned<DriverError>>,
             Factory,
         >,
     >,
     shutdown_token: CancellationToken,
 ) where
-    Factory: waymark_state_manager_core::Factory<Value = Arc<waymark_state_vm_runtimes::Spawned>>
-        + Send
+    Factory: waymark_state_manager_core::Factory<
+            Value = Arc<waymark_state_vm_runtimes::Spawned<DriverError>>,
+        > + Send
         + Sync
         + 'static,
     Factory::Key: Eq + Hash + Clone + std::fmt::Debug + Send + Sync + 'static,
     Factory::Error: std::fmt::Debug,
+    DriverError: Send + 'static,
 {
     let shutdown = shutdown_token.clone().cancelled_owned();
     let mut shutdown = std::pin::pin!(shutdown);
@@ -71,23 +73,25 @@ pub async fn run<Factory>(
 /// the VM driver exits or global shutdown fires. Dropping the handles on
 /// return releases the pinning and decrements the state-manager refcount.
 #[tracing::instrument(skip_all, fields(instance_id = ?pinned.id()))]
-async fn drive_one<Factory>(
+async fn drive_one<Factory, DriverError>(
     pinned: waymark_workload_pinning_manager::PinnedHandle<Factory::Key>,
     state: Arc<
         waymark_state_manager::State<
             Factory::Key,
-            Arc<waymark_state_vm_runtimes::Spawned>,
+            Arc<waymark_state_vm_runtimes::Spawned<DriverError>>,
             Factory,
         >,
     >,
     shutdown: CancellationToken,
 ) where
-    Factory: waymark_state_manager_core::Factory<Value = Arc<waymark_state_vm_runtimes::Spawned>>
-        + Send
+    Factory: waymark_state_manager_core::Factory<
+            Value = Arc<waymark_state_vm_runtimes::Spawned<DriverError>>,
+        > + Send
         + Sync
         + 'static,
     Factory::Key: Eq + Hash + Clone + std::fmt::Debug + Send + Sync + 'static,
     Factory::Error: std::fmt::Debug,
+    DriverError: Send + 'static,
 {
     let vm = match state.get(pinned.id().clone()).await {
         Ok(vm) => vm,
@@ -106,7 +110,7 @@ async fn drive_one<Factory>(
         _ = shutdown.cancelled() => {
             tracing::debug!("shutting down: evicting VM and unpinning");
             vm.trigger_eviction();
-            vm.evicted().await;
+            let _ = vm.evicted().await;
         }
     }
 

--- a/crates/lib/state-vm-runtimes/src/lib.rs
+++ b/crates/lib/state-vm-runtimes/src/lib.rs
@@ -12,10 +12,12 @@
 
 #![warn(missing_docs)]
 
+mod once_receiver;
 mod snapshot_adapter;
 mod spawner;
 
-pub use self::spawner::Spawned;
+pub use self::snapshot_adapter::SnapshotAdapter;
+pub use self::spawner::{ErrorFor, Evicted, Spawned};
 
 use std::hash::Hash;
 use std::marker::PhantomData;
@@ -177,7 +179,17 @@ where
         Send + 'static,
 {
     type Key = Backend::VmId;
-    type Value = Arc<Spawned>;
+    type Value = Arc<
+        Spawned<
+            ErrorFor<
+                Value,
+                InterpreterProvider::Interpreter,
+                Codec,
+                SnapshotAdapter<Backend::VmId, Backend>,
+                EffectorProvider::Effector,
+            >,
+        >,
+    >;
     type Error = SpawningError<
         <Backend as waymark_state_vm_runtimes_backend::LoadForRevive>::Error,
         ExecutableProvider::Error,

--- a/crates/lib/state-vm-runtimes/src/once_receiver.rs
+++ b/crates/lib/state-vm-runtimes/src/once_receiver.rs
@@ -1,0 +1,42 @@
+//! A shared, take-once wrapper around a oneshot receiver.
+
+/// A shared wrapper around a [`tokio::sync::oneshot::Receiver`] that
+/// hands the received value out exactly once.
+pub struct OnceReceiver<T> {
+    receiver: tokio::sync::Mutex<Option<tokio::sync::oneshot::Receiver<T>>>,
+}
+
+impl<T> OnceReceiver<T> {
+    /// Create a new [`OnceReceiver`] wrapping the given `receiver`.
+    pub fn new(receiver: tokio::sync::oneshot::Receiver<T>) -> Self {
+        Self {
+            receiver: tokio::sync::Mutex::new(Some(receiver)),
+        }
+    }
+
+    /// Receive the value.
+    ///
+    /// The completion outcome is handed out exactly once, to the first
+    /// call to complete: `Some(Ok(_))` is the value, `Some(Err(_))`
+    /// means the sender was dropped without sending. Every call after
+    /// that returns `None`.
+    ///
+    /// # Cancellation safety
+    ///
+    /// This method is cancellation-safe: if the future is dropped
+    /// before completing, the value is retained and remains available
+    /// to the next caller.
+    pub async fn recv(&self) -> Option<Result<T, tokio::sync::oneshot::error::RecvError>> {
+        let mut guard = self.receiver.lock().await;
+        // Awaiting the receiver by `&mut` (never taking it out of the
+        // slot) is what makes cancellation safe: a dropped call leaves
+        // the receiver — and the pending value — in place. The slot is
+        // cleared only by the poll that observes the completion, which
+        // also shields later calls from the receiver's poll-after-
+        // complete panic.
+        let receiver = guard.as_mut()?;
+        let result = receiver.await;
+        *guard = None;
+        Some(result)
+    }
+}

--- a/crates/lib/state-vm-runtimes/src/snapshot_adapter.rs
+++ b/crates/lib/state-vm-runtimes/src/snapshot_adapter.rs
@@ -1,8 +1,11 @@
 use std::sync::Arc;
 
 /// Adapter that binds a VM id to a shared backend.
-pub(crate) struct SnapshotAdapter<VmId, Backend> {
+pub struct SnapshotAdapter<VmId, Backend> {
+    /// The VM whose snapshots this adapter persists.
     pub vm_id: VmId,
+
+    /// The backend the snapshots are persisted to.
     pub backend: Arc<Backend>,
 }
 

--- a/crates/lib/state-vm-runtimes/src/spawner.rs
+++ b/crates/lib/state-vm-runtimes/src/spawner.rs
@@ -5,9 +5,21 @@ use std::sync::Arc;
 use tokio_util::sync::CancellationToken;
 use tracing::Instrument as _;
 
+/// The outcome of awaiting a VM eviction; see [`Spawned::evicted`].
+#[derive(Debug)]
+pub enum Evicted<DriverError> {
+    /// The driver exited with this error; the caller took it and now
+    /// owns handling it.
+    DriverError(DriverError),
+
+    /// The exit error was already taken by a competing caller; that
+    /// caller owns handling it.
+    HandledElsewhere,
+}
+
 /// A spawned VM handle that exposes the access to the VM.
 #[must_use = "driver thread is aborted when this handle is dropped"]
-pub struct Spawned {
+pub struct Spawned<DriverError> {
     /// Gracefully cancels the driver loop.
     driver_loop_cancel: CancellationToken,
 
@@ -16,8 +28,9 @@ pub struct Spawned {
     /// That's the one that waits for the driver to complete.
     driver_completion_task: Option<tokio::task::JoinHandle<()>>,
 
-    /// Cancelled when the driver thread exits (the VM is evicted).
-    driver_evicted: CancellationToken,
+    /// Delivers the exit error reported by the driver completion task;
+    /// see [`Spawned::evicted`].
+    driver_error: crate::once_receiver::OnceReceiver<DriverError>,
 
     /// Opaque handles kept alive while this VM is running.
     #[allow(
@@ -28,11 +41,31 @@ pub struct Spawned {
     keepalive_handles: Vec<Box<dyn Send + Sync>>,
 }
 
-impl Spawned {
-    /// Returns a future that resolves when the VM driver thread exits
-    /// (the VM is evicted).
-    pub fn evicted(&self) -> impl std::future::Future<Output = ()> + '_ {
-        self.driver_evicted.cancelled()
+impl<DriverError> Spawned<DriverError> {
+    /// Wait for the VM driver thread to exit (the VM is evicted) and
+    /// take the exit error.
+    ///
+    /// The error is handed out exactly once: the first call to complete
+    /// receives [`Evicted::DriverError`], and every call after that receives
+    /// [`Evicted::HandledElsewhere`].
+    ///
+    /// # Cancellation safety
+    ///
+    /// This method is cancellation-safe: if the future is dropped
+    /// before completing, the error is retained and remains available
+    /// to the next caller.
+    pub async fn evicted(&self) -> Evicted<DriverError> {
+        match self.driver_error.recv().await {
+            Some(Ok(error)) => Evicted::DriverError(error),
+            // The completion task is never aborted (dropping the
+            // `Spawned` merely detaches it) and every statement between
+            // its spawn and the send is infallible, so the sender
+            // cannot be dropped without sending — short of runtime
+            // teardown, during which no caller is left running to
+            // observe it.
+            Some(Err(_)) => unreachable!("driver completion task gone without reporting"),
+            None => Evicted::HandledElsewhere,
+        }
     }
 
     /// Trigger the graceful eviction of the VM.
@@ -67,11 +100,17 @@ impl Spawned {
     }
 }
 
-impl Drop for Spawned {
+impl<DriverError> Drop for Spawned<DriverError> {
     fn drop(&mut self) {
         self.driver_loop_cancel.cancel();
     }
 }
+
+/// The exit error a spawned VM driver reports, as computed from the
+/// higher-level types the VM is spawned with.
+pub type ErrorFor<Value, Interpreter, Codec, Persister, Effector> = waymark_vm_driver_thread::Error<
+    waymark_vm_driver::ErrorFor<Value, Interpreter, Arc<Codec>, Persister, Effector>,
+>;
 
 /// Spawn a new VM runtime on a dedicated OS thread.
 #[tracing::instrument(skip_all)]
@@ -81,7 +120,7 @@ pub(crate) async fn spawn<Codec, Executable, Interpreter, Value, Effector, Persi
     effector: Effector,
     persister: Persister,
     keepalive_handles: Vec<Box<dyn Send + Sync>>,
-) -> Spawned
+) -> Spawned<ErrorFor<Value, Interpreter, Codec, Persister, Effector>>
 where
     Codec: waymark_vm_codec_core::SerializerProvider<Ok = ()>,
     Codec: Send + Sync + 'static,
@@ -121,7 +160,7 @@ where
     <Effector as waymark_vm_driver_core::PromiseSettler>::Error: Send,
 {
     let cancel = CancellationToken::new();
-    let driver_evicted = CancellationToken::new();
+    let (error_tx, error_rx) = tokio::sync::oneshot::channel();
     let driver = waymark_vm_driver_thread::spawn(waymark_vm_driver::Params {
         runtime,
         effector,
@@ -131,20 +170,11 @@ where
     });
 
     let completion = tokio::spawn({
-        let driver_evicted = driver_evicted.clone();
-        {
-            async move {
-                let _driver_evicted = driver_evicted.drop_guard();
-                let Err(error) = driver.await;
-                match error {
-                    waymark_vm_driver_thread::Error::Driver(error) => {
-                        tracing::error!(?error, "vm driver terminated");
-                    }
-                    waymark_vm_driver_thread::Error::Thread(error) => {
-                        tracing::error!(?error, "vm thread panicked");
-                    }
-                }
-            }
+        // The send signals the eviction; if the task is aborted before
+        // the driver exits, dropping the sender signals it instead.
+        async move {
+            let Err(error) = driver.await;
+            let _ = error_tx.send(error);
         }
         .in_current_span()
     });
@@ -152,7 +182,7 @@ where
     Spawned {
         driver_loop_cancel: cancel,
         driver_completion_task: Some(completion),
-        driver_evicted,
+        driver_error: crate::once_receiver::OnceReceiver::new(error_rx),
         keepalive_handles,
     }
 }


### PR DESCRIPTION
Goes in after #471

---

This is a small change that unlocks making decision at the execution runtime level based on the vm-driver and vm-driver-thread execution result (which can only be an error, with infallible `Ok` variant).