### PR TITLE
Correct the `vm-driver`-level semantics on the stale promise resolutions

### DIFF
--- a/crates/lib/execution-driver/src/lib.rs
+++ b/crates/lib/execution-driver/src/lib.rs
@@ -20,7 +20,6 @@ use waymark_state_vm_runtimes::Evicted;
 
 /// The exit error of the VMs the execution driver drives.
 type DriverErrorFor<
-    Value,
     ExecutionError,
     SnapshotSerializationError,
     SnapshotPersistenceError,
@@ -28,7 +27,6 @@ type DriverErrorFor<
     GettingPromiseSettlementsError,
 > = waymark_vm_driver_thread::Error<
     waymark_vm_driver::Error<
-        Value,
         ExecutionError,
         SnapshotSerializationError,
         SnapshotPersistenceError,
@@ -40,7 +38,6 @@ type DriverErrorFor<
 /// The state manager the execution driver operates on.
 type StateFor<
     Factory,
-    Value,
     ExecutionError,
     SnapshotSerializationError,
     SnapshotPersistenceError,
@@ -51,7 +48,6 @@ type StateFor<
     Arc<
         waymark_state_vm_runtimes::Spawned<
             DriverErrorFor<
-                Value,
                 ExecutionError,
                 SnapshotSerializationError,
                 SnapshotPersistenceError,
@@ -71,7 +67,6 @@ type StateFor<
 #[tracing::instrument(skip_all)]
 pub async fn run<
     Factory,
-    Value,
     ExecutionError,
     SnapshotSerializationError,
     SnapshotPersistenceError,
@@ -84,7 +79,6 @@ pub async fn run<
     state: Arc<
         StateFor<
             Factory,
-            Value,
             ExecutionError,
             SnapshotSerializationError,
             SnapshotPersistenceError,
@@ -98,7 +92,6 @@ pub async fn run<
             Value = Arc<
                 waymark_state_vm_runtimes::Spawned<
                     DriverErrorFor<
-                        Value,
                         ExecutionError,
                         SnapshotSerializationError,
                         SnapshotPersistenceError,
@@ -112,7 +105,6 @@ pub async fn run<
         + 'static,
     Factory::Key: Eq + Hash + Clone + std::fmt::Debug + Send + Sync + 'static,
     Factory::Error: std::fmt::Debug,
-    Value: Send + 'static,
     ExecutionError: Send + 'static,
     SnapshotSerializationError: Send + 'static,
     SnapshotPersistenceError: Send + 'static,
@@ -149,7 +141,6 @@ pub async fn run<
 #[tracing::instrument(skip_all, fields(instance_id = ?pinned.id()))]
 async fn drive_one<
     Factory,
-    Value,
     ExecutionError,
     SnapshotSerializationError,
     SnapshotPersistenceError,
@@ -160,7 +151,6 @@ async fn drive_one<
     state: Arc<
         StateFor<
             Factory,
-            Value,
             ExecutionError,
             SnapshotSerializationError,
             SnapshotPersistenceError,
@@ -174,7 +164,6 @@ async fn drive_one<
             Value = Arc<
                 waymark_state_vm_runtimes::Spawned<
                     DriverErrorFor<
-                        Value,
                         ExecutionError,
                         SnapshotSerializationError,
                         SnapshotPersistenceError,
@@ -188,7 +177,6 @@ async fn drive_one<
         + 'static,
     Factory::Key: Eq + Hash + Clone + std::fmt::Debug + Send + Sync + 'static,
     Factory::Error: std::fmt::Debug,
-    Value: Send + 'static,
     ExecutionError: Send + 'static,
     SnapshotSerializationError: Send + 'static,
     SnapshotPersistenceError: Send + 'static,

--- a/crates/lib/state-vm-runtimes/src/lib.rs
+++ b/crates/lib/state-vm-runtimes/src/lib.rs
@@ -182,7 +182,6 @@ where
     type Value = Arc<
         Spawned<
             ErrorFor<
-                Value,
                 InterpreterProvider::Interpreter,
                 Codec,
                 SnapshotAdapter<Backend::VmId, Backend>,

--- a/crates/lib/state-vm-runtimes/src/spawner.rs
+++ b/crates/lib/state-vm-runtimes/src/spawner.rs
@@ -108,8 +108,8 @@ impl<DriverError> Drop for Spawned<DriverError> {
 
 /// The exit error a spawned VM driver reports, as computed from the
 /// higher-level types the VM is spawned with.
-pub type ErrorFor<Value, Interpreter, Codec, Persister, Effector> = waymark_vm_driver_thread::Error<
-    waymark_vm_driver::ErrorFor<Value, Interpreter, Arc<Codec>, Persister, Effector>,
+pub type ErrorFor<Interpreter, Codec, Persister, Effector> = waymark_vm_driver_thread::Error<
+    waymark_vm_driver::ErrorFor<Interpreter, Arc<Codec>, Persister, Effector>,
 >;
 
 /// Spawn a new VM runtime on a dedicated OS thread.
@@ -120,7 +120,7 @@ pub(crate) async fn spawn<Codec, Executable, Interpreter, Value, Effector, Persi
     effector: Effector,
     persister: Persister,
     keepalive_handles: Vec<Box<dyn Send + Sync>>,
-) -> Spawned<ErrorFor<Value, Interpreter, Codec, Persister, Effector>>
+) -> Spawned<ErrorFor<Interpreter, Codec, Persister, Effector>>
 where
     Codec: waymark_vm_codec_core::SerializerProvider<Ok = ()>,
     Codec: Send + Sync + 'static,

--- a/crates/lib/vm-driver-thread/src/lib.rs
+++ b/crates/lib/vm-driver-thread/src/lib.rs
@@ -25,8 +25,7 @@ pub enum Error<DriverError> {
 
 /// Convenience alias for [`Handle`] that computes the concrete type
 /// parameters from the higher-level types used by [`spawn`].
-pub type HandleFor<Value, Interpreter, Codec, Persister, Effector> = Handle<
-    <Value as waymark_vm_runtime_promise_core::Resolvable>::ReadyValue,
+pub type HandleFor<Interpreter, Codec, Persister, Effector> = Handle<
     <Interpreter as waymark_vm_interpreter::Interpreter>::Error,
     <Codec as waymark_vm_codec_core::SerializerProvider>::Error,
     <Persister as waymark_vm_driver_core::SnapshotPersister>::Error,
@@ -44,7 +43,7 @@ pub type HandleFor<Value, Interpreter, Codec, Persister, Effector> = Handle<
 /// Current tracing span is carried over to the driver thread.
 pub fn spawn<Executable, Interpreter, Value, Effector, Persister, Codec>(
     params: driver::Params<Executable, Interpreter, Value, Effector, Persister, Codec>,
-) -> HandleFor<Value, Interpreter, Codec, Persister, Effector>
+) -> HandleFor<Interpreter, Codec, Persister, Effector>
 where
     // Executable
     Executable: waymark_vm_executable::InstructionsProvider + Send + 'static,
@@ -95,7 +94,6 @@ where
 /// to finish. On completion, returns either the driver's terminal error or
 /// a thread-level panic error.
 pub struct Handle<
-    Value,
     ExecutionError,
     SnapshotSerializationError,
     SnapshotPersistenceError,
@@ -103,7 +101,6 @@ pub struct Handle<
     GettingPromiseSettlementsError,
 > {
     task: DriverTaskJoinHandle<
-        Value,
         ExecutionError,
         SnapshotSerializationError,
         SnapshotPersistenceError,
@@ -114,7 +111,6 @@ pub struct Handle<
 
 /// Join handle for the OS thread running the driver loop.
 type DriverTaskJoinHandle<
-    Value,
     ExecutionError,
     SnapshotSerializationError,
     SnapshotPersistenceError,
@@ -124,7 +120,6 @@ type DriverTaskJoinHandle<
     Result<
         core::convert::Infallible,
         driver::Error<
-            Value,
             ExecutionError,
             SnapshotSerializationError,
             SnapshotPersistenceError,
@@ -135,7 +130,6 @@ type DriverTaskJoinHandle<
 >;
 
 impl<
-    Value,
     ExecutionError,
     SnapshotSerializationError,
     SnapshotPersistenceError,
@@ -143,7 +137,6 @@ impl<
     GettingPromiseSettlementsError,
 > IntoFuture
     for Handle<
-        Value,
         ExecutionError,
         SnapshotSerializationError,
         SnapshotPersistenceError,
@@ -151,7 +144,6 @@ impl<
         GettingPromiseSettlementsError,
     >
 where
-    Value: core::fmt::Debug + Send + 'static,
     ExecutionError: core::fmt::Debug + Send + 'static,
     SnapshotSerializationError: core::fmt::Debug + Send + 'static,
     SnapshotPersistenceError: core::fmt::Debug + Send + 'static,
@@ -162,7 +154,6 @@ where
         core::convert::Infallible,
         Error<
             driver::Error<
-                Value,
                 ExecutionError,
                 SnapshotSerializationError,
                 SnapshotPersistenceError,

--- a/crates/lib/vm-driver/src/lib.rs
+++ b/crates/lib/vm-driver/src/lib.rs
@@ -12,11 +12,11 @@ use nonempty_collections::{IntoIteratorExt as _, NEVec, NonEmptyIterator as _};
 use tokio_util::sync::CancellationToken;
 use waymark_vm_driver_core::{PromiseResolution, PromiseSettlement};
 use waymark_vm_runtime::{FrameFor, Runtime};
+use waymark_vm_runtime_core::ResolvePromiseError;
 
 /// Errors returned by the driver loop.
 #[derive(Debug)]
 pub enum Error<
-    Value,
     ExecutionError,
     SnapshotSerializationError,
     SnapshotPersistenceError,
@@ -44,20 +44,13 @@ pub enum Error<
     /// Getting promise settlements has failed.
     GettingPromiseSettlements(GettingPromiseSettlementsError),
 
-    /// Resolving a promise failed.
-    ResolvingPromise(waymark_vm_runtime_core::ResolvePromiseError<Value>),
-
-    /// Rejecting a promise failed.
-    RejectingPromise(waymark_vm_runtime_core::RejectPromiseError<Value>),
-
     /// The driver was cancelled via its [`CancellationToken`].
     Cancelled,
 }
 
 /// Convenience alias for [`Error`] that computes the concrete error
 /// types from the higher-level type parameters used by [`run`].
-pub type ErrorFor<Value, Interpreter, Codec, Persister, Effector> = Error<
-    <Value as waymark_vm_runtime_promise_core::Resolvable>::ReadyValue,
+pub type ErrorFor<Interpreter, Codec, Persister, Effector> = Error<
     <Interpreter as waymark_vm_interpreter::Interpreter>::Error,
     <Codec as waymark_vm_codec_core::SerializerProvider>::Error,
     <Persister as waymark_vm_driver_core::SnapshotPersister>::Error,
@@ -95,7 +88,7 @@ where
 /// triggered, or another error variant when a fatal error occurs.
 pub async fn run<Executable, Interpreter, Value, Effector, Persister, Codec>(
     params: Params<Executable, Interpreter, Value, Effector, Persister, Codec>,
-) -> Result<core::convert::Infallible, ErrorFor<Value, Interpreter, Codec, Persister, Effector>>
+) -> Result<core::convert::Infallible, ErrorFor<Interpreter, Codec, Persister, Effector>>
 where
     Executable: waymark_vm_executable::InstructionsProvider,
     Executable::FunctionId: Copy + serde::Serialize,
@@ -163,18 +156,48 @@ where
                 ack,
             } = settlement;
 
+            // Stale settlements are normal under at-least-once
+            // delivery: a redelivery of an applied settlement finds its
+            // promise already settled, or — once settled promise states
+            // are garbage collected — not present at all.  Either way
+            // there is nothing to apply and the settlement is still
+            // acked below: the ack is what removes the durable record,
+            // and without it it would redeliver forever.  Benign by
+            // enumeration, not by default: the matches are exhaustive
+            // over the two known variants, so a new error variant is a
+            // compile error here, forcing a conscious classification.
             match resolution {
                 PromiseResolution::Resolved(value) => {
                     tracing::info!(?promise_state_id, ?value, "promise resolution");
-                    runtime
-                        .resolve_promise(promise_state_id, value)
-                        .map_err(Error::ResolvingPromise)?;
+                    match runtime.resolve_promise(promise_state_id, value) {
+                        Ok(()) => {}
+                        Err(
+                            error @ (ResolvePromiseError::AlreadyResolved(_)
+                            | ResolvePromiseError::PromiseStateNotFound(_)),
+                        ) => {
+                            tracing::info!(
+                                ?promise_state_id,
+                                ?error,
+                                "stale promise resolution ignored"
+                            );
+                        }
+                    }
                 }
                 PromiseResolution::Rejected(exception) => {
                     tracing::info!(?promise_state_id, ?exception, "promise rejection");
-                    runtime
-                        .reject_promise(promise_state_id, exception)
-                        .map_err(Error::RejectingPromise)?;
+                    match runtime.reject_promise(promise_state_id, exception) {
+                        Ok(()) => {}
+                        Err(
+                            error @ (ResolvePromiseError::AlreadyResolved(_)
+                            | ResolvePromiseError::PromiseStateNotFound(_)),
+                        ) => {
+                            tracing::info!(
+                                ?promise_state_id,
+                                ?error,
+                                "stale promise rejection ignored"
+                            );
+                        }
+                    }
                 }
             }
 

--- a/crates/lib/vm-driver/tests/integration.rs
+++ b/crates/lib/vm-driver/tests/integration.rs
@@ -4,7 +4,7 @@ use tokio_util::sync::CancellationToken;
 use waymark_vm_codec_rmp::RmpCodec;
 use waymark_vm_driver::{Error, Params, run};
 use waymark_vm_driver_core::{PromiseResolution, PromiseSettlement};
-use waymark_vm_runtime_core::{RegisterId, ResolvePromiseError};
+use waymark_vm_runtime_core::RegisterId;
 use waymark_vm_runtime_exception::Exception;
 use waymark_vm_runtime_promise_core::PromiseStateId;
 use waymark_vm_runtime_test::{
@@ -177,11 +177,14 @@ async fn returns_step_errors() {
 }
 
 #[tokio::test]
-async fn duplicate_resolutions_error() {
+async fn duplicate_resolutions_are_ignored() {
     let (effects_tx, _effects_rx) = tokio::sync::mpsc::channel::<EmittedEffect<TestEffect>>(1);
     let (settlements_tx, settlements_rx) =
         tokio::sync::mpsc::channel::<PromiseSettlement<TestReadyValue, ()>>(2);
 
+    // At-least-once delivery: the same promise settled twice.  The
+    // first resolution wins, the redelivery is dropped, and the VM
+    // runs to completion.
     settlements_tx
         .send(PromiseSettlement {
             promise_state_id: PromiseStateId(0),
@@ -198,6 +201,7 @@ async fn duplicate_resolutions_error() {
         })
         .await
         .unwrap();
+    drop(settlements_tx);
 
     let result = run(Params {
         runtime: runtime(executable(vec![function(
@@ -217,34 +221,48 @@ async fn duplicate_resolutions_error() {
     })
     .await;
 
-    let Err(Error::ResolvingPromise(ResolvePromiseError::AlreadyResolved(err))) = result else {
-        panic!("expected AlreadyResolved");
-    };
-    assert_eq!(err.new_value, TestReadyValue::Int(11));
+    assert!(matches!(result, Err(Error::NoReadyFramesOrWaitingPromises)));
 }
 
 #[tokio::test]
-async fn unknown_promise_id_error() {
+async fn duplicate_rejection_after_resolution_is_ignored() {
     let (effects_tx, _effects_rx) = tokio::sync::mpsc::channel::<EmittedEffect<TestEffect>>(1);
     let (settlements_tx, settlements_rx) =
-        tokio::sync::mpsc::channel::<PromiseSettlement<TestReadyValue, ()>>(1);
+        tokio::sync::mpsc::channel::<PromiseSettlement<TestReadyValue, ()>>(2);
 
+    // A redelivered settlement may even change flavor: a rejection
+    // arriving for an already-resolved promise is dropped the same way.
     settlements_tx
         .send(PromiseSettlement {
-            promise_state_id: PromiseStateId(9),
-            resolution: PromiseResolution::Resolved(TestReadyValue::Int(41)),
+            promise_state_id: PromiseStateId(0),
+            resolution: PromiseResolution::Resolved(TestReadyValue::Int(10)),
             ack: (),
         })
         .await
         .unwrap();
+    settlements_tx
+        .send(PromiseSettlement {
+            promise_state_id: PromiseStateId(0),
+            resolution: PromiseResolution::Rejected(Exception {
+                type_id: "late".to_string(),
+                details: TestReadyValue::Int(99),
+            }),
+            ack: (),
+        })
+        .await
+        .unwrap();
+    drop(settlements_tx);
 
     let result = run(Params {
         runtime: runtime(executable(vec![function(
             1,
-            vec![vec![TestInstruction::Suspend {
-                dst: RegisterId(0),
-                resume: StateId(1),
-            }]],
+            vec![
+                vec![TestInstruction::Suspend {
+                    dst: RegisterId(0),
+                    resume: StateId(1),
+                }],
+                vec![TestInstruction::Exit],
+            ],
         )])),
         effector: (effects_tx, settlements_rx),
         persister: (),
@@ -253,11 +271,55 @@ async fn unknown_promise_id_error() {
     })
     .await;
 
-    let Err(Error::ResolvingPromise(ResolvePromiseError::PromiseStateNotFound(err))) = result
-    else {
-        panic!("expected PromiseStateNotFound");
-    };
-    assert_eq!(err.promise_state_id, PromiseStateId(9));
+    assert!(matches!(result, Err(Error::NoReadyFramesOrWaitingPromises)));
+}
+
+#[tokio::test]
+async fn unknown_promise_ids_are_ignored() {
+    let (effects_tx, _effects_rx) = tokio::sync::mpsc::channel::<EmittedEffect<TestEffect>>(1);
+    let (settlements_tx, settlements_rx) =
+        tokio::sync::mpsc::channel::<PromiseSettlement<TestReadyValue, ()>>(2);
+
+    // A settlement for a promise this runtime does not know — e.g. a
+    // stale redelivery for a state that was garbage collected.  It is
+    // dropped, and the settlement that follows still applies normally.
+    settlements_tx
+        .send(PromiseSettlement {
+            promise_state_id: PromiseStateId(9),
+            resolution: PromiseResolution::Resolved(TestReadyValue::Int(41)),
+            ack: (),
+        })
+        .await
+        .unwrap();
+    settlements_tx
+        .send(PromiseSettlement {
+            promise_state_id: PromiseStateId(0),
+            resolution: PromiseResolution::Resolved(TestReadyValue::Int(10)),
+            ack: (),
+        })
+        .await
+        .unwrap();
+    drop(settlements_tx);
+
+    let result = run(Params {
+        runtime: runtime(executable(vec![function(
+            1,
+            vec![
+                vec![TestInstruction::Suspend {
+                    dst: RegisterId(0),
+                    resume: StateId(1),
+                }],
+                vec![TestInstruction::Exit],
+            ],
+        )])),
+        effector: (effects_tx, settlements_rx),
+        persister: (),
+        codec: RmpCodec,
+        cancel: CancellationToken::new(),
+    })
+    .await;
+
+    assert!(matches!(result, Err(Error::NoReadyFramesOrWaitingPromises)));
 }
 
 #[tokio::test]


### PR DESCRIPTION
Goes in after #478.