### PR TITLE
Switch from passing timestamps to passing durations to the DB layer

### DIFF
--- a/crates/lib/action-effect-reconciler-backend/src/lock_vm_action_call_requests.rs
+++ b/crates/lib/action-effect-reconciler-backend/src/lock_vm_action_call_requests.rs
@@ -14,8 +14,12 @@ pub trait LockVmActionCallRequests: HasVmId + HasLockOwnerId + HasTimestamp {
     /// locked rows for delivery.
     ///
     /// A row is eligible when it is unlocked or its lock expired at or
-    /// before `now`.  Rows locked by another owner and unexpired are left
-    /// untouched and reported via
+    /// before the store's own now.  `now` is the caller-clock instant
+    /// `lock.expires_at` was computed against: the taken lock's expiry
+    /// is stored as the store's now plus `expires_at - now` — a
+    /// difference of two caller-clock values, so no cross-node clock
+    /// agreement is needed.  Rows locked by another owner and unexpired
+    /// are left untouched and reported via
     /// [`VmLockOutcome::held_elsewhere`] — an attempt is presumed running
     /// in that owner's pool.
     ///

--- a/crates/lib/backend-postgres/src/action_call_requests/mod.rs
+++ b/crates/lib/backend-postgres/src/action_call_requests/mod.rs
@@ -116,7 +116,7 @@ impl waymark_action_effect_reconciler_backend::RecordActionCallRequests for Post
             INSERT INTO action_call_requests
                 (vm_id, promise_state_id, effect_number, request,
                  locked_by, lock_expires_at)
-            SELECT t.*, $5, $6
+            SELECT t.*, $5, NOW() + ($6 * interval '1 microsecond')
             FROM UNNEST($1::uuid[], $2::bigint[], $3::bigint[], $4::bytea[])
                 AS t(vm_id, promise_state_id, effect_number, request)
             ON CONFLICT (vm_id, promise_state_id) DO NOTHING
@@ -128,7 +128,7 @@ impl waymark_action_effect_reconciler_backend::RecordActionCallRequests for Post
         .bind(&effect_numbers)
         .bind(&requests)
         .bind(lock.owner)
-        .bind(lock.expires_at)
+        .bind(crate::remaining_micros(Utc::now(), lock.expires_at))
         .fetch_all(&self.pool)
         .timed(crate::query_timing_histogram!(
             "insert:action_call_requests"
@@ -234,15 +234,14 @@ impl waymark_action_effect_reconciler_backend::LockVmActionCallRequests for Post
         let locked_rows = sqlx::query(
             r#"
             UPDATE action_call_requests
-            SET locked_by = $2, lock_expires_at = $3
-            WHERE vm_id = $1 AND (locked_by IS NULL OR lock_expires_at <= $4)
+            SET locked_by = $2, lock_expires_at = NOW() + ($3 * interval '1 microsecond')
+            WHERE vm_id = $1 AND (locked_by IS NULL OR lock_expires_at <= NOW())
             RETURNING vm_id, promise_state_id, effect_number, request
             "#,
         )
         .bind(vm_id)
         .bind(lock.owner)
-        .bind(lock.expires_at)
-        .bind(now)
+        .bind(crate::remaining_micros(now, lock.expires_at))
         .fetch_all(&self.pool)
         .timed(crate::query_timing_histogram!(
             "update:action_call_requests_lock"
@@ -325,7 +324,7 @@ impl waymark_action_effect_reconciler_backend::RenewActionCallRequestLocks for P
             ),
             renewed AS (
                 UPDATE action_call_requests r
-                SET lock_expires_at = $4
+                SET lock_expires_at = NOW() + ($4 * interval '1 microsecond')
                 FROM input i
                 WHERE r.vm_id = i.vm_id
                     AND r.promise_state_id = i.promise_state_id
@@ -345,7 +344,7 @@ impl waymark_action_effect_reconciler_backend::RenewActionCallRequestLocks for P
         .bind(&columns.vm_ids)
         .bind(&columns.promise_state_ids)
         .bind(lock.owner)
-        .bind(lock.expires_at)
+        .bind(crate::remaining_micros(Utc::now(), lock.expires_at))
         .fetch_all(&self.pool)
         .timed(crate::query_timing_histogram!(
             "update:action_call_requests_renew"

--- a/crates/lib/backend-postgres/src/lib.rs
+++ b/crates/lib/backend-postgres/src/lib.rs
@@ -154,3 +154,19 @@ pub enum Error {
     #[error(transparent)]
     Sqlx(sqlx::Error),
 }
+
+/// The remaining time to a caller-clock deadline as microseconds for
+/// `interval` arithmetic in SQL: the difference of two caller-clock
+/// values, so the stored deadline (the store's now plus this duration)
+/// tracks the caller's without any cross-clock comparison.  Negative
+/// when the deadline already passed — storing an already-lapsed
+/// deadline is the honest statement.  Saturated at the (unreachable)
+/// ±292k-year chrono overflow bounds.
+pub(crate) fn remaining_micros(
+    now: chrono::DateTime<chrono::Utc>,
+    deadline: chrono::DateTime<chrono::Utc>,
+) -> i64 {
+    (deadline - now)
+        .num_microseconds()
+        .unwrap_or(if deadline >= now { i64::MAX } else { i64::MIN })
+}

--- a/crates/lib/backend-postgres/src/sleep_requests/mod.rs
+++ b/crates/lib/backend-postgres/src/sleep_requests/mod.rs
@@ -63,14 +63,18 @@ impl waymark_sleep_reconciler_backend::RecordSleeps for PostgresBackend {
         let mut vm_ids = Vec::with_capacity(records.len().get());
         let mut promise_state_ids = Vec::with_capacity(records.len().get());
         let mut effect_numbers = Vec::with_capacity(records.len().get());
-        let mut wake_ats = Vec::with_capacity(records.len().get());
+        let mut wake_micros = Vec::with_capacity(records.len().get());
+        // One caller-clock base for the whole batch: each stored deadline
+        // is the store's now plus (wake_at - now), a difference of two
+        // caller-clock values.
+        let now = chrono::Utc::now();
         for record in records.iter() {
             vm_ids.push(record.vm_id);
             promise_state_ids
                 .push(i64::try_from(record.promise_state_id.0).map_err(Self::Error::OutOfRange)?);
             effect_numbers
                 .push(i64::try_from(record.effect_number.0).map_err(Self::Error::OutOfRange)?);
-            wake_ats.push(record.wake_at);
+            wake_micros.push(crate::remaining_micros(now, record.wake_at));
         }
 
         Self::count_query(&self.query_counts, "insert:sleep_requests");
@@ -83,8 +87,10 @@ impl waymark_sleep_reconciler_backend::RecordSleeps for PostgresBackend {
             r#"
             INSERT INTO sleep_requests
                 (vm_id, promise_state_id, effect_number, wake_at)
-            SELECT * FROM UNNEST($1::uuid[], $2::bigint[], $3::bigint[], $4::timestamptz[])
-                AS t(vm_id, promise_state_id, effect_number, wake_at)
+            SELECT t.vm_id, t.promise_state_id, t.effect_number,
+                   NOW() + (t.wake_micros * interval '1 microsecond')
+            FROM UNNEST($1::uuid[], $2::bigint[], $3::bigint[], $4::bigint[])
+                AS t(vm_id, promise_state_id, effect_number, wake_micros)
             ON CONFLICT (vm_id, promise_state_id) DO NOTHING
             RETURNING vm_id, promise_state_id
             "#,
@@ -92,7 +98,7 @@ impl waymark_sleep_reconciler_backend::RecordSleeps for PostgresBackend {
         .bind(&vm_ids)
         .bind(&promise_state_ids)
         .bind(&effect_numbers)
-        .bind(&wake_ats)
+        .bind(&wake_micros)
         .fetch_all(&self.pool)
         .timed(crate::query_timing_histogram!("insert:sleep_requests"))
         .await
@@ -175,7 +181,9 @@ impl waymark_sleep_reconciler_backend::PollDueSleeps for PostgresBackend {
     #[function_name::named]
     async fn poll_due_sleeps(
         &self,
-        now: chrono::DateTime<chrono::Utc>,
+        // Dueness is judged on the store's clock alone; the caller's
+        // clock plays no part once the deadline is stored.
+        _now: chrono::DateTime<chrono::Utc>,
         demand: NESlice<'_, SleepKey<InstanceId>>,
     ) -> Result<Vec<SleepKey<InstanceId>>, Self::Error> {
         let columns = key_columns(demand.iter()).map_err(Self::Error::OutOfRange)?;
@@ -192,12 +200,11 @@ impl waymark_sleep_reconciler_backend::PollDueSleeps for PostgresBackend {
             FROM sleep_requests s
             JOIN UNNEST($1::uuid[], $2::bigint[]) AS d(vm_id, promise_state_id)
                 ON s.vm_id = d.vm_id AND s.promise_state_id = d.promise_state_id
-            WHERE s.wake_at <= $3
+            WHERE s.wake_at <= NOW()
             "#,
         )
         .bind(&columns.vm_ids)
         .bind(&columns.promise_state_ids)
-        .bind(now)
         .fetch_all(&self.pool)
         .timed(crate::query_timing_histogram!("select:sleep_requests_poll"))
         .await

--- a/crates/lib/backend-postgres/src/sleep_requests/tests.rs
+++ b/crates/lib/backend-postgres/src/sleep_requests/tests.rs
@@ -65,8 +65,19 @@ async fn record_then_poll_returns_only_demanded_and_due() {
     assert_eq!(polled[..], [key(vm_a, 1)]);
 
     // Once the deadline passes, the future one becomes due as well.
+    // Dueness is on the database clock, so rewind the stored deadline
+    // instead of polling with a future timestamp.
+    sqlx::query(
+        "UPDATE sleep_requests SET wake_at = NOW() - interval '1 second' \
+         WHERE vm_id = $1 AND promise_state_id = $2",
+    )
+    .bind(vm_a)
+    .bind(2i64)
+    .execute(backend.pool())
+    .await
+    .expect("rewind the stored deadline");
     let polled = backend
-        .poll_due_sleeps(future + Duration::seconds(1), demand.as_nonempty_slice())
+        .poll_due_sleeps(now, demand.as_nonempty_slice())
         .await
         .expect("poll past the deadline");
     assert_eq!(polled.len(), 2);

--- a/crates/lib/backend-postgres/src/workload_pinning/mod.rs
+++ b/crates/lib/backend-postgres/src/workload_pinning/mod.rs
@@ -48,25 +48,27 @@ impl waymark_workload_pinning_backend::PollUnpinnedWorkloads for PostgresBackend
         max_items: NonZeroUsize,
     ) -> Result<Option<NEVec<Self::WorkloadId>>, Self::Error> {
         Self::count_query(&self.query_counts, "update:runnable_workloads_poll");
+        // Staleness check and fresh expiry both use the database clock:
+        // the steal comparison is single-clock and needs no cross-node
+        // time agreement.
         let rows = sqlx::query(
             r#"
             UPDATE runnable_workloads
-            SET node_id = $3, expires_at = $4, updated_at = NOW()
+            SET node_id = $2, expires_at = NOW() + ($3 * interval '1 microsecond'), updated_at = NOW()
             WHERE workload_id IN (
                 SELECT workload_id
                 FROM runnable_workloads
-                WHERE node_id IS NULL OR expires_at <= $1
+                WHERE node_id IS NULL OR expires_at <= NOW()
                 ORDER BY updated_at
-                LIMIT $2
+                LIMIT $1
                 FOR UPDATE SKIP LOCKED
             )
             RETURNING workload_id
             "#,
         )
-        .bind(now)
         .bind(max_items.get() as i64)
         .bind(pinning.node_id)
-        .bind(pinning.expires_at)
+        .bind(crate::remaining_micros(now, pinning.expires_at))
         .fetch_all(&self.pool)
         .timed(crate::query_timing_histogram!(
             "update:runnable_workloads_poll"
@@ -89,8 +91,7 @@ impl waymark_workload_pinning_backend::KeepalivePinnings for PostgresBackend {
     #[function_name::named]
     fn refresh_pinnings<'a>(
         &'a self,
-        // TODO: the trait should be updated to drop this param
-        _now: Self::Timestamp,
+        now: Self::Timestamp,
         pinning: Pinning<Self::NodeId, Self::Timestamp>,
         workload_ids: impl nonempty_collections::IntoNonEmptyIterator<Item = Self::WorkloadId> + 'a,
     ) -> impl Future<
@@ -109,20 +110,20 @@ impl waymark_workload_pinning_backend::KeepalivePinnings for PostgresBackend {
             // release nulls it, so either makes this UPDATE match zero rows and
             // report the pinning as lost. Row-level locking serializes a
             // concurrent poll-steal against this refresh, so whichever commits
-            // first wins deterministically. Guarding on `expires_at > now` here
+            // first wins deterministically. Guarding on `expires_at > NOW()` here
             // would instead drop a still-owned pinning that nobody contested
             // just because a heartbeat landed late.
             let rows = sqlx::query(
                 r#"
                 UPDATE runnable_workloads
-                SET expires_at = $3, updated_at = NOW()
+                SET expires_at = NOW() + ($3 * interval '1 microsecond'), updated_at = NOW()
                 WHERE node_id = $1 AND workload_id = ANY($2)
                 RETURNING workload_id
                 "#,
             )
             .bind(pinning.node_id)
             .bind(ids.as_ref())
-            .bind(pinning.expires_at)
+            .bind(crate::remaining_micros(now, pinning.expires_at))
             .fetch_all(&self.pool)
             .timed(crate::query_timing_histogram!(
                 "update:runnable_workloads_refresh"

--- a/crates/lib/workload-pinning-backend/src/poll.rs
+++ b/crates/lib/workload-pinning-backend/src/poll.rs
@@ -23,7 +23,12 @@ pub trait PollUnpinnedWorkloads: HasTimestamp + HasNodeId + HasWorkloadId {
     /// Workloads are guaranteed to be freshly pinned with
     /// the provided `pinning`.
     ///
-    /// `now` is used for expiration checks of stale pinnings.
+    /// `now` is the caller-clock instant `pinning.expires_at` was
+    /// computed against.  Implementations keep expiry on the store's
+    /// clock alone: staleness is judged against the store's own now,
+    /// and the fresh expiry is stored as the store's now plus the
+    /// remaining duration `expires_at - now` — a difference of two
+    /// caller-clock values, so no cross-node clock agreement is needed.
     ///
     /// Returns `Ok(None)` if no workloads were available.
     fn poll_unpinned(


### PR DESCRIPTION
Goes in after #479.

---

This is a controversial change; there is some justification for it. The downside is what happens when there is artificial latency between our app and the DB; the resolution to this is that should be fine, as long as we have local execution deadline (we have it for actions and we'll be adding it soon for VMs) that's always more pessimistic than the effective expiration interval that the database-side of the locking/pinning sees, as long as that timeout is not greater than the total latency between the rust-side `now` and the DB-side `now` capture points (not the difference in `now` time values - but the difference in real time passed; only the true latency matters, the different in "clock values" are irrelevant).