### PR TITLE
Defensive fencing for workloads

### DIFF
--- a/crates/bin/start-workers/src/main.rs
+++ b/crates/bin/start-workers/src/main.rs
@@ -20,6 +20,7 @@
 //! - WAYMARK_PERSIST_INTERVAL_MS: Result persistence tick (default: 500)
 //! - WAYMARK_LOCK_TTL_MS: Instance lock TTL (default: 15000)
 //! - WAYMARK_LOCK_HEARTBEAT_MS: Lock refresh heartbeat interval (default: 5000)
+//! - WAYMARK_PINNING_FENCING_MARGIN_MS: How early a pinning is fenced before its ttl (default: 1000)
 //! - WAYMARK_EVICT_SLEEP_THRESHOLD_MS: Sleep duration before evicting idle instances (default: 10000)
 //! - WAYMARK_EXPIRED_LOCK_RECLAIMER_INTERVAL_MS: Sweep interval for expired queue locks (default: 15000)
 //! - WAYMARK_EXPIRED_LOCK_RECLAIMER_BATCH_SIZE: Max expired locks to reclaim per sweep (default: 1000)
@@ -156,6 +157,7 @@ async fn main() -> Result<()> {
         max_pinned: config.max_concurrent_instances,
         pinning_ttl: config.lock_ttl,
         pinning_heartbeat: config.lock_heartbeat,
+        pinning_fencing_margin: config.pinning_fencing_margin,
         sleep_poll_interval: config.sleep_poll_interval,
         vm_retention: config.vm_retention,
         vm_sweep_interval: config.vm_sweep_interval,

--- a/crates/lib/config/src/lib.rs
+++ b/crates/lib/config/src/lib.rs
@@ -26,6 +26,7 @@ pub struct WorkerConfig {
     pub persistence_interval: Option<NonZeroDuration>,
     pub lock_ttl: NonZeroDuration,
     pub lock_heartbeat: NonZeroDuration,
+    pub pinning_fencing_margin: NonZeroDuration,
     pub action_effect_reconciler_lock_ttl: NonZeroDuration,
     pub action_effect_reconciler_lock_heartbeat: NonZeroDuration,
     pub evict_sleep_threshold: NonZeroDuration,
@@ -75,6 +76,9 @@ impl WorkerConfig {
         let FromMillis(lock_ttl) = envfury::or_parse("WAYMARK_LOCK_TTL_MS", "15000")?;
 
         let FromMillis(lock_heartbeat) = envfury::or_parse("WAYMARK_LOCK_HEARTBEAT_MS", "5000")?;
+
+        let FromMillis(pinning_fencing_margin) =
+            envfury::or_parse("WAYMARK_PINNING_FENCING_MARGIN_MS", "1000")?;
 
         let FromMillis(action_effect_reconciler_lock_ttl) =
             envfury::or_parse("WAYMARK_ACTION_EFFECT_RECONCILER_LOCK_TTL_MS", "15000")?;
@@ -155,6 +159,7 @@ impl WorkerConfig {
             persistence_interval,
             lock_ttl,
             lock_heartbeat,
+            pinning_fencing_margin,
             action_effect_reconciler_lock_ttl,
             action_effect_reconciler_lock_heartbeat,
             evict_sleep_threshold,

--- a/crates/lib/execution-bringup/src/lib.rs
+++ b/crates/lib/execution-bringup/src/lib.rs
@@ -40,6 +40,11 @@ pub struct Config<NodeId> {
     /// How often to refresh pinnings on active workloads.
     pub pinning_heartbeat: NonZeroDuration,
 
+    /// How much earlier than the pinning ttl a pinning is fenced when it
+    /// cannot be re-confirmed — the margin budgets the eviction latency
+    /// between the fence signal and the workload actually stopping.
+    pub pinning_fencing_margin: NonZeroDuration,
+
     /// How long the durable-sleeps demand poller waits between polls
     /// while demand is registered.
     pub sleep_poll_interval: NonZeroDuration,
@@ -190,6 +195,7 @@ where
         max_pinned,
         pinning_ttl,
         pinning_heartbeat,
+        pinning_fencing_margin,
         sleep_poll_interval,
         vm_retention,
         vm_sweep_interval,
@@ -487,9 +493,7 @@ where
         max_pinned,
         pinning_ttl,
         pinning_heartbeat,
-        // TODO(fencing commit 3): surface through `Config` and the env.
-        pinning_fencing_margin: NonZeroDuration::new(std::time::Duration::from_secs(1))
-            .expect("one second is non-zero"),
+        pinning_fencing_margin,
     };
 
     let pinning_manager = tokio::spawn(async move {

--- a/crates/lib/execution-bringup/src/lib.rs
+++ b/crates/lib/execution-bringup/src/lib.rs
@@ -487,6 +487,9 @@ where
         max_pinned,
         pinning_ttl,
         pinning_heartbeat,
+        // TODO(fencing commit 3): surface through `Config` and the env.
+        pinning_fencing_margin: NonZeroDuration::new(std::time::Duration::from_secs(1))
+            .expect("one second is non-zero"),
     };
 
     let pinning_manager = tokio::spawn(async move {

--- a/crates/lib/execution-driver/src/lib.rs
+++ b/crates/lib/execution-driver/src/lib.rs
@@ -193,8 +193,17 @@ async fn drive_one<
 
     tracing::debug!("VM running");
 
+    let mut fenced = false;
     let evicted = tokio::select! {
         evicted = vm.evicted() => evicted,
+        _ = pinned.fenced() => {
+            // The pinning lapsed or was lost to another node — this node
+            // can no longer prove it holds it, so stop driving the VM.
+            tracing::warn!("pinning fenced; evicting VM");
+            fenced = true;
+            vm.trigger_eviction();
+            vm.evicted().await
+        }
         _ = shutdown.cancelled() => {
             tracing::debug!("shutting down: evicting VM");
             vm.trigger_eviction();
@@ -204,6 +213,15 @@ async fn drive_one<
 
     // The pin is lifted only after `evicted()` has resolved — the VM
     // driver has fully exited by then.
+
+    // A fenced pinning is lost: another node may already hold it, so it
+    // is not ours to park. Release it unconditionally.
+    if fenced {
+        tracing::debug!("VM evicted after fence, releasing");
+        drop(pinned);
+        return;
+    }
+
     match evicted {
         Evicted::DriverError(waymark_vm_driver_thread::Error::Driver(
             waymark_vm_driver::Error::NoReadyFramesOrWaitingPromises,

--- a/crates/lib/workload-pinning-manager/src/lib.rs
+++ b/crates/lib/workload-pinning-manager/src/lib.rs
@@ -4,6 +4,7 @@
 
 mod maintenance;
 mod outcome;
+mod pinned_batch;
 mod pinned_handle;
 mod poll;
 
@@ -69,6 +70,14 @@ where
 
     /// How often to refresh pinnings on active workloads.
     pub pinning_heartbeat: NonZeroDuration,
+
+    /// How much earlier than the pinning ttl the local lapse deadline
+    /// falls: a pinning not re-confirmed within `pinning_ttl -
+    /// pinning_fencing_margin` of its (monotonic, pre-send) anchor
+    /// lapses and the workload is fenced — the margin budgets the
+    /// eviction latency between the fence signal and the workload
+    /// actually stopping.
+    pub pinning_fencing_margin: NonZeroDuration,
 }
 
 /// Run the workload management loop.
@@ -88,7 +97,7 @@ where
     <Backend as waymark_workload_pinning_backend::KeepalivePinnings>::Error: std::fmt::Debug,
     <Backend as waymark_workload_pinning_backend::UnpinWorkloads>::Error: std::fmt::Debug,
     Backend::NodeId: Clone,
-    Backend::WorkloadId: Clone + std::hash::Hash + Eq,
+    Backend::WorkloadId: Clone + std::hash::Hash + Eq + std::fmt::Debug,
 {
     let Params {
         shutdown_token,
@@ -99,6 +108,7 @@ where
         max_pinned,
         pinning_ttl,
         pinning_heartbeat,
+        pinning_fencing_margin,
     } = params;
 
     info!(
@@ -111,10 +121,8 @@ where
     let (evict_tx, evict_rx) = tokio::sync::mpsc::unbounded_channel();
 
     // Poll → Maintain: dispatch newly-pinned IDs with a oneshot to get back the count.
-    let (batch_tx, batch_rx) = tokio::sync::mpsc::channel::<(
-        NEVec<Backend::WorkloadId>,
-        tokio::sync::oneshot::Sender<usize>,
-    )>(1);
+    let (batch_tx, batch_rx) =
+        tokio::sync::mpsc::channel::<pinned_batch::PinnedBatch<Backend::WorkloadId>>(1);
     // Maintain → Poll: push updated count after evictions.
     let (count_tx, count_rx) = tokio::sync::mpsc::unbounded_channel::<usize>();
 
@@ -145,6 +153,7 @@ where
         shutdown_token: force_shutdown_token,
         pinning_heartbeat,
         pinning_ttl,
+        pinning_fencing_margin,
     });
 
     // When the maintenance loop exits — for any reason — cancel the

--- a/crates/lib/workload-pinning-manager/src/maintenance/active_set.rs
+++ b/crates/lib/workload-pinning-manager/src/maintenance/active_set.rs
@@ -1,0 +1,186 @@
+//! The workloads the maintenance loop vouches for.
+//!
+//! See [`ActiveSet`].
+
+use std::collections::{HashMap, HashSet};
+
+use nonempty_collections::IntoIteratorExt as _;
+use tokio_util::sync::CancellationToken;
+use tracing::warn;
+
+/// The tracked liveness of one workload's pinning.
+struct PinningLiveness {
+    /// The local monotonic deadline by which a refresh must confirm the
+    /// pinning, or it lapses.
+    lapses_at: tokio::time::Instant,
+
+    /// Cancelled when the pinning lapses or is lost — the fence: the
+    /// matching [`PinnedHandle`](crate::PinnedHandle) holds a clone.
+    fence: CancellationToken,
+}
+
+/// The workloads whose pinnings the maintenance loop vouches for.
+///
+/// Tracking is what keeps a pinning alive: a tracked workload is
+/// refreshed on every heartbeat and its liveness watched. Ceasing to
+/// track a workload therefore **always** fences it — from that moment
+/// its pinning is no longer refreshed and will lapse, so whoever still
+/// holds the matching [`PinnedHandle`](crate::PinnedHandle) must be told
+/// to stop. Both ways to stop tracking —
+/// [`fence_and_stop_tracking`](ActiveSet::fence_and_stop_tracking) and
+/// [`fence_all_and_into_ids`](ActiveSet::fence_all_and_into_ids) — fence
+/// by construction, so a caller cannot drop a workload while leaving its
+/// holder unaware.
+///
+/// The converse does not hold: fencing alone does not stop tracking. A
+/// workload fenced on loss or lapse stays tracked — no longer refreshed,
+/// deliberately left to lapse — until its eviction flows back through
+/// the normal channel.
+pub struct ActiveSet<Id> {
+    tracked: HashMap<Id, PinningLiveness>,
+}
+
+impl<Id> ActiveSet<Id> {
+    /// Create an empty set.
+    pub fn new() -> Self {
+        Self {
+            tracked: HashMap::new(),
+        }
+    }
+
+    /// How many workloads are tracked, fenced or not.
+    pub fn tracked_count(&self) -> usize {
+        self.tracked.len()
+    }
+}
+
+impl<Id> ActiveSet<Id>
+where
+    Id: std::hash::Hash + Eq,
+{
+    /// Begin tracking a newly pinned workload.
+    pub fn track_newly_pinned(
+        &mut self,
+        id: Id,
+        lapses_at: tokio::time::Instant,
+        fence: CancellationToken,
+    ) {
+        self.tracked
+            .insert(id, PinningLiveness { lapses_at, fence });
+    }
+
+    /// Push the lapse deadline out after a refresh confirmed the pinning.
+    ///
+    /// A workload that is no longer tracked — evicted while the refresh
+    /// was in flight — is ignored.
+    pub fn extend_after_confirmed_refresh(&mut self, id: &Id, lapses_at: tokio::time::Instant) {
+        let Some(liveness) = self.tracked.get_mut(id) else {
+            return;
+        };
+        liveness.lapses_at = lapses_at;
+    }
+}
+
+impl<Id> ActiveSet<Id>
+where
+    Id: std::hash::Hash + Eq + std::fmt::Debug,
+{
+    /// Fence a workload whose pinning a refresh reported held by another
+    /// node, keeping it tracked so it is no longer refreshed.
+    pub fn fence_lost_pinning(&mut self, id: &Id) {
+        let Some(liveness) = self.tracked.get(id) else {
+            return;
+        };
+        if liveness.fence.is_cancelled() {
+            return;
+        }
+        warn!(?id, "pinning lost to another node; fencing workload");
+        liveness.fence.cancel();
+    }
+}
+
+impl<Id> ActiveSet<Id>
+where
+    Id: std::fmt::Debug,
+{
+    /// Fence every tracked workload whose lapse deadline has passed,
+    /// keeping them tracked so they are no longer refreshed.
+    pub fn fence_lapsed_pinnings(&mut self, now: tokio::time::Instant) {
+        for (id, liveness) in &self.tracked {
+            if liveness.fence.is_cancelled() || liveness.lapses_at > now {
+                continue;
+            }
+            warn!(
+                ?id,
+                "pinning lapsed without a confirmed refresh; fencing workload"
+            );
+            liveness.fence.cancel();
+        }
+    }
+}
+
+impl<Id> ActiveSet<Id>
+where
+    Id: std::hash::Hash + Eq,
+{
+    /// Stop tracking an evicted workload, fencing it on the way out.
+    ///
+    /// The workload is no longer refreshed from this point, so its
+    /// pinning would lapse regardless — the fence says so outright.
+    pub fn fence_and_stop_tracking(&mut self, id: &Id) {
+        let Some(liveness) = self.tracked.remove(id) else {
+            return;
+        };
+        liveness.fence.cancel();
+    }
+
+    /// Fence every tracked workload and surrender their ids.
+    ///
+    /// Used when the loop exits with an error: the caller releases these
+    /// pinnings during cleanup, so every holder must be told to stop
+    /// before that happens.
+    pub fn fence_all_and_into_ids(self) -> HashSet<Id> {
+        self.tracked
+            .into_iter()
+            .map(|(id, liveness)| {
+                liveness.fence.cancel();
+                id
+            })
+            .collect()
+    }
+}
+
+impl<Id> ActiveSet<Id>
+where
+    Id: Clone,
+{
+    /// The ids whose pinnings still need refreshing.
+    ///
+    /// Fenced workloads are excluded — their pinnings are deliberately
+    /// left to lapse.
+    pub fn ids_needing_refresh(
+        &self,
+    ) -> Option<impl nonempty_collections::NonEmptyIterator<Item = Id> + Clone + '_> {
+        self.tracked
+            .iter()
+            .filter(|(_, liveness)| !liveness.fence.is_cancelled())
+            .map(|(id, _)| id.clone())
+            .try_into_nonempty_iter()
+    }
+}
+
+impl<Id> ActiveSet<Id> {
+    /// The earliest lapse deadline still standing.
+    ///
+    /// Fenced workloads are excluded — their signal has already fired.
+    pub fn earliest_lapse_deadline(&self) -> Option<tokio::time::Instant> {
+        self.tracked
+            .values()
+            .filter(|liveness| !liveness.fence.is_cancelled())
+            .map(|liveness| liveness.lapses_at)
+            .min()
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/lib/workload-pinning-manager/src/maintenance/active_set/tests.rs
+++ b/crates/lib/workload-pinning-manager/src/maintenance/active_set/tests.rs
@@ -1,0 +1,143 @@
+use std::time::Duration;
+
+use tokio_util::sync::CancellationToken;
+
+use super::ActiveSet;
+
+fn instant() -> tokio::time::Instant {
+    tokio::time::Instant::now()
+}
+
+#[tokio::test]
+async fn tracking_counts_fenced_and_unfenced_alike() {
+    let mut active = ActiveSet::new();
+    assert_eq!(active.tracked_count(), 0);
+
+    let fence = CancellationToken::new();
+    active.track_newly_pinned(1u64, instant(), fence.clone());
+    active.track_newly_pinned(2u64, instant(), CancellationToken::new());
+    assert_eq!(active.tracked_count(), 2);
+
+    // Fencing alone must not stop tracking.
+    active.fence_lost_pinning(&1u64);
+    assert!(fence.is_cancelled());
+    assert_eq!(active.tracked_count(), 2);
+}
+
+#[tokio::test]
+async fn stopping_tracking_fences_the_workload() {
+    let mut active = ActiveSet::new();
+    let fence = CancellationToken::new();
+    active.track_newly_pinned(1u64, instant(), fence.clone());
+
+    active.fence_and_stop_tracking(&1u64);
+
+    assert!(
+        fence.is_cancelled(),
+        "dropping a workload must fence it — it is no longer refreshed"
+    );
+    assert_eq!(active.tracked_count(), 0);
+}
+
+#[tokio::test]
+async fn surrendering_the_ids_fences_every_workload() {
+    let mut active = ActiveSet::new();
+    let fence1 = CancellationToken::new();
+    let fence2 = CancellationToken::new();
+    active.track_newly_pinned(1u64, instant(), fence1.clone());
+    active.track_newly_pinned(2u64, instant(), fence2.clone());
+
+    let ids = active.fence_all_and_into_ids();
+
+    assert!(
+        fence1.is_cancelled() && fence2.is_cancelled(),
+        "every holder must be fenced before the caller releases the pinnings"
+    );
+    assert_eq!(ids.len(), 2);
+    assert!(ids.contains(&1u64) && ids.contains(&2u64));
+}
+
+#[tokio::test]
+async fn fenced_workloads_are_left_out_of_refresh() {
+    let mut active = ActiveSet::new();
+    active.track_newly_pinned(1u64, instant(), CancellationToken::new());
+    active.track_newly_pinned(2u64, instant(), CancellationToken::new());
+
+    active.fence_lost_pinning(&1u64);
+
+    let ids = active.ids_needing_refresh().expect("id 2 still needs it");
+    let ids: Vec<u64> = ids.into_iter().collect();
+    assert_eq!(ids, vec![2u64], "the fenced pinning is left to lapse");
+}
+
+#[tokio::test]
+async fn refresh_ids_are_none_when_everything_is_fenced() {
+    let mut active = ActiveSet::new();
+    active.track_newly_pinned(1u64, instant(), CancellationToken::new());
+    active.fence_lost_pinning(&1u64);
+
+    assert!(active.ids_needing_refresh().is_none());
+    assert_eq!(
+        active.tracked_count(),
+        1,
+        "still tracked, just not refreshed"
+    );
+}
+
+#[tokio::test]
+async fn the_earliest_deadline_skips_fenced_workloads() {
+    let mut active = ActiveSet::new();
+    let now = instant();
+    let soon = now + Duration::from_secs(1);
+    let later = now + Duration::from_secs(10);
+
+    active.track_newly_pinned(1u64, soon, CancellationToken::new());
+    active.track_newly_pinned(2u64, later, CancellationToken::new());
+    assert_eq!(active.earliest_lapse_deadline(), Some(soon));
+
+    // Once the soonest one is fenced its deadline no longer counts.
+    active.fence_lost_pinning(&1u64);
+    assert_eq!(active.earliest_lapse_deadline(), Some(later));
+
+    active.fence_lost_pinning(&2u64);
+    assert_eq!(active.earliest_lapse_deadline(), None);
+}
+
+#[tokio::test]
+async fn a_confirmed_refresh_pushes_the_deadline_out() {
+    let mut active = ActiveSet::new();
+    let now = instant();
+    active.track_newly_pinned(1u64, now, CancellationToken::new());
+
+    let extended = now + Duration::from_secs(5);
+    active.extend_after_confirmed_refresh(&1u64, extended);
+
+    assert_eq!(active.earliest_lapse_deadline(), Some(extended));
+}
+
+#[tokio::test]
+async fn extending_an_untracked_workload_is_a_no_op() {
+    let mut active = ActiveSet::new();
+
+    // Evicted while the refresh was in flight — must not resurrect it.
+    active.extend_after_confirmed_refresh(&1u64, instant());
+
+    assert_eq!(active.tracked_count(), 0);
+}
+
+#[tokio::test]
+async fn only_lapsed_pinnings_are_fenced() {
+    let mut active = ActiveSet::new();
+    let now = instant();
+    let lapsed = CancellationToken::new();
+    let standing = CancellationToken::new();
+
+    active.track_newly_pinned(1u64, now, lapsed.clone());
+    active.track_newly_pinned(2u64, now + Duration::from_secs(10), standing.clone());
+
+    active.fence_lapsed_pinnings(now);
+
+    assert!(lapsed.is_cancelled(), "the deadline passed");
+    assert!(!standing.is_cancelled(), "this one still has time");
+    assert_eq!(active.tracked_count(), 2, "fencing keeps them tracked");
+}

--- a/crates/lib/workload-pinning-manager/src/maintenance/mod.rs
+++ b/crates/lib/workload-pinning-manager/src/maintenance/mod.rs
@@ -41,6 +41,14 @@
 //! back through the normal channel; the loop's responsibility ends at
 //! the signal.
 //!
+//! The converse is an invariant of
+//! [`ActiveSet`](self::active_set::ActiveSet): because tracking is what
+//! drives the refresh, a workload that stops being tracked is always
+//! fenced on the way out — including when the loop exits with an error
+//! and hands the remaining ids to the caller to release. Releasing a
+//! pinning whose holder was never told to stop is precisely the
+//! double-drive the fence exists to prevent.
+//!
 //! # Heartbeat retry policy
 //!
 //! Heartbeat refreshes are critical for keeping pinnings alive.
@@ -49,18 +57,20 @@
 //! If the retry also fails the loop exits with [`Error::Refresh`] so the
 //! caller can release the pinnings cleanly before they expire.
 
+mod active_set;
 mod error;
 
 pub use self::error::*;
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::sync::Arc;
 
-use nonempty_collections::{IntoIteratorExt as _, NEVec, NonEmptyIterator as _};
+use nonempty_collections::NEVec;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 use waymark_nonzero_duration::NonZeroDuration;
 
+use self::active_set::ActiveSet;
 use crate::pinned_batch::PinnedBatch;
 
 pub(super) struct MaintainParams<Backend>
@@ -80,17 +90,6 @@ where
     pub pinning_heartbeat: NonZeroDuration,
     pub pinning_ttl: NonZeroDuration,
     pub pinning_fencing_margin: NonZeroDuration,
-}
-
-/// The tracked liveness of one active workload's pinning.
-struct PinningLiveness {
-    /// The local monotonic deadline by which a refresh must confirm the
-    /// pinning, or it lapses.
-    lapses_at: tokio::time::Instant,
-
-    /// Cancelled when the pinning lapses or is lost — the fence: the
-    /// matching [`PinnedHandle`](crate::PinnedHandle) holds a clone.
-    fence: CancellationToken,
 }
 
 pub(super) async fn run_maintenance_loop<Backend>(
@@ -125,7 +124,7 @@ where
         .get()
         .saturating_sub(pinning_fencing_margin.get());
 
-    let mut active: HashMap<Backend::WorkloadId, PinningLiveness> = HashMap::new();
+    let mut active: ActiveSet<Backend::WorkloadId> = ActiveSet::new();
     let mut poll_exited = false;
     let shutdown = shutdown_token.child_token().cancelled_owned();
     let mut shutdown = std::pin::pin!(shutdown);
@@ -133,18 +132,11 @@ where
     heartbeat_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
     let result = loop {
-        if poll_exited && active.is_empty() {
+        if poll_exited && active.tracked_count() == 0 {
             break Ok(());
         }
 
-        // The earliest lapse deadline still standing; already-fenced
-        // workloads are excluded — their signal has fired and only the
-        // eviction flow removes them.
-        let next_lapse = active
-            .values()
-            .filter(|state| !state.fence.is_cancelled())
-            .map(|state| state.lapses_at)
-            .min();
+        let next_lapse = active.earliest_lapse_deadline();
 
         tokio::select! {
             result = batch_rx.recv(), if !poll_exited => {
@@ -152,14 +144,14 @@ where
                     Some(PinnedBatch { pinned_at, pinned, reply }) => {
                         let lapses_at = pinned_at + lapse_after;
                         for (id, fence) in pinned {
-                            active.insert(id, PinningLiveness { lapses_at, fence });
+                            active.track_newly_pinned(id, lapses_at, fence);
                         }
-                        let _ = reply.send(active.len());
+                        let _ = reply.send(active.tracked_count());
                     }
                     None => {
                         poll_exited = true;
-                        if !active.is_empty() {
-                            info!("poll loop exited, {} active IDs remain", active.len());
+                        if active.tracked_count() > 0 {
+                            info!("poll loop exited, {} active IDs remain", active.tracked_count());
                         }
                     }
                 }
@@ -171,26 +163,14 @@ where
                     unpins.push(eviction);
                 }
                 if let Err(error) = (*backend).unpin_workloads(node_id.clone(), unpins.clone()).await {
-                    break Err((MaintenanceError::Unpin(error), active.into_keys().collect()));
+                    break Err((MaintenanceError::Unpin(error), active.fence_all_and_into_ids()));
                 }
                 for (id, _mode) in unpins {
-                    active.remove(&id);
+                    active.fence_and_stop_tracking(&id);
                 }
-                let _ = count_tx.send(active.len());
+                let _ = count_tx.send(active.tracked_count());
             }
             _ = heartbeat_tick.tick() => {
-                // Refresh every pinning still standing — a fenced
-                // workload's pinning is deliberately left to lapse.
-                let Some(ids) = active
-                    .iter()
-                    .filter(|(_, state)| !state.fence.is_cancelled())
-                    .map(|(id, _)| id.clone())
-                    .try_into_nonempty_iter()
-                else {
-                    continue;
-                };
-                let ids: NEVec<_> = ids.collect();
-
                 // Both nows are captured before issuing the refresh:
                 // the store stamps the new expiry after this instant,
                 // so `fencing_now + lapse_after` is a conservative
@@ -198,54 +178,45 @@ where
                 // same refresh, so it reuses them.
                 let fencing_now = tokio::time::Instant::now();
                 let timestamp_now = chrono::Utc::now();
-                let statuses = match refresh_active_pinnings(&*backend, timestamp_now, node_id.clone(), ids.clone(), pinning_ttl).await {
-                    Ok(statuses) => statuses,
-                    Err(error) => {
-                        warn!(?error, "heartbeat refresh failed, retrying immediately");
-                        // Retry once immediately — must complete before pins expire.
-                        match refresh_active_pinnings(&*backend, timestamp_now, node_id.clone(), ids, pinning_ttl).await {
-                            Ok(statuses) => statuses,
-                            Err(error) => {
-                                break Err((MaintenanceError::Refresh(error), active.into_keys().collect()));
-                            }
+
+                // The ids borrow `active`, so the refresh is scoped:
+                // applying the statuses below needs it back, mutably.
+                let refreshed = {
+                    let Some(ids) = active.ids_needing_refresh() else {
+                        continue;
+                    };
+                    match refresh_active_pinnings(&*backend, timestamp_now, node_id.clone(), ids.clone(), pinning_ttl).await {
+                        Ok(statuses) => Ok(statuses),
+                        Err(error) => {
+                            warn!(?error, "heartbeat refresh failed, retrying immediately");
+                            // Retry once immediately — must complete before pins expire.
+                            refresh_active_pinnings(&*backend, timestamp_now, node_id.clone(), ids, pinning_ttl).await
                         }
                     }
                 };
 
-                {
-                    let lapses_at = fencing_now + lapse_after;
-                    for status in statuses {
-                        let Some(state) = active.get_mut(&status.workload_id) else {
-                            // Evicted while the refresh was in flight.
-                            continue;
-                        };
-                        if status.pinning.is_some() {
-                            state.lapses_at = lapses_at;
-                        } else if !state.fence.is_cancelled() {
-                            warn!(
-                                workload_id = ?status.workload_id,
-                                "pinning lost to another node; fencing workload"
-                            );
-                            state.fence.cancel();
-                        }
+                let statuses = match refreshed {
+                    Ok(statuses) => statuses,
+                    Err(error) => {
+                        break Err((MaintenanceError::Refresh(error), active.fence_all_and_into_ids()));
+                    }
+                };
+
+                let lapses_at = fencing_now + lapse_after;
+                for status in statuses {
+                    if status.pinning.is_some() {
+                        active.extend_after_confirmed_refresh(&status.workload_id, lapses_at);
+                    } else {
+                        active.fence_lost_pinning(&status.workload_id);
                     }
                 }
             }
             _ = async { tokio::time::sleep_until(next_lapse.unwrap()).await }, if next_lapse.is_some() => {
-                let now = tokio::time::Instant::now();
-                for (id, state) in active.iter() {
-                    if !state.fence.is_cancelled() && state.lapses_at <= now {
-                        warn!(
-                            workload_id = ?id,
-                            "pinning lapsed without a confirmed refresh; fencing workload"
-                        );
-                        state.fence.cancel();
-                    }
-                }
+                active.fence_lapsed_pinnings(tokio::time::Instant::now());
             }
             _ = &mut shutdown => {
                 warn!("maintenance loop force shutdown");
-                break Err((MaintenanceError::ForceShutdown, active.into_keys().collect()));
+                break Err((MaintenanceError::ForceShutdown, active.fence_all_and_into_ids()));
             }
         }
     };

--- a/crates/lib/workload-pinning-manager/src/maintenance/mod.rs
+++ b/crates/lib/workload-pinning-manager/src/maintenance/mod.rs
@@ -1,28 +1,45 @@
-//! Maintenance loop — handles evictions, pinnings refresh, and batch registration.
+//! Maintenance loop — handles evictions, pinnings refresh, batch
+//! registration, and the pinning fences.
 //!
 //! # Exit contract
 //!
 //! The maintenance loop keeps running as long as there is work to do.
-//! Work exists whenever **either** condition holds:
+//! Work exists whenever **any** condition holds:
 //!
 //! - `batch_rx` is still open — the poll loop is alive and may dispatch
 //!   newly-pinned workload IDs at any time.
-//! - `active_ids` is non-empty — there are in-flight workloads whose
-//!   pinnings must be refreshed and whose evictions must be processed.
+//! - `active` is non-empty — there are in-flight workloads whose
+//!   pinnings must be refreshed, whose liveness must be watched, and
+//!   whose evictions must be processed.
 //!
-//! The **terminal state** is reached when **both** conditions are false:
-//! `batch_rx` has been closed (the poll loop has exited) **and**
-//! `active_ids` is empty (all in-flight work has been evicted). At that
+//! The **terminal state** is reached when **both** conditions are
+//! false: `batch_rx` has been closed (the poll loop has exited) **and**
+//! `active` is empty (all in-flight work has been evicted). At that
 //! point no future work can arrive and the loop exits cleanly.
 //!
-//! On exit (whether clean or errored) the remaining `active_ids` set is
-//! sent through `cleanup_tx` so the caller can release any pinnings
-//! that were still held.
-//!
 //! The maintenance loop listens to its own shutdown token for emergency
-//! cancellation — this is separate from the poll loop's graceful-shutdown
-//! token. Under normal operation the loop exits naturally when the poll
-//! loop has stopped and all active IDs have been evicted.
+//! cancellation — this is separate from the poll loop's
+//! graceful-shutdown token. Under normal operation the loop exits
+//! naturally as above.
+//!
+//! # Pinning liveness and the fence
+//!
+//! Each active workload's pinning has a tracked liveness: a lapse
+//! deadline on the local monotonic clock — the instant captured
+//! **before** the (re-)pinning call was sent, plus the ttl, minus the
+//! configured fencing margin. The pre-send anchor makes the local
+//! deadline conservative with respect to the store-authoritative
+//! expiry regardless of the call's latency. A confirmed refresh pushes
+//! the deadline out; liveness ends when the pinning **lapses** (the
+//! deadline passes without a confirmed refresh) or is **lost** (a
+//! refresh reports it held by another node). Either way the workload
+//! is fenced: its fence token is cancelled, signalling the holder of
+//! the matching [`PinnedHandle`](crate::PinnedHandle) that the pinning
+//! can no longer be proven held. What the holder does about that is its
+//! own concern — the loop only raises the signal. A fenced workload
+//! stays tracked (though no longer refreshed) until its eviction flows
+//! back through the normal channel; the loop's responsibility ends at
+//! the signal.
 //!
 //! # Heartbeat retry policy
 //!
@@ -36,13 +53,15 @@ mod error;
 
 pub use self::error::*;
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
-use nonempty_collections::{IntoIteratorExt as _, NEVec};
+use nonempty_collections::{IntoIteratorExt as _, NEVec, NonEmptyIterator as _};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 use waymark_nonzero_duration::NonZeroDuration;
+
+use crate::pinned_batch::PinnedBatch;
 
 pub(super) struct MaintainParams<Backend>
 where
@@ -51,10 +70,7 @@ where
 {
     pub backend: Arc<Backend>,
     pub node_id: Backend::NodeId,
-    pub batch_rx: tokio::sync::mpsc::Receiver<(
-        NEVec<Backend::WorkloadId>,
-        tokio::sync::oneshot::Sender<usize>,
-    )>,
+    pub batch_rx: tokio::sync::mpsc::Receiver<PinnedBatch<Backend::WorkloadId>>,
     pub evict_rx: tokio::sync::mpsc::UnboundedReceiver<(
         Backend::WorkloadId,
         waymark_workload_pinning_core::UnpinMode,
@@ -63,6 +79,18 @@ where
     pub shutdown_token: CancellationToken,
     pub pinning_heartbeat: NonZeroDuration,
     pub pinning_ttl: NonZeroDuration,
+    pub pinning_fencing_margin: NonZeroDuration,
+}
+
+/// The tracked liveness of one active workload's pinning.
+struct PinningLiveness {
+    /// The local monotonic deadline by which a refresh must confirm the
+    /// pinning, or it lapses.
+    lapses_at: tokio::time::Instant,
+
+    /// Cancelled when the pinning lapses or is lost — the fence: the
+    /// matching [`PinnedHandle`](crate::PinnedHandle) holds a clone.
+    fence: CancellationToken,
 }
 
 pub(super) async fn run_maintenance_loop<Backend>(
@@ -75,7 +103,7 @@ where
         >,
     Backend: waymark_workload_pinning_backend::UnpinWorkloads,
     Backend::NodeId: Clone,
-    Backend::WorkloadId: Clone + std::hash::Hash + Eq,
+    Backend::WorkloadId: Clone + std::hash::Hash + Eq + std::fmt::Debug,
 {
     let MaintainParams {
         backend,
@@ -86,9 +114,18 @@ where
         shutdown_token,
         pinning_heartbeat,
         pinning_ttl,
+        pinning_fencing_margin,
     } = params;
 
-    let mut active_ids: HashSet<Backend::WorkloadId> = HashSet::new();
+    // How long past its pre-send anchor a pinning stays locally
+    // trusted.  A margin at or above the ttl degenerates to zero:
+    // workloads fence immediately, which such a configuration is
+    // asking for.
+    let lapse_after = pinning_ttl
+        .get()
+        .saturating_sub(pinning_fencing_margin.get());
+
+    let mut active: HashMap<Backend::WorkloadId, PinningLiveness> = HashMap::new();
     let mut poll_exited = false;
     let shutdown = shutdown_token.child_token().cancelled_owned();
     let mut shutdown = std::pin::pin!(shutdown);
@@ -96,23 +133,33 @@ where
     heartbeat_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
     let result = loop {
-        if poll_exited && active_ids.is_empty() {
+        if poll_exited && active.is_empty() {
             break Ok(());
         }
+
+        // The earliest lapse deadline still standing; already-fenced
+        // workloads are excluded — their signal has fired and only the
+        // eviction flow removes them.
+        let next_lapse = active
+            .values()
+            .filter(|state| !state.fence.is_cancelled())
+            .map(|state| state.lapses_at)
+            .min();
 
         tokio::select! {
             result = batch_rx.recv(), if !poll_exited => {
                 match result {
-                    Some((ids, reply)) => {
-                        for id in ids.iter() {
-                            active_ids.insert(id.clone());
+                    Some(PinnedBatch { pinned_at, pinned, reply }) => {
+                        let lapses_at = pinned_at + lapse_after;
+                        for (id, fence) in pinned {
+                            active.insert(id, PinningLiveness { lapses_at, fence });
                         }
-                        let _ = reply.send(active_ids.len());
+                        let _ = reply.send(active.len());
                     }
                     None => {
                         poll_exited = true;
-                        if !active_ids.is_empty() {
-                            info!("poll loop exited, {} active IDs remain", active_ids.len());
+                        if !active.is_empty() {
+                            info!("poll loop exited, {} active IDs remain", active.len());
                         }
                     }
                 }
@@ -124,31 +171,81 @@ where
                     unpins.push(eviction);
                 }
                 if let Err(error) = (*backend).unpin_workloads(node_id.clone(), unpins.clone()).await {
-                    break Err((MaintenanceError::Unpin(error), active_ids));
+                    break Err((MaintenanceError::Unpin(error), active.into_keys().collect()));
                 }
                 for (id, _mode) in unpins {
-                    active_ids.remove(&id);
+                    active.remove(&id);
                 }
-                let _ = count_tx.send(active_ids.len());
+                let _ = count_tx.send(active.len());
             }
             _ = heartbeat_tick.tick() => {
-                let Some(ids) = active_ids.iter().cloned().try_into_nonempty_iter() else {
+                // Refresh every pinning still standing — a fenced
+                // workload's pinning is deliberately left to lapse.
+                let Some(ids) = active
+                    .iter()
+                    .filter(|(_, state)| !state.fence.is_cancelled())
+                    .map(|(id, _)| id.clone())
+                    .try_into_nonempty_iter()
+                else {
                     continue;
                 };
-                match refresh_active_pinnings(&*backend, chrono::Utc::now(), node_id.clone(), ids.clone(), pinning_ttl).await {
-                    Ok(()) => {}
+                let ids: NEVec<_> = ids.collect();
+
+                // Both nows are captured before issuing the refresh:
+                // the store stamps the new expiry after this instant,
+                // so `fencing_now + lapse_after` is a conservative
+                // local deadline.  The immediate retry re-sends the
+                // same refresh, so it reuses them.
+                let fencing_now = tokio::time::Instant::now();
+                let timestamp_now = chrono::Utc::now();
+                let statuses = match refresh_active_pinnings(&*backend, timestamp_now, node_id.clone(), ids.clone(), pinning_ttl).await {
+                    Ok(statuses) => statuses,
                     Err(error) => {
                         warn!(?error, "heartbeat refresh failed, retrying immediately");
                         // Retry once immediately — must complete before pins expire.
-                        if let Err(error) = refresh_active_pinnings(&*backend, chrono::Utc::now(), node_id.clone(), ids, pinning_ttl).await {
-                            break Err((MaintenanceError::Refresh(error), active_ids));
+                        match refresh_active_pinnings(&*backend, timestamp_now, node_id.clone(), ids, pinning_ttl).await {
+                            Ok(statuses) => statuses,
+                            Err(error) => {
+                                break Err((MaintenanceError::Refresh(error), active.into_keys().collect()));
+                            }
                         }
+                    }
+                };
+
+                {
+                    let lapses_at = fencing_now + lapse_after;
+                    for status in statuses {
+                        let Some(state) = active.get_mut(&status.workload_id) else {
+                            // Evicted while the refresh was in flight.
+                            continue;
+                        };
+                        if status.pinning.is_some() {
+                            state.lapses_at = lapses_at;
+                        } else if !state.fence.is_cancelled() {
+                            warn!(
+                                workload_id = ?status.workload_id,
+                                "pinning lost to another node; fencing workload"
+                            );
+                            state.fence.cancel();
+                        }
+                    }
+                }
+            }
+            _ = async { tokio::time::sleep_until(next_lapse.unwrap()).await }, if next_lapse.is_some() => {
+                let now = tokio::time::Instant::now();
+                for (id, state) in active.iter() {
+                    if !state.fence.is_cancelled() && state.lapses_at <= now {
+                        warn!(
+                            workload_id = ?id,
+                            "pinning lapsed without a confirmed refresh; fencing workload"
+                        );
+                        state.fence.cancel();
                     }
                 }
             }
             _ = &mut shutdown => {
                 warn!("maintenance loop force shutdown");
-                break Err((MaintenanceError::ForceShutdown, active_ids));
+                break Err((MaintenanceError::ForceShutdown, active.into_keys().collect()));
             }
         }
     };
@@ -157,14 +254,18 @@ where
     result
 }
 
-/// Refresh pinnings on all active workloads.
+/// Refresh pinnings on all active workloads, returning the per-workload
+/// statuses.
 pub(super) async fn refresh_active_pinnings<Backend>(
     backend: &Backend,
     now: chrono::DateTime<chrono::Utc>,
     node_id: Backend::NodeId,
     ids: impl nonempty_collections::IntoNonEmptyIterator<Item = Backend::WorkloadId>,
     pinning_ttl: NonZeroDuration,
-) -> Result<(), <Backend as waymark_workload_pinning_backend::KeepalivePinnings>::Error>
+) -> Result<
+    NEVec<waymark_workload_pinning_backend::PinningStatusFor<Backend>>,
+    <Backend as waymark_workload_pinning_backend::KeepalivePinnings>::Error,
+>
 where
     Backend: waymark_workload_pinning_backend::KeepalivePinnings<
             Timestamp = chrono::DateTime<chrono::Utc>,
@@ -177,11 +278,11 @@ where
         expires_at,
     };
 
-    backend.refresh_pinnings(now, pinning, ids).await?;
+    let statuses = backend.refresh_pinnings(now, pinning, ids).await?;
 
     debug!("refreshed workload pinnings");
 
-    Ok(())
+    Ok(statuses)
 }
 
 #[cfg(test)]

--- a/crates/lib/workload-pinning-manager/src/maintenance/tests.rs
+++ b/crates/lib/workload-pinning-manager/src/maintenance/tests.rs
@@ -2,18 +2,20 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use mockall::predicate;
-use nonempty_collections::{NEVec, nev};
+use nonempty_collections::nev;
 use tokio::sync::mpsc;
 use tokio::sync::oneshot;
 use tokio_util::sync::CancellationToken;
+use waymark_nonzero_duration::NonZeroDuration;
 use waymark_workload_pinning_backend::PinningStatus;
 use waymark_workload_pinning_core::UnpinMode;
 
 use super::{MaintainParams, refresh_active_pinnings, run_maintenance_loop};
+use crate::pinned_batch::PinnedBatch;
 use crate::poll::poll_and_pin;
 use crate::test_utils::helpers::{
-    long_heartbeat, short_heartbeat, test_max_concurrent, test_node_id, test_pinning,
-    test_pinning_ttl,
+    long_heartbeat, short_heartbeat, test_fencing_margin, test_max_concurrent, test_node_id,
+    test_pinning, test_pinning_ttl,
 };
 use crate::test_utils::mock::MockBackend;
 
@@ -23,7 +25,7 @@ use crate::test_utils::mock::MockBackend;
 async fn maintain_loop_exits_when_batch_closed_and_empty() {
     let backend = Arc::new(MockBackend::new());
 
-    let (batch_tx, batch_rx) = mpsc::channel::<(NEVec<u64>, oneshot::Sender<usize>)>(1);
+    let (batch_tx, batch_rx) = mpsc::channel::<PinnedBatch<u64>>(1);
     let (evict_tx, evict_rx) = mpsc::unbounded_channel::<(u64, UnpinMode)>();
     let (count_tx, _count_rx) = mpsc::unbounded_channel::<usize>();
 
@@ -42,6 +44,7 @@ async fn maintain_loop_exits_when_batch_closed_and_empty() {
             shutdown_token: CancellationToken::new(),
             pinning_heartbeat: long_heartbeat(),
             pinning_ttl: test_pinning_ttl(),
+            pinning_fencing_margin: test_fencing_margin(),
         }),
     )
     .await
@@ -81,7 +84,7 @@ async fn maintain_loop_continues_until_last_eviction_after_batch_closed() {
 
     let backend = Arc::new(backend);
 
-    let (batch_tx, batch_rx) = mpsc::channel::<(NEVec<u64>, oneshot::Sender<usize>)>(1);
+    let (batch_tx, batch_rx) = mpsc::channel::<PinnedBatch<u64>>(1);
     let (evict_tx, evict_rx) = mpsc::unbounded_channel::<(u64, UnpinMode)>();
     let (count_tx, _count_rx) = mpsc::unbounded_channel::<usize>();
 
@@ -89,7 +92,11 @@ async fn maintain_loop_continues_until_last_eviction_after_batch_closed() {
     // for the maintenance loop to acknowledge the ID before evicting.
     let (reply_tx, reply_rx) = oneshot::channel::<usize>();
     batch_tx
-        .send((nev![id], reply_tx))
+        .send(PinnedBatch {
+            pinned_at: tokio::time::Instant::now(),
+            pinned: nev![(id, CancellationToken::new())],
+            reply: reply_tx,
+        })
         .await
         .expect("batch send");
 
@@ -105,6 +112,7 @@ async fn maintain_loop_continues_until_last_eviction_after_batch_closed() {
         shutdown_token: CancellationToken::new(),
         pinning_heartbeat: long_heartbeat(),
         pinning_ttl: test_pinning_ttl(),
+        pinning_fencing_margin: test_fencing_margin(),
     });
     tokio::pin!(loop_future);
 
@@ -166,14 +174,18 @@ async fn maintain_loop_heartbeats_fire_for_active_ids() {
 
     let backend = Arc::new(backend);
 
-    let (batch_tx, batch_rx) = mpsc::channel::<(NEVec<u64>, oneshot::Sender<usize>)>(1);
+    let (batch_tx, batch_rx) = mpsc::channel::<PinnedBatch<u64>>(1);
     let (evict_tx, evict_rx) = mpsc::unbounded_channel::<(u64, UnpinMode)>();
     let (count_tx, _count_rx) = mpsc::unbounded_channel::<usize>();
 
     // Stage a batch so there is an active ID to heartbeat.
     let (reply_tx, _reply_rx) = oneshot::channel::<usize>();
     batch_tx
-        .send((nev![id], reply_tx))
+        .send(PinnedBatch {
+            pinned_at: tokio::time::Instant::now(),
+            pinned: nev![(id, CancellationToken::new())],
+            reply: reply_tx,
+        })
         .await
         .expect("batch send");
 
@@ -187,6 +199,7 @@ async fn maintain_loop_heartbeats_fire_for_active_ids() {
         shutdown_token: CancellationToken::new(),
         pinning_heartbeat: short_heartbeat(),
         pinning_ttl: test_pinning_ttl(),
+        pinning_fencing_margin: test_fencing_margin(),
     });
     tokio::pin!(loop_future);
 
@@ -261,14 +274,18 @@ async fn maintain_loop_heartbeats_after_batch_closed() {
 
     let backend = Arc::new(backend);
 
-    let (batch_tx, batch_rx) = mpsc::channel::<(NEVec<u64>, oneshot::Sender<usize>)>(1);
+    let (batch_tx, batch_rx) = mpsc::channel::<PinnedBatch<u64>>(1);
     let (evict_tx, evict_rx) = mpsc::unbounded_channel::<(u64, UnpinMode)>();
     let (count_tx, _count_rx) = mpsc::unbounded_channel::<usize>();
 
     // Stage a batch.
     let (reply_tx, _reply_rx) = oneshot::channel::<usize>();
     batch_tx
-        .send((nev![id], reply_tx))
+        .send(PinnedBatch {
+            pinned_at: tokio::time::Instant::now(),
+            pinned: nev![(id, CancellationToken::new())],
+            reply: reply_tx,
+        })
         .await
         .expect("batch send");
 
@@ -284,6 +301,7 @@ async fn maintain_loop_heartbeats_after_batch_closed() {
         shutdown_token: CancellationToken::new(),
         pinning_heartbeat: short_heartbeat(),
         pinning_ttl: test_pinning_ttl(),
+        pinning_fencing_margin: test_fencing_margin(),
     });
     tokio::pin!(loop_future);
 
@@ -447,13 +465,17 @@ async fn maintain_loop_exits_on_unpin_error() {
 
     let backend = Arc::new(backend);
 
-    let (batch_tx, batch_rx) = mpsc::channel::<(NEVec<u64>, oneshot::Sender<usize>)>(1);
+    let (batch_tx, batch_rx) = mpsc::channel::<PinnedBatch<u64>>(1);
     let (evict_tx, evict_rx) = mpsc::unbounded_channel::<(u64, UnpinMode)>();
     let (count_tx, _count_rx) = mpsc::unbounded_channel::<usize>();
 
     let (reply_tx, reply_rx) = oneshot::channel::<usize>();
     batch_tx
-        .send((nev![id], reply_tx))
+        .send(PinnedBatch {
+            pinned_at: tokio::time::Instant::now(),
+            pinned: nev![(id, CancellationToken::new())],
+            reply: reply_tx,
+        })
         .await
         .expect("batch send");
     drop(batch_tx);
@@ -465,8 +487,9 @@ async fn maintain_loop_exits_on_unpin_error() {
         evict_rx,
         count_tx,
         shutdown_token: CancellationToken::new(),
-        pinning_heartbeat: long_heartbeat(),
+        pinning_heartbeat: short_heartbeat(),
         pinning_ttl: test_pinning_ttl(),
+        pinning_fencing_margin: test_fencing_margin(),
     });
     tokio::pin!(loop_future);
 
@@ -523,13 +546,17 @@ async fn maintain_loop_exits_on_force_shutdown() {
 
     let backend = Arc::new(backend);
 
-    let (batch_tx, batch_rx) = mpsc::channel::<(NEVec<u64>, oneshot::Sender<usize>)>(1);
+    let (batch_tx, batch_rx) = mpsc::channel::<PinnedBatch<u64>>(1);
     let (evict_tx, evict_rx) = mpsc::unbounded_channel::<(u64, UnpinMode)>();
     let (count_tx, _count_rx) = mpsc::unbounded_channel::<usize>();
 
     let (reply_tx, reply_rx) = oneshot::channel::<usize>();
     batch_tx
-        .send((nev![id], reply_tx))
+        .send(PinnedBatch {
+            pinned_at: tokio::time::Instant::now(),
+            pinned: nev![(id, CancellationToken::new())],
+            reply: reply_tx,
+        })
         .await
         .expect("batch send");
     drop(batch_tx);
@@ -544,6 +571,7 @@ async fn maintain_loop_exits_on_force_shutdown() {
         shutdown_token: shutdown.clone(),
         pinning_heartbeat: long_heartbeat(),
         pinning_ttl: test_pinning_ttl(),
+        pinning_fencing_margin: test_fencing_margin(),
     });
     tokio::pin!(loop_future);
 
@@ -605,14 +633,18 @@ async fn maintain_loop_exits_on_refresh_error() {
 
     let backend = Arc::new(backend);
 
-    let (batch_tx, batch_rx) = mpsc::channel::<(NEVec<u64>, oneshot::Sender<usize>)>(1);
+    let (batch_tx, batch_rx) = mpsc::channel::<PinnedBatch<u64>>(1);
     let (evict_tx, evict_rx) = mpsc::unbounded_channel::<(u64, UnpinMode)>();
     let (count_tx, _count_rx) = mpsc::unbounded_channel::<usize>();
 
     // Stage a batch so there is an active ID to trigger a heartbeat.
     let (reply_tx, reply_rx) = oneshot::channel::<usize>();
     batch_tx
-        .send((nev![id], reply_tx))
+        .send(PinnedBatch {
+            pinned_at: tokio::time::Instant::now(),
+            pinned: nev![(id, CancellationToken::new())],
+            reply: reply_tx,
+        })
         .await
         .expect("batch send");
     drop(batch_tx);
@@ -626,6 +658,7 @@ async fn maintain_loop_exits_on_refresh_error() {
         shutdown_token: CancellationToken::new(),
         pinning_heartbeat: short_heartbeat(),
         pinning_ttl: test_pinning_ttl(),
+        pinning_fencing_margin: test_fencing_margin(),
     });
     tokio::pin!(loop_future);
 
@@ -688,13 +721,17 @@ async fn maintain_loop_forwards_park_mode() {
 
     let backend = Arc::new(backend);
 
-    let (batch_tx, batch_rx) = mpsc::channel::<(NEVec<u64>, oneshot::Sender<usize>)>(1);
+    let (batch_tx, batch_rx) = mpsc::channel::<PinnedBatch<u64>>(1);
     let (evict_tx, evict_rx) = mpsc::unbounded_channel::<(u64, UnpinMode)>();
     let (count_tx, _count_rx) = mpsc::unbounded_channel::<usize>();
 
     let (reply_tx, reply_rx) = oneshot::channel::<usize>();
     batch_tx
-        .send((nev![id], reply_tx))
+        .send(PinnedBatch {
+            pinned_at: tokio::time::Instant::now(),
+            pinned: nev![(id, CancellationToken::new())],
+            reply: reply_tx,
+        })
         .await
         .expect("batch send");
     drop(batch_tx);
@@ -708,6 +745,7 @@ async fn maintain_loop_forwards_park_mode() {
         shutdown_token: CancellationToken::new(),
         pinning_heartbeat: long_heartbeat(),
         pinning_ttl: test_pinning_ttl(),
+        pinning_fencing_margin: test_fencing_margin(),
     });
     tokio::pin!(loop_future);
 
@@ -764,13 +802,20 @@ async fn maintain_loop_coalesces_queued_evictions() {
 
     let backend = Arc::new(backend);
 
-    let (batch_tx, batch_rx) = mpsc::channel::<(NEVec<u64>, oneshot::Sender<usize>)>(1);
+    let (batch_tx, batch_rx) = mpsc::channel::<PinnedBatch<u64>>(1);
     let (evict_tx, evict_rx) = mpsc::unbounded_channel::<(u64, UnpinMode)>();
     let (count_tx, _count_rx) = mpsc::unbounded_channel::<usize>();
 
     let (reply_tx, reply_rx) = oneshot::channel::<usize>();
     batch_tx
-        .send((nev![1u64, 2u64], reply_tx))
+        .send(PinnedBatch {
+            pinned_at: tokio::time::Instant::now(),
+            pinned: nev![
+                (1u64, CancellationToken::new()),
+                (2u64, CancellationToken::new())
+            ],
+            reply: reply_tx,
+        })
         .await
         .expect("batch send");
     drop(batch_tx);
@@ -784,6 +829,7 @@ async fn maintain_loop_coalesces_queued_evictions() {
         shutdown_token: CancellationToken::new(),
         pinning_heartbeat: long_heartbeat(),
         pinning_ttl: test_pinning_ttl(),
+        pinning_fencing_margin: test_fencing_margin(),
     });
     tokio::pin!(loop_future);
 
@@ -810,4 +856,534 @@ async fn maintain_loop_coalesces_queued_evictions() {
         .await
         .expect("loop should exit after draining the evictions");
     assert!(result.is_ok(), "expected Ok, got {result:?}");
+}
+
+/// A refresh reporting the pinning lost to another node must fence the
+/// workload immediately.
+#[tokio::test(flavor = "multi_thread")]
+async fn refresh_lost_status_fences_the_workload() {
+    let id = 1u64;
+    let node_id = test_node_id();
+
+    let mut backend = MockBackend::new();
+    backend
+        .expect_refresh_pinnings()
+        .times(1..)
+        .returning(move |_, _, _| {
+            Box::pin(std::future::ready(Ok(nev![PinningStatus {
+                workload_id: id,
+                pinning: None,
+            }])))
+        });
+    backend
+        .expect_unpin_workloads()
+        .times(1)
+        .returning(move |_, _| Box::pin(std::future::ready(Ok(()))));
+
+    let backend = Arc::new(backend);
+
+    let (batch_tx, batch_rx) = mpsc::channel::<PinnedBatch<u64>>(1);
+    let (evict_tx, evict_rx) = mpsc::unbounded_channel::<(u64, UnpinMode)>();
+    let (count_tx, _count_rx) = mpsc::unbounded_channel::<usize>();
+
+    let fence = CancellationToken::new();
+    let (reply_tx, reply_rx) = oneshot::channel::<usize>();
+    batch_tx
+        .send(PinnedBatch {
+            pinned_at: tokio::time::Instant::now(),
+            pinned: nev![(id, fence.clone())],
+            reply: reply_tx,
+        })
+        .await
+        .expect("batch send");
+    drop(batch_tx);
+
+    let loop_future = run_maintenance_loop(MaintainParams {
+        backend: Arc::clone(&backend),
+        node_id,
+        batch_rx,
+        evict_rx,
+        count_tx,
+        shutdown_token: CancellationToken::new(),
+        pinning_heartbeat: short_heartbeat(),
+        pinning_ttl: test_pinning_ttl(),
+        pinning_fencing_margin: test_fencing_margin(),
+    });
+    tokio::pin!(loop_future);
+
+    tokio::select! {
+        _ = reply_rx => {}
+        result = &mut loop_future => panic!("loop exited early: {result:?}"),
+    }
+
+    // The heartbeat discovers the loss and fences.
+    tokio::select! {
+        _ = fence.cancelled() => {}
+        result = &mut loop_future => panic!("loop exited before fencing: {result:?}"),
+        _ = tokio::time::sleep(Duration::from_secs(5)) => panic!("workload was never fenced"),
+    }
+
+    // The fence only signals — eviction still drains the loop.
+    evict_tx.send((id, UnpinMode::Release)).expect("evict send");
+    let result = tokio::time::timeout(Duration::from_secs(5), &mut loop_future)
+        .await
+        .expect("loop should drain after the eviction");
+    assert!(result.is_ok(), "expected a clean drain, got {result:?}");
+}
+
+/// A pinning that is not re-confirmed by its local deadline must lapse
+/// and fence the workload — here no refresh fires at all before the
+/// deadline.
+#[tokio::test(flavor = "multi_thread")]
+async fn pinning_lapses_when_no_refresh_confirms_in_time() {
+    let id = 1u64;
+    let node_id = test_node_id();
+
+    let mut backend = MockBackend::new();
+    backend
+        .expect_refresh_pinnings()
+        .times(0..)
+        .returning(move |_, _, _| {
+            let pinning = test_pinning(node_id, 1);
+            Box::pin(std::future::ready(Ok(nev![PinningStatus {
+                workload_id: id,
+                pinning: Some(pinning),
+            }])))
+        });
+    backend
+        .expect_unpin_workloads()
+        .times(1)
+        .returning(move |_, _| Box::pin(std::future::ready(Ok(()))));
+
+    let backend = Arc::new(backend);
+
+    let (batch_tx, batch_rx) = mpsc::channel::<PinnedBatch<u64>>(1);
+    let (evict_tx, evict_rx) = mpsc::unbounded_channel::<(u64, UnpinMode)>();
+    let (count_tx, _count_rx) = mpsc::unbounded_channel::<usize>();
+
+    let fence = CancellationToken::new();
+    let (reply_tx, reply_rx) = oneshot::channel::<usize>();
+    batch_tx
+        .send(PinnedBatch {
+            pinned_at: tokio::time::Instant::now(),
+            pinned: nev![(id, fence.clone())],
+            reply: reply_tx,
+        })
+        .await
+        .expect("batch send");
+    drop(batch_tx);
+
+    let loop_future = run_maintenance_loop(MaintainParams {
+        backend: Arc::clone(&backend),
+        node_id,
+        batch_rx,
+        evict_rx,
+        count_tx,
+        shutdown_token: CancellationToken::new(),
+        pinning_heartbeat: long_heartbeat(),
+        // Lapse deadline: 300ms ttl - 100ms margin = 200ms after the anchor.
+        pinning_ttl: NonZeroDuration::new(Duration::from_millis(300)).unwrap(),
+        pinning_fencing_margin: NonZeroDuration::new(Duration::from_millis(100)).unwrap(),
+    });
+    tokio::pin!(loop_future);
+
+    tokio::select! {
+        _ = reply_rx => {}
+        result = &mut loop_future => panic!("loop exited early: {result:?}"),
+    }
+
+    let fenced_at = tokio::time::Instant::now();
+    tokio::select! {
+        _ = fence.cancelled() => {}
+        result = &mut loop_future => panic!("loop exited before fencing: {result:?}"),
+        _ = tokio::time::sleep(Duration::from_secs(5)) => panic!("the pinning never lapsed"),
+    }
+    assert!(
+        fenced_at.elapsed() >= Duration::from_millis(100),
+        "fenced suspiciously early"
+    );
+
+    evict_tx.send((id, UnpinMode::Release)).expect("evict send");
+    let result = tokio::time::timeout(Duration::from_secs(5), &mut loop_future)
+        .await
+        .expect("loop should drain after the eviction");
+    assert!(result.is_ok(), "expected a clean drain, got {result:?}");
+}
+
+/// Confirmed refreshes keep pushing the lapse deadline out — a healthy
+/// workload never fences.
+#[tokio::test(flavor = "multi_thread")]
+async fn confirmed_refresh_extends_the_fence() {
+    let id = 1u64;
+    let node_id = test_node_id();
+
+    let mut backend = MockBackend::new();
+    backend
+        .expect_refresh_pinnings()
+        .times(1..)
+        .returning(move |_, _, _| {
+            let pinning = test_pinning(node_id, 1);
+            Box::pin(std::future::ready(Ok(nev![PinningStatus {
+                workload_id: id,
+                pinning: Some(pinning),
+            }])))
+        });
+    backend
+        .expect_unpin_workloads()
+        .times(1)
+        .returning(move |_, _| Box::pin(std::future::ready(Ok(()))));
+
+    let backend = Arc::new(backend);
+
+    let (batch_tx, batch_rx) = mpsc::channel::<PinnedBatch<u64>>(1);
+    let (evict_tx, evict_rx) = mpsc::unbounded_channel::<(u64, UnpinMode)>();
+    let (count_tx, _count_rx) = mpsc::unbounded_channel::<usize>();
+
+    let fence = CancellationToken::new();
+    let (reply_tx, reply_rx) = oneshot::channel::<usize>();
+    batch_tx
+        .send(PinnedBatch {
+            pinned_at: tokio::time::Instant::now(),
+            pinned: nev![(id, fence.clone())],
+            reply: reply_tx,
+        })
+        .await
+        .expect("batch send");
+    drop(batch_tx);
+
+    let loop_future = run_maintenance_loop(MaintainParams {
+        backend: Arc::clone(&backend),
+        node_id,
+        batch_rx,
+        evict_rx,
+        count_tx,
+        shutdown_token: CancellationToken::new(),
+        // Refreshes land well inside the 200ms lapse window.
+        pinning_heartbeat: NonZeroDuration::new(Duration::from_millis(50)).unwrap(),
+        pinning_ttl: NonZeroDuration::new(Duration::from_millis(300)).unwrap(),
+        pinning_fencing_margin: NonZeroDuration::new(Duration::from_millis(100)).unwrap(),
+    });
+    tokio::pin!(loop_future);
+
+    tokio::select! {
+        _ = reply_rx => {}
+        result = &mut loop_future => panic!("loop exited early: {result:?}"),
+    }
+
+    // Several lapse windows pass; the deadline keeps moving out.
+    tokio::select! {
+        _ = fence.cancelled() => panic!("healthy workload was fenced"),
+        result = &mut loop_future => panic!("loop exited early: {result:?}"),
+        _ = tokio::time::sleep(Duration::from_millis(700)) => {}
+    }
+
+    evict_tx.send((id, UnpinMode::Release)).expect("evict send");
+    let result = tokio::time::timeout(Duration::from_secs(5), &mut loop_future)
+        .await
+        .expect("loop should drain after the eviction");
+    assert!(result.is_ok(), "expected a clean drain, got {result:?}");
+}
+
+/// Fencing is per-workload: losing one pinning must fence only that
+/// workload and leave a healthy sibling — one that keeps refreshing —
+/// untouched.
+#[tokio::test(flavor = "multi_thread")]
+async fn fencing_one_workload_leaves_a_healthy_sibling_untouched() {
+    let id1 = 1u64;
+    let id2 = 2u64;
+    let node_id = test_node_id();
+
+    let mut backend = MockBackend::new();
+    // Every refresh reports id1 lost and id2 still held.  Once id1 is
+    // fenced it drops out of the refresh set, so returning its status
+    // here is a harmless no-op on later ticks.
+    backend
+        .expect_refresh_pinnings()
+        .times(1..)
+        .returning(move |_, _, _| {
+            let pinning = test_pinning(node_id, 1);
+            Box::pin(std::future::ready(Ok(nev![
+                PinningStatus {
+                    workload_id: id1,
+                    pinning: None,
+                },
+                PinningStatus {
+                    workload_id: id2,
+                    pinning: Some(pinning),
+                },
+            ])))
+        });
+    backend
+        .expect_unpin_workloads()
+        .times(1..)
+        .returning(move |_, _| Box::pin(std::future::ready(Ok(()))));
+
+    let backend = Arc::new(backend);
+
+    let (batch_tx, batch_rx) = mpsc::channel::<PinnedBatch<u64>>(1);
+    let (evict_tx, evict_rx) = mpsc::unbounded_channel::<(u64, UnpinMode)>();
+    let (count_tx, _count_rx) = mpsc::unbounded_channel::<usize>();
+
+    let fence1 = CancellationToken::new();
+    let fence2 = CancellationToken::new();
+    let (reply_tx, reply_rx) = oneshot::channel::<usize>();
+    batch_tx
+        .send(PinnedBatch {
+            pinned_at: tokio::time::Instant::now(),
+            pinned: nev![(id1, fence1.clone()), (id2, fence2.clone())],
+            reply: reply_tx,
+        })
+        .await
+        .expect("batch send");
+    drop(batch_tx);
+
+    let loop_future = run_maintenance_loop(MaintainParams {
+        backend: Arc::clone(&backend),
+        node_id,
+        batch_rx,
+        evict_rx,
+        count_tx,
+        shutdown_token: CancellationToken::new(),
+        pinning_heartbeat: short_heartbeat(),
+        pinning_ttl: test_pinning_ttl(),
+        pinning_fencing_margin: test_fencing_margin(),
+    });
+    tokio::pin!(loop_future);
+
+    tokio::select! {
+        _ = reply_rx => {}
+        result = &mut loop_future => panic!("loop exited early: {result:?}"),
+    }
+
+    // The heartbeat discovers id1's loss and fences it — id2 must not
+    // fence alongside it.
+    tokio::select! {
+        _ = fence1.cancelled() => {}
+        _ = fence2.cancelled() => panic!("healthy sibling was fenced"),
+        result = &mut loop_future => panic!("loop exited before fencing: {result:?}"),
+        _ = tokio::time::sleep(Duration::from_secs(5)) => panic!("workload 1 was never fenced"),
+    }
+
+    // id2 keeps refreshing across several more ticks and never fences.
+    tokio::select! {
+        _ = fence2.cancelled() => panic!("healthy sibling fenced after id1"),
+        result = &mut loop_future => panic!("loop exited unexpectedly: {result:?}"),
+        _ = tokio::time::sleep(Duration::from_millis(400)) => {}
+    }
+    assert!(!fence2.is_cancelled(), "the healthy sibling must stay live");
+
+    // The fence only signals — both still drain via eviction.
+    evict_tx
+        .send((id1, UnpinMode::Release))
+        .expect("evict send");
+    evict_tx
+        .send((id2, UnpinMode::Release))
+        .expect("evict send");
+    let result = tokio::time::timeout(Duration::from_secs(5), &mut loop_future)
+        .await
+        .expect("loop should drain after the evictions");
+    assert!(result.is_ok(), "expected a clean drain, got {result:?}");
+}
+
+/// A fenced workload is deliberately left to lapse: it must drop out of
+/// the refresh set while a healthy sibling keeps being refreshed.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_fenced_workload_is_dropped_from_refresh() {
+    let id1 = 1u64;
+    let id2 = 2u64;
+    let node_id = test_node_id();
+
+    // Records the id set handed to each refresh call.
+    let (refresh_ids_tx, mut refresh_ids_rx) = mpsc::unbounded_channel::<Vec<u64>>();
+
+    let mut backend = MockBackend::new();
+    backend
+        .expect_refresh_pinnings()
+        .times(1..)
+        .returning(move |_, _, ids| {
+            let observed: Vec<u64> = ids.into_iter().collect();
+            refresh_ids_tx.send(observed).ok();
+            let pinning = test_pinning(node_id, 1);
+            Box::pin(std::future::ready(Ok(nev![
+                PinningStatus {
+                    workload_id: id1,
+                    pinning: None,
+                },
+                PinningStatus {
+                    workload_id: id2,
+                    pinning: Some(pinning),
+                },
+            ])))
+        });
+    backend
+        .expect_unpin_workloads()
+        .times(1..)
+        .returning(move |_, _| Box::pin(std::future::ready(Ok(()))));
+
+    let backend = Arc::new(backend);
+
+    let (batch_tx, batch_rx) = mpsc::channel::<PinnedBatch<u64>>(1);
+    let (evict_tx, evict_rx) = mpsc::unbounded_channel::<(u64, UnpinMode)>();
+    let (count_tx, _count_rx) = mpsc::unbounded_channel::<usize>();
+
+    let fence1 = CancellationToken::new();
+    let fence2 = CancellationToken::new();
+    let (reply_tx, reply_rx) = oneshot::channel::<usize>();
+    batch_tx
+        .send(PinnedBatch {
+            pinned_at: tokio::time::Instant::now(),
+            pinned: nev![(id1, fence1.clone()), (id2, fence2.clone())],
+            reply: reply_tx,
+        })
+        .await
+        .expect("batch send");
+    drop(batch_tx);
+
+    let loop_future = run_maintenance_loop(MaintainParams {
+        backend: Arc::clone(&backend),
+        node_id,
+        batch_rx,
+        evict_rx,
+        count_tx,
+        shutdown_token: CancellationToken::new(),
+        pinning_heartbeat: short_heartbeat(),
+        pinning_ttl: test_pinning_ttl(),
+        pinning_fencing_margin: test_fencing_margin(),
+    });
+    tokio::pin!(loop_future);
+
+    tokio::select! {
+        _ = reply_rx => {}
+        result = &mut loop_future => panic!("loop exited early: {result:?}"),
+    }
+
+    // Wait for id1 to fence on the reported loss.
+    tokio::select! {
+        _ = fence1.cancelled() => {}
+        result = &mut loop_future => panic!("loop exited before fencing: {result:?}"),
+        _ = tokio::time::sleep(Duration::from_secs(5)) => panic!("workload 1 was never fenced"),
+    }
+
+    // Discard the id sets from refreshes issued up to and including the
+    // one that fenced id1 — those legitimately still contain id1.
+    while refresh_ids_rx.try_recv().is_ok() {}
+
+    // Every refresh from here on must exclude the fenced id1 and keep
+    // refreshing the healthy id2.
+    for _ in 0..2 {
+        let observed = tokio::select! {
+            observed = refresh_ids_rx.recv() => observed.expect("a further refresh"),
+            result = &mut loop_future => panic!("loop exited unexpectedly: {result:?}"),
+            _ = tokio::time::sleep(Duration::from_secs(5)) => panic!("no further refresh fired"),
+        };
+        assert!(
+            !observed.contains(&id1),
+            "the fenced workload must not be refreshed, got {observed:?}"
+        );
+        assert!(
+            observed.contains(&id2),
+            "the healthy sibling must keep refreshing, got {observed:?}"
+        );
+    }
+
+    // Drain both via eviction so the loop exits.
+    evict_tx
+        .send((id1, UnpinMode::Release))
+        .expect("evict send");
+    evict_tx
+        .send((id2, UnpinMode::Release))
+        .expect("evict send");
+    let result = tokio::time::timeout(Duration::from_secs(5), &mut loop_future)
+        .await
+        .expect("loop should drain after the evictions");
+    assert!(result.is_ok(), "expected a clean drain, got {result:?}");
+}
+
+/// A refresh that fails once and succeeds on its immediate retry must
+/// extend the fence from the retry's statuses — the workload stays live.
+///
+/// The failure lands on the *second* refresh call (the first heartbeat
+/// coincides with the batch anchor, so extending there proves nothing).
+/// With `heartbeat < lapse_after < 2 * heartbeat`, a dropped retry would
+/// leave the stale deadline to lapse before the next clean tick, so the
+/// workload surviving proves the retry's statuses were applied.
+#[tokio::test(flavor = "multi_thread")]
+async fn refresh_recovers_on_retry_and_extends_the_fence() {
+    let id = 1u64;
+    let node_id = test_node_id();
+
+    let mut backend = MockBackend::new();
+    // Call #1 (first tick) succeeds; call #2 (second tick's initial
+    // attempt) fails; its immediate retry (call #3) and everything after
+    // succeed.
+    let mut calls = 0;
+    backend
+        .expect_refresh_pinnings()
+        .times(3..)
+        .returning(move |_, _, _| {
+            calls += 1;
+            if calls == 2 {
+                return Box::pin(std::future::ready(Err(crate::test_utils::mock::MockError)));
+            }
+            let pinning = test_pinning(node_id, 1);
+            Box::pin(std::future::ready(Ok(nev![PinningStatus {
+                workload_id: id,
+                pinning: Some(pinning),
+            }])))
+        });
+    backend
+        .expect_unpin_workloads()
+        .times(1)
+        .returning(move |_, _| Box::pin(std::future::ready(Ok(()))));
+
+    let backend = Arc::new(backend);
+
+    let (batch_tx, batch_rx) = mpsc::channel::<PinnedBatch<u64>>(1);
+    let (evict_tx, evict_rx) = mpsc::unbounded_channel::<(u64, UnpinMode)>();
+    let (count_tx, _count_rx) = mpsc::unbounded_channel::<usize>();
+
+    let fence = CancellationToken::new();
+    let (reply_tx, reply_rx) = oneshot::channel::<usize>();
+    batch_tx
+        .send(PinnedBatch {
+            pinned_at: tokio::time::Instant::now(),
+            pinned: nev![(id, fence.clone())],
+            reply: reply_tx,
+        })
+        .await
+        .expect("batch send");
+    drop(batch_tx);
+
+    let loop_future = run_maintenance_loop(MaintainParams {
+        backend: Arc::clone(&backend),
+        node_id,
+        batch_rx,
+        evict_rx,
+        count_tx,
+        shutdown_token: CancellationToken::new(),
+        // heartbeat 200ms < lapse_after 300ms < 2 * heartbeat 400ms.
+        pinning_heartbeat: NonZeroDuration::new(Duration::from_millis(200)).unwrap(),
+        pinning_ttl: NonZeroDuration::new(Duration::from_millis(400)).unwrap(),
+        pinning_fencing_margin: NonZeroDuration::new(Duration::from_millis(100)).unwrap(),
+    });
+    tokio::pin!(loop_future);
+
+    tokio::select! {
+        _ = reply_rx => {}
+        result = &mut loop_future => panic!("loop exited early: {result:?}"),
+    }
+
+    // Past the failing tick (~200ms) and the deadline a dropped retry
+    // would leave standing (~300ms), through the next clean tick (~400ms).
+    tokio::select! {
+        _ = fence.cancelled() => panic!("workload fenced despite a recovered refresh"),
+        result = &mut loop_future => panic!("loop exited early: {result:?}"),
+        _ = tokio::time::sleep(Duration::from_millis(450)) => {}
+    }
+
+    evict_tx.send((id, UnpinMode::Release)).expect("evict send");
+    let result = tokio::time::timeout(Duration::from_secs(5), &mut loop_future)
+        .await
+        .expect("loop should drain after the eviction");
+    assert!(result.is_ok(), "expected a clean drain, got {result:?}");
 }

--- a/crates/lib/workload-pinning-manager/src/maintenance/tests.rs
+++ b/crates/lib/workload-pinning-manager/src/maintenance/tests.rs
@@ -1387,3 +1387,84 @@ async fn refresh_recovers_on_retry_and_extends_the_fence() {
         .expect("loop should drain after the eviction");
     assert!(result.is_ok(), "expected a clean drain, got {result:?}");
 }
+
+/// A fatal exit hands the still-held ids to the caller for cleanup
+/// release — so every holder must be fenced on the way out, or its
+/// driver would keep running against a pinning the caller just released.
+#[tokio::test(flavor = "multi_thread")]
+async fn force_shutdown_fences_the_tracked_workloads() {
+    let id = 1u64;
+    let node_id = test_node_id();
+
+    let mut backend = MockBackend::new();
+    backend
+        .expect_refresh_pinnings()
+        .times(0..)
+        .returning(move |_, _, _| {
+            let pinning = test_pinning(node_id, 1);
+            Box::pin(std::future::ready(Ok(nev![PinningStatus {
+                workload_id: id,
+                pinning: Some(pinning),
+            }])))
+        });
+
+    let backend = Arc::new(backend);
+
+    let (batch_tx, batch_rx) = mpsc::channel::<PinnedBatch<u64>>(1);
+    let (evict_tx, evict_rx) = mpsc::unbounded_channel::<(u64, UnpinMode)>();
+    let (count_tx, _count_rx) = mpsc::unbounded_channel::<usize>();
+
+    let fence = CancellationToken::new();
+    let (reply_tx, reply_rx) = oneshot::channel::<usize>();
+    batch_tx
+        .send(PinnedBatch {
+            pinned_at: tokio::time::Instant::now(),
+            pinned: nev![(id, fence.clone())],
+            reply: reply_tx,
+        })
+        .await
+        .expect("batch send");
+    drop(batch_tx);
+
+    let shutdown = CancellationToken::new();
+    let loop_future = run_maintenance_loop(MaintainParams {
+        backend: Arc::clone(&backend),
+        node_id,
+        batch_rx,
+        evict_rx,
+        count_tx,
+        shutdown_token: shutdown.clone(),
+        pinning_heartbeat: long_heartbeat(),
+        pinning_ttl: test_pinning_ttl(),
+        pinning_fencing_margin: test_fencing_margin(),
+    });
+    tokio::pin!(loop_future);
+
+    tokio::select! {
+        size = reply_rx => assert_eq!(size.expect("batch ack"), 1),
+        result = &mut loop_future => panic!("loop exited before processing batch: {result:?}"),
+        _ = tokio::time::sleep(Duration::from_secs(5)) => panic!("batch was never processed"),
+    }
+
+    assert!(!fence.is_cancelled(), "not fenced while healthy");
+
+    shutdown.cancel();
+
+    let result = tokio::time::timeout(Duration::from_secs(5), &mut loop_future)
+        .await
+        .expect("loop should exit on force shutdown");
+
+    match result {
+        Err((crate::MaintenanceError::ForceShutdown, ids)) => {
+            assert!(ids.contains(&id), "the id must be handed back for cleanup");
+        }
+        other => panic!("expected ForceShutdown error, got {other:?}"),
+    }
+
+    assert!(
+        fence.is_cancelled(),
+        "the holder must be fenced before cleanup releases its pinning"
+    );
+
+    drop(evict_tx);
+}

--- a/crates/lib/workload-pinning-manager/src/pinned_batch.rs
+++ b/crates/lib/workload-pinning-manager/src/pinned_batch.rs
@@ -1,0 +1,24 @@
+//! The poll → maintenance dispatch message.
+//!
+//! See [`PinnedBatch`].
+
+use nonempty_collections::NEVec;
+use tokio_util::sync::CancellationToken;
+
+/// A batch of newly pinned workloads dispatched from the poll loop to
+/// the maintenance loop.
+pub(crate) struct PinnedBatch<WorkloadId> {
+    /// The local monotonic instant captured immediately before the
+    /// pinning call was issued — the conservative base for the fence
+    /// deadlines of these workloads.
+    pub pinned_at: tokio::time::Instant,
+
+    /// The newly pinned workload IDs, each with the fence token the
+    /// maintenance loop cancels when the pinning can no longer be
+    /// proven held.  The matching [`PinnedHandle`](crate::PinnedHandle)
+    /// holds a clone of the token.
+    pub pinned: NEVec<(WorkloadId, CancellationToken)>,
+
+    /// Replies with the updated active-workload count.
+    pub reply: tokio::sync::oneshot::Sender<usize>,
+}

--- a/crates/lib/workload-pinning-manager/src/pinned_handle.rs
+++ b/crates/lib/workload-pinning-manager/src/pinned_handle.rs
@@ -2,6 +2,7 @@
 //!
 //! See [`PinnedHandle`].
 
+use tokio_util::sync::CancellationToken;
 use waymark_workload_pinning_core::UnpinMode;
 
 /// A handle to a pinned workload.
@@ -18,6 +19,7 @@ use waymark_workload_pinning_core::UnpinMode;
 pub struct PinnedHandle<WorkloadId> {
     id: Option<WorkloadId>,
     evict_tx: tokio::sync::mpsc::UnboundedSender<(WorkloadId, UnpinMode)>,
+    fence: CancellationToken,
 }
 
 impl<WorkloadId> PinnedHandle<WorkloadId> {
@@ -25,10 +27,12 @@ impl<WorkloadId> PinnedHandle<WorkloadId> {
     pub(crate) fn new(
         id: WorkloadId,
         evict_tx: tokio::sync::mpsc::UnboundedSender<(WorkloadId, UnpinMode)>,
+        fence: CancellationToken,
     ) -> Self {
         Self {
             id: Some(id),
             evict_tx,
+            fence,
         }
     }
 
@@ -38,6 +42,21 @@ impl<WorkloadId> PinnedHandle<WorkloadId> {
         // neither uses the handle after taking it — so any other caller
         // observes the `id` present.
         unsafe { self.id.as_ref().unwrap_unchecked() }
+    }
+
+    /// Resolve when the workload is fenced.
+    ///
+    /// Fencing means this node can no longer prove it holds the
+    /// pinning: the pinning **lapsed** (its local deadline passed
+    /// without a confirmed refresh) or was **lost** (a refresh reported
+    /// it held by another node).  The workload may already be executing
+    /// elsewhere.  What to do about that is the consumer's concern; this
+    /// signal only reports the fact.
+    ///
+    /// Cancellation-safe: fencing is a latched state, so the future can
+    /// be dropped and re-created freely.
+    pub async fn fenced(&self) {
+        self.fence.cancelled().await;
     }
 
     /// Unpin the workload with the given mode.

--- a/crates/lib/workload-pinning-manager/src/pinned_handle/tests.rs
+++ b/crates/lib/workload-pinning-manager/src/pinned_handle/tests.rs
@@ -1,3 +1,4 @@
+use tokio_util::sync::CancellationToken;
 use waymark_workload_pinning_core::UnpinMode;
 
 use super::PinnedHandle;
@@ -5,7 +6,7 @@ use super::PinnedHandle;
 #[test]
 fn unpin_park_sends_park_exactly_once() {
     let (evict_tx, mut evict_rx) = tokio::sync::mpsc::unbounded_channel();
-    let handle = PinnedHandle::new(1u64, evict_tx);
+    let handle = PinnedHandle::new(1u64, evict_tx, CancellationToken::new());
 
     handle.unpin(UnpinMode::Park);
 
@@ -20,7 +21,7 @@ fn unpin_park_sends_park_exactly_once() {
 #[test]
 fn unpin_release_sends_release_exactly_once() {
     let (evict_tx, mut evict_rx) = tokio::sync::mpsc::unbounded_channel();
-    let handle = PinnedHandle::new(2u64, evict_tx);
+    let handle = PinnedHandle::new(2u64, evict_tx, CancellationToken::new());
 
     handle.unpin(UnpinMode::Release);
 
@@ -34,7 +35,7 @@ fn unpin_release_sends_release_exactly_once() {
 #[test]
 fn drop_sends_release() {
     let (evict_tx, mut evict_rx) = tokio::sync::mpsc::unbounded_channel();
-    let handle = PinnedHandle::new(3u64, evict_tx);
+    let handle = PinnedHandle::new(3u64, evict_tx, CancellationToken::new());
 
     drop(handle);
 
@@ -48,7 +49,7 @@ fn drop_sends_release() {
 #[test]
 fn unpin_with_closed_receiver_does_not_panic() {
     let (evict_tx, evict_rx) = tokio::sync::mpsc::unbounded_channel::<(u64, UnpinMode)>();
-    let handle = PinnedHandle::new(4u64, evict_tx);
+    let handle = PinnedHandle::new(4u64, evict_tx, CancellationToken::new());
 
     drop(evict_rx);
 
@@ -58,7 +59,20 @@ fn unpin_with_closed_receiver_does_not_panic() {
 #[test]
 fn id_returns_the_workload_id() {
     let (evict_tx, _evict_rx) = tokio::sync::mpsc::unbounded_channel::<(u64, UnpinMode)>();
-    let handle = PinnedHandle::new(5u64, evict_tx);
+    let handle = PinnedHandle::new(5u64, evict_tx, CancellationToken::new());
 
     assert_eq!(*handle.id(), 5u64);
+}
+
+#[tokio::test]
+async fn fenced_resolves_when_the_fence_is_cancelled() {
+    let (evict_tx, _evict_rx) = tokio::sync::mpsc::unbounded_channel::<(u64, UnpinMode)>();
+    let fence = CancellationToken::new();
+    let handle = PinnedHandle::new(6u64, evict_tx, fence.clone());
+
+    fence.cancel();
+
+    // Resolves immediately once breached; the breach is latched.
+    handle.fenced().await;
+    handle.fenced().await;
 }

--- a/crates/lib/workload-pinning-manager/src/poll/mod.rs
+++ b/crates/lib/workload-pinning-manager/src/poll/mod.rs
@@ -14,6 +14,7 @@ use tracing::info;
 use waymark_nonzero_duration::NonZeroDuration;
 
 use crate::PinnedHandle;
+use crate::pinned_batch::PinnedBatch;
 
 pub(super) struct PollParams<Backend>
 where
@@ -27,10 +28,7 @@ where
         Backend::WorkloadId,
         waymark_workload_pinning_core::UnpinMode,
     )>,
-    pub batch_tx: tokio::sync::mpsc::Sender<(
-        NEVec<Backend::WorkloadId>,
-        tokio::sync::oneshot::Sender<usize>,
-    )>,
+    pub batch_tx: tokio::sync::mpsc::Sender<PinnedBatch<Backend::WorkloadId>>,
     pub count_rx: tokio::sync::mpsc::UnboundedReceiver<usize>,
     pub shutdown_token: CancellationToken,
     pub max_pinned: NonZeroUsize,
@@ -144,10 +142,7 @@ async fn poll_and_dispatch<Backend>(
     node_id: Backend::NodeId,
     max_items: NonZeroUsize,
     pinning_ttl: NonZeroDuration,
-    batch_tx: &tokio::sync::mpsc::Sender<(
-        NEVec<Backend::WorkloadId>,
-        tokio::sync::oneshot::Sender<usize>,
-    )>,
+    batch_tx: &tokio::sync::mpsc::Sender<PinnedBatch<Backend::WorkloadId>>,
     pinned_tx: &tokio::sync::mpsc::Sender<NEVec<PinnedHandle<Backend::WorkloadId>>>,
     evict_tx: &tokio::sync::mpsc::UnboundedSender<(
         Backend::WorkloadId,
@@ -161,6 +156,11 @@ where
     Backend: waymark_workload_pinning_backend::HasTimestamp,
     Backend::WorkloadId: Clone,
 {
+    // The local anchor of these pinnings, captured before the pinning
+    // call is sent: the store-side expiry cannot land earlier than
+    // `pinned_at + ttl`, so the fence deadline derived from it in the
+    // maintenance loop is conservative.
+    let pinned_at = tokio::time::Instant::now();
     let ids = poll_and_pin(backend, node_id, max_items, pinning_ttl)
         .await
         .map_err(PollLoopError::Poll)?;
@@ -170,9 +170,18 @@ where
         return Ok(None);
     };
 
+    let pinned: NEVec<(Backend::WorkloadId, CancellationToken)> = ids
+        .into_nonempty_iter()
+        .map(|id| (id, CancellationToken::new()))
+        .collect();
+
     let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
     batch_tx
-        .send((ids.clone(), reply_tx))
+        .send(PinnedBatch {
+            pinned_at,
+            pinned: pinned.clone(),
+            reply: reply_tx,
+        })
         .await
         .map_err(|_| PollLoopError::MaintenanceClosed)?;
 
@@ -180,9 +189,9 @@ where
         .await
         .map_err(|_| PollLoopError::MaintenanceUnresponsive)?;
 
-    let handles: NEVec<_> = ids
+    let handles: NEVec<_> = pinned
         .into_nonempty_iter()
-        .map(|id| PinnedHandle::new(id, evict_tx.clone()))
+        .map(|(id, fence)| PinnedHandle::new(id, evict_tx.clone(), fence))
         .collect();
     pinned_tx
         .send(handles)

--- a/crates/lib/workload-pinning-manager/src/poll/tests.rs
+++ b/crates/lib/workload-pinning-manager/src/poll/tests.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use mockall::predicate;
-use nonempty_collections::{NEVec, nev};
+use nonempty_collections::nev;
 use tokio_util::sync::CancellationToken;
 
 use super::{PollParams, poll_and_pin, run_poll_loop};
@@ -140,7 +140,7 @@ async fn poll_loop_exits_on_pinned_receiver_closed() {
     let (pinned_tx, pinned_rx) = tokio::sync::mpsc::channel(1);
     let (evict_tx, _evict_rx) = tokio::sync::mpsc::unbounded_channel();
     let (batch_tx, mut batch_rx) =
-        tokio::sync::mpsc::channel::<(NEVec<u64>, tokio::sync::oneshot::Sender<usize>)>(1);
+        tokio::sync::mpsc::channel::<crate::pinned_batch::PinnedBatch<u64>>(1);
     let (count_tx, count_rx) = tokio::sync::mpsc::unbounded_channel();
 
     // Drop the pinned-handle receiver before the loop dispatches.
@@ -149,7 +149,7 @@ async fn poll_loop_exits_on_pinned_receiver_closed() {
     // Spawn a helper to consume the batch and reply — without this the
     // poll loop hangs waiting for the batch ack.
     let batch_acker = tokio::spawn(async move {
-        while let Some((_ids, reply)) = batch_rx.recv().await {
+        while let Some(crate::pinned_batch::PinnedBatch { reply, .. }) = batch_rx.recv().await {
             let _ = reply.send(0);
         }
     });

--- a/crates/lib/workload-pinning-manager/src/test_utils/helpers.rs
+++ b/crates/lib/workload-pinning-manager/src/test_utils/helpers.rs
@@ -25,6 +25,10 @@ pub(crate) fn short_heartbeat() -> NonZeroDuration {
     NonZeroDuration::new(Duration::from_millis(100)).unwrap()
 }
 
+pub(crate) fn test_fencing_margin() -> NonZeroDuration {
+    NonZeroDuration::new(Duration::from_millis(1)).unwrap()
+}
+
 pub(crate) fn test_now() -> chrono::DateTime<chrono::Utc> {
     chrono::DateTime::from_timestamp(1_700_000_000, 0).unwrap()
 }

--- a/crates/lib/workload-pinning-manager/src/tests.rs
+++ b/crates/lib/workload-pinning-manager/src/tests.rs
@@ -10,8 +10,8 @@ use waymark_workload_pinning_backend::PinningStatus;
 use waymark_workload_pinning_core::UnpinMode;
 
 use crate::test_utils::helpers::{
-    long_heartbeat, short_heartbeat, test_max_concurrent, test_node_id, test_pinning,
-    test_pinning_ttl,
+    long_heartbeat, short_heartbeat, test_fencing_margin, test_max_concurrent, test_node_id,
+    test_pinning, test_pinning_ttl,
 };
 use crate::test_utils::mock::{MockBackend, MockError};
 use crate::{Params, PinnedHandle, run};
@@ -39,6 +39,7 @@ async fn run_exits_on_cancellation() {
         max_pinned: test_max_concurrent(),
         pinning_ttl: test_pinning_ttl(),
         pinning_heartbeat: short_heartbeat(),
+        pinning_fencing_margin: test_fencing_margin(),
     });
 
     tokio::pin!(run_future);
@@ -93,6 +94,7 @@ async fn run_propagates_poll_error() {
         max_pinned: test_max_concurrent(),
         pinning_ttl: test_pinning_ttl(),
         pinning_heartbeat: short_heartbeat(),
+        pinning_fencing_margin: test_fencing_margin(),
     });
 
     let outcome = tokio::time::timeout(Duration::from_secs(5), run_future)
@@ -171,6 +173,7 @@ async fn maintenance_drains_after_poll_error() {
             max_pinned: test_max_concurrent(),
             pinning_ttl: test_pinning_ttl(),
             pinning_heartbeat: short_heartbeat(),
+            pinning_fencing_margin: test_fencing_margin(),
         }),
     )
     .await
@@ -289,6 +292,7 @@ async fn maintenance_heartbeats_after_poll_is_dead() {
             max_pinned: test_max_concurrent(),
             pinning_ttl: test_pinning_ttl(),
             pinning_heartbeat: NonZeroDuration::new(heartbeat).unwrap(),
+            pinning_fencing_margin: test_fencing_margin(),
         }),
     )
     .await
@@ -353,6 +357,7 @@ async fn cleanup_unpins_remaining_workloads_on_force_shutdown() {
         max_pinned: test_max_concurrent(),
         pinning_ttl: test_pinning_ttl(),
         pinning_heartbeat: long_heartbeat(),
+        pinning_fencing_margin: test_fencing_margin(),
     });
     tokio::pin!(run_future);
 
@@ -435,6 +440,7 @@ async fn cleanup_reports_unpin_error() {
         max_pinned: test_max_concurrent(),
         pinning_ttl: test_pinning_ttl(),
         pinning_heartbeat: long_heartbeat(),
+        pinning_fencing_margin: test_fencing_margin(),
     });
     tokio::pin!(run_future);
 
@@ -523,6 +529,7 @@ async fn unpin_park_flows_end_to_end() {
             max_pinned: test_max_concurrent(),
             pinning_ttl: test_pinning_ttl(),
             pinning_heartbeat: short_heartbeat(),
+            pinning_fencing_margin: test_fencing_margin(),
         }),
     )
     .await


### PR DESCRIPTION
Goes in after #480.

---

This PR adds defensive fencing to the workload pinning, and thus, effectively, to the VM execution.

The main idea is in addition to keeping track of the execution state at the database, we also locally keep track of the pinning liveness.

We set up a deadline that expires at the same time that the pinning expires at the database. We set it when we poll the pinning for the first time, and update it when we renew the pinning via keepalive. If, for whatever reason, the deadline expires  we call the pinning "lapsed", and tigger the fencing on it. The fencing is also triggered if the pinning it the renewal reports that we no longer hold the pinning - in which case we call the pinning "lost".

So:
- now, pinning can be "lapsed" and/or "lost"
- both trigger pinning "fencing"

When the pinning is fenced - we evict the VM without parking.

---

TODO:
- [x] self-review
- [x] optimize
- [x] revisit wording and terminology
- [x] more advanced workload maintenance edge case handling (retry unpins and etc)