### PR TITLE
Refactor and correct unpin loop / cleanup at workload pinnings

### DIFF
--- a/crates/lib/execution-bringup/src/lib.rs
+++ b/crates/lib/execution-bringup/src/lib.rs
@@ -493,6 +493,9 @@ where
         max_pinned,
         pinning_ttl,
         pinning_heartbeat,
+        // TODO: surface through `Config` and the env.
+        unpin_retry_interval: NonZeroDuration::new(std::time::Duration::from_secs(5))
+            .expect("five seconds is non-zero"),
         pinning_fencing_margin,
     };
 
@@ -504,8 +507,8 @@ where
         if let Some(error) = outcome.maintenance_error {
             tracing::error!(?error, "workload pinning manager maintenance loop failed");
         }
-        if let Some(error) = outcome.cleanup_error {
-            tracing::warn!(?error, "workload pinning manager cleanup failed");
+        if let Some(error) = outcome.unpin_error {
+            tracing::warn!(?error, "workload pinning manager unpin loop failed");
         }
     });
 

--- a/crates/lib/workload-pinning-manager/src/lib.rs
+++ b/crates/lib/workload-pinning-manager/src/lib.rs
@@ -7,6 +7,7 @@ mod outcome;
 mod pinned_batch;
 mod pinned_handle;
 mod poll;
+mod unpin;
 
 #[cfg(test)]
 mod test_utils {
@@ -22,7 +23,7 @@ pub use self::poll::*;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
 
-use nonempty_collections::{IntoIteratorExt as _, NEVec, NonEmptyIterator as _};
+use nonempty_collections::NEVec;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 use waymark_nonzero_duration::NonZeroDuration;
@@ -71,6 +72,13 @@ where
     /// How often to refresh pinnings on active workloads.
     pub pinning_heartbeat: NonZeroDuration,
 
+    /// How long to wait before retrying a failed unpin.
+    ///
+    /// Together with the loop's failure tolerance this is the budget for
+    /// riding out a database blip before the pinnings of evicted
+    /// workloads are abandoned and left to lapse.
+    pub unpin_retry_interval: NonZeroDuration,
+
     /// How much earlier than the pinning ttl the local lapse deadline
     /// falls: a pinning not re-confirmed within `pinning_ttl -
     /// pinning_fencing_margin` of its (monotonic, pre-send) anchor
@@ -82,9 +90,9 @@ where
 
 /// Run the workload management loop.
 ///
-/// Returns a [`RunOutcomeFor`] that preserves the independent results of
-/// the poll loop, maintenance loop, and cleanup phase so callers can
-/// inspect every stage of the run lifecycle.
+/// Runs the poll, maintenance and unpin loops concurrently. Returns a
+/// [`RunOutcomeFor`] that preserves each loop's result independently so
+/// callers can inspect every stage of the run lifecycle.
 pub async fn run<Backend>(params: Params<Backend>) -> RunOutcomeFor<Backend>
 where
     Backend:
@@ -108,6 +116,7 @@ where
         max_pinned,
         pinning_ttl,
         pinning_heartbeat,
+        unpin_retry_interval,
         pinning_fencing_margin,
     } = params;
 
@@ -125,6 +134,9 @@ where
         tokio::sync::mpsc::channel::<pinned_batch::PinnedBatch<Backend::WorkloadId>>(1);
     // Maintain → Poll: push updated count after evictions.
     let (count_tx, count_rx) = tokio::sync::mpsc::unbounded_channel::<usize>();
+    // Maintain → Unpin: the durable unpin of an evicted workload.
+    let (unpin_tx, unpin_rx) = tokio::sync::mpsc::unbounded_channel();
+    let unpin_tx = unpin::wrap_tx(unpin_tx);
 
     // Give the poll loop a child token so it can be cancelled internally
     // without affecting the caller's shutdown_token. The child is also
@@ -149,6 +161,7 @@ where
         node_id: node_id.clone(),
         batch_rx,
         evict_rx,
+        unpin_tx: unpin_tx.clone(),
         count_tx,
         shutdown_token: force_shutdown_token,
         pinning_heartbeat,
@@ -156,43 +169,54 @@ where
         pinning_fencing_margin,
     });
 
+    // The unpin loop outlives the maintenance loop by design: it closes
+    // only once every sender is gone, so it still drains the evictions —
+    // and the cleanup below — that maintenance forwards on its way out.
+    let unpin_future = unpin::run_unpin_loop(unpin::UnpinParams {
+        backend: Arc::clone(&backend),
+        node_id: node_id.clone(),
+        unpin_rx,
+        retry_interval: unpin_retry_interval,
+    });
+
     // When the maintenance loop exits — for any reason — cancel the
     // poll loop's child token so it exits promptly. There is no point
     // accepting new work without maintenance.
     // (Poll exits never cancel maintenance; maintenance must always drain.)
+    //
+    // Whatever pinnings it still held are routed into the unpin loop, so
+    // cleanup goes through the same retrying machinery as every other
+    // unpin.  They are always released: no park decision was made for
+    // them, so they must remain runnable.
     let maintenance_future = async move {
         let _cancel_poll = poll_shutdown.drop_guard();
-        maintenance_future.await
+        let unpin_tx = unpin_tx;
+        let result = match maintenance_future.await {
+            Ok(()) => Ok(()),
+            Err((error, ids)) => {
+                if !ids.is_empty() {
+                    debug!("releasing pinnings on shutdown");
+                    for id in ids {
+                        unpin_tx.request(id, waymark_workload_pinning_core::UnpinMode::Release);
+                    }
+                }
+                Err(error)
+            }
+        };
+
+        // Closing the input is what lets the unpin loop drain and exit,
+        // so it is done explicitly rather than left to the drop order.
+        drop(unpin_tx);
+        result
     };
 
-    let (poll_result, maintenance_result) = tokio::join!(poll_future, maintenance_future);
-
-    // The maintenance loop returns active IDs alongside any error so
-    // they can be released during cleanup.  On a clean exit the set
-    // is always empty and there is nothing to release.
-    let (maintenance_error, active_ids) = match maintenance_result {
-        Ok(()) => (None, None),
-        Err((error, ids)) => (Some(error), Some(ids)),
-    };
-
-    let mut cleanup_error = None;
-    if let Some(ids) = active_ids
-        && let Some(ids) = ids.try_into_nonempty_iter()
-    {
-        debug!("releasing pinnings on shutdown");
-        // Cleanup always releases: no park decision was made for these
-        // workloads, so they must remain runnable.
-        let unpins = ids.map(|id| (id, waymark_workload_pinning_core::UnpinMode::Release));
-        if let Err(error) = backend.unpin_workloads(node_id, unpins).await {
-            warn!(?error, "failed to unpin workloads during cleanup");
-            cleanup_error = Some(error);
-        }
-    }
+    let (poll_result, maintenance_result, unpin_result) =
+        tokio::join!(poll_future, maintenance_future, unpin_future);
 
     RunOutcome {
         poll_error: poll_result.err(),
-        maintenance_error,
-        cleanup_error,
+        maintenance_error: maintenance_result.err(),
+        unpin_error: unpin_result.err(),
     }
 }
 

--- a/crates/lib/workload-pinning-manager/src/maintenance/error.rs
+++ b/crates/lib/workload-pinning-manager/src/maintenance/error.rs
@@ -2,14 +2,10 @@
 
 /// Errors that can occur in the maintenance loop.
 #[derive(Debug, thiserror::Error)]
-pub enum MaintenanceError<KeepaliveError, UnpinError> {
+pub enum MaintenanceError<KeepaliveError> {
     /// Refreshing pinnings failed.
     #[error("refresh pinnings: {0}")]
     Refresh(#[source] KeepaliveError),
-
-    /// Unpinning workloads failed.
-    #[error("unpin workloads: {0}")]
-    Unpin(#[source] UnpinError),
 
     /// The loop was force-shutdown.
     #[error("maintenance loop force shutdown")]
@@ -17,7 +13,5 @@ pub enum MaintenanceError<KeepaliveError, UnpinError> {
 }
 
 /// Convenience alias for [`MaintenanceError`] parameterized on a backend.
-pub type MaintenanceErrorFor<Backend> = MaintenanceError<
-    <Backend as waymark_workload_pinning_backend::KeepalivePinnings>::Error,
-    <Backend as waymark_workload_pinning_backend::UnpinWorkloads>::Error,
->;
+pub type MaintenanceErrorFor<Backend> =
+    MaintenanceError<<Backend as waymark_workload_pinning_backend::KeepalivePinnings>::Error>;

--- a/crates/lib/workload-pinning-manager/src/maintenance/mod.rs
+++ b/crates/lib/workload-pinning-manager/src/maintenance/mod.rs
@@ -56,6 +56,10 @@
 //! transient database errors without waiting for the next tick interval.
 //! If the retry also fails the loop exits with [`Error::Refresh`] so the
 //! caller can release the pinnings cleanly before they expire.
+//!
+//! Evictions are only untracked (and fenced) here — the durable unpin
+//! is forwarded to the [unpin loop](crate::unpin), which is what keeps
+//! a slow database round-trip from stalling the heartbeat.
 
 mod active_set;
 mod error;
@@ -85,6 +89,7 @@ where
         Backend::WorkloadId,
         waymark_workload_pinning_core::UnpinMode,
     )>,
+    pub unpin_tx: crate::unpin::UnpinSender<Backend::WorkloadId>,
     pub count_tx: tokio::sync::mpsc::UnboundedSender<usize>,
     pub shutdown_token: CancellationToken,
     pub pinning_heartbeat: NonZeroDuration,
@@ -100,7 +105,6 @@ where
     Backend: waymark_workload_pinning_backend::KeepalivePinnings<
             Timestamp = chrono::DateTime<chrono::Utc>,
         >,
-    Backend: waymark_workload_pinning_backend::UnpinWorkloads,
     Backend::NodeId: Clone,
     Backend::WorkloadId: Clone + std::hash::Hash + Eq + std::fmt::Debug,
 {
@@ -109,6 +113,7 @@ where
         node_id,
         mut batch_rx,
         mut evict_rx,
+        unpin_tx,
         count_tx,
         shutdown_token,
         pinning_heartbeat,
@@ -157,16 +162,16 @@ where
                 }
             }
             Some(eviction) = evict_rx.recv() => {
-                // Coalesce everything already queued into one batch.
-                let mut unpins = NEVec::new(eviction);
+                // Coalesce everything already queued.
+                let mut evictions = vec![eviction];
                 while let Ok(eviction) = evict_rx.try_recv() {
-                    unpins.push(eviction);
+                    evictions.push(eviction);
                 }
-                if let Err(error) = (*backend).unpin_workloads(node_id.clone(), unpins.clone()).await {
-                    break Err((MaintenanceError::Unpin(error), active.fence_all_and_into_ids()));
-                }
-                for (id, _mode) in unpins {
+                for (id, mode) in evictions {
+                    // Done being driven — stop tracking it (which fences
+                    // it); the durable unpin is the unpin loop's job.
                     active.fence_and_stop_tracking(&id);
+                    unpin_tx.request(id, mode);
                 }
                 let _ = count_tx.send(active.tracked_count());
             }

--- a/crates/lib/workload-pinning-manager/src/maintenance/tests.rs
+++ b/crates/lib/workload-pinning-manager/src/maintenance/tests.rs
@@ -28,6 +28,8 @@ async fn maintain_loop_exits_when_batch_closed_and_empty() {
     let (batch_tx, batch_rx) = mpsc::channel::<PinnedBatch<u64>>(1);
     let (evict_tx, evict_rx) = mpsc::unbounded_channel::<(u64, UnpinMode)>();
     let (count_tx, _count_rx) = mpsc::unbounded_channel::<usize>();
+    let (unpin_tx, _unpin_rx) = mpsc::unbounded_channel::<(u64, UnpinMode)>();
+    let unpin_tx = crate::unpin::wrap_tx(unpin_tx);
 
     // Close both channels — no work can ever arrive.
     drop(batch_tx);
@@ -40,6 +42,7 @@ async fn maintain_loop_exits_when_batch_closed_and_empty() {
             node_id: test_node_id(),
             batch_rx,
             evict_rx,
+            unpin_tx,
             count_tx,
             shutdown_token: CancellationToken::new(),
             pinning_heartbeat: long_heartbeat(),
@@ -62,13 +65,6 @@ async fn maintain_loop_continues_until_last_eviction_after_batch_closed() {
     let node_id = test_node_id();
 
     let mut backend = MockBackend::new();
-    backend
-        .expect_unpin_workloads()
-        .with(
-            predicate::eq(node_id),
-            predicate::eq(nev![(id, UnpinMode::Release)]),
-        )
-        .return_once(move |_, _| Box::pin(std::future::ready(Ok(()))));
     // The heartbeat interval is long enough that refresh should never
     // fire, but allow it optionally so the test doesn't panic if it does.
     backend
@@ -87,6 +83,8 @@ async fn maintain_loop_continues_until_last_eviction_after_batch_closed() {
     let (batch_tx, batch_rx) = mpsc::channel::<PinnedBatch<u64>>(1);
     let (evict_tx, evict_rx) = mpsc::unbounded_channel::<(u64, UnpinMode)>();
     let (count_tx, _count_rx) = mpsc::unbounded_channel::<usize>();
+    let (unpin_tx, _unpin_rx) = mpsc::unbounded_channel::<(u64, UnpinMode)>();
+    let unpin_tx = crate::unpin::wrap_tx(unpin_tx);
 
     // Stage a batch.  The reply oneshot is kept alive so we can wait
     // for the maintenance loop to acknowledge the ID before evicting.
@@ -108,6 +106,7 @@ async fn maintain_loop_continues_until_last_eviction_after_batch_closed() {
         node_id,
         batch_rx,
         evict_rx,
+        unpin_tx,
         count_tx,
         shutdown_token: CancellationToken::new(),
         pinning_heartbeat: long_heartbeat(),
@@ -164,19 +163,14 @@ async fn maintain_loop_heartbeats_fire_for_active_ids() {
                 pinning: Some(pinning.clone()),
             }])))
         });
-    backend
-        .expect_unpin_workloads()
-        .with(
-            predicate::eq(node_id),
-            predicate::eq(nev![(id, UnpinMode::Release)]),
-        )
-        .return_once(move |_, _| Box::pin(std::future::ready(Ok(()))));
 
     let backend = Arc::new(backend);
 
     let (batch_tx, batch_rx) = mpsc::channel::<PinnedBatch<u64>>(1);
     let (evict_tx, evict_rx) = mpsc::unbounded_channel::<(u64, UnpinMode)>();
     let (count_tx, _count_rx) = mpsc::unbounded_channel::<usize>();
+    let (unpin_tx, _unpin_rx) = mpsc::unbounded_channel::<(u64, UnpinMode)>();
+    let unpin_tx = crate::unpin::wrap_tx(unpin_tx);
 
     // Stage a batch so there is an active ID to heartbeat.
     let (reply_tx, _reply_rx) = oneshot::channel::<usize>();
@@ -195,6 +189,7 @@ async fn maintain_loop_heartbeats_fire_for_active_ids() {
         node_id,
         batch_rx,
         evict_rx,
+        unpin_tx,
         count_tx,
         shutdown_token: CancellationToken::new(),
         pinning_heartbeat: short_heartbeat(),
@@ -264,19 +259,14 @@ async fn maintain_loop_heartbeats_after_batch_closed() {
                 pinning: Some(pinning.clone()),
             }])))
         });
-    backend
-        .expect_unpin_workloads()
-        .with(
-            predicate::eq(node_id),
-            predicate::eq(nev![(id, UnpinMode::Release)]),
-        )
-        .return_once(move |_, _| Box::pin(std::future::ready(Ok(()))));
 
     let backend = Arc::new(backend);
 
     let (batch_tx, batch_rx) = mpsc::channel::<PinnedBatch<u64>>(1);
     let (evict_tx, evict_rx) = mpsc::unbounded_channel::<(u64, UnpinMode)>();
     let (count_tx, _count_rx) = mpsc::unbounded_channel::<usize>();
+    let (unpin_tx, _unpin_rx) = mpsc::unbounded_channel::<(u64, UnpinMode)>();
+    let unpin_tx = crate::unpin::wrap_tx(unpin_tx);
 
     // Stage a batch.
     let (reply_tx, _reply_rx) = oneshot::channel::<usize>();
@@ -297,6 +287,7 @@ async fn maintain_loop_heartbeats_after_batch_closed() {
         node_id,
         batch_rx,
         evict_rx,
+        unpin_tx,
         count_tx,
         shutdown_token: CancellationToken::new(),
         pinning_heartbeat: short_heartbeat(),
@@ -435,95 +426,6 @@ async fn refresh_pinnings_propagates_error() {
     assert!(result.is_err());
 }
 
-/// When an unpin fails, the maintenance loop must exit with
-/// the error and return the remaining active IDs.
-#[tokio::test]
-async fn maintain_loop_exits_on_unpin_error() {
-    let id = 1u64;
-    let node_id = test_node_id();
-
-    let mut backend = MockBackend::new();
-    backend
-        .expect_unpin_workloads()
-        .with(
-            predicate::eq(node_id),
-            predicate::eq(nev![(id, UnpinMode::Release)]),
-        )
-        .return_once(move |_, _| {
-            Box::pin(std::future::ready(Err(crate::test_utils::mock::MockError)))
-        });
-    backend
-        .expect_refresh_pinnings()
-        .times(0..)
-        .returning(move |_, _, _| {
-            let pinning = test_pinning(node_id, 1);
-            Box::pin(std::future::ready(Ok(nev![PinningStatus {
-                workload_id: id,
-                pinning: Some(pinning),
-            }])))
-        });
-
-    let backend = Arc::new(backend);
-
-    let (batch_tx, batch_rx) = mpsc::channel::<PinnedBatch<u64>>(1);
-    let (evict_tx, evict_rx) = mpsc::unbounded_channel::<(u64, UnpinMode)>();
-    let (count_tx, _count_rx) = mpsc::unbounded_channel::<usize>();
-
-    let (reply_tx, reply_rx) = oneshot::channel::<usize>();
-    batch_tx
-        .send(PinnedBatch {
-            pinned_at: tokio::time::Instant::now(),
-            pinned: nev![(id, CancellationToken::new())],
-            reply: reply_tx,
-        })
-        .await
-        .expect("batch send");
-    drop(batch_tx);
-
-    let loop_future = run_maintenance_loop(MaintainParams {
-        backend: Arc::clone(&backend),
-        node_id,
-        batch_rx,
-        evict_rx,
-        count_tx,
-        shutdown_token: CancellationToken::new(),
-        pinning_heartbeat: short_heartbeat(),
-        pinning_ttl: test_pinning_ttl(),
-        pinning_fencing_margin: test_fencing_margin(),
-    });
-    tokio::pin!(loop_future);
-
-    // Wait for the batch ack — the ID must be in active_ids before
-    // we evict, otherwise the eviction is a no-op.
-    let batch_size = tokio::select! {
-        size = reply_rx => size.expect("maintain loop should ack the batch"),
-        result = &mut loop_future => {
-            panic!("loop exited before processing batch: {result:?}");
-        }
-        _ = tokio::time::sleep(Duration::from_secs(5)) => {
-            panic!("batch was never processed");
-        }
-    };
-    assert_eq!(batch_size, 1);
-
-    // Evict the ID — the unpin call will fail.
-    evict_tx.send((id, UnpinMode::Release)).expect("evict send");
-
-    let result = tokio::time::timeout(Duration::from_secs(5), &mut loop_future)
-        .await
-        .expect("loop should exit on unpin error");
-
-    match result {
-        Err((crate::MaintenanceError::Unpin(_), ids)) => {
-            assert!(
-                ids.contains(&id),
-                "the failed-to-unpin id must remain in active_ids, got {ids:?}"
-            );
-        }
-        other => panic!("expected Unpin error, got {other:?}"),
-    }
-}
-
 /// When the shutdown token fires, the maintenance loop must exit
 /// immediately with [`crate::MaintenanceError::ForceShutdown`] and
 /// return whatever active IDs remain.
@@ -549,6 +451,8 @@ async fn maintain_loop_exits_on_force_shutdown() {
     let (batch_tx, batch_rx) = mpsc::channel::<PinnedBatch<u64>>(1);
     let (evict_tx, evict_rx) = mpsc::unbounded_channel::<(u64, UnpinMode)>();
     let (count_tx, _count_rx) = mpsc::unbounded_channel::<usize>();
+    let (unpin_tx, _unpin_rx) = mpsc::unbounded_channel::<(u64, UnpinMode)>();
+    let unpin_tx = crate::unpin::wrap_tx(unpin_tx);
 
     let (reply_tx, reply_rx) = oneshot::channel::<usize>();
     batch_tx
@@ -567,6 +471,7 @@ async fn maintain_loop_exits_on_force_shutdown() {
         node_id,
         batch_rx,
         evict_rx,
+        unpin_tx,
         count_tx,
         shutdown_token: shutdown.clone(),
         pinning_heartbeat: long_heartbeat(),
@@ -626,16 +531,14 @@ async fn maintain_loop_exits_on_refresh_error() {
             Box::pin(std::future::ready(Err(crate::test_utils::mock::MockError)))
         });
     // unpin should never fire — the refresh failure exits the loop first
-    backend
-        .expect_unpin_workloads()
-        .times(0)
-        .returning(move |_, _| Box::pin(std::future::ready(Ok(()))));
 
     let backend = Arc::new(backend);
 
     let (batch_tx, batch_rx) = mpsc::channel::<PinnedBatch<u64>>(1);
     let (evict_tx, evict_rx) = mpsc::unbounded_channel::<(u64, UnpinMode)>();
     let (count_tx, _count_rx) = mpsc::unbounded_channel::<usize>();
+    let (unpin_tx, _unpin_rx) = mpsc::unbounded_channel::<(u64, UnpinMode)>();
+    let unpin_tx = crate::unpin::wrap_tx(unpin_tx);
 
     // Stage a batch so there is an active ID to trigger a heartbeat.
     let (reply_tx, reply_rx) = oneshot::channel::<usize>();
@@ -654,6 +557,7 @@ async fn maintain_loop_exits_on_refresh_error() {
         node_id,
         batch_rx,
         evict_rx,
+        unpin_tx,
         count_tx,
         shutdown_token: CancellationToken::new(),
         pinning_heartbeat: short_heartbeat(),
@@ -702,13 +606,6 @@ async fn maintain_loop_forwards_park_mode() {
 
     let mut backend = MockBackend::new();
     backend
-        .expect_unpin_workloads()
-        .with(
-            predicate::eq(node_id),
-            predicate::eq(nev![(id, UnpinMode::Park)]),
-        )
-        .return_once(move |_, _| Box::pin(std::future::ready(Ok(()))));
-    backend
         .expect_refresh_pinnings()
         .times(0..)
         .returning(move |_, _, _| {
@@ -724,6 +621,8 @@ async fn maintain_loop_forwards_park_mode() {
     let (batch_tx, batch_rx) = mpsc::channel::<PinnedBatch<u64>>(1);
     let (evict_tx, evict_rx) = mpsc::unbounded_channel::<(u64, UnpinMode)>();
     let (count_tx, _count_rx) = mpsc::unbounded_channel::<usize>();
+    let (unpin_tx, _unpin_rx) = mpsc::unbounded_channel::<(u64, UnpinMode)>();
+    let unpin_tx = crate::unpin::wrap_tx(unpin_tx);
 
     let (reply_tx, reply_rx) = oneshot::channel::<usize>();
     batch_tx
@@ -741,6 +640,7 @@ async fn maintain_loop_forwards_park_mode() {
         node_id,
         batch_rx,
         evict_rx,
+        unpin_tx,
         count_tx,
         shutdown_token: CancellationToken::new(),
         pinning_heartbeat: long_heartbeat(),
@@ -777,13 +677,6 @@ async fn maintain_loop_coalesces_queued_evictions() {
 
     let mut backend = MockBackend::new();
     backend
-        .expect_unpin_workloads()
-        .with(
-            predicate::eq(node_id),
-            predicate::eq(nev![(1u64, UnpinMode::Release), (2u64, UnpinMode::Park)]),
-        )
-        .return_once(move |_, _| Box::pin(std::future::ready(Ok(()))));
-    backend
         .expect_refresh_pinnings()
         .times(0..)
         .returning(move |_, _, _| {
@@ -805,6 +698,8 @@ async fn maintain_loop_coalesces_queued_evictions() {
     let (batch_tx, batch_rx) = mpsc::channel::<PinnedBatch<u64>>(1);
     let (evict_tx, evict_rx) = mpsc::unbounded_channel::<(u64, UnpinMode)>();
     let (count_tx, _count_rx) = mpsc::unbounded_channel::<usize>();
+    let (unpin_tx, _unpin_rx) = mpsc::unbounded_channel::<(u64, UnpinMode)>();
+    let unpin_tx = crate::unpin::wrap_tx(unpin_tx);
 
     let (reply_tx, reply_rx) = oneshot::channel::<usize>();
     batch_tx
@@ -825,6 +720,7 @@ async fn maintain_loop_coalesces_queued_evictions() {
         node_id,
         batch_rx,
         evict_rx,
+        unpin_tx,
         count_tx,
         shutdown_token: CancellationToken::new(),
         pinning_heartbeat: long_heartbeat(),
@@ -875,16 +771,14 @@ async fn refresh_lost_status_fences_the_workload() {
                 pinning: None,
             }])))
         });
-    backend
-        .expect_unpin_workloads()
-        .times(1)
-        .returning(move |_, _| Box::pin(std::future::ready(Ok(()))));
 
     let backend = Arc::new(backend);
 
     let (batch_tx, batch_rx) = mpsc::channel::<PinnedBatch<u64>>(1);
     let (evict_tx, evict_rx) = mpsc::unbounded_channel::<(u64, UnpinMode)>();
     let (count_tx, _count_rx) = mpsc::unbounded_channel::<usize>();
+    let (unpin_tx, _unpin_rx) = mpsc::unbounded_channel::<(u64, UnpinMode)>();
+    let unpin_tx = crate::unpin::wrap_tx(unpin_tx);
 
     let fence = CancellationToken::new();
     let (reply_tx, reply_rx) = oneshot::channel::<usize>();
@@ -903,6 +797,7 @@ async fn refresh_lost_status_fences_the_workload() {
         node_id,
         batch_rx,
         evict_rx,
+        unpin_tx,
         count_tx,
         shutdown_token: CancellationToken::new(),
         pinning_heartbeat: short_heartbeat(),
@@ -950,16 +845,14 @@ async fn pinning_lapses_when_no_refresh_confirms_in_time() {
                 pinning: Some(pinning),
             }])))
         });
-    backend
-        .expect_unpin_workloads()
-        .times(1)
-        .returning(move |_, _| Box::pin(std::future::ready(Ok(()))));
 
     let backend = Arc::new(backend);
 
     let (batch_tx, batch_rx) = mpsc::channel::<PinnedBatch<u64>>(1);
     let (evict_tx, evict_rx) = mpsc::unbounded_channel::<(u64, UnpinMode)>();
     let (count_tx, _count_rx) = mpsc::unbounded_channel::<usize>();
+    let (unpin_tx, _unpin_rx) = mpsc::unbounded_channel::<(u64, UnpinMode)>();
+    let unpin_tx = crate::unpin::wrap_tx(unpin_tx);
 
     let fence = CancellationToken::new();
     let (reply_tx, reply_rx) = oneshot::channel::<usize>();
@@ -978,6 +871,7 @@ async fn pinning_lapses_when_no_refresh_confirms_in_time() {
         node_id,
         batch_rx,
         evict_rx,
+        unpin_tx,
         count_tx,
         shutdown_token: CancellationToken::new(),
         pinning_heartbeat: long_heartbeat(),
@@ -1028,16 +922,14 @@ async fn confirmed_refresh_extends_the_fence() {
                 pinning: Some(pinning),
             }])))
         });
-    backend
-        .expect_unpin_workloads()
-        .times(1)
-        .returning(move |_, _| Box::pin(std::future::ready(Ok(()))));
 
     let backend = Arc::new(backend);
 
     let (batch_tx, batch_rx) = mpsc::channel::<PinnedBatch<u64>>(1);
     let (evict_tx, evict_rx) = mpsc::unbounded_channel::<(u64, UnpinMode)>();
     let (count_tx, _count_rx) = mpsc::unbounded_channel::<usize>();
+    let (unpin_tx, _unpin_rx) = mpsc::unbounded_channel::<(u64, UnpinMode)>();
+    let unpin_tx = crate::unpin::wrap_tx(unpin_tx);
 
     let fence = CancellationToken::new();
     let (reply_tx, reply_rx) = oneshot::channel::<usize>();
@@ -1056,6 +948,7 @@ async fn confirmed_refresh_extends_the_fence() {
         node_id,
         batch_rx,
         evict_rx,
+        unpin_tx,
         count_tx,
         shutdown_token: CancellationToken::new(),
         // Refreshes land well inside the 200ms lapse window.
@@ -1113,16 +1006,14 @@ async fn fencing_one_workload_leaves_a_healthy_sibling_untouched() {
                 },
             ])))
         });
-    backend
-        .expect_unpin_workloads()
-        .times(1..)
-        .returning(move |_, _| Box::pin(std::future::ready(Ok(()))));
 
     let backend = Arc::new(backend);
 
     let (batch_tx, batch_rx) = mpsc::channel::<PinnedBatch<u64>>(1);
     let (evict_tx, evict_rx) = mpsc::unbounded_channel::<(u64, UnpinMode)>();
     let (count_tx, _count_rx) = mpsc::unbounded_channel::<usize>();
+    let (unpin_tx, _unpin_rx) = mpsc::unbounded_channel::<(u64, UnpinMode)>();
+    let unpin_tx = crate::unpin::wrap_tx(unpin_tx);
 
     let fence1 = CancellationToken::new();
     let fence2 = CancellationToken::new();
@@ -1142,6 +1033,7 @@ async fn fencing_one_workload_leaves_a_healthy_sibling_untouched() {
         node_id,
         batch_rx,
         evict_rx,
+        unpin_tx,
         count_tx,
         shutdown_token: CancellationToken::new(),
         pinning_heartbeat: short_heartbeat(),
@@ -1215,16 +1107,14 @@ async fn a_fenced_workload_is_dropped_from_refresh() {
                 },
             ])))
         });
-    backend
-        .expect_unpin_workloads()
-        .times(1..)
-        .returning(move |_, _| Box::pin(std::future::ready(Ok(()))));
 
     let backend = Arc::new(backend);
 
     let (batch_tx, batch_rx) = mpsc::channel::<PinnedBatch<u64>>(1);
     let (evict_tx, evict_rx) = mpsc::unbounded_channel::<(u64, UnpinMode)>();
     let (count_tx, _count_rx) = mpsc::unbounded_channel::<usize>();
+    let (unpin_tx, _unpin_rx) = mpsc::unbounded_channel::<(u64, UnpinMode)>();
+    let unpin_tx = crate::unpin::wrap_tx(unpin_tx);
 
     let fence1 = CancellationToken::new();
     let fence2 = CancellationToken::new();
@@ -1244,6 +1134,7 @@ async fn a_fenced_workload_is_dropped_from_refresh() {
         node_id,
         batch_rx,
         evict_rx,
+        unpin_tx,
         count_tx,
         shutdown_token: CancellationToken::new(),
         pinning_heartbeat: short_heartbeat(),
@@ -1331,16 +1222,14 @@ async fn refresh_recovers_on_retry_and_extends_the_fence() {
                 pinning: Some(pinning),
             }])))
         });
-    backend
-        .expect_unpin_workloads()
-        .times(1)
-        .returning(move |_, _| Box::pin(std::future::ready(Ok(()))));
 
     let backend = Arc::new(backend);
 
     let (batch_tx, batch_rx) = mpsc::channel::<PinnedBatch<u64>>(1);
     let (evict_tx, evict_rx) = mpsc::unbounded_channel::<(u64, UnpinMode)>();
     let (count_tx, _count_rx) = mpsc::unbounded_channel::<usize>();
+    let (unpin_tx, _unpin_rx) = mpsc::unbounded_channel::<(u64, UnpinMode)>();
+    let unpin_tx = crate::unpin::wrap_tx(unpin_tx);
 
     let fence = CancellationToken::new();
     let (reply_tx, reply_rx) = oneshot::channel::<usize>();
@@ -1359,6 +1248,7 @@ async fn refresh_recovers_on_retry_and_extends_the_fence() {
         node_id,
         batch_rx,
         evict_rx,
+        unpin_tx,
         count_tx,
         shutdown_token: CancellationToken::new(),
         // heartbeat 200ms < lapse_after 300ms < 2 * heartbeat 400ms.
@@ -1413,6 +1303,8 @@ async fn force_shutdown_fences_the_tracked_workloads() {
     let (batch_tx, batch_rx) = mpsc::channel::<PinnedBatch<u64>>(1);
     let (evict_tx, evict_rx) = mpsc::unbounded_channel::<(u64, UnpinMode)>();
     let (count_tx, _count_rx) = mpsc::unbounded_channel::<usize>();
+    let (unpin_tx, _unpin_rx) = mpsc::unbounded_channel::<(u64, UnpinMode)>();
+    let unpin_tx = crate::unpin::wrap_tx(unpin_tx);
 
     let fence = CancellationToken::new();
     let (reply_tx, reply_rx) = oneshot::channel::<usize>();
@@ -1432,6 +1324,7 @@ async fn force_shutdown_fences_the_tracked_workloads() {
         node_id,
         batch_rx,
         evict_rx,
+        unpin_tx,
         count_tx,
         shutdown_token: shutdown.clone(),
         pinning_heartbeat: long_heartbeat(),

--- a/crates/lib/workload-pinning-manager/src/outcome.rs
+++ b/crates/lib/workload-pinning-manager/src/outcome.rs
@@ -15,12 +15,14 @@ pub struct RunOutcome<PollError, KeepaliveError, UnpinError> {
     pub poll_error: Option<PollLoopError<PollError>>,
 
     /// Error from the maintenance loop, if any.
-    pub maintenance_error: Option<MaintenanceError<KeepaliveError, UnpinError>>,
+    pub maintenance_error: Option<MaintenanceError<KeepaliveError>>,
 
-    /// If cleanup failed, the error from unpinning remaining workloads.
-    /// `None` means either there were no remaining pinnings or they were
-    /// released successfully.
-    pub cleanup_error: Option<UnpinError>,
+    /// Error from the unpin loop, if any.
+    ///
+    /// The loop gave up on unpins it could not apply — including the
+    /// pinnings routed to it for cleanup when the other loops exited.
+    /// Those pinnings are left to lapse on their own.
+    pub unpin_error: Option<UnpinError>,
 }
 
 /// Convenience alias for [`RunOutcome`] parameterized on a backend.
@@ -38,7 +40,7 @@ impl<PollError, KeepaliveError, UnpinError> RunOutcome<PollError, KeepaliveError
             Self {
                 poll_error: None,
                 maintenance_error: None,
-                cleanup_error: None
+                unpin_error: None
             }
         )
     }

--- a/crates/lib/workload-pinning-manager/src/test_utils/helpers.rs
+++ b/crates/lib/workload-pinning-manager/src/test_utils/helpers.rs
@@ -25,6 +25,10 @@ pub(crate) fn short_heartbeat() -> NonZeroDuration {
     NonZeroDuration::new(Duration::from_millis(100)).unwrap()
 }
 
+pub(crate) fn test_unpin_retry_interval() -> NonZeroDuration {
+    NonZeroDuration::new(Duration::from_millis(50)).unwrap()
+}
+
 pub(crate) fn test_fencing_margin() -> NonZeroDuration {
     NonZeroDuration::new(Duration::from_millis(1)).unwrap()
 }

--- a/crates/lib/workload-pinning-manager/src/tests.rs
+++ b/crates/lib/workload-pinning-manager/src/tests.rs
@@ -11,7 +11,7 @@ use waymark_workload_pinning_core::UnpinMode;
 
 use crate::test_utils::helpers::{
     long_heartbeat, short_heartbeat, test_fencing_margin, test_max_concurrent, test_node_id,
-    test_pinning, test_pinning_ttl,
+    test_pinning, test_pinning_ttl, test_unpin_retry_interval,
 };
 use crate::test_utils::mock::{MockBackend, MockError};
 use crate::{Params, PinnedHandle, run};
@@ -39,6 +39,7 @@ async fn run_exits_on_cancellation() {
         max_pinned: test_max_concurrent(),
         pinning_ttl: test_pinning_ttl(),
         pinning_heartbeat: short_heartbeat(),
+        unpin_retry_interval: test_unpin_retry_interval(),
         pinning_fencing_margin: test_fencing_margin(),
     });
 
@@ -94,6 +95,7 @@ async fn run_propagates_poll_error() {
         max_pinned: test_max_concurrent(),
         pinning_ttl: test_pinning_ttl(),
         pinning_heartbeat: short_heartbeat(),
+        unpin_retry_interval: test_unpin_retry_interval(),
         pinning_fencing_margin: test_fencing_margin(),
     });
 
@@ -173,6 +175,7 @@ async fn maintenance_drains_after_poll_error() {
             max_pinned: test_max_concurrent(),
             pinning_ttl: test_pinning_ttl(),
             pinning_heartbeat: short_heartbeat(),
+            unpin_retry_interval: test_unpin_retry_interval(),
             pinning_fencing_margin: test_fencing_margin(),
         }),
     )
@@ -292,6 +295,7 @@ async fn maintenance_heartbeats_after_poll_is_dead() {
             max_pinned: test_max_concurrent(),
             pinning_ttl: test_pinning_ttl(),
             pinning_heartbeat: NonZeroDuration::new(heartbeat).unwrap(),
+            unpin_retry_interval: test_unpin_retry_interval(),
             pinning_fencing_margin: test_fencing_margin(),
         }),
     )
@@ -357,6 +361,7 @@ async fn cleanup_unpins_remaining_workloads_on_force_shutdown() {
         max_pinned: test_max_concurrent(),
         pinning_ttl: test_pinning_ttl(),
         pinning_heartbeat: long_heartbeat(),
+        unpin_retry_interval: test_unpin_retry_interval(),
         pinning_fencing_margin: test_fencing_margin(),
     });
     tokio::pin!(run_future);
@@ -384,9 +389,9 @@ async fn cleanup_unpins_remaining_workloads_on_force_shutdown() {
         other => panic!("expected ForceShutdown, got {other:?}"),
     }
     assert!(
-        outcome.cleanup_error.is_none(),
-        "expected clean cleanup, got {:?}",
-        outcome.cleanup_error
+        outcome.unpin_error.is_none(),
+        "expected no unpin error, got {:?}",
+        outcome.unpin_error
     );
 
     // Explicit: the cleanup unpin was called exactly once.
@@ -396,8 +401,8 @@ async fn cleanup_unpins_remaining_workloads_on_force_shutdown() {
 }
 
 /// When the cleanup unpin itself fails, the error must surface on
-/// `cleanup_error` instead of being swallowed.
-#[tokio::test]
+/// `unpin_error` instead of being swallowed.
+#[tokio::test(flavor = "multi_thread")]
 async fn cleanup_reports_unpin_error() {
     let id = 1u64;
     let node_id = test_node_id();
@@ -423,7 +428,19 @@ async fn cleanup_reports_unpin_error() {
             predicate::eq(node_id),
             predicate::eq(nev![(id, UnpinMode::Release)]),
         )
-        .return_once(move |_, _| Box::pin(std::future::ready(Err(MockError))));
+        .returning(move |_, _| Box::pin(std::future::ready(Err(MockError))));
+    // The heartbeat is short so the unpin loop's retries land inside the
+    // test window; refreshes are incidental here.
+    backend
+        .expect_refresh_pinnings()
+        .times(0..)
+        .returning(move |_, _, _| {
+            let pinning = test_pinning(node_id, 1);
+            Box::pin(std::future::ready(Ok(nev![PinningStatus {
+                workload_id: id,
+                pinning: Some(pinning),
+            }])))
+        });
 
     let backend = Arc::new(backend);
 
@@ -439,7 +456,8 @@ async fn cleanup_reports_unpin_error() {
         pinned_tx,
         max_pinned: test_max_concurrent(),
         pinning_ttl: test_pinning_ttl(),
-        pinning_heartbeat: long_heartbeat(),
+        pinning_heartbeat: short_heartbeat(),
+        unpin_retry_interval: test_unpin_retry_interval(),
         pinning_fencing_margin: test_fencing_margin(),
     });
     tokio::pin!(run_future);
@@ -452,14 +470,14 @@ async fn cleanup_reports_unpin_error() {
 
     force_shutdown.cancel();
 
-    let outcome = tokio::time::timeout(Duration::from_secs(5), &mut run_future)
+    let outcome = tokio::time::timeout(Duration::from_secs(10), &mut run_future)
         .await
         .expect("run should exit after force shutdown");
 
     drop(handles);
 
     assert!(
-        outcome.cleanup_error.is_some(),
+        outcome.unpin_error.is_some(),
         "expected the cleanup unpin failure to be reported"
     );
 }
@@ -529,6 +547,7 @@ async fn unpin_park_flows_end_to_end() {
             max_pinned: test_max_concurrent(),
             pinning_ttl: test_pinning_ttl(),
             pinning_heartbeat: short_heartbeat(),
+            unpin_retry_interval: test_unpin_retry_interval(),
             pinning_fencing_margin: test_fencing_margin(),
         }),
     )
@@ -543,8 +562,8 @@ async fn unpin_park_flows_end_to_end() {
     mock.checkpoint();
 
     assert!(
-        outcome.cleanup_error.is_none(),
-        "expected no cleanup, got {:?}",
-        outcome.cleanup_error
+        outcome.unpin_error.is_none(),
+        "expected no unpin error, got {:?}",
+        outcome.unpin_error
     );
 }

--- a/crates/lib/workload-pinning-manager/src/unpin/mod.rs
+++ b/crates/lib/workload-pinning-manager/src/unpin/mod.rs
@@ -1,0 +1,179 @@
+//! Unpin loop — applies the durable unpins of evicted workloads.
+//!
+//! The loop runs alongside the poll and maintenance loops rather than
+//! inside them: unpinning is a database round-trip, and doing it on the
+//! maintenance loop would stall the heartbeat behind it. A stalled
+//! heartbeat means pinnings lapse, which would fence healthy workloads
+//! for no reason other than a slow unpin.
+//!
+//! # Exit contract
+//!
+//! The loop keeps running while either its input is open — the
+//! maintenance loop may still forward evictions — or something is still
+//! pending. It exits cleanly once the input has closed **and** every
+//! unpin has landed.
+//!
+//! Because the maintenance loop routes the pinnings it still holds into
+//! this loop before dropping its sender, the final cleanup goes through
+//! the same machinery as every other unpin, retries included. This is
+//! the only place that calls
+//! [`UnpinWorkloads`](waymark_workload_pinning_backend::UnpinWorkloads).
+//!
+//! # Retry policy
+//!
+//! A failed unpin is not fatal: the batch stays queued and is retried on
+//! the retry interval, so a transient database error does not abandon
+//! the pinnings. Only after [`MAX_UNPIN_FAILURES`] consecutive failures
+//! does the loop give up and return the error — the pinnings it could
+//! not release are left to lapse on their own.
+
+mod sender;
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use nonempty_collections::NEVec;
+use tracing::{debug, warn};
+use waymark_nonzero_duration::NonZeroDuration;
+
+pub use self::sender::{UnpinSender, wrap_tx};
+
+/// How many consecutive unpin failures the loop tolerates — keeping the
+/// batch queued and retrying — before giving up.
+const MAX_UNPIN_FAILURES: usize = 5;
+
+pub(super) struct UnpinParams<Backend>
+where
+    Backend: waymark_workload_pinning_backend::HasNodeId,
+    Backend: waymark_workload_pinning_backend::HasWorkloadId,
+{
+    pub backend: Arc<Backend>,
+    pub node_id: Backend::NodeId,
+    pub unpin_rx: tokio::sync::mpsc::UnboundedReceiver<(
+        Backend::WorkloadId,
+        waymark_workload_pinning_core::UnpinMode,
+    )>,
+    pub retry_interval: NonZeroDuration,
+}
+
+pub(super) async fn run_unpin_loop<Backend>(
+    params: UnpinParams<Backend>,
+) -> Result<(), <Backend as waymark_workload_pinning_backend::UnpinWorkloads>::Error>
+where
+    Backend: waymark_workload_pinning_backend::UnpinWorkloads,
+    Backend::NodeId: Clone,
+    Backend::WorkloadId: Clone + std::hash::Hash + Eq,
+{
+    let UnpinParams {
+        backend,
+        node_id,
+        mut unpin_rx,
+        retry_interval,
+    } = params;
+
+    // Keyed by workload id: a later eviction supersedes one still
+    // queued for the same workload, since it carries the newer decision
+    // about how that pinning should end.
+    let mut pending: HashMap<Backend::WorkloadId, waymark_workload_pinning_core::UnpinMode> =
+        HashMap::new();
+    let mut failures = 0usize;
+    let mut retry_at: Option<tokio::time::Instant> = None;
+    let mut input_closed = false;
+
+    let result = loop {
+        if input_closed && pending.is_empty() {
+            break Ok(());
+        }
+
+        tokio::select! {
+            eviction = unpin_rx.recv(), if !input_closed => {
+                match eviction {
+                    Some(eviction) => {
+                        // Coalesce everything already queued into one batch.
+                        pending.insert(eviction.0, eviction.1);
+                        while let Ok((id, mode)) = unpin_rx.try_recv() {
+                            pending.insert(id, mode);
+                        }
+                    }
+                    None => {
+                        input_closed = true;
+                        if !pending.is_empty() {
+                            debug!(
+                                "eviction input closed, {} unpins still pending",
+                                pending.len()
+                            );
+                        }
+                        continue;
+                    }
+                }
+            }
+            _ = async { tokio::time::sleep_until(retry_at.unwrap()).await }, if retry_at.is_some() => {}
+        }
+
+        if let Some(error) =
+            flush_pending_unpins(&*backend, node_id.clone(), &mut pending, &mut failures).await
+        {
+            warn!(
+                abandoned = pending.len(),
+                "giving up on pending unpins; leaving those pinnings to lapse"
+            );
+            break Err(error);
+        }
+
+        // A still-pending batch means the flush failed; come back for it.
+        retry_at =
+            (!pending.is_empty()).then(|| tokio::time::Instant::now() + retry_interval.get());
+    };
+
+    debug!("unpin loop exiting");
+    result
+}
+
+/// Attempt to unpin every pending workload in one batch.
+///
+/// On success the landed entries are dropped and the failure counter
+/// reset. On failure the batch stays queued for a later retry and the
+/// counter is bumped; once it reaches [`MAX_UNPIN_FAILURES`] the error is
+/// returned so the caller can give up.
+async fn flush_pending_unpins<Backend>(
+    backend: &Backend,
+    node_id: Backend::NodeId,
+    pending: &mut HashMap<Backend::WorkloadId, waymark_workload_pinning_core::UnpinMode>,
+    failures: &mut usize,
+) -> Option<<Backend as waymark_workload_pinning_backend::UnpinWorkloads>::Error>
+where
+    Backend: waymark_workload_pinning_backend::UnpinWorkloads,
+    Backend::WorkloadId: Clone + std::hash::Hash + Eq,
+{
+    // Nothing pending is not a failure — there is simply no batch.
+    let batch = NEVec::try_from_vec(
+        pending
+            .iter()
+            .map(|(id, mode)| (id.clone(), *mode))
+            .collect(),
+    )?;
+
+    match backend.unpin_workloads(node_id, batch).await {
+        Ok(()) => {
+            // The loop records evictions only between flushes, never
+            // during one, so everything queued is what just landed.
+            pending.clear();
+            *failures = 0;
+            debug!("unpinned workloads");
+            None
+        }
+        Err(error) => {
+            // The batch stays queued for the next attempt.
+            *failures += 1;
+            warn!(
+                ?error,
+                failures = *failures,
+                "unpin failed; keeping the batch queued for retry"
+            );
+            (*failures >= MAX_UNPIN_FAILURES).then_some(error)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/lib/workload-pinning-manager/src/unpin/sender.rs
+++ b/crates/lib/workload-pinning-manager/src/unpin/sender.rs
@@ -1,0 +1,48 @@
+//! The sending half of the unpin request channel.
+//!
+//! See [`UnpinSender`].
+
+use waymark_workload_pinning_core::UnpinMode;
+
+/// The sending half of the unpin request channel: a thin wrapper that
+/// lets a caller ask for the durable unpin of an evicted workload
+/// without handling the channel itself.
+///
+/// Cheap to clone, and every holder feeds the same [unpin
+/// loop](super::run_unpin_loop): requests are coalesced into batches,
+/// applied with retries, and a later request for a workload supersedes
+/// one still pending for it.
+pub struct UnpinSender<Id> {
+    tx: tokio::sync::mpsc::UnboundedSender<(Id, UnpinMode)>,
+}
+
+impl<Id> UnpinSender<Id> {
+    /// Request the durable unpin of a workload.
+    ///
+    /// Returns nothing and cannot fail: the unpin loop applies the
+    /// request on its own schedule. If the loop has already exited the
+    /// request is dropped, leaving that pinning to lapse — the same
+    /// outcome as the loop giving up on it.
+    pub fn request(&self, id: Id, mode: UnpinMode) {
+        let _ = self.tx.send((id, mode));
+    }
+}
+
+// Cloning the sender never depends on the id being cloneable, so this
+// cannot be derived.
+impl<Id> Clone for UnpinSender<Id> {
+    fn clone(&self) -> Self {
+        Self {
+            tx: self.tx.clone(),
+        }
+    }
+}
+
+/// Wrap the sending half of an unpin request channel.
+///
+/// The channel itself is created by the caller, alongside the others it
+/// wires up; the receiving half goes to
+/// [`UnpinParams::unpin_rx`](super::UnpinParams::unpin_rx).
+pub fn wrap_tx<Id>(tx: tokio::sync::mpsc::UnboundedSender<(Id, UnpinMode)>) -> UnpinSender<Id> {
+    UnpinSender { tx }
+}

--- a/crates/lib/workload-pinning-manager/src/unpin/tests.rs
+++ b/crates/lib/workload-pinning-manager/src/unpin/tests.rs
@@ -1,0 +1,193 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use mockall::predicate;
+use nonempty_collections::nev;
+use tokio::sync::mpsc;
+use waymark_nonzero_duration::NonZeroDuration;
+use waymark_workload_pinning_core::UnpinMode;
+
+use super::{UnpinParams, run_unpin_loop};
+use crate::test_utils::helpers::{short_heartbeat, test_node_id};
+use crate::test_utils::mock::{MockBackend, MockError};
+
+/// With nothing ever sent, closing the input exits the loop cleanly.
+#[tokio::test]
+async fn exits_cleanly_when_the_input_closes_empty() {
+    let backend = Arc::new(MockBackend::new());
+    let (unpin_tx, unpin_rx) = mpsc::unbounded_channel::<(u64, UnpinMode)>();
+    drop(unpin_tx);
+
+    let result = tokio::time::timeout(
+        Duration::from_secs(5),
+        run_unpin_loop(UnpinParams {
+            backend,
+            node_id: test_node_id(),
+            unpin_rx,
+            retry_interval: short_heartbeat(),
+        }),
+    )
+    .await
+    .expect("the loop should exit promptly");
+
+    assert!(result.is_ok(), "expected Ok, got {result:?}");
+}
+
+/// Evictions are applied, and the mode each carries is preserved.
+#[tokio::test(flavor = "multi_thread")]
+async fn applies_evictions_with_their_modes() {
+    let node_id = test_node_id();
+
+    let mut backend = MockBackend::new();
+    backend
+        .expect_unpin_workloads()
+        .times(1)
+        .with(
+            predicate::eq(node_id),
+            predicate::eq(nev![(1u64, UnpinMode::Park)]),
+        )
+        .returning(move |_, _| Box::pin(std::future::ready(Ok(()))));
+
+    let backend = Arc::new(backend);
+    let (unpin_tx, unpin_rx) = mpsc::unbounded_channel::<(u64, UnpinMode)>();
+    unpin_tx.send((1u64, UnpinMode::Park)).expect("send");
+    drop(unpin_tx);
+
+    let result = tokio::time::timeout(
+        Duration::from_secs(5),
+        run_unpin_loop(UnpinParams {
+            backend: Arc::clone(&backend),
+            node_id,
+            unpin_rx,
+            retry_interval: short_heartbeat(),
+        }),
+    )
+    .await
+    .expect("the loop should drain and exit");
+
+    assert!(result.is_ok(), "expected Ok, got {result:?}");
+
+    let mut mock = Arc::into_inner(backend).expect("exclusively owned after the loop exits");
+    mock.checkpoint();
+}
+
+/// A transient failure keeps the batch queued and retries it, rather
+/// than abandoning the pinnings.
+#[tokio::test(flavor = "multi_thread")]
+async fn retries_a_failed_unpin_until_it_lands() {
+    let node_id = test_node_id();
+
+    let mut backend = MockBackend::new();
+    let mut attempts = 0;
+    backend
+        .expect_unpin_workloads()
+        .times(2)
+        .returning(move |_, _| {
+            attempts += 1;
+            if attempts == 1 {
+                return Box::pin(std::future::ready(Err(MockError)));
+            }
+            Box::pin(std::future::ready(Ok(())))
+        });
+
+    let backend = Arc::new(backend);
+    let (unpin_tx, unpin_rx) = mpsc::unbounded_channel::<(u64, UnpinMode)>();
+    unpin_tx.send((1u64, UnpinMode::Release)).expect("send");
+    drop(unpin_tx);
+
+    let result = tokio::time::timeout(
+        Duration::from_secs(5),
+        run_unpin_loop(UnpinParams {
+            backend: Arc::clone(&backend),
+            node_id,
+            unpin_rx,
+            retry_interval: short_heartbeat(),
+        }),
+    )
+    .await
+    .expect("the loop should drain once the retry lands");
+
+    assert!(result.is_ok(), "expected Ok, got {result:?}");
+
+    // Explicit: the failed attempt and the successful retry both ran.
+    let mut mock = Arc::into_inner(backend).expect("exclusively owned after the loop exits");
+    mock.checkpoint();
+}
+
+/// After `MAX_UNPIN_FAILURES` consecutive failures the loop gives up and
+/// surfaces the error.
+#[tokio::test(flavor = "multi_thread")]
+async fn gives_up_after_repeated_failures() {
+    let node_id = test_node_id();
+
+    let mut backend = MockBackend::new();
+    backend
+        .expect_unpin_workloads()
+        .times(super::MAX_UNPIN_FAILURES)
+        .returning(move |_, _| Box::pin(std::future::ready(Err(MockError))));
+
+    let backend = Arc::new(backend);
+    let (unpin_tx, unpin_rx) = mpsc::unbounded_channel::<(u64, UnpinMode)>();
+    unpin_tx.send((1u64, UnpinMode::Release)).expect("send");
+    drop(unpin_tx);
+
+    let result = tokio::time::timeout(
+        Duration::from_secs(10),
+        run_unpin_loop(UnpinParams {
+            backend: Arc::clone(&backend),
+            node_id,
+            unpin_rx,
+            retry_interval: short_heartbeat(),
+        }),
+    )
+    .await
+    .expect("the loop should give up");
+
+    assert!(result.is_err(), "expected the error to surface");
+
+    let mut mock = Arc::into_inner(backend).expect("exclusively owned after the loop exits");
+    mock.checkpoint();
+}
+
+/// Evictions queued together are coalesced into one call, and a repeat
+/// eviction of the same workload supersedes the earlier mode.
+#[tokio::test(flavor = "multi_thread")]
+async fn coalesces_queued_evictions_and_supersedes_repeats() {
+    let node_id = test_node_id();
+
+    let mut backend = MockBackend::new();
+    backend
+        .expect_unpin_workloads()
+        .times(1)
+        .withf(move |_, workloads| {
+            let mut got: Vec<_> = workloads.iter().copied().collect();
+            got.sort_by_key(|(id, _mode)| *id);
+            got == vec![(1u64, UnpinMode::Park), (2u64, UnpinMode::Release)]
+        })
+        .returning(move |_, _| Box::pin(std::future::ready(Ok(()))));
+
+    let backend = Arc::new(backend);
+    let (unpin_tx, unpin_rx) = mpsc::unbounded_channel::<(u64, UnpinMode)>();
+    // Queue everything before the loop runs so it coalesces in one pass.
+    unpin_tx.send((1u64, UnpinMode::Release)).expect("send");
+    unpin_tx.send((2u64, UnpinMode::Release)).expect("send");
+    unpin_tx.send((1u64, UnpinMode::Park)).expect("send");
+    drop(unpin_tx);
+
+    let result = tokio::time::timeout(
+        Duration::from_secs(5),
+        run_unpin_loop(UnpinParams {
+            backend: Arc::clone(&backend),
+            node_id,
+            unpin_rx,
+            retry_interval: NonZeroDuration::new(Duration::from_millis(50)).unwrap(),
+        }),
+    )
+    .await
+    .expect("the loop should drain and exit");
+
+    assert!(result.is_ok(), "expected Ok, got {result:?}");
+
+    let mut mock = Arc::into_inner(backend).expect("exclusively owned after the loop exits");
+    mock.checkpoint();
+}


### PR DESCRIPTION
Goes in after #481 

---

This PR corrects a potential keepalive skip by decoupling the unpins into a separate loop. It also folds the cleanup into the same unpin loop, and makes sure the termination (i.e.shutdown) ordering it correct.