### PR TITLE
Extract settled vm promise state variants into a unified enum

### DIFF
--- a/crates/lib/vm-driver/src/lib.rs
+++ b/crates/lib/vm-driver/src/lib.rs
@@ -172,7 +172,7 @@ where
                     match runtime.resolve_promise(promise_state_id, value) {
                         Ok(()) => {}
                         Err(
-                            error @ (ResolvePromiseError::AlreadyResolved(_)
+                            error @ (ResolvePromiseError::AlreadySettled(_)
                             | ResolvePromiseError::PromiseStateNotFound(_)),
                         ) => {
                             tracing::info!(
@@ -188,7 +188,7 @@ where
                     match runtime.reject_promise(promise_state_id, exception) {
                         Ok(()) => {}
                         Err(
-                            error @ (ResolvePromiseError::AlreadyResolved(_)
+                            error @ (ResolvePromiseError::AlreadySettled(_)
                             | ResolvePromiseError::PromiseStateNotFound(_)),
                         ) => {
                             tracing::info!(

--- a/crates/lib/vm-driver/src/lib.rs
+++ b/crates/lib/vm-driver/src/lib.rs
@@ -12,7 +12,7 @@ use nonempty_collections::{IntoIteratorExt as _, NEVec, NonEmptyIterator as _};
 use tokio_util::sync::CancellationToken;
 use waymark_vm_driver_core::{PromiseResolution, PromiseSettlement};
 use waymark_vm_runtime::{FrameFor, Runtime};
-use waymark_vm_runtime_core::ResolvePromiseError;
+use waymark_vm_runtime_core::SettlePromiseError;
 
 /// Errors returned by the driver loop.
 #[derive(Debug)]
@@ -172,8 +172,8 @@ where
                     match runtime.resolve_promise(promise_state_id, value) {
                         Ok(()) => {}
                         Err(
-                            error @ (ResolvePromiseError::AlreadySettled(_)
-                            | ResolvePromiseError::PromiseStateNotFound(_)),
+                            error @ (SettlePromiseError::AlreadySettled(_)
+                            | SettlePromiseError::PromiseStateNotFound(_)),
                         ) => {
                             tracing::info!(
                                 ?promise_state_id,
@@ -188,8 +188,8 @@ where
                     match runtime.reject_promise(promise_state_id, exception) {
                         Ok(()) => {}
                         Err(
-                            error @ (ResolvePromiseError::AlreadySettled(_)
-                            | ResolvePromiseError::PromiseStateNotFound(_)),
+                            error @ (SettlePromiseError::AlreadySettled(_)
+                            | SettlePromiseError::PromiseStateNotFound(_)),
                         ) => {
                             tracing::info!(
                                 ?promise_state_id,

--- a/crates/lib/vm-interpreter-coreset/src/error.rs
+++ b/crates/lib/vm-interpreter-coreset/src/error.rs
@@ -95,7 +95,7 @@ pub enum ReturnFnCallError {
     #[error("function call result promise was not found")]
     ReturnPromiseNotFound,
 
-    /// The destination promise for the function call had already been resolved.
-    #[error("function call result promise has already been resolved")]
-    ReturnPromiseAlreadyResolved,
+    /// The destination promise for the function call had already settled.
+    #[error("function call result promise has already settled")]
+    ReturnPromiseAlreadySettled,
 }

--- a/crates/lib/vm-interpreter-coreset/src/lib.rs
+++ b/crates/lib/vm-interpreter-coreset/src/lib.rs
@@ -9,6 +9,7 @@ use derive_where::derive_where;
 use waymark_vm_interpreter::ExecutionOutcome;
 use waymark_vm_runtime_core::{
     Continuation, ExceptionHandlers, Frame, FrameKind, PromiseState, Registers, RuntimeState,
+    SettledPromiseState,
 };
 
 pub use self::error::*;
@@ -218,7 +219,7 @@ where
                             .map_err(AwaitError::SourcePromiseStateNotFound)
                             .map_err(Error::Await)?;
                         return Ok(match promise_state {
-                            PromiseState::Resolved(value) => {
+                            PromiseState::Settled(SettledPromiseState::Resolved(value)) => {
                                 Continuation::immediate_resume(
                                     &mut frame,
                                     *resume,
@@ -228,7 +229,7 @@ where
                                 state.ready.push_back(frame);
                                 ExecutionOutcome::ExitFrame
                             }
-                            PromiseState::Rejected(exception) => {
+                            PromiseState::Settled(SettledPromiseState::Rejected(exception)) => {
                                 Continuation::<_, _, _, ()>::immediate_raise_exception(
                                     &mut frame,
                                     *resume,

--- a/crates/lib/vm-interpreter-coreset/src/lib.rs
+++ b/crates/lib/vm-interpreter-coreset/src/lib.rs
@@ -84,10 +84,10 @@ where
                 state
                     .reject_promise(ret, exception)
                     .map_err(|error| match error {
-                        waymark_vm_runtime_core::ResolvePromiseError::PromiseStateNotFound(_) => {
+                        waymark_vm_runtime_core::SettlePromiseError::PromiseStateNotFound(_) => {
                             ReturnFnCallError::ReturnPromiseNotFound
                         }
-                        waymark_vm_runtime_core::ResolvePromiseError::AlreadySettled(_) => {
+                        waymark_vm_runtime_core::SettlePromiseError::AlreadySettled(_) => {
                             ReturnFnCallError::ReturnPromiseAlreadySettled
                         }
                     })
@@ -294,10 +294,10 @@ where
                             .resolve_promise(ret, val)
                             .map_err(|error| {
                                 match error {
-                                waymark_vm_runtime_core::ResolvePromiseError::PromiseStateNotFound(
+                                waymark_vm_runtime_core::SettlePromiseError::PromiseStateNotFound(
                                     _,
                                 ) => ReturnFnCallError::ReturnPromiseNotFound,
-                                waymark_vm_runtime_core::ResolvePromiseError::AlreadySettled(
+                                waymark_vm_runtime_core::SettlePromiseError::AlreadySettled(
                                     _,
                                 ) => ReturnFnCallError::ReturnPromiseAlreadySettled,
                             }

--- a/crates/lib/vm-interpreter-coreset/src/lib.rs
+++ b/crates/lib/vm-interpreter-coreset/src/lib.rs
@@ -87,8 +87,8 @@ where
                         waymark_vm_runtime_core::ResolvePromiseError::PromiseStateNotFound(_) => {
                             ReturnFnCallError::ReturnPromiseNotFound
                         }
-                        waymark_vm_runtime_core::ResolvePromiseError::AlreadyResolved(_) => {
-                            ReturnFnCallError::ReturnPromiseAlreadyResolved
+                        waymark_vm_runtime_core::ResolvePromiseError::AlreadySettled(_) => {
+                            ReturnFnCallError::ReturnPromiseAlreadySettled
                         }
                     })
                     .map_err(FnExitError::FnCall)?;
@@ -297,9 +297,9 @@ where
                                 waymark_vm_runtime_core::ResolvePromiseError::PromiseStateNotFound(
                                     _,
                                 ) => ReturnFnCallError::ReturnPromiseNotFound,
-                                waymark_vm_runtime_core::ResolvePromiseError::AlreadyResolved(
+                                waymark_vm_runtime_core::ResolvePromiseError::AlreadySettled(
                                     _,
-                                ) => ReturnFnCallError::ReturnPromiseAlreadyResolved,
+                                ) => ReturnFnCallError::ReturnPromiseAlreadySettled,
                             }
                             })
                             .map_err(FnExitError::FnCall)

--- a/crates/lib/vm-runtime-core/src/promise_state.rs
+++ b/crates/lib/vm-runtime-core/src/promise_state.rs
@@ -11,19 +11,19 @@ pub enum SettledPromiseState<Value> {
     Rejected(waymark_vm_runtime_exception::Exception<Value>),
 }
 
-/// An errors that occurs when an attempt to resolve an already resolved
+/// An error that occurs when an attempt to settle an already settled
 /// promise is made.
 ///
-/// Resolving a promise is idempotent, so you could ignore this error if there
-/// is no strong need for the promise to be resolved with *this* particular
+/// Settling a promise is idempotent, so you could ignore this error if there
+/// is no strong need for the promise to be settled with *this* particular
 /// operation. The consequence of this error is that the value that was
-/// provided for resolving the promise has not been able to be stored in
+/// provided for settling the promise has not been able to be stored in
 /// the promise.
 #[derive(Debug, thiserror::Error)]
-#[error("resolving an already resolved promise")]
-pub struct ResolvingAlreadyResolvedPromiseError<Value> {
+#[error("settling an already settled promise")]
+pub struct SettlingAlreadySettledPromiseError<Value> {
     /// The new value that has not been able to be stored in
-    /// the already-resolved promise.
+    /// the already-settled promise.
     pub new_value: Value,
 }
 
@@ -47,14 +47,14 @@ impl<FunctionId, StateId, Value> PromiseState<FunctionId, StateId, Value> {
     /// Idempotently resolve a promise.
     ///
     /// Returns a list of continuations to resume, or an error if this promise
-    /// has already been resolved.
+    /// has already settled.
     #[allow(clippy::type_complexity)]
     pub fn resolve(
         &mut self,
         value: Value,
     ) -> Result<
         Vec<crate::Continuation<FunctionId, StateId, Value, crate::ResumeWithValue>>,
-        ResolvingAlreadyResolvedPromiseError<Value>,
+        SettlingAlreadySettledPromiseError<Value>,
     > {
         let replaced = std::mem::replace(self, Self::Settled(SettledPromiseState::Resolved(value)));
         match replaced {
@@ -71,7 +71,7 @@ impl<FunctionId, StateId, Value> PromiseState<FunctionId, StateId, Value> {
                     unreachable!();
                 };
 
-                Err(ResolvingAlreadyResolvedPromiseError { new_value })
+                Err(SettlingAlreadySettledPromiseError { new_value })
             }
         }
     }
@@ -83,7 +83,7 @@ impl<FunctionId, StateId, Value> PromiseState<FunctionId, StateId, Value> {
         exception: waymark_vm_runtime_exception::Exception<Value>,
     ) -> Result<
         Vec<crate::Continuation<FunctionId, StateId, Value, crate::ResumeWithValue>>,
-        ResolvingAlreadyResolvedPromiseError<waymark_vm_runtime_exception::Exception<Value>>,
+        SettlingAlreadySettledPromiseError<waymark_vm_runtime_exception::Exception<Value>>,
     > {
         let replaced = std::mem::replace(
             self,
@@ -103,7 +103,7 @@ impl<FunctionId, StateId, Value> PromiseState<FunctionId, StateId, Value> {
                     unreachable!();
                 };
 
-                Err(ResolvingAlreadyResolvedPromiseError { new_value })
+                Err(SettlingAlreadySettledPromiseError { new_value })
             }
         }
     }

--- a/crates/lib/vm-runtime-core/src/promise_state.rs
+++ b/crates/lib/vm-runtime-core/src/promise_state.rs
@@ -1,3 +1,16 @@
+/// The settled outcome of a promise.
+///
+/// A promise settles at most once, with either of the two kinds of outcomes.
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum SettledPromiseState<Value> {
+    /// The promise has been resolved successfully with a value.
+    Resolved(Value),
+
+    /// The promise has been rejected with an exception.
+    Rejected(waymark_vm_runtime_exception::Exception<Value>),
+}
+
 /// An errors that occurs when an attempt to resolve an already resolved
 /// promise is made.
 ///
@@ -18,26 +31,22 @@ pub struct ResolvingAlreadyResolvedPromiseError<Value> {
 #[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum PromiseState<FunctionId, StateId, Value> {
-    /// A list of continuations to resume when a promise resolves.
+    /// A list of continuations to resume when a promise settles.
     ///
     /// Awaiting on it will add the frame to the list of continuations.
     Waiting(Vec<crate::Continuation<FunctionId, StateId, Value, crate::ResumeWithValue>>),
 
-    /// A promise that has been resolved successfully.
+    /// A promise that has settled.
     ///
-    /// Awaiting on it will resume immediately.
-    Resolved(Value),
-
-    /// A promise that has been rejected with an exception.
-    ///
-    /// Awaiting on it will resume immediately by raising the exception.
-    Rejected(waymark_vm_runtime_exception::Exception<Value>),
+    /// Awaiting on it will resume immediately - with the value on
+    /// a resolution, or by raising the exception on a rejection.
+    Settled(SettledPromiseState<Value>),
 }
 
 impl<FunctionId, StateId, Value> PromiseState<FunctionId, StateId, Value> {
     /// Idempotently resolve a promise.
     ///
-    /// Returns a list of continuations to resume, or an error is this promise
+    /// Returns a list of continuations to resume, or an error if this promise
     /// has already been resolved.
     #[allow(clippy::type_complexity)]
     pub fn resolve(
@@ -47,35 +56,24 @@ impl<FunctionId, StateId, Value> PromiseState<FunctionId, StateId, Value> {
         Vec<crate::Continuation<FunctionId, StateId, Value, crate::ResumeWithValue>>,
         ResolvingAlreadyResolvedPromiseError<Value>,
     > {
-        let replaced = std::mem::replace(self, Self::Resolved(value));
-        let continuations = match replaced {
-            PromiseState::Waiting(continuations) => continuations,
-            PromiseState::Resolved(old_value) => {
+        let replaced = std::mem::replace(self, Self::Settled(SettledPromiseState::Resolved(value)));
+        match replaced {
+            PromiseState::Waiting(continuations) => Ok(continuations),
+            PromiseState::Settled(original) => {
                 // This shouldn't happen often.
                 std::hint::cold_path();
 
-                // Replace the value back as we want first-wins semantics.
-                let new_value = std::mem::replace(self, Self::Resolved(old_value));
+                // Replace the original settlement back as we want
+                // first-wins semantics.
+                let new_settlement = std::mem::replace(self, Self::Settled(original));
 
-                let Self::Resolved(new_value) = new_value else {
+                let Self::Settled(SettledPromiseState::Resolved(new_value)) = new_settlement else {
                     unreachable!();
                 };
 
-                return Err(ResolvingAlreadyResolvedPromiseError { new_value });
+                Err(ResolvingAlreadyResolvedPromiseError { new_value })
             }
-            PromiseState::Rejected(old_exception) => {
-                std::hint::cold_path();
-
-                let new_value = std::mem::replace(self, Self::Rejected(old_exception));
-
-                let Self::Resolved(new_value) = new_value else {
-                    unreachable!();
-                };
-
-                return Err(ResolvingAlreadyResolvedPromiseError { new_value });
-            }
-        };
-        Ok(continuations)
+        }
     }
 
     /// Idempotently reject a promise.
@@ -87,37 +85,27 @@ impl<FunctionId, StateId, Value> PromiseState<FunctionId, StateId, Value> {
         Vec<crate::Continuation<FunctionId, StateId, Value, crate::ResumeWithValue>>,
         ResolvingAlreadyResolvedPromiseError<waymark_vm_runtime_exception::Exception<Value>>,
     > {
-        let replaced = std::mem::replace(self, Self::Rejected(exception));
-        let continuations = match replaced {
-            PromiseState::Waiting(continuations) => continuations,
-            PromiseState::Resolved(old_value) => {
+        let replaced = std::mem::replace(
+            self,
+            Self::Settled(SettledPromiseState::Rejected(exception)),
+        );
+        match replaced {
+            PromiseState::Waiting(continuations) => Ok(continuations),
+            PromiseState::Settled(original) => {
+                // This shouldn't happen often.
                 std::hint::cold_path();
 
-                let new_exception = std::mem::replace(self, Self::Resolved(old_value));
+                // Replace the original settlement back as we want
+                // first-wins semantics.
+                let new_settlement = std::mem::replace(self, Self::Settled(original));
 
-                let Self::Rejected(new_exception) = new_exception else {
+                let Self::Settled(SettledPromiseState::Rejected(new_value)) = new_settlement else {
                     unreachable!();
                 };
 
-                return Err(ResolvingAlreadyResolvedPromiseError {
-                    new_value: new_exception,
-                });
+                Err(ResolvingAlreadyResolvedPromiseError { new_value })
             }
-            PromiseState::Rejected(old_exception) => {
-                std::hint::cold_path();
-
-                let new_exception = std::mem::replace(self, Self::Rejected(old_exception));
-
-                let Self::Rejected(new_exception) = new_exception else {
-                    unreachable!();
-                };
-
-                return Err(ResolvingAlreadyResolvedPromiseError {
-                    new_value: new_exception,
-                });
-            }
-        };
-        Ok(continuations)
+        }
     }
 }
 
@@ -126,7 +114,7 @@ mod tests {
     use waymark_vm_runtime_exception::Exception;
     use waymark_vm_runtime_promise_value::PromiseValue;
 
-    use super::PromiseState;
+    use super::{PromiseState, SettledPromiseState};
     use crate::{Continuation, ExceptionHandlers, Frame, FrameKind, RegisterId, Registers};
 
     #[derive(Debug, Clone, PartialEq, Eq)]
@@ -159,7 +147,7 @@ mod tests {
     }
 
     #[test]
-    fn resolve_waiting_promise_returns_continuations_and_marks_ready() {
+    fn resolve_waiting_promise_returns_continuations_and_marks_resolved() {
         let mut state = PromiseState::Waiting(vec![continuation(RegisterId(1), 3)]);
 
         let continuations = state
@@ -169,7 +157,9 @@ mod tests {
         assert_eq!(continuations.len(), 1);
         assert!(matches!(
             &state,
-            PromiseState::Resolved(PromiseValue::Ready(TestReadyValue::Int(value))) if *value == 17
+            PromiseState::Settled(SettledPromiseState::Resolved(PromiseValue::Ready(
+                TestReadyValue::Int(value)
+            ))) if *value == 17
         ));
 
         let resumed = continuations
@@ -178,20 +168,22 @@ mod tests {
             .expect("continuation is returned")
             .resume(PromiseValue::Ready(TestReadyValue::Int(17)));
         assert_eq!(resumed.state, 3);
+        assert_eq!(resumed.regs.get(RegisterId(0)), None);
         assert_eq!(
             resumed.regs.get(RegisterId(1)),
             Some(&PromiseValue::Ready(TestReadyValue::Int(17)))
         );
+        assert!(resumed.exception.is_none());
     }
 
     #[test]
-    fn resolve_ready_promise_returns_error_and_preserves_original_value() {
-        let mut state = PromiseState::<&'static str, usize, TestValue>::Resolved(
-            PromiseValue::Ready(TestReadyValue::Int(5)),
+    fn resolve_settled_promise_returns_error_and_preserves_original_settlement() {
+        let mut state = PromiseState::<&'static str, usize, TestValue>::Settled(
+            SettledPromiseState::Resolved(PromiseValue::Ready(TestReadyValue::Int(5))),
         );
 
         let err = match state.resolve(PromiseValue::Ready(TestReadyValue::Int(9))) {
-            Ok(_) => panic!("resolved promise should reject a second value"),
+            Ok(_) => panic!("settled promise should reject a second settlement"),
             Err(err) => err,
         };
 
@@ -201,12 +193,14 @@ mod tests {
         ));
         assert!(matches!(
             &state,
-            PromiseState::Resolved(PromiseValue::Ready(TestReadyValue::Int(value))) if *value == 5
+            PromiseState::Settled(SettledPromiseState::Resolved(PromiseValue::Ready(
+                TestReadyValue::Int(value)
+            ))) if *value == 5
         ));
     }
 
     #[test]
-    fn resolve_waiting_promise_preserves_exception_results() {
+    fn reject_waiting_promise_preserves_exceptional_settlements() {
         let mut state = PromiseState::Waiting(vec![continuation(RegisterId(1), 3)]);
 
         let continuations = state
@@ -214,11 +208,11 @@ mod tests {
                 type_id: "ValueError".to_owned(),
                 details: PromiseValue::Ready(TestReadyValue::Int(17)),
             })
-            .expect("waiting promise should resolve exceptionally");
+            .expect("waiting promise should settle exceptionally");
 
         assert!(matches!(
             &state,
-            PromiseState::Rejected(Exception { type_id, details })
+            PromiseState::Settled(SettledPromiseState::Rejected(Exception { type_id, details }))
                 if type_id == "ValueError"
                     && *details == PromiseValue::Ready(TestReadyValue::Int(17))
         ));

--- a/crates/lib/vm-runtime-core/src/promise_states.rs
+++ b/crates/lib/vm-runtime-core/src/promise_states.rs
@@ -3,10 +3,6 @@ use waymark_vm_runtime_promise_core::PromiseStateId;
 
 use crate::{Continuation, PromiseState, SettlingAlreadySettledPromiseError};
 
-/// Errors returned when rejecting a promise state.
-pub type RejectPromiseError<Value> =
-    ResolvePromiseError<waymark_vm_runtime_exception::Exception<Value>>;
-
 /// A list of promise states.
 #[derive(Debug)]
 #[cfg_attr(
@@ -87,9 +83,9 @@ impl<FunctionId, StateId, Value> PromiseStates<FunctionId, StateId, Value> {
     }
 }
 
-/// Errors returned when resolving a promise state.
+/// Errors returned when settling a promise state.
 #[derive(Debug, thiserror::Error)]
-pub enum ResolvePromiseError<Value> {
+pub enum SettlePromiseError<Value> {
     /// The requested promise state ID does not exist.
     #[error(transparent)]
     PromiseStateNotFound(PromiseStateNotFoundError),
@@ -112,52 +108,53 @@ impl<FunctionId, StateId, Value> PromiseStates<FunctionId, StateId, Value> {
         value: Value,
     ) -> Result<
         Vec<crate::Continuation<FunctionId, StateId, Value, crate::ResumeWithValue>>,
-        ResolvePromiseError<Value>,
+        SettlePromiseError<Value>,
     > {
         let promise_state = self
             .get_mut(promise_state_id)
-            .map_err(ResolvePromiseError::PromiseStateNotFound)?;
+            .map_err(SettlePromiseError::PromiseStateNotFound)?;
 
         promise_state
             .resolve(value)
-            .map_err(ResolvePromiseError::AlreadySettled)
+            .map_err(SettlePromiseError::AlreadySettled)
     }
 
     /// Idempotently reject a promise at a given `promise_state_id`.
-    #[allow(clippy::type_complexity)]
+    #[expect(
+        clippy::type_complexity,
+        reason = "we purposely avoid alias for the error"
+    )]
     pub fn reject(
         &mut self,
         promise_state_id: PromiseStateId,
         exception: waymark_vm_runtime_exception::Exception<Value>,
     ) -> Result<
         Vec<Continuation<FunctionId, StateId, Value, crate::ResumeWithValue>>,
-        RejectPromiseError<Value>,
+        SettlePromiseError<waymark_vm_runtime_exception::Exception<Value>>,
     > {
         let promise_state = self
             .get_mut(promise_state_id)
-            .map_err(ResolvePromiseError::PromiseStateNotFound)?;
+            .map_err(SettlePromiseError::PromiseStateNotFound)?;
 
         promise_state
             .reject(exception)
-            .map_err(ResolvePromiseError::AlreadySettled)
+            .map_err(SettlePromiseError::AlreadySettled)
     }
 }
 
-impl<Value> ResolvePromiseError<Value> {
-    /// Map the `Value` of this [`ResolvePromiseError`] into `OtherValue` using
+impl<Value> SettlePromiseError<Value> {
+    /// Map the `Value` of this [`SettlePromiseError`] into `OtherValue` using
     /// function `f`.
     pub fn map<OtherValue>(
         self,
         f: impl FnOnce(Value) -> OtherValue,
-    ) -> ResolvePromiseError<OtherValue> {
+    ) -> SettlePromiseError<OtherValue> {
         match self {
-            Self::PromiseStateNotFound(error) => ResolvePromiseError::PromiseStateNotFound(error),
+            Self::PromiseStateNotFound(error) => SettlePromiseError::PromiseStateNotFound(error),
             Self::AlreadySettled(error) => {
                 let SettlingAlreadySettledPromiseError { new_value } = error;
                 let new_value = f(new_value);
-                ResolvePromiseError::AlreadySettled(SettlingAlreadySettledPromiseError {
-                    new_value,
-                })
+                SettlePromiseError::AlreadySettled(SettlingAlreadySettledPromiseError { new_value })
             }
         }
     }
@@ -167,7 +164,7 @@ impl<Value> ResolvePromiseError<Value> {
 mod tests {
     use waymark_vm_runtime_exception::Exception;
 
-    use super::{PromiseStateId, PromiseStateNotFoundError, PromiseStates, ResolvePromiseError};
+    use super::{PromiseStateId, PromiseStateNotFoundError, PromiseStates, SettlePromiseError};
     use crate::{
         Continuation, ExceptionHandlers, Frame, FrameKind, PromiseState, RegisterId, Registers,
         SettledPromiseState,
@@ -234,7 +231,7 @@ mod tests {
     fn resolve_rejects_unknown_promise_state_ids() {
         let mut states = PromiseStates::<&'static str, usize, i32>::new();
 
-        let Err(ResolvePromiseError::PromiseStateNotFound(PromiseStateNotFoundError {
+        let Err(SettlePromiseError::PromiseStateNotFound(PromiseStateNotFoundError {
             promise_state_id,
         })) = states.resolve(PromiseStateId(4), 23)
         else {

--- a/crates/lib/vm-runtime-core/src/promise_states.rs
+++ b/crates/lib/vm-runtime-core/src/promise_states.rs
@@ -103,7 +103,7 @@ impl<FunctionId, StateId, Value> PromiseStates<FunctionId, StateId, Value> {
     /// Idempotently resolve a promise at a given `promise_state_id` with
     /// the provided `value`.
     ///
-    /// Returns a list of continuations to resume, or an error is this promise
+    /// Returns a list of continuations to resume, or an error if this promise
     /// has already been resolved.
     #[allow(clippy::type_complexity)]
     pub fn resolve(
@@ -166,6 +166,7 @@ mod tests {
     use super::{PromiseStateId, PromiseStateNotFoundError, PromiseStates, ResolvePromiseError};
     use crate::{
         Continuation, ExceptionHandlers, Frame, FrameKind, PromiseState, RegisterId, Registers,
+        SettledPromiseState,
     };
 
     fn continuation(
@@ -221,7 +222,7 @@ mod tests {
         assert_eq!(continuations.len(), 1);
         assert!(matches!(
             states.get(promise_state_id).expect("promise state exists"),
-            PromiseState::Resolved(value) if *value == 23
+            PromiseState::Settled(SettledPromiseState::Resolved(value)) if *value == 23
         ));
     }
 
@@ -257,7 +258,7 @@ mod tests {
         assert!(continuations.is_empty());
         assert!(matches!(
             states.get(promise_state_id).expect("promise state exists"),
-            PromiseState::Rejected(Exception { type_id, details })
+            PromiseState::Settled(SettledPromiseState::Rejected(Exception { type_id, details }))
                 if type_id == "ValueError" && *details == 23
         ));
     }

--- a/crates/lib/vm-runtime-core/src/promise_states.rs
+++ b/crates/lib/vm-runtime-core/src/promise_states.rs
@@ -1,7 +1,7 @@
 use index_type::typed_vec::TypedVec;
 use waymark_vm_runtime_promise_core::PromiseStateId;
 
-use crate::{Continuation, PromiseState, ResolvingAlreadyResolvedPromiseError};
+use crate::{Continuation, PromiseState, SettlingAlreadySettledPromiseError};
 
 /// Errors returned when rejecting a promise state.
 pub type RejectPromiseError<Value> =
@@ -92,11 +92,11 @@ impl<FunctionId, StateId, Value> PromiseStates<FunctionId, StateId, Value> {
 pub enum ResolvePromiseError<Value> {
     /// The requested promise state ID does not exist.
     #[error(transparent)]
-    PromiseStateNotFound(#[from] PromiseStateNotFoundError),
+    PromiseStateNotFound(PromiseStateNotFoundError),
 
-    /// The promise state has already been resolved.
+    /// The promise state has already settled.
     #[error(transparent)]
-    AlreadyResolved(#[from] ResolvingAlreadyResolvedPromiseError<Value>),
+    AlreadySettled(SettlingAlreadySettledPromiseError<Value>),
 }
 
 impl<FunctionId, StateId, Value> PromiseStates<FunctionId, StateId, Value> {
@@ -104,7 +104,7 @@ impl<FunctionId, StateId, Value> PromiseStates<FunctionId, StateId, Value> {
     /// the provided `value`.
     ///
     /// Returns a list of continuations to resume, or an error if this promise
-    /// has already been resolved.
+    /// has already settled.
     #[allow(clippy::type_complexity)]
     pub fn resolve(
         &mut self,
@@ -114,11 +114,13 @@ impl<FunctionId, StateId, Value> PromiseStates<FunctionId, StateId, Value> {
         Vec<crate::Continuation<FunctionId, StateId, Value, crate::ResumeWithValue>>,
         ResolvePromiseError<Value>,
     > {
-        let promise_state = self.get_mut(promise_state_id)?;
+        let promise_state = self
+            .get_mut(promise_state_id)
+            .map_err(ResolvePromiseError::PromiseStateNotFound)?;
 
         promise_state
             .resolve(value)
-            .map_err(ResolvePromiseError::AlreadyResolved)
+            .map_err(ResolvePromiseError::AlreadySettled)
     }
 
     /// Idempotently reject a promise at a given `promise_state_id`.
@@ -131,11 +133,13 @@ impl<FunctionId, StateId, Value> PromiseStates<FunctionId, StateId, Value> {
         Vec<Continuation<FunctionId, StateId, Value, crate::ResumeWithValue>>,
         RejectPromiseError<Value>,
     > {
-        let promise_state = self.get_mut(promise_state_id)?;
+        let promise_state = self
+            .get_mut(promise_state_id)
+            .map_err(ResolvePromiseError::PromiseStateNotFound)?;
 
         promise_state
             .reject(exception)
-            .map_err(ResolvePromiseError::AlreadyResolved)
+            .map_err(ResolvePromiseError::AlreadySettled)
     }
 }
 
@@ -148,10 +152,10 @@ impl<Value> ResolvePromiseError<Value> {
     ) -> ResolvePromiseError<OtherValue> {
         match self {
             Self::PromiseStateNotFound(error) => ResolvePromiseError::PromiseStateNotFound(error),
-            Self::AlreadyResolved(error) => {
-                let ResolvingAlreadyResolvedPromiseError { new_value } = error;
+            Self::AlreadySettled(error) => {
+                let SettlingAlreadySettledPromiseError { new_value } = error;
                 let new_value = f(new_value);
-                ResolvePromiseError::AlreadyResolved(ResolvingAlreadyResolvedPromiseError {
+                ResolvePromiseError::AlreadySettled(SettlingAlreadySettledPromiseError {
                     new_value,
                 })
             }

--- a/crates/lib/vm-runtime-core/src/runtime_state.rs
+++ b/crates/lib/vm-runtime-core/src/runtime_state.rs
@@ -93,7 +93,7 @@ mod tests {
     use super::RuntimeState;
     use crate::{
         Continuation, ExceptionHandlers, Frame, FrameKind, PromiseState, PromiseStates, RegisterId,
-        Registers, ResolvePromiseError,
+        Registers, ResolvePromiseError, SettledPromiseState,
     };
 
     #[derive(Debug, Clone, PartialEq, Eq)]
@@ -152,12 +152,14 @@ mod tests {
 
         assert_eq!(runtime.ready.len(), 2);
 
-        let PromiseState::Resolved(PromiseValue::Ready(TestReadyValue::Int(value))) = runtime
+        let PromiseState::Settled(SettledPromiseState::Resolved(PromiseValue::Ready(
+            TestReadyValue::Int(value),
+        ))) = runtime
             .promise_states
             .get(promise_state_id)
             .expect("promise state exists")
         else {
-            panic!("promise state should be ready with a resolved value");
+            panic!("promise state should be settled with a resolved value");
         };
         assert_eq!(*value, 41);
 
@@ -185,7 +187,9 @@ mod tests {
         let promise_state = promise_states
             .get_mut(promise_state_id)
             .expect("promise state exists");
-        *promise_state = PromiseState::Resolved(PromiseValue::Ready(TestReadyValue::Int(7)));
+        *promise_state = PromiseState::Settled(SettledPromiseState::Resolved(PromiseValue::Ready(
+            TestReadyValue::Int(7),
+        )));
 
         let mut runtime = RuntimeState {
             ready: VecDeque::new(),
@@ -210,7 +214,9 @@ mod tests {
         assert_eq!(value, 9);
         assert!(runtime.ready.is_empty());
 
-        let PromiseState::Resolved(PromiseValue::Ready(TestReadyValue::Int(value))) = runtime
+        let PromiseState::Settled(SettledPromiseState::Resolved(PromiseValue::Ready(
+            TestReadyValue::Int(value),
+        ))) = runtime
             .promise_states
             .get(promise_state_id)
             .expect("promise state exists")
@@ -244,12 +250,12 @@ mod tests {
             .reject_promise(promise_state_id, exception.clone())
             .expect("waiting promise should resolve exceptionally");
 
-        let PromiseState::Rejected(stored_exception) = runtime
+        let PromiseState::Settled(SettledPromiseState::Rejected(stored_exception)) = runtime
             .promise_states
             .get(promise_state_id)
             .expect("promise state exists")
         else {
-            panic!("promise state should be ready with an exception");
+            panic!("promise state should be settled with an exception");
         };
         assert_eq!(stored_exception.type_id, exception.type_id);
         assert_eq!(stored_exception.details, exception.details);

--- a/crates/lib/vm-runtime-core/src/runtime_state.rs
+++ b/crates/lib/vm-runtime-core/src/runtime_state.rs
@@ -3,7 +3,7 @@ use std::collections::VecDeque;
 use waymark_vm_runtime_effect::EffectNumber;
 use waymark_vm_runtime_promise_core::PromiseStateId;
 
-use crate::{Frame, PromiseStates, RejectPromiseError, ResolvePromiseError};
+use crate::{Frame, PromiseStates, SettlePromiseError};
 
 /// The state shape of the runtime.
 ///
@@ -48,7 +48,7 @@ where
         &mut self,
         promise_state_id: PromiseStateId,
         value: Value,
-    ) -> Result<(), ResolvePromiseError<Value>> {
+    ) -> Result<(), SettlePromiseError<Value>> {
         let continuations = self
             .promise_states
             .resolve(promise_state_id, value.clone())?;
@@ -68,7 +68,7 @@ where
         &mut self,
         promise_state_id: PromiseStateId,
         exception: waymark_vm_runtime_exception::Exception<Value>,
-    ) -> Result<(), RejectPromiseError<Value>> {
+    ) -> Result<(), SettlePromiseError<waymark_vm_runtime_exception::Exception<Value>>> {
         let continuations = self
             .promise_states
             .reject(promise_state_id, exception.clone())?;
@@ -93,7 +93,7 @@ mod tests {
     use super::RuntimeState;
     use crate::{
         Continuation, ExceptionHandlers, Frame, FrameKind, PromiseState, PromiseStates, RegisterId,
-        Registers, ResolvePromiseError, SettledPromiseState,
+        Registers, SettlePromiseError, SettledPromiseState,
     };
 
     #[derive(Debug, Clone, PartialEq, Eq)]
@@ -204,7 +204,7 @@ mod tests {
             )
             .expect_err("already settled promise should reject a second value");
 
-        let ResolvePromiseError::AlreadySettled(err) = err else {
+        let SettlePromiseError::AlreadySettled(err) = err else {
             panic!("duplicate resolution should surface an already-settled error");
         };
 

--- a/crates/lib/vm-runtime-core/src/runtime_state.rs
+++ b/crates/lib/vm-runtime-core/src/runtime_state.rs
@@ -181,7 +181,7 @@ mod tests {
     }
 
     #[test]
-    fn resolve_promise_returns_error_when_promise_is_already_resolved() {
+    fn resolve_promise_returns_error_when_promise_has_already_settled() {
         let mut promise_states = PromiseStates::<&'static str, usize, TestValue>::new();
         let promise_state_id = promise_states.prepare();
         let promise_state = promise_states
@@ -202,10 +202,10 @@ mod tests {
                 promise_state_id,
                 PromiseValue::Ready(TestReadyValue::Int(9)),
             )
-            .expect_err("already resolved promise should reject a second value");
+            .expect_err("already settled promise should reject a second value");
 
-        let ResolvePromiseError::AlreadyResolved(err) = err else {
-            panic!("duplicate resolution should surface an already-resolved error");
+        let ResolvePromiseError::AlreadySettled(err) = err else {
+            panic!("duplicate resolution should surface an already-settled error");
         };
 
         let PromiseValue::Ready(TestReadyValue::Int(value)) = err.new_value else {

--- a/crates/lib/vm-runtime/src/lib.rs
+++ b/crates/lib/vm-runtime/src/lib.rs
@@ -11,8 +11,7 @@ pub mod step;
 use std::collections::VecDeque;
 
 use waymark_vm_runtime_core::{
-    ExceptionHandlers, Frame, FrameKind, PromiseStates, Registers, RejectPromiseError,
-    ResolvePromiseError, RuntimeState,
+    ExceptionHandlers, Frame, FrameKind, PromiseStates, Registers, RuntimeState, SettlePromiseError,
 };
 use waymark_vm_runtime_promise_core::PromiseStateId;
 
@@ -215,7 +214,7 @@ where
         &mut self,
         promise_state_id: PromiseStateId,
         value: Value::ReadyValue,
-    ) -> Result<(), ResolvePromiseError<Value::ReadyValue>> {
+    ) -> Result<(), SettlePromiseError<Value::ReadyValue>> {
         self.state
             .resolve_promise(promise_state_id, Value::from_ready(value))
             .map_err(|error| {
@@ -238,7 +237,8 @@ where
         &mut self,
         promise_state_id: PromiseStateId,
         exception: waymark_vm_runtime_exception::Exception<Value::ReadyValue>,
-    ) -> Result<(), RejectPromiseError<Value::ReadyValue>> {
+    ) -> Result<(), SettlePromiseError<waymark_vm_runtime_exception::Exception<Value::ReadyValue>>>
+    {
         let exception = waymark_vm_runtime_exception::Exception {
             type_id: exception.type_id,
             details: Value::from_ready(exception.details),

--- a/crates/lib/vm-runtime/src/lib.rs
+++ b/crates/lib/vm-runtime/src/lib.rs
@@ -232,6 +232,8 @@ where
     }
 
     /// Reject an async computation for a given promise.
+    ///
+    /// Notifies all continuations that wait on it.
     pub fn reject_promise(
         &mut self,
         promise_state_id: PromiseStateId,

--- a/crates/lib/vm-runtime/tests/integration.rs
+++ b/crates/lib/vm-runtime/tests/integration.rs
@@ -1,6 +1,6 @@
 use waymark_vm_runtime::{CallSpec, RunError};
 use waymark_vm_runtime_core::{
-    CaptureRuntimeView, FullRuntimeView, RegisterId, ResolvePromiseError,
+    CaptureRuntimeView, FullRuntimeView, RegisterId, SettlePromiseError,
 };
 use waymark_vm_runtime_effect::EffectNumber;
 use waymark_vm_runtime_exception::Exception;
@@ -206,7 +206,7 @@ fn resolve_promise_rejects_unknown_promise_ids_without_disturbing_waiting_work()
         .resolve_promise(PromiseStateId(9), TestReadyValue::Int(41))
         .expect_err("unknown promise IDs should be rejected");
 
-    let ResolvePromiseError::PromiseStateNotFound(err) = err else {
+    let SettlePromiseError::PromiseStateNotFound(err) = err else {
         panic!("invalid promise IDs should surface a not-found error");
     };
     assert_eq!(err.promise_state_id, PromiseStateId(9));
@@ -245,7 +245,7 @@ fn resolve_promise_preserves_the_first_value_when_duplicate_resolution_occurs() 
         .resolve_promise(PromiseStateId(0), TestReadyValue::Int(11))
         .expect_err("already-settled promise should reject a new value");
 
-    let ResolvePromiseError::AlreadySettled(err) = err else {
+    let SettlePromiseError::AlreadySettled(err) = err else {
         panic!("duplicate resolutions should report already-settled errors");
     };
 

--- a/crates/lib/vm-runtime/tests/integration.rs
+++ b/crates/lib/vm-runtime/tests/integration.rs
@@ -243,10 +243,10 @@ fn resolve_promise_preserves_the_first_value_when_duplicate_resolution_occurs() 
 
     let err = runtime
         .resolve_promise(PromiseStateId(0), TestReadyValue::Int(11))
-        .expect_err("already-ready promise should reject a new value");
+        .expect_err("already-settled promise should reject a new value");
 
-    let ResolvePromiseError::AlreadyResolved(err) = err else {
-        panic!("duplicate resolutions should report already-resolved errors");
+    let ResolvePromiseError::AlreadySettled(err) = err else {
+        panic!("duplicate resolutions should report already-settled errors");
     };
 
     assert_eq!(err.new_value, TestReadyValue::Int(11));


### PR DESCRIPTION
Goes in after #482

---

This PR refactors some VM runtime oddities to prepare for future work in this are (support for racing two or more promises).