### PR TITLE
Add support for racing promises at the vm runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5913,6 +5913,7 @@ name = "waymark-vm-interpreter-coreset"
 version = "0.1.0"
 dependencies = [
  "derive-where",
+ "nonempty-collections",
  "thiserror",
  "waymark-vm-bytecode",
  "waymark-vm-exception-handler",

--- a/crates/lib/vm-driver/src/lib.rs
+++ b/crates/lib/vm-driver/src/lib.rs
@@ -12,7 +12,7 @@ use nonempty_collections::{IntoIteratorExt as _, NEVec, NonEmptyIterator as _};
 use tokio_util::sync::CancellationToken;
 use waymark_vm_driver_core::{PromiseResolution, PromiseSettlement};
 use waymark_vm_runtime::{FrameFor, Runtime};
-use waymark_vm_runtime_core::SettlePromiseError;
+use waymark_vm_runtime_core::{SettlePromiseError, SettlePromiseStateError};
 
 /// Errors returned by the driver loop.
 #[derive(Debug)]
@@ -43,6 +43,11 @@ pub enum Error<
 
     /// Getting promise settlements has failed.
     GettingPromiseSettlements(GettingPromiseSettlementsError),
+
+    /// A settlement propagation hit a race arm targeting a missing race
+    /// promise - the runtime state is corrupted and the VM cannot
+    /// continue.
+    RaceArmTargetNotFound(waymark_vm_runtime_core::PromiseStateNotFoundError),
 
     /// The driver was cancelled via its [`CancellationToken`].
     Cancelled,
@@ -172,14 +177,19 @@ where
                     match runtime.resolve_promise(promise_state_id, value) {
                         Ok(()) => {}
                         Err(
-                            error @ (SettlePromiseError::AlreadySettled(_)
-                            | SettlePromiseError::PromiseStateNotFound(_)),
+                            error @ SettlePromiseError::PromiseState(
+                                SettlePromiseStateError::AlreadySettled(_)
+                                | SettlePromiseStateError::PromiseStateNotFound(_),
+                            ),
                         ) => {
                             tracing::info!(
                                 ?promise_state_id,
                                 ?error,
                                 "stale promise resolution ignored"
                             );
+                        }
+                        Err(SettlePromiseError::RaceArmTargetNotFound(error)) => {
+                            return Err(Error::RaceArmTargetNotFound(error));
                         }
                     }
                 }
@@ -188,14 +198,19 @@ where
                     match runtime.reject_promise(promise_state_id, exception) {
                         Ok(()) => {}
                         Err(
-                            error @ (SettlePromiseError::AlreadySettled(_)
-                            | SettlePromiseError::PromiseStateNotFound(_)),
+                            error @ SettlePromiseError::PromiseState(
+                                SettlePromiseStateError::AlreadySettled(_)
+                                | SettlePromiseStateError::PromiseStateNotFound(_),
+                            ),
                         ) => {
                             tracing::info!(
                                 ?promise_state_id,
                                 ?error,
                                 "stale promise rejection ignored"
                             );
+                        }
+                        Err(SettlePromiseError::RaceArmTargetNotFound(error)) => {
+                            return Err(Error::RaceArmTargetNotFound(error));
                         }
                     }
                 }

--- a/crates/lib/vm-instructions-coreset/src/lib.rs
+++ b/crates/lib/vm-instructions-coreset/src/lib.rs
@@ -68,6 +68,29 @@ pub enum CoreSet<Spec: self::Spec> {
         resume: Spec::StateId,
     },
 
+    /// Create a race promise that resolves with the index of the first
+    /// source to settle.
+    ///
+    /// The sources are scanned in the listed order: a source that holds
+    /// a ready value or an already-settled promise wins outright and no
+    /// race promise is allocated. Otherwise a race promise is created and
+    /// every source gets a race arm that resolves it upon settlement -
+    /// the first arm to fire wins, and a settlement of either kind fires
+    /// the arm the same way.
+    ///
+    /// This instruction does not suspend the execution: awaiting the race
+    /// promise - and then the winning source - is up to the subsequent
+    /// instructions.
+    Race {
+        /// The register in the current frame to store the race promise at.
+        dst: Spec::RegisterId,
+
+        /// The registers holding the sources to race.
+        ///
+        /// Must not be empty.
+        srcs: Vec<Spec::RegisterId>,
+    },
+
     /// Push one exception-handler block as the new innermost active scope.
     PushExceptionHandlers {
         /// Handlers to activate for subsequent execution in this frame.

--- a/crates/lib/vm-interpreter-coreset/Cargo.toml
+++ b/crates/lib/vm-interpreter-coreset/Cargo.toml
@@ -14,6 +14,7 @@ waymark-vm-runtime-promise-core = { workspace = true }
 waymark-vm-runtime-value = { workspace = true }
 
 derive-where = { workspace = true }
+nonempty-collections = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]

--- a/crates/lib/vm-interpreter-coreset/src/error.rs
+++ b/crates/lib/vm-interpreter-coreset/src/error.rs
@@ -8,6 +8,10 @@ pub enum Error<Spec: waymark_vm_instructions_coreset::Spec> {
     #[error("await: {0}")]
     Await(#[source] AwaitError),
 
+    /// Racing promises failed.
+    #[error("race: {0}")]
+    Race(#[source] RaceError),
+
     /// Returning from a function failed.
     #[error("return: {0}")]
     Return(#[source] FnExitError),
@@ -50,6 +54,25 @@ pub enum AwaitError {
     /// The pending promise no longer existed in the runtime state.
     #[error("source promise state: {0}")]
     SourcePromiseStateNotFound(#[source] PromiseStateNotFoundError),
+}
+
+/// Errors produced while evaluating a `Race` instruction.
+#[derive(Debug, thiserror::Error)]
+pub enum RaceError {
+    /// The instruction listed no sources to race.
+    ///
+    /// This is a mistake in the bytecode - a race with no sources would
+    /// never settle and the racing frame would suspend forever.
+    #[error("race has no sources")]
+    EmptySources,
+
+    /// A pending source promise no longer existed in the runtime state.
+    #[error("source promise state: {0}")]
+    SourcePromiseStateNotFound(#[source] PromiseStateNotFoundError),
+
+    /// The winning arm index could not be represented as a value.
+    #[error("arm index: {0}")]
+    ArmIndexNotRepresentable(#[source] crate::value::FromRaceArmIndexError),
 }
 
 /// Errors produced while evaluating a `JumpIf` instruction.

--- a/crates/lib/vm-interpreter-coreset/src/error.rs
+++ b/crates/lib/vm-interpreter-coreset/src/error.rs
@@ -98,4 +98,9 @@ pub enum ReturnFnCallError {
     /// The destination promise for the function call had already settled.
     #[error("function call result promise has already settled")]
     ReturnPromiseAlreadySettled,
+
+    /// The settlement propagation hit a race arm targeting a missing race
+    /// promise - the runtime state is corrupted.
+    #[error("race arm target promise was not found")]
+    ReturnRaceArmTargetNotFound,
 }

--- a/crates/lib/vm-interpreter-coreset/src/lib.rs
+++ b/crates/lib/vm-interpreter-coreset/src/lib.rs
@@ -84,11 +84,16 @@ where
                 state
                     .reject_promise(ret, exception)
                     .map_err(|error| match error {
-                        waymark_vm_runtime_core::SettlePromiseError::PromiseStateNotFound(_) => {
-                            ReturnFnCallError::ReturnPromiseNotFound
-                        }
-                        waymark_vm_runtime_core::SettlePromiseError::AlreadySettled(_) => {
-                            ReturnFnCallError::ReturnPromiseAlreadySettled
+                        waymark_vm_runtime_core::SettlePromiseError::PromiseState(
+                            waymark_vm_runtime_core::SettlePromiseStateError::PromiseStateNotFound(
+                                _,
+                            ),
+                        ) => ReturnFnCallError::ReturnPromiseNotFound,
+                        waymark_vm_runtime_core::SettlePromiseError::PromiseState(
+                            waymark_vm_runtime_core::SettlePromiseStateError::AlreadySettled(_),
+                        ) => ReturnFnCallError::ReturnPromiseAlreadySettled,
+                        waymark_vm_runtime_core::SettlePromiseError::RaceArmTargetNotFound(_) => {
+                            ReturnFnCallError::ReturnRaceArmTargetNotFound
                         }
                     })
                     .map_err(FnExitError::FnCall)?;
@@ -238,8 +243,10 @@ where
                                 state.ready.push_back(frame);
                                 ExecutionOutcome::ExitFrame
                             }
-                            PromiseState::Waiting(continuations) => {
-                                continuations.push(Continuation::capture(frame, *resume, *dst));
+                            PromiseState::Waiting(waiters) => {
+                                waiters.push(waymark_vm_runtime_core::Waiter::Continuation(
+                                    Continuation::capture(frame, *resume, *dst),
+                                ));
                                 ExecutionOutcome::ExitFrame
                             }
                         });
@@ -294,12 +301,19 @@ where
                             .resolve_promise(ret, val)
                             .map_err(|error| {
                                 match error {
-                                waymark_vm_runtime_core::SettlePromiseError::PromiseStateNotFound(
-                                    _,
+                                waymark_vm_runtime_core::SettlePromiseError::PromiseState(
+                                    waymark_vm_runtime_core::SettlePromiseStateError::PromiseStateNotFound(
+                                        _,
+                                    ),
                                 ) => ReturnFnCallError::ReturnPromiseNotFound,
-                                waymark_vm_runtime_core::SettlePromiseError::AlreadySettled(
-                                    _,
+                                waymark_vm_runtime_core::SettlePromiseError::PromiseState(
+                                    waymark_vm_runtime_core::SettlePromiseStateError::AlreadySettled(
+                                        _,
+                                    ),
                                 ) => ReturnFnCallError::ReturnPromiseAlreadySettled,
+                                waymark_vm_runtime_core::SettlePromiseError::RaceArmTargetNotFound(
+                                    _,
+                                ) => ReturnFnCallError::ReturnRaceArmTargetNotFound,
                             }
                             })
                             .map_err(FnExitError::FnCall)

--- a/crates/lib/vm-interpreter-coreset/src/lib.rs
+++ b/crates/lib/vm-interpreter-coreset/src/lib.rs
@@ -257,6 +257,75 @@ where
                     }
                 }
             }
+            waymark_vm_instructions_coreset::CoreSet::Race { dst, srcs } => {
+                // The instruction set stays plain-`Vec`; lift the sources
+                // into a non-empty view here - a race with no sources
+                // would never settle.
+                let Some(srcs) = nonempty_collections::NESlice::try_from_slice(srcs) else {
+                    return Err(Error::Race(RaceError::EmptySources));
+                };
+
+                // Scan the sources in the listed order for one that has
+                // already settled, collecting the pending promise ids
+                // along the way.
+                let mut winner = None;
+                let mut pending = Vec::with_capacity(srcs.len().get());
+                for (arm_index, src) in srcs.iter().enumerate() {
+                    match frame.regs[*src].as_ready() {
+                        Ok(_) => {
+                            winner = Some(arm_index);
+                            break;
+                        }
+                        Err(waymark_vm_runtime_promise_core::UnresolvedPromiseError {
+                            promise_state_id,
+                        }) => {
+                            let promise_state = state
+                                .promise_states
+                                .get(promise_state_id)
+                                .map_err(RaceError::SourcePromiseStateNotFound)
+                                .map_err(Error::Race)?;
+                            match promise_state {
+                                PromiseState::Settled(_) => {
+                                    winner = Some(arm_index);
+                                    break;
+                                }
+                                PromiseState::Waiting(_) => pending.push(promise_state_id),
+                            }
+                        }
+                    }
+                }
+
+                if let Some(arm_index) = winner {
+                    // A settled source wins outright - no race promise
+                    // is allocated.
+                    let resolution = Value::from_race_arm_index(arm_index)
+                        .map_err(RaceError::ArmIndexNotRepresentable)
+                        .map_err(Error::Race)?;
+                    frame.regs.set(*dst, resolution);
+                } else {
+                    let race = state.promise_states.prepare();
+                    for (arm_index, promise_state_id) in pending.into_iter().enumerate() {
+                        let resolution = Value::from_race_arm_index(arm_index)
+                            .map_err(RaceError::ArmIndexNotRepresentable)
+                            .map_err(Error::Race)?;
+
+                        // The scan above just observed these promise states
+                        // as waiting, and nothing runs in between: the store
+                        // is append-only and no settlement can occur
+                        // mid-instruction.
+                        let Ok(promise_state) = state.promise_states.get_mut(promise_state_id)
+                        else {
+                            unreachable!();
+                        };
+                        let PromiseState::Waiting(waiters) = promise_state else {
+                            unreachable!();
+                        };
+
+                        waiters.push(waymark_vm_runtime_core::Waiter::RaceArm { race, resolution });
+                    }
+                    frame.regs.set(*dst, Value::from_pending(race));
+                }
+            }
             waymark_vm_instructions_coreset::CoreSet::PushExceptionHandlers { handlers } => {
                 frame.exception_handler_blocks.push(handlers.clone());
             }

--- a/crates/lib/vm-interpreter-coreset/src/value.rs
+++ b/crates/lib/vm-interpreter-coreset/src/value.rs
@@ -20,9 +20,27 @@ pub trait CaptureCallArgument {
     fn capture_call_argument(&self) -> Self;
 }
 
+/// An error from the [`FromRaceArmIndex`].
+#[derive(Debug, thiserror::Error)]
+#[error("the race arm index is out of bounds for the value")]
+pub struct FromRaceArmIndexError;
+
+/// Construct the value that a race promise resolves with - the index of
+/// the arm that settled first.
+pub trait FromRaceArmIndex: Sized {
+    /// Construct the arm-index value.
+    ///
+    /// Returns an error if the index cannot be represented by this
+    /// value type.
+    fn from_race_arm_index(arm_index: usize) -> Result<Self, FromRaceArmIndexError>;
+}
+
 /// A unifying trait for all value requirements.
 pub trait Value:
-    waymark_vm_runtime_value::RootValueAccess<RootValue = Self> + CaptureCallArgument + ShouldJump
+    waymark_vm_runtime_value::RootValueAccess<RootValue = Self>
+    + CaptureCallArgument
+    + ShouldJump
+    + FromRaceArmIndex
 {
 }
 
@@ -30,5 +48,6 @@ impl<T> Value for T where
     T: waymark_vm_runtime_value::RootValueAccess<RootValue = Self>
         + CaptureCallArgument
         + ShouldJump
+        + FromRaceArmIndex
 {
 }

--- a/crates/lib/vm-interpreter-coreset/tests/support/mod.rs
+++ b/crates/lib/vm-interpreter-coreset/tests/support/mod.rs
@@ -82,6 +82,16 @@ impl waymark_vm_interpreter_coreset::value::ShouldJump for TestValue {
     }
 }
 
+impl waymark_vm_interpreter_coreset::value::FromRaceArmIndex for TestValue {
+    fn from_race_arm_index(
+        arm_index: usize,
+    ) -> Result<Self, waymark_vm_interpreter_coreset::value::FromRaceArmIndexError> {
+        let arm_index = i64::try_from(arm_index)
+            .map_err(|_| waymark_vm_interpreter_coreset::value::FromRaceArmIndexError)?;
+        Ok(Self::Ready(TestReadyValue::Int(arm_index)))
+    }
+}
+
 impl Suspendable for TestValue {
     fn from_pending(promise_state_id: PromiseStateId) -> Self {
         Self::Pending(promise_state_id)

--- a/crates/lib/vm-interpreter-fullset/tests/integration.rs
+++ b/crates/lib/vm-interpreter-fullset/tests/integration.rs
@@ -6,6 +6,7 @@
 mod support;
 
 mod extcall;
+mod race;
 mod sleep;
 mod state_entry;
 mod synchronous;

--- a/crates/lib/vm-interpreter-fullset/tests/race/mod.rs
+++ b/crates/lib/vm-interpreter-fullset/tests/race/mod.rs
@@ -1,0 +1,256 @@
+//! `CoreSet::Race` creates a race promise that resolves with the index of
+//! the first source to settle.
+
+use waymark_vm_instructions_coreset::CoreSet;
+use waymark_vm_instructions_extcallset::ExtCallSet;
+use waymark_vm_interpreter_fullset::Effect;
+use waymark_vm_runtime::RunError;
+use waymark_vm_runtime_core::RegisterId;
+use waymark_vm_runtime_test::{StateId, executable, function};
+
+use crate::support::{
+    Instruction, TestActionRef, TestReadyValue, new_runtime, new_runtime_with_args,
+};
+
+fn action_call_promise_state_id(
+    effect: Effect<TestReadyValue, TestActionRef, TestReadyValue>,
+) -> waymark_vm_runtime_promise_core::PromiseStateId {
+    match effect {
+        Effect::ExtCallSet(waymark_vm_interpreter_extcallset::Effect::ActionCall {
+            promise_state_id,
+            ..
+        }) => promise_state_id,
+        other => panic!("expected an action call effect: {other:?}"),
+    }
+}
+
+fn completed_value(
+    effect: Effect<TestReadyValue, TestActionRef, TestReadyValue>,
+) -> TestReadyValue {
+    match effect {
+        Effect::CoreSet(waymark_vm_interpreter_coreset::Effect::Complete(value)) => value,
+        other => panic!("expected the program to complete: {other:?}"),
+    }
+}
+
+/// Two pending action calls raced: the race promise stays pending until
+/// a source settles, then resolves with the settled arm's index.
+#[test]
+fn race_of_pending_sources_resolves_with_the_first_settled_arm_index() {
+    let executable = executable(vec![function::<Instruction>(
+        5,
+        vec![
+            vec![
+                ExtCallSet::ActionCall {
+                    dst: RegisterId(0),
+                    action_ref: TestActionRef(1),
+                    args: Vec::new(),
+                    resume: StateId(1),
+                }
+                .into(),
+            ],
+            vec![
+                ExtCallSet::ActionCall {
+                    dst: RegisterId(1),
+                    action_ref: TestActionRef(2),
+                    args: Vec::new(),
+                    resume: StateId(2),
+                }
+                .into(),
+            ],
+            vec![
+                CoreSet::Race {
+                    dst: RegisterId(2),
+                    srcs: vec![RegisterId(0), RegisterId(1)],
+                }
+                .into(),
+                CoreSet::Await {
+                    dst: RegisterId(3),
+                    src: RegisterId(2),
+                    resume: StateId(3),
+                }
+                .into(),
+            ],
+            vec![CoreSet::Return { src: RegisterId(3) }.into()],
+        ],
+    )]);
+
+    let mut runtime = new_runtime(executable);
+
+    let first_effect = runtime.run().expect("first action call should emit");
+    let first_promise = action_call_promise_state_id(first_effect.effect);
+
+    let second_effect = runtime.run().expect("second action call should emit");
+    let second_promise = action_call_promise_state_id(second_effect.effect);
+
+    assert!(
+        matches!(runtime.run(), Err(RunError::NoReadyFrame)),
+        "the frame should suspend awaiting the race promise"
+    );
+
+    runtime
+        .resolve_promise(second_promise, TestReadyValue::Int(99))
+        .expect("second source should resolve cleanly");
+
+    let emitted_effect = runtime.run().expect("race winner should complete the run");
+    assert_eq!(
+        completed_value(emitted_effect.effect),
+        TestReadyValue::Int(1)
+    );
+
+    // The losing source settles later and its race arm is inert.
+    runtime
+        .resolve_promise(first_promise, TestReadyValue::Int(7))
+        .expect("late loser settlement should be accepted and inert");
+}
+
+/// A source whose promise has already settled wins at scan time - the
+/// race never suspends and no race promise is allocated.
+#[test]
+fn race_with_an_already_settled_source_wins_at_scan_time() {
+    let executable = executable(vec![function::<Instruction>(
+        4,
+        vec![
+            vec![
+                ExtCallSet::ActionCall {
+                    dst: RegisterId(0),
+                    action_ref: TestActionRef(1),
+                    args: Vec::new(),
+                    resume: StateId(1),
+                }
+                .into(),
+            ],
+            vec![
+                // The promise in register 1 settles before the race
+                // instruction runs; the still-pending action call in
+                // register 0 is listed first but loses the scan.
+                ExtCallSet::ActionCall {
+                    dst: RegisterId(1),
+                    action_ref: TestActionRef(2),
+                    args: Vec::new(),
+                    resume: StateId(2),
+                }
+                .into(),
+            ],
+            vec![
+                CoreSet::Race {
+                    dst: RegisterId(2),
+                    srcs: vec![RegisterId(0), RegisterId(1)],
+                }
+                .into(),
+                CoreSet::Await {
+                    dst: RegisterId(3),
+                    src: RegisterId(2),
+                    resume: StateId(3),
+                }
+                .into(),
+            ],
+            vec![CoreSet::Return { src: RegisterId(3) }.into()],
+        ],
+    )]);
+
+    let mut runtime = new_runtime(executable);
+
+    let first_effect = runtime.run().expect("first action call should emit");
+    let _first_promise = action_call_promise_state_id(first_effect.effect);
+
+    let second_effect = runtime.run().expect("second action call should emit");
+    let second_promise = action_call_promise_state_id(second_effect.effect);
+
+    // Settle the second source before the race instruction runs.
+    runtime
+        .resolve_promise(second_promise, TestReadyValue::Int(99))
+        .expect("second source should resolve cleanly");
+
+    let emitted_effect = runtime
+        .run()
+        .expect("race should win at scan time and complete without suspending");
+    assert_eq!(
+        completed_value(emitted_effect.effect),
+        TestReadyValue::Int(1)
+    );
+}
+
+/// A source register holding a plain ready value - not a promise at all -
+/// counts as settled and wins at scan time.
+#[test]
+fn race_with_a_ready_value_source_wins_at_scan_time() {
+    let executable = executable(vec![function::<Instruction>(
+        4,
+        vec![
+            vec![
+                ExtCallSet::ActionCall {
+                    dst: RegisterId(1),
+                    action_ref: TestActionRef(1),
+                    args: Vec::new(),
+                    resume: StateId(1),
+                }
+                .into(),
+            ],
+            vec![
+                // Register 0 holds the ready function argument.
+                CoreSet::Race {
+                    dst: RegisterId(2),
+                    srcs: vec![RegisterId(1), RegisterId(0)],
+                }
+                .into(),
+                CoreSet::Await {
+                    dst: RegisterId(3),
+                    src: RegisterId(2),
+                    resume: StateId(2),
+                }
+                .into(),
+            ],
+            vec![CoreSet::Return { src: RegisterId(3) }.into()],
+        ],
+    )]);
+
+    let mut runtime = new_runtime_with_args(executable, vec![TestReadyValue::Int(5)]);
+
+    let action_effect = runtime.run().expect("the action call should emit");
+    let _action_promise = action_call_promise_state_id(action_effect.effect);
+
+    let emitted_effect = runtime
+        .run()
+        .expect("race should win at scan time and complete without suspending");
+    assert_eq!(
+        completed_value(emitted_effect.effect),
+        TestReadyValue::Int(1)
+    );
+}
+
+/// A race with no sources is a bytecode mistake and fails the run.
+#[test]
+fn race_with_no_sources_fails_the_run() {
+    let executable = executable(vec![function::<Instruction>(
+        2,
+        vec![vec![
+            CoreSet::Race {
+                dst: RegisterId(0),
+                srcs: Vec::new(),
+            }
+            .into(),
+            CoreSet::Return { src: RegisterId(0) }.into(),
+        ]],
+    )]);
+
+    let mut runtime = new_runtime(executable);
+
+    let err = runtime
+        .run()
+        .expect_err("a race with no sources should fail the run");
+
+    assert!(
+        matches!(
+            &err,
+            RunError::Step(waymark_vm_runtime::step::Error::Execution(
+                waymark_vm_interpreter_fullset::Error::CoreSet(
+                    waymark_vm_interpreter_coreset::Error::Race(
+                        waymark_vm_interpreter_coreset::RaceError::EmptySources
+                    )
+                )
+            ))
+        ),
+        "unexpected error: {err:?}"
+    );
+}

--- a/crates/lib/vm-interpreter-fullset/tests/support/mod.rs
+++ b/crates/lib/vm-interpreter-fullset/tests/support/mod.rs
@@ -114,6 +114,16 @@ impl waymark_vm_interpreter_coreset::value::ShouldJump for TestReadyValue {
     }
 }
 
+impl waymark_vm_interpreter_coreset::value::FromRaceArmIndex for TestReadyValue {
+    fn from_race_arm_index(
+        arm_index: usize,
+    ) -> Result<Self, waymark_vm_interpreter_coreset::value::FromRaceArmIndexError> {
+        let arm_index = i64::try_from(arm_index)
+            .map_err(|_| waymark_vm_interpreter_coreset::value::FromRaceArmIndexError)?;
+        Ok(Self::Int(arm_index))
+    }
+}
+
 impl waymark_vm_interpreter_pureset::value::CaptureCopy for TestReadyValue {
     fn capture_copy(&self) -> Self {
         self.clone()
@@ -393,6 +403,14 @@ impl waymark_vm_interpreter_coreset::value::ShouldJump for TestValue {
             .require_ready_ref()
             .map_err(|_| waymark_vm_interpreter_coreset::value::NotAConditionalError)?;
         value.should_jump()
+    }
+}
+
+impl waymark_vm_interpreter_coreset::value::FromRaceArmIndex for TestValue {
+    fn from_race_arm_index(
+        arm_index: usize,
+    ) -> Result<Self, waymark_vm_interpreter_coreset::value::FromRaceArmIndexError> {
+        Ok(Self::Ready(TestReadyValue::from_race_arm_index(arm_index)?))
     }
 }
 

--- a/crates/lib/vm-runtime-core/src/lib.rs
+++ b/crates/lib/vm-runtime-core/src/lib.rs
@@ -10,6 +10,7 @@ mod promise_state;
 mod promise_states;
 mod registers;
 mod runtime_state;
+mod waiter;
 
 pub use self::capture_runtime_view::*;
 pub use self::continuation::*;
@@ -19,3 +20,4 @@ pub use self::promise_state::*;
 pub use self::promise_states::*;
 pub use self::registers::*;
 pub use self::runtime_state::*;
+pub use self::waiter::*;

--- a/crates/lib/vm-runtime-core/src/promise_state.rs
+++ b/crates/lib/vm-runtime-core/src/promise_state.rs
@@ -31,10 +31,10 @@ pub struct SettlingAlreadySettledPromiseError<Value> {
 #[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum PromiseState<FunctionId, StateId, Value> {
-    /// A list of continuations to resume when a promise settles.
+    /// A list of waiters to notify when a promise settles.
     ///
-    /// Awaiting on it will add the frame to the list of continuations.
-    Waiting(Vec<crate::Continuation<FunctionId, StateId, Value, crate::ResumeWithValue>>),
+    /// Awaiting on it will add the frame to the list of waiters.
+    Waiting(Vec<crate::Waiter<FunctionId, StateId, Value>>),
 
     /// A promise that has settled.
     ///
@@ -46,19 +46,18 @@ pub enum PromiseState<FunctionId, StateId, Value> {
 impl<FunctionId, StateId, Value> PromiseState<FunctionId, StateId, Value> {
     /// Idempotently resolve a promise.
     ///
-    /// Returns a list of continuations to resume, or an error if this promise
+    /// Returns a list of waiters to notify, or an error if this promise
     /// has already settled.
-    #[allow(clippy::type_complexity)]
     pub fn resolve(
         &mut self,
         value: Value,
     ) -> Result<
-        Vec<crate::Continuation<FunctionId, StateId, Value, crate::ResumeWithValue>>,
+        Vec<crate::Waiter<FunctionId, StateId, Value>>,
         SettlingAlreadySettledPromiseError<Value>,
     > {
         let replaced = std::mem::replace(self, Self::Settled(SettledPromiseState::Resolved(value)));
         match replaced {
-            PromiseState::Waiting(continuations) => Ok(continuations),
+            PromiseState::Waiting(waiters) => Ok(waiters),
             PromiseState::Settled(original) => {
                 // This shouldn't happen often.
                 std::hint::cold_path();
@@ -77,12 +76,15 @@ impl<FunctionId, StateId, Value> PromiseState<FunctionId, StateId, Value> {
     }
 
     /// Idempotently reject a promise.
+    ///
+    /// Returns a list of waiters to notify, or an error if this promise
+    /// has already settled.
     #[allow(clippy::type_complexity)]
     pub fn reject(
         &mut self,
         exception: waymark_vm_runtime_exception::Exception<Value>,
     ) -> Result<
-        Vec<crate::Continuation<FunctionId, StateId, Value, crate::ResumeWithValue>>,
+        Vec<crate::Waiter<FunctionId, StateId, Value>>,
         SettlingAlreadySettledPromiseError<waymark_vm_runtime_exception::Exception<Value>>,
     > {
         let replaced = std::mem::replace(
@@ -90,7 +92,7 @@ impl<FunctionId, StateId, Value> PromiseState<FunctionId, StateId, Value> {
             Self::Settled(SettledPromiseState::Rejected(exception)),
         );
         match replaced {
-            PromiseState::Waiting(continuations) => Ok(continuations),
+            PromiseState::Waiting(waiters) => Ok(waiters),
             PromiseState::Settled(original) => {
                 // This shouldn't happen often.
                 std::hint::cold_path();
@@ -115,7 +117,7 @@ mod tests {
     use waymark_vm_runtime_promise_value::PromiseValue;
 
     use super::{PromiseState, SettledPromiseState};
-    use crate::{Continuation, ExceptionHandlers, Frame, FrameKind, RegisterId, Registers};
+    use crate::{Continuation, ExceptionHandlers, Frame, FrameKind, RegisterId, Registers, Waiter};
 
     #[derive(Debug, Clone, PartialEq, Eq)]
     enum TestReadyValue {
@@ -148,7 +150,8 @@ mod tests {
 
     #[test]
     fn resolve_waiting_promise_returns_continuations_and_marks_resolved() {
-        let mut state = PromiseState::Waiting(vec![continuation(RegisterId(1), 3)]);
+        let mut state =
+            PromiseState::Waiting(vec![Waiter::Continuation(continuation(RegisterId(1), 3))]);
 
         let continuations = state
             .resolve(PromiseValue::Ready(TestReadyValue::Int(17)))
@@ -162,11 +165,10 @@ mod tests {
             ))) if *value == 17
         ));
 
-        let resumed = continuations
-            .into_iter()
-            .next()
-            .expect("continuation is returned")
-            .resume(PromiseValue::Ready(TestReadyValue::Int(17)));
+        let Some(Waiter::Continuation(continuation)) = continuations.into_iter().next() else {
+            panic!("continuation waiter is returned");
+        };
+        let resumed = continuation.resume(PromiseValue::Ready(TestReadyValue::Int(17)));
         assert_eq!(resumed.state, 3);
         assert_eq!(resumed.regs.get(RegisterId(0)), None);
         assert_eq!(
@@ -201,7 +203,8 @@ mod tests {
 
     #[test]
     fn reject_waiting_promise_preserves_exceptional_settlements() {
-        let mut state = PromiseState::Waiting(vec![continuation(RegisterId(1), 3)]);
+        let mut state =
+            PromiseState::Waiting(vec![Waiter::Continuation(continuation(RegisterId(1), 3))]);
 
         let continuations = state
             .reject(Exception {
@@ -217,14 +220,13 @@ mod tests {
                     && *details == PromiseValue::Ready(TestReadyValue::Int(17))
         ));
 
-        let resumed = continuations
-            .into_iter()
-            .next()
-            .expect("continuation is returned")
-            .raise_exception(Exception {
-                type_id: "ValueError".to_owned(),
-                details: PromiseValue::Ready(TestReadyValue::Int(17)),
-            });
+        let Some(Waiter::Continuation(continuation)) = continuations.into_iter().next() else {
+            panic!("continuation waiter is returned");
+        };
+        let resumed = continuation.raise_exception(Exception {
+            type_id: "ValueError".to_owned(),
+            details: PromiseValue::Ready(TestReadyValue::Int(17)),
+        });
 
         let Some(exception) = resumed.exception else {
             panic!("exceptional resume should raise into the frame");

--- a/crates/lib/vm-runtime-core/src/promise_states.rs
+++ b/crates/lib/vm-runtime-core/src/promise_states.rs
@@ -1,7 +1,7 @@
 use index_type::typed_vec::TypedVec;
 use waymark_vm_runtime_promise_core::PromiseStateId;
 
-use crate::{Continuation, PromiseState, SettlingAlreadySettledPromiseError};
+use crate::{PromiseState, SettlingAlreadySettledPromiseError};
 
 /// A list of promise states.
 #[derive(Debug)]
@@ -85,7 +85,7 @@ impl<FunctionId, StateId, Value> PromiseStates<FunctionId, StateId, Value> {
 
 /// Errors returned when settling a promise state.
 #[derive(Debug, thiserror::Error)]
-pub enum SettlePromiseError<Value> {
+pub enum SettlePromiseStateError<Value> {
     /// The requested promise state ID does not exist.
     #[error(transparent)]
     PromiseStateNotFound(PromiseStateNotFoundError),
@@ -95,31 +95,53 @@ pub enum SettlePromiseError<Value> {
     AlreadySettled(SettlingAlreadySettledPromiseError<Value>),
 }
 
+impl<Value> SettlePromiseStateError<Value> {
+    /// Map the `Value` of this [`SettlePromiseStateError`] into `OtherValue`
+    /// using function `f`.
+    pub fn map<OtherValue>(
+        self,
+        f: impl FnOnce(Value) -> OtherValue,
+    ) -> SettlePromiseStateError<OtherValue> {
+        match self {
+            Self::PromiseStateNotFound(error) => {
+                SettlePromiseStateError::PromiseStateNotFound(error)
+            }
+            Self::AlreadySettled(error) => {
+                let SettlingAlreadySettledPromiseError { new_value } = error;
+                let new_value = f(new_value);
+                SettlePromiseStateError::AlreadySettled(SettlingAlreadySettledPromiseError {
+                    new_value,
+                })
+            }
+        }
+    }
+}
+
 impl<FunctionId, StateId, Value> PromiseStates<FunctionId, StateId, Value> {
     /// Idempotently resolve a promise at a given `promise_state_id` with
     /// the provided `value`.
     ///
-    /// Returns a list of continuations to resume, or an error if this promise
+    /// Returns a list of waiters to notify, or an error if this promise
     /// has already settled.
-    #[allow(clippy::type_complexity)]
     pub fn resolve(
         &mut self,
         promise_state_id: PromiseStateId,
         value: Value,
-    ) -> Result<
-        Vec<crate::Continuation<FunctionId, StateId, Value, crate::ResumeWithValue>>,
-        SettlePromiseError<Value>,
-    > {
+    ) -> Result<Vec<crate::Waiter<FunctionId, StateId, Value>>, SettlePromiseStateError<Value>>
+    {
         let promise_state = self
             .get_mut(promise_state_id)
-            .map_err(SettlePromiseError::PromiseStateNotFound)?;
+            .map_err(SettlePromiseStateError::PromiseStateNotFound)?;
 
         promise_state
             .resolve(value)
-            .map_err(SettlePromiseError::AlreadySettled)
+            .map_err(SettlePromiseStateError::AlreadySettled)
     }
 
     /// Idempotently reject a promise at a given `promise_state_id`.
+    ///
+    /// Returns a list of waiters to notify, or an error if this promise
+    /// has already settled.
     #[expect(
         clippy::type_complexity,
         reason = "we purposely avoid alias for the error"
@@ -129,34 +151,16 @@ impl<FunctionId, StateId, Value> PromiseStates<FunctionId, StateId, Value> {
         promise_state_id: PromiseStateId,
         exception: waymark_vm_runtime_exception::Exception<Value>,
     ) -> Result<
-        Vec<Continuation<FunctionId, StateId, Value, crate::ResumeWithValue>>,
-        SettlePromiseError<waymark_vm_runtime_exception::Exception<Value>>,
+        Vec<crate::Waiter<FunctionId, StateId, Value>>,
+        SettlePromiseStateError<waymark_vm_runtime_exception::Exception<Value>>,
     > {
         let promise_state = self
             .get_mut(promise_state_id)
-            .map_err(SettlePromiseError::PromiseStateNotFound)?;
+            .map_err(SettlePromiseStateError::PromiseStateNotFound)?;
 
         promise_state
             .reject(exception)
-            .map_err(SettlePromiseError::AlreadySettled)
-    }
-}
-
-impl<Value> SettlePromiseError<Value> {
-    /// Map the `Value` of this [`SettlePromiseError`] into `OtherValue` using
-    /// function `f`.
-    pub fn map<OtherValue>(
-        self,
-        f: impl FnOnce(Value) -> OtherValue,
-    ) -> SettlePromiseError<OtherValue> {
-        match self {
-            Self::PromiseStateNotFound(error) => SettlePromiseError::PromiseStateNotFound(error),
-            Self::AlreadySettled(error) => {
-                let SettlingAlreadySettledPromiseError { new_value } = error;
-                let new_value = f(new_value);
-                SettlePromiseError::AlreadySettled(SettlingAlreadySettledPromiseError { new_value })
-            }
-        }
+            .map_err(SettlePromiseStateError::AlreadySettled)
     }
 }
 
@@ -164,10 +168,12 @@ impl<Value> SettlePromiseError<Value> {
 mod tests {
     use waymark_vm_runtime_exception::Exception;
 
-    use super::{PromiseStateId, PromiseStateNotFoundError, PromiseStates, SettlePromiseError};
+    use super::{
+        PromiseStateId, PromiseStateNotFoundError, PromiseStates, SettlePromiseStateError,
+    };
     use crate::{
         Continuation, ExceptionHandlers, Frame, FrameKind, PromiseState, RegisterId, Registers,
-        SettledPromiseState,
+        SettledPromiseState, Waiter,
     };
 
     fn continuation(
@@ -214,7 +220,7 @@ mod tests {
         let state = states
             .get_mut(promise_state_id)
             .expect("promise state exists");
-        *state = PromiseState::Waiting(vec![continuation(RegisterId(0), 4)]);
+        *state = PromiseState::Waiting(vec![Waiter::Continuation(continuation(RegisterId(0), 4))]);
 
         let continuations = states
             .resolve(promise_state_id, 23)
@@ -231,7 +237,7 @@ mod tests {
     fn resolve_rejects_unknown_promise_state_ids() {
         let mut states = PromiseStates::<&'static str, usize, i32>::new();
 
-        let Err(SettlePromiseError::PromiseStateNotFound(PromiseStateNotFoundError {
+        let Err(SettlePromiseStateError::PromiseStateNotFound(PromiseStateNotFoundError {
             promise_state_id,
         })) = states.resolve(PromiseStateId(4), 23)
         else {

--- a/crates/lib/vm-runtime-core/src/runtime_state.rs
+++ b/crates/lib/vm-runtime-core/src/runtime_state.rs
@@ -3,7 +3,43 @@ use std::collections::VecDeque;
 use waymark_vm_runtime_effect::EffectNumber;
 use waymark_vm_runtime_promise_core::PromiseStateId;
 
-use crate::{Frame, PromiseStates, SettlePromiseError};
+use crate::{
+    Frame, PromiseStateNotFoundError, PromiseStates, SettlePromiseStateError, SettledPromiseState,
+    Waiter,
+};
+
+/// Errors returned when settling a promise at the runtime state and
+/// notifying its waiters.
+#[derive(Debug, thiserror::Error)]
+pub enum SettlePromiseError<Value> {
+    /// Resolving the promise state in the store failed.
+    #[error(transparent)]
+    PromiseState(SettlePromiseStateError<Value>),
+
+    /// A fired race arm targeted a race promise that does not exist.
+    ///
+    /// This is an invariant violation: an unsettled race promise is never
+    /// removed, so a dangling race arm means the runtime state is corrupted.
+    /// When this error is returned the settlement propagation was aborted
+    /// midway - the runtime state is partially mutated and must be
+    /// discarded.
+    #[error("race arm target: {0}")]
+    RaceArmTargetNotFound(#[source] PromiseStateNotFoundError),
+}
+
+impl<Value> SettlePromiseError<Value> {
+    /// Map the `Value` of this [`SettlePromiseError`] into `OtherValue` using
+    /// function `f`.
+    pub fn map<OtherValue>(
+        self,
+        f: impl FnOnce(Value) -> OtherValue,
+    ) -> SettlePromiseError<OtherValue> {
+        match self {
+            Self::PromiseState(error) => SettlePromiseError::PromiseState(error.map(f)),
+            Self::RaceArmTargetNotFound(error) => SettlePromiseError::RaceArmTargetNotFound(error),
+        }
+    }
+}
 
 /// The state shape of the runtime.
 ///
@@ -43,43 +79,97 @@ where
 {
     /// Provide an async computation value for a given promise.
     ///
-    /// Notifies all continuations that wait on it.
+    /// Notifies all waiters: resumes the suspended frames with the value and
+    /// fires the race arms.
     pub fn resolve_promise(
         &mut self,
         promise_state_id: PromiseStateId,
         value: Value,
     ) -> Result<(), SettlePromiseError<Value>> {
-        let continuations = self
+        let waiters = self
             .promise_states
-            .resolve(promise_state_id, value.clone())?;
+            .resolve(promise_state_id, value.clone())
+            .map_err(SettlePromiseError::PromiseState)?;
 
-        for continuation in continuations {
-            let frame = continuation.resume(value.clone());
-            self.ready.push_back(frame);
-        }
-
-        Ok(())
+        notify_waiters(
+            &mut self.ready,
+            &mut self.promise_states,
+            waiters,
+            SettledPromiseState::Resolved(value),
+        )
+        .map_err(SettlePromiseError::RaceArmTargetNotFound)
     }
 
     /// Reject an async computation for a given promise.
     ///
-    /// Notifies all continuations that wait on it.
+    /// Notifies all waiters: resumes the suspended frames with the raised
+    /// exception and fires the race arms.
     pub fn reject_promise(
         &mut self,
         promise_state_id: PromiseStateId,
         exception: waymark_vm_runtime_exception::Exception<Value>,
     ) -> Result<(), SettlePromiseError<waymark_vm_runtime_exception::Exception<Value>>> {
-        let continuations = self
+        let waiters = self
             .promise_states
-            .reject(promise_state_id, exception.clone())?;
+            .reject(promise_state_id, exception.clone())
+            .map_err(SettlePromiseError::PromiseState)?;
 
-        for continuation in continuations {
-            let frame = continuation.raise_exception(exception.clone());
-            self.ready.push_back(frame);
-        }
-
-        Ok(())
+        notify_waiters(
+            &mut self.ready,
+            &mut self.promise_states,
+            waiters,
+            SettledPromiseState::Rejected(exception),
+        )
+        .map_err(SettlePromiseError::RaceArmTargetNotFound)
     }
+}
+
+/// Notify a drained waiter list with the settlement that fired it,
+/// propagating through any race arms.
+///
+/// Resumed frames go to the `ready` queue.  A fired race arm resolves its
+/// race promise in `promise_states` with the arm's pre-built resolution
+/// value, which drains the race promise's own waiters in turn -
+/// a settlement of either kind fires the arm the same way.  An arm that
+/// lost its race finds the race promise already settled and is inert by
+/// the first-wins semantics.
+fn notify_waiters<FunctionId, StateId, Value>(
+    ready: &mut VecDeque<Frame<FunctionId, StateId, Value>>,
+    promise_states: &mut PromiseStates<FunctionId, StateId, Value>,
+    waiters: Vec<Waiter<FunctionId, StateId, Value>>,
+    settlement: SettledPromiseState<Value>,
+) -> Result<(), PromiseStateNotFoundError>
+where
+    Value: Clone,
+{
+    let mut worklist = vec![(waiters, settlement)];
+
+    while let Some((waiters, settlement)) = worklist.pop() {
+        for waiter in waiters {
+            match waiter {
+                Waiter::Continuation(continuation) => {
+                    let frame = match &settlement {
+                        SettledPromiseState::Resolved(value) => continuation.resume(value.clone()),
+                        SettledPromiseState::Rejected(exception) => {
+                            continuation.raise_exception(exception.clone())
+                        }
+                    };
+                    ready.push_back(frame);
+                }
+                Waiter::RaceArm { race, resolution } => {
+                    let race_state = promise_states.get_mut(race)?;
+                    // The only resolve error is the already-settled one
+                    // ([`SettlingAlreadySettledPromiseError`]): this arm
+                    // lost the race - inert by the first-wins semantics.
+                    if let Ok(race_waiters) = race_state.resolve(resolution.clone()) {
+                        worklist.push((race_waiters, SettledPromiseState::Resolved(resolution)));
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]
@@ -93,8 +183,9 @@ mod tests {
     use super::RuntimeState;
     use crate::{
         Continuation, ExceptionHandlers, Frame, FrameKind, PromiseState, PromiseStates, RegisterId,
-        Registers, SettlePromiseError, SettledPromiseState,
+        Registers, SettlePromiseError, SettlePromiseStateError, SettledPromiseState, Waiter,
     };
+    use waymark_vm_runtime_promise_core::PromiseStateId;
 
     #[derive(Debug, Clone, PartialEq, Eq)]
     enum TestReadyValue {
@@ -133,8 +224,8 @@ mod tests {
             .get_mut(promise_state_id)
             .expect("promise state exists");
         *promise_state = PromiseState::Waiting(vec![
-            continuation(RegisterId(0), 3),
-            continuation(RegisterId(1), 5),
+            Waiter::Continuation(continuation(RegisterId(0), 3)),
+            Waiter::Continuation(continuation(RegisterId(1), 5)),
         ]);
 
         let mut runtime = RuntimeState {
@@ -204,7 +295,8 @@ mod tests {
             )
             .expect_err("already settled promise should reject a second value");
 
-        let SettlePromiseError::AlreadySettled(err) = err else {
+        let SettlePromiseError::PromiseState(SettlePromiseStateError::AlreadySettled(err)) = err
+        else {
             panic!("duplicate resolution should surface an already-settled error");
         };
 
@@ -233,7 +325,8 @@ mod tests {
         let promise_state = promise_states
             .get_mut(promise_state_id)
             .expect("promise state exists");
-        *promise_state = PromiseState::Waiting(vec![continuation(RegisterId(0), 3)]);
+        *promise_state =
+            PromiseState::Waiting(vec![Waiter::Continuation(continuation(RegisterId(0), 3))]);
 
         let mut runtime = RuntimeState {
             ready: VecDeque::new(),
@@ -274,8 +367,11 @@ mod tests {
         let promise_state = promise_states
             .get_mut(promise_state_id)
             .expect("promise state exists");
-        *promise_state =
-            PromiseState::Waiting(vec![Continuation::capture(frame(0), 3, RegisterId(0))]);
+        *promise_state = PromiseState::Waiting(vec![Waiter::Continuation(Continuation::capture(
+            frame(0),
+            3,
+            RegisterId(0),
+        ))]);
 
         let mut runtime = RuntimeState {
             ready: VecDeque::new(),
@@ -303,5 +399,200 @@ mod tests {
             exception.details,
             PromiseValue::Ready(TestReadyValue::Int(41))
         );
+    }
+
+    fn race_arm(race: PromiseStateId, arm_index: i32) -> Waiter<&'static str, usize, TestValue> {
+        Waiter::RaceArm {
+            race,
+            resolution: PromiseValue::Ready(TestReadyValue::Int(arm_index)),
+        }
+    }
+
+    fn runtime_state(
+        promise_states: PromiseStates<&'static str, usize, TestValue>,
+    ) -> RuntimeState<&'static str, usize, TestValue> {
+        RuntimeState {
+            ready: VecDeque::new(),
+            promise_states,
+            effect_counter: EffectNumber(0),
+        }
+    }
+
+    #[test]
+    fn resolve_promise_fires_race_arms_and_resolves_the_race() {
+        let mut promise_states = PromiseStates::<&'static str, usize, TestValue>::new();
+        let source = promise_states.prepare();
+        let race = promise_states.prepare();
+        *promise_states.get_mut(source).expect("source exists") =
+            PromiseState::Waiting(vec![race_arm(race, 0)]);
+        *promise_states.get_mut(race).expect("race exists") =
+            PromiseState::Waiting(vec![Waiter::Continuation(continuation(RegisterId(0), 7))]);
+
+        let mut runtime = runtime_state(promise_states);
+
+        runtime
+            .resolve_promise(source, PromiseValue::Ready(TestReadyValue::Int(41)))
+            .expect("source promise should resolve");
+
+        assert!(matches!(
+            runtime.promise_states.get(race).expect("race exists"),
+            PromiseState::Settled(SettledPromiseState::Resolved(PromiseValue::Ready(
+                TestReadyValue::Int(arm_index)
+            ))) if *arm_index == 0
+        ));
+
+        let resumed = runtime.ready.pop_front().expect("race waiter is resumed");
+        assert_eq!(resumed.state, 7);
+        assert_eq!(
+            resumed.regs.get(RegisterId(0)),
+            Some(&PromiseValue::Ready(TestReadyValue::Int(0)))
+        );
+        assert!(resumed.exception.is_none());
+    }
+
+    #[test]
+    fn reject_promise_fires_race_arms_resolving_the_race() {
+        let mut promise_states = PromiseStates::<&'static str, usize, TestValue>::new();
+        let source = promise_states.prepare();
+        let race = promise_states.prepare();
+        *promise_states.get_mut(source).expect("source exists") =
+            PromiseState::Waiting(vec![race_arm(race, 1)]);
+        *promise_states.get_mut(race).expect("race exists") =
+            PromiseState::Waiting(vec![Waiter::Continuation(continuation(RegisterId(0), 7))]);
+
+        let mut runtime = runtime_state(promise_states);
+
+        runtime
+            .reject_promise(
+                source,
+                Exception {
+                    type_id: "ValueError".to_owned(),
+                    details: PromiseValue::Ready(TestReadyValue::Int(41)),
+                },
+            )
+            .expect("source promise should reject");
+
+        // The race promise resolves with the arm index even though
+        // the settlement that fired the arm was a rejection.
+        assert!(matches!(
+            runtime.promise_states.get(race).expect("race exists"),
+            PromiseState::Settled(SettledPromiseState::Resolved(PromiseValue::Ready(
+                TestReadyValue::Int(arm_index)
+            ))) if *arm_index == 1
+        ));
+
+        let resumed = runtime.ready.pop_front().expect("race waiter is resumed");
+        assert_eq!(resumed.state, 7);
+        assert_eq!(
+            resumed.regs.get(RegisterId(0)),
+            Some(&PromiseValue::Ready(TestReadyValue::Int(1)))
+        );
+        assert!(resumed.exception.is_none());
+    }
+
+    #[test]
+    fn race_arm_that_lost_the_race_is_inert() {
+        let mut promise_states = PromiseStates::<&'static str, usize, TestValue>::new();
+        let source = promise_states.prepare();
+        let race = promise_states.prepare();
+        *promise_states.get_mut(source).expect("source exists") = PromiseState::Waiting(vec![
+            race_arm(race, 1),
+            Waiter::Continuation(continuation(RegisterId(0), 3)),
+        ]);
+        *promise_states.get_mut(race).expect("race exists") = PromiseState::Settled(
+            SettledPromiseState::Resolved(PromiseValue::Ready(TestReadyValue::Int(0))),
+        );
+
+        let mut runtime = runtime_state(promise_states);
+
+        runtime
+            .resolve_promise(source, PromiseValue::Ready(TestReadyValue::Int(41)))
+            .expect("source promise should resolve despite the lost race");
+
+        // The race promise keeps the winning arm's resolution.
+        assert!(matches!(
+            runtime.promise_states.get(race).expect("race exists"),
+            PromiseState::Settled(SettledPromiseState::Resolved(PromiseValue::Ready(
+                TestReadyValue::Int(arm_index)
+            ))) if *arm_index == 0
+        ));
+
+        // The source's other waiters are still notified.
+        let resumed = runtime.ready.pop_front().expect("source waiter is resumed");
+        assert_eq!(resumed.state, 3);
+        assert_eq!(
+            resumed.regs.get(RegisterId(0)),
+            Some(&PromiseValue::Ready(TestReadyValue::Int(41)))
+        );
+        assert!(runtime.ready.is_empty());
+    }
+
+    #[test]
+    fn race_arms_propagate_through_nested_races() {
+        let mut promise_states = PromiseStates::<&'static str, usize, TestValue>::new();
+        let source = promise_states.prepare();
+        let inner_race = promise_states.prepare();
+        let outer_race = promise_states.prepare();
+        *promise_states.get_mut(source).expect("source exists") =
+            PromiseState::Waiting(vec![race_arm(inner_race, 0)]);
+        *promise_states
+            .get_mut(inner_race)
+            .expect("inner race exists") = PromiseState::Waiting(vec![race_arm(outer_race, 5)]);
+        *promise_states
+            .get_mut(outer_race)
+            .expect("outer race exists") =
+            PromiseState::Waiting(vec![Waiter::Continuation(continuation(RegisterId(1), 9))]);
+
+        let mut runtime = runtime_state(promise_states);
+
+        runtime
+            .resolve_promise(source, PromiseValue::Ready(TestReadyValue::Int(41)))
+            .expect("source promise should resolve");
+
+        assert!(matches!(
+            runtime
+                .promise_states
+                .get(inner_race)
+                .expect("inner race exists"),
+            PromiseState::Settled(SettledPromiseState::Resolved(PromiseValue::Ready(
+                TestReadyValue::Int(arm_index)
+            ))) if *arm_index == 0
+        ));
+        assert!(matches!(
+            runtime
+                .promise_states
+                .get(outer_race)
+                .expect("outer race exists"),
+            PromiseState::Settled(SettledPromiseState::Resolved(PromiseValue::Ready(
+                TestReadyValue::Int(arm_index)
+            ))) if *arm_index == 5
+        ));
+
+        let resumed = runtime.ready.pop_front().expect("outer waiter is resumed");
+        assert_eq!(resumed.state, 9);
+        assert_eq!(
+            resumed.regs.get(RegisterId(1)),
+            Some(&PromiseValue::Ready(TestReadyValue::Int(5)))
+        );
+    }
+
+    #[test]
+    fn race_arm_with_missing_target_returns_the_invariant_violation_error() {
+        let mut promise_states = PromiseStates::<&'static str, usize, TestValue>::new();
+        let source = promise_states.prepare();
+        let missing_race = PromiseStateId(9);
+        *promise_states.get_mut(source).expect("source exists") =
+            PromiseState::Waiting(vec![race_arm(missing_race, 0)]);
+
+        let mut runtime = runtime_state(promise_states);
+
+        let err = runtime
+            .resolve_promise(source, PromiseValue::Ready(TestReadyValue::Int(41)))
+            .expect_err("dangling race arm should surface the invariant violation");
+
+        let SettlePromiseError::RaceArmTargetNotFound(err) = err else {
+            panic!("dangling race arm should report a race-arm-target error");
+        };
+        assert_eq!(err.promise_state_id, missing_race);
     }
 }

--- a/crates/lib/vm-runtime-core/src/waiter.rs
+++ b/crates/lib/vm-runtime-core/src/waiter.rs
@@ -1,0 +1,27 @@
+use waymark_vm_runtime_promise_core::PromiseStateId;
+
+use crate::{Continuation, ResumeWithValue};
+
+/// A party waiting on a promise to settle.
+#[derive(Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum Waiter<FunctionId, StateId, Value> {
+    /// A suspended frame to resume when the promise settles.
+    Continuation(Continuation<FunctionId, StateId, Value, ResumeWithValue>),
+
+    /// The promise is an arm of a race: its settlement resolves the race
+    /// promise with the pre-built arm-index value.
+    ///
+    /// A settlement of either kind fires the arm the same way - the race
+    /// promise only ever learns *which* arm settled first, never how.
+    /// The first arm to fire wins; later firings find the race promise
+    /// already settled and are inert.
+    RaceArm {
+        /// The race promise to resolve when this arm settles.
+        race: PromiseStateId,
+
+        /// The value to resolve the race promise with - the arm's index,
+        /// pre-constructed at arm installation time.
+        resolution: Value,
+    },
+}

--- a/crates/lib/vm-runtime-promise-value/src/coreset.rs
+++ b/crates/lib/vm-runtime-promise-value/src/coreset.rs
@@ -27,3 +27,14 @@ where
         }
     }
 }
+
+impl<T> waymark_vm_interpreter_coreset::value::FromRaceArmIndex for PromiseValue<T>
+where
+    T: waymark_vm_interpreter_coreset::value::FromRaceArmIndex,
+{
+    fn from_race_arm_index(
+        arm_index: usize,
+    ) -> Result<Self, waymark_vm_interpreter_coreset::value::FromRaceArmIndexError> {
+        Ok(Self::Ready(T::from_race_arm_index(arm_index)?))
+    }
+}

--- a/crates/lib/vm-runtime-test/src/lib.rs
+++ b/crates/lib/vm-runtime-test/src/lib.rs
@@ -164,7 +164,9 @@ impl Interpreter for TestInterpreter {
                     .get_mut(promise_state_id)
                     .expect("prepared promise state should exist");
                 *promise_state =
-                    PromiseState::Waiting(vec![Continuation::capture(frame, resume, dst)]);
+                    PromiseState::Waiting(vec![waymark_vm_runtime_core::Waiter::Continuation(
+                        Continuation::capture(frame, resume, dst),
+                    )]);
                 Ok(ExecutionOutcome::ExitFrame)
             }
             TestInstruction::EmitRegister(register) => {

--- a/crates/lib/vm-runtime/tests/integration.rs
+++ b/crates/lib/vm-runtime/tests/integration.rs
@@ -1,6 +1,6 @@
 use waymark_vm_runtime::{CallSpec, RunError};
 use waymark_vm_runtime_core::{
-    CaptureRuntimeView, FullRuntimeView, RegisterId, SettlePromiseError,
+    CaptureRuntimeView, FullRuntimeView, RegisterId, SettlePromiseError, SettlePromiseStateError,
 };
 use waymark_vm_runtime_effect::EffectNumber;
 use waymark_vm_runtime_exception::Exception;
@@ -206,7 +206,8 @@ fn resolve_promise_rejects_unknown_promise_ids_without_disturbing_waiting_work()
         .resolve_promise(PromiseStateId(9), TestReadyValue::Int(41))
         .expect_err("unknown promise IDs should be rejected");
 
-    let SettlePromiseError::PromiseStateNotFound(err) = err else {
+    let SettlePromiseError::PromiseState(SettlePromiseStateError::PromiseStateNotFound(err)) = err
+    else {
         panic!("invalid promise IDs should surface a not-found error");
     };
     assert_eq!(err.promise_state_id, PromiseStateId(9));
@@ -245,7 +246,7 @@ fn resolve_promise_preserves_the_first_value_when_duplicate_resolution_occurs() 
         .resolve_promise(PromiseStateId(0), TestReadyValue::Int(11))
         .expect_err("already-settled promise should reject a new value");
 
-    let SettlePromiseError::AlreadySettled(err) = err else {
+    let SettlePromiseError::PromiseState(SettlePromiseStateError::AlreadySettled(err)) = err else {
         panic!("duplicate resolutions should report already-settled errors");
     };
 

--- a/crates/lib/vm-value/src/coreset.rs
+++ b/crates/lib/vm-value/src/coreset.rs
@@ -15,3 +15,13 @@ impl waymark_vm_interpreter_coreset::value::CaptureCallArgument for ReadyValue {
         self.clone()
     }
 }
+
+impl waymark_vm_interpreter_coreset::value::FromRaceArmIndex for ReadyValue {
+    fn from_race_arm_index(
+        arm_index: usize,
+    ) -> Result<Self, waymark_vm_interpreter_coreset::value::FromRaceArmIndexError> {
+        let arm_index = i64::try_from(arm_index)
+            .map_err(|_| waymark_vm_interpreter_coreset::value::FromRaceArmIndexError)?;
+        Ok(Self::Int(arm_index))
+    }
+}


### PR DESCRIPTION
Goes in after #484.

Superseded by #486.

---

This PR adds support for racing promises and obtaining an indicator of which of the promises finished first.

It theoretically weakens the determinism guarantees of the VM runtime, however in practice we have implemented the vm-driver in such a way that the execution is still deterministic with respect to the snapshots history in relation to the promise resolutions; this means that the determinism depends on the order at which the database and rust-side internals produce the promise settlements matters.

This is important for future features like VCR; in essence this means that the level at which we have to record the VCR logs (tapes) is the promise settlements so we can record the exact same effective order those records appear (and preserve the VM runtime `run()`s / promise settlement batching lock-steps). This shall make the VCR feature capture all non-deterministic behaviors such that it can faithfully reproduce the life of a recorded VM on replay. Todo: verify this statement.

