### PR TITLE
Add "select" control flow instruction to the VM

### DIFF
--- a/crates/lib/vm-instructions-coreset/src/lib.rs
+++ b/crates/lib/vm-instructions-coreset/src/lib.rs
@@ -68,6 +68,23 @@ pub enum CoreSet<Spec: self::Spec> {
         resume: Spec::StateId,
     },
 
+    /// Suspend the execution until the first of several promises settles,
+    /// resuming through that promise's arm.
+    ///
+    /// The arms are scanned in the listed order: an arm whose source holds
+    /// a ready value or an already-settled promise is taken immediately.
+    /// Otherwise the frame is kept aside and resumed - exactly once - by
+    /// whichever arm settles first. Either settlement kind takes an arm
+    /// the same way: a resolution delivers the value to the arm's `dst`,
+    /// a rejection raises - resuming from the arm's `resume` state either
+    /// way. The losing arms are inert.
+    Select {
+        /// The arms to select over.
+        ///
+        /// Must not be empty.
+        arms: Vec<SelectArm<Spec::RegisterId, Spec::StateId>>,
+    },
+
     /// Push one exception-handler block as the new innermost active scope.
     PushExceptionHandlers {
         /// Handlers to activate for subsequent execution in this frame.
@@ -108,4 +125,18 @@ pub enum CoreSet<Spec: self::Spec> {
         /// The register in the current from to take the return value from.
         src: Spec::RegisterId,
     },
+}
+
+/// One arm of a [`CoreSet::Select`] instruction.
+#[derive(Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct SelectArm<RegisterId, StateId> {
+    /// The register containing the promise this arm watches.
+    pub src: RegisterId,
+
+    /// The register to store this arm's resolved value at.
+    pub dst: RegisterId,
+
+    /// Resume from this state when this arm is taken.
+    pub resume: StateId,
 }

--- a/crates/lib/vm-interpreter-coreset/src/error.rs
+++ b/crates/lib/vm-interpreter-coreset/src/error.rs
@@ -8,6 +8,10 @@ pub enum Error<Spec: waymark_vm_instructions_coreset::Spec> {
     #[error("await: {0}")]
     Await(#[source] AwaitError),
 
+    /// Selecting over promises failed.
+    #[error("select: {0}")]
+    Select(#[source] SelectError),
+
     /// Returning from a function failed.
     #[error("return: {0}")]
     Return(#[source] FnExitError),
@@ -42,6 +46,22 @@ pub enum CallError<FunctionId> {
         /// The function ID that was looked up in the executable.
         function_id: FunctionId,
     },
+}
+
+/// Errors produced while evaluating a `Select` instruction.
+#[derive(Debug, thiserror::Error)]
+pub enum SelectError {
+    /// The instruction listed no arms.
+    ///
+    /// This is a mistake in the bytecode - a select with no arms would
+    /// never settle and the selecting frame would suspend forever.
+    #[error("select has no arms")]
+    EmptyArms,
+
+    /// A pending arm source promise no longer existed in the runtime
+    /// state.
+    #[error("arm source promise state: {0}")]
+    SourcePromiseStateNotFound(#[source] PromiseStateNotFoundError),
 }
 
 /// Errors produced while evaluating an `Await` instruction.

--- a/crates/lib/vm-interpreter-coreset/src/lib.rs
+++ b/crates/lib/vm-interpreter-coreset/src/lib.rs
@@ -252,6 +252,80 @@ where
                     }
                 }
             }
+            waymark_vm_instructions_coreset::CoreSet::Select { arms } => {
+                if arms.is_empty() {
+                    return Err(Error::Select(SelectError::EmptyArms));
+                }
+
+                // Scan the arms in the listed order for one whose source
+                // has already settled - taking it immediately, mirroring
+                // the immediate paths of `Await` - and collect the pending
+                // sources meanwhile.
+                let mut pending = Vec::with_capacity(arms.len());
+                for arm in arms {
+                    let promise_state_id = match frame.regs[arm.src].as_ready() {
+                        Ok(value) => {
+                            // A ready source wins the scan outright.
+                            let value = Value::from_ready(value.clone());
+                            frame.regs.set(arm.dst, value);
+                            frame.state = arm.resume;
+                            return Ok(ExecutionOutcome::Continue(frame));
+                        }
+                        Err(waymark_vm_runtime_promise_core::UnresolvedPromiseError {
+                            promise_state_id,
+                        }) => promise_state_id,
+                    };
+                    let promise_state = state
+                        .promise_states
+                        .get(promise_state_id)
+                        .map_err(SelectError::SourcePromiseStateNotFound)
+                        .map_err(Error::Select)?;
+                    match promise_state {
+                        PromiseState::Settled(SettledPromiseState::Resolved(value)) => {
+                            Continuation::immediate_resume(
+                                &mut frame,
+                                arm.resume,
+                                arm.dst,
+                                value.clone(),
+                            );
+                            state.ready.push_back(frame);
+                            return Ok(ExecutionOutcome::ExitFrame);
+                        }
+                        PromiseState::Settled(SettledPromiseState::Rejected(exception)) => {
+                            Continuation::immediate_raise_exception(
+                                &mut frame,
+                                arm.resume,
+                                exception.clone(),
+                            );
+                            state.ready.push_back(frame);
+                            return Ok(ExecutionOutcome::ExitFrame);
+                        }
+                        PromiseState::Waiting(_) => {
+                            pending.push((promise_state_id, arm.dst, arm.resume));
+                        }
+                    }
+                }
+
+                // Every arm waits: keep the frame aside and plant a claim
+                // on each source.
+                let handle = state
+                    .select_states
+                    .insert(Continuation::capture_select(frame));
+                for (promise_state_id, dst, resume) in pending {
+                    // The scan above just observed these promise states as
+                    // waiting, and nothing runs in between.
+                    let Ok(promise_state) = state.promise_states.get_mut(promise_state_id) else {
+                        unreachable!();
+                    };
+                    let PromiseState::Waiting(waiters) = promise_state else {
+                        unreachable!();
+                    };
+                    waiters.push(waymark_vm_runtime_core::PromiseWaiter::Select(
+                        handle.arm(dst, resume),
+                    ));
+                }
+                return Ok(ExecutionOutcome::ExitFrame);
+            }
             waymark_vm_instructions_coreset::CoreSet::PushExceptionHandlers { handlers } => {
                 frame.exception_handler_blocks.push(handlers.clone());
             }

--- a/crates/lib/vm-interpreter-coreset/src/lib.rs
+++ b/crates/lib/vm-interpreter-coreset/src/lib.rs
@@ -230,7 +230,7 @@ where
                                 ExecutionOutcome::ExitFrame
                             }
                             PromiseState::Settled(SettledPromiseState::Rejected(exception)) => {
-                                Continuation::<_, _, _, ()>::immediate_raise_exception(
+                                Continuation::immediate_raise_exception(
                                     &mut frame,
                                     *resume,
                                     exception.clone(),
@@ -238,8 +238,10 @@ where
                                 state.ready.push_back(frame);
                                 ExecutionOutcome::ExitFrame
                             }
-                            PromiseState::Waiting(continuations) => {
-                                continuations.push(Continuation::capture(frame, *resume, *dst));
+                            PromiseState::Waiting(waiters) => {
+                                waiters.push(waymark_vm_runtime_core::PromiseWaiter::Await(
+                                    Continuation::capture(frame, *resume, *dst),
+                                ));
                                 ExecutionOutcome::ExitFrame
                             }
                         });

--- a/crates/lib/vm-interpreter-fullset/tests/integration.rs
+++ b/crates/lib/vm-interpreter-fullset/tests/integration.rs
@@ -6,6 +6,7 @@
 mod support;
 
 mod extcall;
+mod select;
 mod sleep;
 mod state_entry;
 mod synchronous;

--- a/crates/lib/vm-interpreter-fullset/tests/select/mod.rs
+++ b/crates/lib/vm-interpreter-fullset/tests/select/mod.rs
@@ -1,0 +1,262 @@
+//! `CoreSet::Select` suspends the runtime on several promises at once and
+//! resumes through the arm of whichever settles first.
+
+use waymark_vm_instructions_coreset::{CoreSet, SelectArm};
+use waymark_vm_instructions_extcallset::ExtCallSet;
+use waymark_vm_interpreter_fullset::Effect;
+use waymark_vm_runtime::RunError;
+use waymark_vm_runtime_core::RegisterId;
+use waymark_vm_runtime_exception::Exception;
+use waymark_vm_runtime_test::{StateId, executable, function};
+
+use crate::support::{
+    Instruction, TestActionRef, TestReadyValue, new_runtime, new_runtime_with_args,
+};
+
+fn action_call_promise_state_id(
+    effect: Effect<TestReadyValue, TestActionRef, TestReadyValue>,
+) -> waymark_vm_runtime_promise_core::PromiseStateId {
+    match effect {
+        Effect::ExtCallSet(waymark_vm_interpreter_extcallset::Effect::ActionCall {
+            promise_state_id,
+            ..
+        }) => promise_state_id,
+        other => panic!("expected an action call effect: {other:?}"),
+    }
+}
+
+fn completed_value(
+    effect: Effect<TestReadyValue, TestActionRef, TestReadyValue>,
+) -> TestReadyValue {
+    match effect {
+        Effect::CoreSet(waymark_vm_interpreter_coreset::Effect::Complete(value)) => value,
+        other => panic!("expected the program to complete: {other:?}"),
+    }
+}
+
+/// The executable shared by the pending-source tests: two action calls
+/// selected over, with each arm returning its own delivery register.
+fn two_action_select_executable() -> waymark_vm_bytecode::Executable<Instruction> {
+    executable(vec![function::<Instruction>(
+        4,
+        vec![
+            vec![
+                ExtCallSet::ActionCall {
+                    dst: RegisterId(0),
+                    action_ref: TestActionRef(1),
+                    args: Vec::new(),
+                    resume: StateId(1),
+                }
+                .into(),
+            ],
+            vec![
+                ExtCallSet::ActionCall {
+                    dst: RegisterId(1),
+                    action_ref: TestActionRef(2),
+                    args: Vec::new(),
+                    resume: StateId(2),
+                }
+                .into(),
+            ],
+            vec![
+                CoreSet::Select {
+                    arms: vec![
+                        SelectArm {
+                            src: RegisterId(0),
+                            dst: RegisterId(2),
+                            resume: StateId(3),
+                        },
+                        SelectArm {
+                            src: RegisterId(1),
+                            dst: RegisterId(3),
+                            resume: StateId(4),
+                        },
+                    ],
+                }
+                .into(),
+            ],
+            vec![CoreSet::Return { src: RegisterId(2) }.into()],
+            vec![CoreSet::Return { src: RegisterId(3) }.into()],
+        ],
+    )])
+}
+
+/// The first settled arm resumes the frame at its own state with its own
+/// delivery register - and the losing arm is inert.
+#[test]
+fn select_over_pending_sources_resumes_through_the_first_settled_arm() {
+    let mut runtime = new_runtime(two_action_select_executable());
+
+    let first_effect = runtime.run().expect("first action call should emit");
+    let first_promise = action_call_promise_state_id(first_effect.effect);
+
+    let second_effect = runtime.run().expect("second action call should emit");
+    let second_promise = action_call_promise_state_id(second_effect.effect);
+
+    assert!(
+        matches!(runtime.run(), Err(RunError::NoReadyFrame)),
+        "the frame should suspend selecting over the sources"
+    );
+
+    runtime
+        .resolve_promise(second_promise, TestReadyValue::Int(99))
+        .expect("second source should resolve cleanly");
+
+    let emitted_effect = runtime.run().expect("taken arm should complete the run");
+    assert_eq!(
+        completed_value(emitted_effect.effect),
+        TestReadyValue::Int(99)
+    );
+
+    // The losing source settles later and its claim is inert.
+    runtime
+        .resolve_promise(first_promise, TestReadyValue::Int(7))
+        .expect("late loser settlement should be accepted and inert");
+}
+
+/// A rejected source takes its arm by raising at the arm's resume state.
+#[test]
+fn select_delivers_rejections_by_raising_at_the_arm() {
+    let mut runtime = new_runtime(two_action_select_executable());
+
+    let first_effect = runtime.run().expect("first action call should emit");
+    let first_promise = action_call_promise_state_id(first_effect.effect);
+
+    let _second_effect = runtime.run().expect("second action call should emit");
+
+    assert!(
+        matches!(runtime.run(), Err(RunError::NoReadyFrame)),
+        "the frame should suspend selecting over the sources"
+    );
+
+    runtime
+        .reject_promise(
+            first_promise,
+            Exception {
+                type_id: "ValueError".to_owned(),
+                details: TestReadyValue::Int(41),
+            },
+        )
+        .expect("first source should reject cleanly");
+
+    let emitted_effect = runtime
+        .run()
+        .expect("the raised arm should surface the exception");
+    match emitted_effect.effect {
+        Effect::CoreSet(waymark_vm_interpreter_coreset::Effect::UnhandledException(exception)) => {
+            assert_eq!(exception.type_id, "ValueError");
+        }
+        other => panic!("expected an unhandled exception: {other:?}"),
+    }
+}
+
+/// A source whose promise has already settled is taken at scan time -
+/// the select never suspends and no claims are planted.
+#[test]
+fn select_with_an_already_settled_source_is_taken_at_scan_time() {
+    let mut runtime = new_runtime(two_action_select_executable());
+
+    let first_effect = runtime.run().expect("first action call should emit");
+    let _first_promise = action_call_promise_state_id(first_effect.effect);
+
+    let second_effect = runtime.run().expect("second action call should emit");
+    let second_promise = action_call_promise_state_id(second_effect.effect);
+
+    // Settle the second source before the select instruction runs.
+    runtime
+        .resolve_promise(second_promise, TestReadyValue::Int(99))
+        .expect("second source should resolve cleanly");
+
+    let emitted_effect = runtime
+        .run()
+        .expect("select should take the settled arm at scan time");
+    assert_eq!(
+        completed_value(emitted_effect.effect),
+        TestReadyValue::Int(99)
+    );
+}
+
+/// A source register holding a plain ready value - not a promise at all -
+/// is taken at scan time.
+#[test]
+fn select_with_a_ready_value_source_is_taken_at_scan_time() {
+    let executable = executable(vec![function::<Instruction>(
+        4,
+        vec![
+            vec![
+                ExtCallSet::ActionCall {
+                    dst: RegisterId(1),
+                    action_ref: TestActionRef(1),
+                    args: Vec::new(),
+                    resume: StateId(1),
+                }
+                .into(),
+            ],
+            vec![
+                // Register 0 holds the ready function argument.
+                CoreSet::Select {
+                    arms: vec![
+                        SelectArm {
+                            src: RegisterId(1),
+                            dst: RegisterId(2),
+                            resume: StateId(2),
+                        },
+                        SelectArm {
+                            src: RegisterId(0),
+                            dst: RegisterId(3),
+                            resume: StateId(3),
+                        },
+                    ],
+                }
+                .into(),
+            ],
+            vec![CoreSet::Return { src: RegisterId(2) }.into()],
+            vec![CoreSet::Return { src: RegisterId(3) }.into()],
+        ],
+    )]);
+
+    let mut runtime = new_runtime_with_args(executable, vec![TestReadyValue::Int(5)]);
+
+    let action_effect = runtime.run().expect("the action call should emit");
+    let _action_promise = action_call_promise_state_id(action_effect.effect);
+
+    let emitted_effect = runtime
+        .run()
+        .expect("select should take the ready arm at scan time");
+    assert_eq!(
+        completed_value(emitted_effect.effect),
+        TestReadyValue::Int(5)
+    );
+}
+
+/// A select with no arms is a bytecode mistake and fails the run.
+#[test]
+fn select_with_no_arms_fails_the_run() {
+    let executable = executable(vec![function::<Instruction>(
+        1,
+        vec![vec![
+            CoreSet::Select { arms: Vec::new() }.into(),
+            CoreSet::Return { src: RegisterId(0) }.into(),
+        ]],
+    )]);
+
+    let mut runtime = new_runtime(executable);
+
+    let err = runtime
+        .run()
+        .expect_err("a select with no arms should fail the run");
+
+    assert!(
+        matches!(
+            &err,
+            RunError::Step(waymark_vm_runtime::step::Error::Execution(
+                waymark_vm_interpreter_fullset::Error::CoreSet(
+                    waymark_vm_interpreter_coreset::Error::Select(
+                        waymark_vm_interpreter_coreset::SelectError::EmptyArms
+                    )
+                )
+            ))
+        ),
+        "unexpected error: {err:?}"
+    );
+}

--- a/crates/lib/vm-runtime-core/src/continuation.rs
+++ b/crates/lib/vm-runtime-core/src/continuation.rs
@@ -27,6 +27,42 @@ pub struct ResumeWithValue {
     pub dst: RegisterId,
 }
 
+/// Specifies that a [`Continuation`] is to resume through one of the arms
+/// of a select, chosen at resume time via [`Continuation::into_arm`].
+///
+/// Typical use is for continuations that suspend on multiple asynchronously
+/// obtained values at once, resuming with whichever settles first.
+#[derive(Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct ResumeSelectArm;
+
+/// One arm of a select: where the arm's settlement is delivered.
+///
+/// Originates in the select's [`crate::PromiseWaiter::Select`] entries -
+/// planted one per raced promise - and is consumed by
+/// [`Continuation::into_arm`] when the arm settles first.
+#[derive(Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct SelectArm<StateId> {
+    /// The register to deliver this arm's resolved value to.
+    dst: RegisterId,
+
+    /// The state to resume the execution from for this arm.
+    resume: StateId,
+}
+
+impl<StateId> SelectArm<StateId> {
+    /// Create a select arm delivering to the `dst` register and resuming
+    /// from the `resume` state.
+    ///
+    /// Crate-internal on purpose: select arms are only ever minted by
+    /// the runtime itself when a select is installed, so they cannot be
+    /// forged from the outside.
+    pub(crate) fn new(dst: RegisterId, resume: StateId) -> Self {
+        Self { dst, resume }
+    }
+}
+
 impl<FunctionId, StateId, Value> Continuation<FunctionId, StateId, Value, ResumeWithValue> {
     /// Capture the given `frame` as a continuation, with a `dst` register
     /// to be populated by a resolved value upon coninuing, and the given
@@ -76,9 +112,7 @@ impl<FunctionId, StateId, Value> Continuation<FunctionId, StateId, Value, Resume
         // Assign the value to the register where it belongs.
         frame.regs.set(dst, value);
     }
-}
 
-impl<FunctionId, StateId, Value, Resumer> Continuation<FunctionId, StateId, Value, Resumer> {
     /// Resume the continuation with a raised exception.
     pub fn raise_exception(
         self,
@@ -111,12 +145,47 @@ impl<FunctionId, StateId, Value, Resumer> Continuation<FunctionId, StateId, Valu
     }
 }
 
+impl<FunctionId, StateId, Value> Continuation<FunctionId, StateId, Value, ResumeSelectArm> {
+    /// Capture the given `frame` as a select continuation.
+    ///
+    /// The frame is not positioned at any resume state yet: the delivery
+    /// target arrives with the claiming arm via [`Continuation::into_arm`].
+    pub fn capture_select(frame: Frame<FunctionId, StateId, Value>) -> Self {
+        Self {
+            resumer: ResumeSelectArm,
+            prepared_resume_frame: frame,
+        }
+    }
+
+    /// Choose the arm that settled, producing an ordinary value-resumable
+    /// continuation positioned at that arm's resume state.
+    pub fn into_arm(
+        self,
+        arm: SelectArm<StateId>,
+    ) -> Continuation<FunctionId, StateId, Value, ResumeWithValue> {
+        let Self {
+            mut prepared_resume_frame,
+            resumer: ResumeSelectArm,
+        } = self;
+        let SelectArm { dst, resume } = arm;
+
+        // Complete what a plain capture does upfront: position the frame
+        // at the chosen arm's resume state.
+        prepared_resume_frame.state = resume;
+
+        Continuation {
+            resumer: ResumeWithValue { dst },
+            prepared_resume_frame,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use waymark_vm_runtime_exception::Exception;
     use waymark_vm_runtime_promise_value::PromiseValue;
 
-    use super::Continuation;
+    use super::{Continuation, SelectArm};
     use crate::{ExceptionHandlers, Frame, FrameKind, RegisterId, Registers};
 
     #[derive(Debug, Clone, PartialEq, Eq)]
@@ -213,5 +282,39 @@ mod tests {
             exception.details,
             PromiseValue::Ready(TestReadyValue::Int(42))
         );
+    }
+
+    #[test]
+    fn capture_select_leaves_the_frame_state_untouched() {
+        let continuation = Continuation::capture_select(frame(1));
+
+        let resumed = continuation
+            .into_arm(SelectArm::new(RegisterId(1), 7))
+            .resume(PromiseValue::Ready(TestReadyValue::Int(42)));
+
+        assert_eq!(resumed.state, 7);
+        assert_eq!(
+            resumed.regs.get(RegisterId(1)),
+            Some(&PromiseValue::Ready(TestReadyValue::Int(42)))
+        );
+        assert!(resumed.exception.is_none());
+    }
+
+    #[test]
+    fn into_arm_positions_the_frame_for_exceptional_resumes_too() {
+        let continuation = Continuation::capture_select(frame(1));
+
+        let resumed = continuation
+            .into_arm(SelectArm::new(RegisterId(0), 9))
+            .raise_exception(Exception {
+                type_id: "ValueError".to_owned(),
+                details: PromiseValue::Ready(TestReadyValue::Int(42)),
+            });
+
+        assert_eq!(resumed.state, 9);
+        let Some(exception) = resumed.exception else {
+            panic!("exceptional resume should raise into the frame");
+        };
+        assert_eq!(exception.type_id, "ValueError");
     }
 }

--- a/crates/lib/vm-runtime-core/src/lib.rs
+++ b/crates/lib/vm-runtime-core/src/lib.rs
@@ -8,8 +8,10 @@ mod frame;
 mod frame_exception_handlers;
 mod promise_state;
 mod promise_states;
+mod promise_waiter;
 mod registers;
 mod runtime_state;
+mod select_states;
 
 pub use self::capture_runtime_view::*;
 pub use self::continuation::*;
@@ -17,5 +19,7 @@ pub use self::frame::*;
 pub use self::frame_exception_handlers::*;
 pub use self::promise_state::*;
 pub use self::promise_states::*;
+pub use self::promise_waiter::*;
 pub use self::registers::*;
 pub use self::runtime_state::*;
+pub use self::select_states::*;

--- a/crates/lib/vm-runtime-core/src/promise_state.rs
+++ b/crates/lib/vm-runtime-core/src/promise_state.rs
@@ -31,10 +31,10 @@ pub struct SettlingAlreadySettledPromiseError<Value> {
 #[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum PromiseState<FunctionId, StateId, Value> {
-    /// A list of continuations to resume when a promise settles.
+    /// A list of waiters to notify when a promise settles.
     ///
-    /// Awaiting on it will add the frame to the list of continuations.
-    Waiting(Vec<crate::Continuation<FunctionId, StateId, Value, crate::ResumeWithValue>>),
+    /// Awaiting on it will add the frame to the list of waiters.
+    Waiting(Vec<crate::PromiseWaiter<FunctionId, StateId, Value>>),
 
     /// A promise that has settled.
     ///
@@ -46,19 +46,18 @@ pub enum PromiseState<FunctionId, StateId, Value> {
 impl<FunctionId, StateId, Value> PromiseState<FunctionId, StateId, Value> {
     /// Idempotently resolve a promise.
     ///
-    /// Returns a list of continuations to resume, or an error if this promise
+    /// Returns a list of waiters to notify, or an error if this promise
     /// has already settled.
-    #[allow(clippy::type_complexity)]
     pub fn resolve(
         &mut self,
         value: Value,
     ) -> Result<
-        Vec<crate::Continuation<FunctionId, StateId, Value, crate::ResumeWithValue>>,
+        Vec<crate::PromiseWaiter<FunctionId, StateId, Value>>,
         SettlingAlreadySettledPromiseError<Value>,
     > {
         let replaced = std::mem::replace(self, Self::Settled(SettledPromiseState::Resolved(value)));
         match replaced {
-            PromiseState::Waiting(continuations) => Ok(continuations),
+            PromiseState::Waiting(waiters) => Ok(waiters),
             PromiseState::Settled(original) => {
                 // This shouldn't happen often.
                 std::hint::cold_path();
@@ -77,12 +76,18 @@ impl<FunctionId, StateId, Value> PromiseState<FunctionId, StateId, Value> {
     }
 
     /// Idempotently reject a promise.
-    #[allow(clippy::type_complexity)]
+    ///
+    /// Returns a list of waiters to notify, or an error if this promise
+    /// has already settled.
+    #[expect(
+        clippy::type_complexity,
+        reason = "we purposely avoid alias for the error"
+    )]
     pub fn reject(
         &mut self,
         exception: waymark_vm_runtime_exception::Exception<Value>,
     ) -> Result<
-        Vec<crate::Continuation<FunctionId, StateId, Value, crate::ResumeWithValue>>,
+        Vec<crate::PromiseWaiter<FunctionId, StateId, Value>>,
         SettlingAlreadySettledPromiseError<waymark_vm_runtime_exception::Exception<Value>>,
     > {
         let replaced = std::mem::replace(
@@ -90,7 +95,7 @@ impl<FunctionId, StateId, Value> PromiseState<FunctionId, StateId, Value> {
             Self::Settled(SettledPromiseState::Rejected(exception)),
         );
         match replaced {
-            PromiseState::Waiting(continuations) => Ok(continuations),
+            PromiseState::Waiting(waiters) => Ok(waiters),
             PromiseState::Settled(original) => {
                 // This shouldn't happen often.
                 std::hint::cold_path();
@@ -115,7 +120,9 @@ mod tests {
     use waymark_vm_runtime_promise_value::PromiseValue;
 
     use super::{PromiseState, SettledPromiseState};
-    use crate::{Continuation, ExceptionHandlers, Frame, FrameKind, RegisterId, Registers};
+    use crate::{
+        Continuation, ExceptionHandlers, Frame, FrameKind, PromiseWaiter, RegisterId, Registers,
+    };
 
     #[derive(Debug, Clone, PartialEq, Eq)]
     enum TestReadyValue {
@@ -148,7 +155,8 @@ mod tests {
 
     #[test]
     fn resolve_waiting_promise_returns_continuations_and_marks_resolved() {
-        let mut state = PromiseState::Waiting(vec![continuation(RegisterId(1), 3)]);
+        let mut state =
+            PromiseState::Waiting(vec![PromiseWaiter::Await(continuation(RegisterId(1), 3))]);
 
         let continuations = state
             .resolve(PromiseValue::Ready(TestReadyValue::Int(17)))
@@ -162,11 +170,10 @@ mod tests {
             ))) if *value == 17
         ));
 
-        let resumed = continuations
-            .into_iter()
-            .next()
-            .expect("continuation is returned")
-            .resume(PromiseValue::Ready(TestReadyValue::Int(17)));
+        let Some(PromiseWaiter::Await(continuation)) = continuations.into_iter().next() else {
+            panic!("continuation waiter is returned");
+        };
+        let resumed = continuation.resume(PromiseValue::Ready(TestReadyValue::Int(17)));
         assert_eq!(resumed.state, 3);
         assert_eq!(resumed.regs.get(RegisterId(0)), None);
         assert_eq!(
@@ -201,7 +208,8 @@ mod tests {
 
     #[test]
     fn reject_waiting_promise_preserves_exceptional_settlements() {
-        let mut state = PromiseState::Waiting(vec![continuation(RegisterId(1), 3)]);
+        let mut state =
+            PromiseState::Waiting(vec![PromiseWaiter::Await(continuation(RegisterId(1), 3))]);
 
         let continuations = state
             .reject(Exception {
@@ -217,14 +225,13 @@ mod tests {
                     && *details == PromiseValue::Ready(TestReadyValue::Int(17))
         ));
 
-        let resumed = continuations
-            .into_iter()
-            .next()
-            .expect("continuation is returned")
-            .raise_exception(Exception {
-                type_id: "ValueError".to_owned(),
-                details: PromiseValue::Ready(TestReadyValue::Int(17)),
-            });
+        let Some(PromiseWaiter::Await(continuation)) = continuations.into_iter().next() else {
+            panic!("continuation waiter is returned");
+        };
+        let resumed = continuation.raise_exception(Exception {
+            type_id: "ValueError".to_owned(),
+            details: PromiseValue::Ready(TestReadyValue::Int(17)),
+        });
 
         let Some(exception) = resumed.exception else {
             panic!("exceptional resume should raise into the frame");

--- a/crates/lib/vm-runtime-core/src/promise_states.rs
+++ b/crates/lib/vm-runtime-core/src/promise_states.rs
@@ -1,7 +1,7 @@
 use index_type::typed_vec::TypedVec;
 use waymark_vm_runtime_promise_core::PromiseStateId;
 
-use crate::{Continuation, PromiseState, SettlingAlreadySettledPromiseError};
+use crate::{PromiseState, SettlingAlreadySettledPromiseError};
 
 /// A list of promise states.
 #[derive(Debug)]
@@ -99,17 +99,14 @@ impl<FunctionId, StateId, Value> PromiseStates<FunctionId, StateId, Value> {
     /// Idempotently resolve a promise at a given `promise_state_id` with
     /// the provided `value`.
     ///
-    /// Returns a list of continuations to resume, or an error if this promise
+    /// Returns a list of waiters to notify, or an error if this promise
     /// has already settled.
-    #[allow(clippy::type_complexity)]
     pub fn resolve(
         &mut self,
         promise_state_id: PromiseStateId,
         value: Value,
-    ) -> Result<
-        Vec<crate::Continuation<FunctionId, StateId, Value, crate::ResumeWithValue>>,
-        SettlePromiseError<Value>,
-    > {
+    ) -> Result<Vec<crate::PromiseWaiter<FunctionId, StateId, Value>>, SettlePromiseError<Value>>
+    {
         let promise_state = self
             .get_mut(promise_state_id)
             .map_err(SettlePromiseError::PromiseStateNotFound)?;
@@ -120,6 +117,9 @@ impl<FunctionId, StateId, Value> PromiseStates<FunctionId, StateId, Value> {
     }
 
     /// Idempotently reject a promise at a given `promise_state_id`.
+    ///
+    /// Returns a list of waiters to notify, or an error if this promise
+    /// has already settled.
     #[expect(
         clippy::type_complexity,
         reason = "we purposely avoid alias for the error"
@@ -129,7 +129,7 @@ impl<FunctionId, StateId, Value> PromiseStates<FunctionId, StateId, Value> {
         promise_state_id: PromiseStateId,
         exception: waymark_vm_runtime_exception::Exception<Value>,
     ) -> Result<
-        Vec<Continuation<FunctionId, StateId, Value, crate::ResumeWithValue>>,
+        Vec<crate::PromiseWaiter<FunctionId, StateId, Value>>,
         SettlePromiseError<waymark_vm_runtime_exception::Exception<Value>>,
     > {
         let promise_state = self
@@ -166,8 +166,8 @@ mod tests {
 
     use super::{PromiseStateId, PromiseStateNotFoundError, PromiseStates, SettlePromiseError};
     use crate::{
-        Continuation, ExceptionHandlers, Frame, FrameKind, PromiseState, RegisterId, Registers,
-        SettledPromiseState,
+        Continuation, ExceptionHandlers, Frame, FrameKind, PromiseState, PromiseWaiter, RegisterId,
+        Registers, SettledPromiseState,
     };
 
     fn continuation(
@@ -214,7 +214,7 @@ mod tests {
         let state = states
             .get_mut(promise_state_id)
             .expect("promise state exists");
-        *state = PromiseState::Waiting(vec![continuation(RegisterId(0), 4)]);
+        *state = PromiseState::Waiting(vec![PromiseWaiter::Await(continuation(RegisterId(0), 4))]);
 
         let continuations = states
             .resolve(promise_state_id, 23)

--- a/crates/lib/vm-runtime-core/src/promise_waiter.rs
+++ b/crates/lib/vm-runtime-core/src/promise_waiter.rs
@@ -1,0 +1,18 @@
+use crate::{Continuation, ResumeWithValue, SelectStateClaim};
+
+/// A party waiting on a promise to settle.
+#[derive(Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum PromiseWaiter<FunctionId, StateId, Value> {
+    /// A continuation to resume when the promise settles.
+    Await(Continuation<FunctionId, StateId, Value, ResumeWithValue>),
+
+    /// The promise is an arm of a select: its settlement claims the select
+    /// continuation and delivers the outcome to the arm's target.
+    ///
+    /// A settlement of either kind fires the arm the same way - resolution
+    /// delivers the value to the arm's target, rejection raises - resuming
+    /// at the arm's resume state either way. The first arm to fire claims
+    /// the select; later firings find it already claimed and are inert.
+    Select(SelectStateClaim<StateId>),
+}

--- a/crates/lib/vm-runtime-core/src/runtime_state.rs
+++ b/crates/lib/vm-runtime-core/src/runtime_state.rs
@@ -3,7 +3,7 @@ use std::collections::VecDeque;
 use waymark_vm_runtime_effect::EffectNumber;
 use waymark_vm_runtime_promise_core::PromiseStateId;
 
-use crate::{Frame, PromiseStates, SettlePromiseError};
+use crate::{Frame, PromiseStates, PromiseWaiter, SelectStates, SettlePromiseError};
 
 /// The state shape of the runtime.
 ///
@@ -31,6 +31,9 @@ pub struct RuntimeState<FunctionId, StateId, Value> {
     // or something like that.
     pub promise_states: PromiseStates<FunctionId, StateId, Value>,
 
+    /// A state of the selects of this runtime.
+    pub select_states: SelectStates<FunctionId, StateId, Value>,
+
     /// Sequential counter of effects produced by this runtime.
     ///
     /// Incremented each time the runtime emits an effect.
@@ -43,17 +46,29 @@ where
 {
     /// Provide an async computation value for a given promise.
     ///
-    /// Notifies all continuations that wait on it.
+    /// Notifies all waiters: resumes the continuations and claims the
+    /// selects this promise is an arm of - delivering the value either way.
     pub fn resolve_promise(
         &mut self,
         promise_state_id: PromiseStateId,
         value: Value,
     ) -> Result<(), SettlePromiseError<Value>> {
-        let continuations = self
+        let waiters = self
             .promise_states
             .resolve(promise_state_id, value.clone())?;
 
-        for continuation in continuations {
+        for waiter in waiters {
+            let continuation = match waiter {
+                PromiseWaiter::Await(continuation) => continuation,
+                PromiseWaiter::Select(select_state_claim) => {
+                    // An already-claimed select means this arm lost -
+                    // inert by the claimed-exactly-once semantics.
+                    let Some(continuation) = self.select_states.claim(select_state_claim) else {
+                        continue;
+                    };
+                    continuation
+                }
+            };
             let frame = continuation.resume(value.clone());
             self.ready.push_back(frame);
         }
@@ -63,17 +78,29 @@ where
 
     /// Reject an async computation for a given promise.
     ///
-    /// Notifies all continuations that wait on it.
+    /// Notifies all waiters: resumes the continuations and claims the
+    /// selects this promise is an arm of - raising the exception either way.
     pub fn reject_promise(
         &mut self,
         promise_state_id: PromiseStateId,
         exception: waymark_vm_runtime_exception::Exception<Value>,
     ) -> Result<(), SettlePromiseError<waymark_vm_runtime_exception::Exception<Value>>> {
-        let continuations = self
+        let waiters = self
             .promise_states
             .reject(promise_state_id, exception.clone())?;
 
-        for continuation in continuations {
+        for waiter in waiters {
+            let continuation = match waiter {
+                PromiseWaiter::Await(continuation) => continuation,
+                PromiseWaiter::Select(select_state_claim) => {
+                    // An already-claimed select means this arm lost -
+                    // inert by the claimed-exactly-once semantics.
+                    let Some(continuation) = self.select_states.claim(select_state_claim) else {
+                        continue;
+                    };
+                    continuation
+                }
+            };
             let frame = continuation.raise_exception(exception.clone());
             self.ready.push_back(frame);
         }
@@ -92,8 +119,9 @@ mod tests {
 
     use super::RuntimeState;
     use crate::{
-        Continuation, ExceptionHandlers, Frame, FrameKind, PromiseState, PromiseStates, RegisterId,
-        Registers, SettlePromiseError, SettledPromiseState,
+        Continuation, ExceptionHandlers, Frame, FrameKind, PromiseState, PromiseStates,
+        PromiseWaiter, RegisterId, Registers, SelectStates, SettlePromiseError,
+        SettledPromiseState,
     };
 
     #[derive(Debug, Clone, PartialEq, Eq)]
@@ -133,13 +161,14 @@ mod tests {
             .get_mut(promise_state_id)
             .expect("promise state exists");
         *promise_state = PromiseState::Waiting(vec![
-            continuation(RegisterId(0), 3),
-            continuation(RegisterId(1), 5),
+            PromiseWaiter::Await(continuation(RegisterId(0), 3)),
+            PromiseWaiter::Await(continuation(RegisterId(1), 5)),
         ]);
 
         let mut runtime = RuntimeState {
             ready: VecDeque::new(),
             promise_states,
+            select_states: SelectStates::new(),
             effect_counter: EffectNumber(0),
         };
 
@@ -194,6 +223,7 @@ mod tests {
         let mut runtime = RuntimeState {
             ready: VecDeque::new(),
             promise_states,
+            select_states: SelectStates::new(),
             effect_counter: EffectNumber(0),
         };
 
@@ -233,11 +263,13 @@ mod tests {
         let promise_state = promise_states
             .get_mut(promise_state_id)
             .expect("promise state exists");
-        *promise_state = PromiseState::Waiting(vec![continuation(RegisterId(0), 3)]);
+        *promise_state =
+            PromiseState::Waiting(vec![PromiseWaiter::Await(continuation(RegisterId(0), 3))]);
 
         let mut runtime = RuntimeState {
             ready: VecDeque::new(),
             promise_states,
+            select_states: SelectStates::new(),
             effect_counter: EffectNumber(0),
         };
 
@@ -274,12 +306,16 @@ mod tests {
         let promise_state = promise_states
             .get_mut(promise_state_id)
             .expect("promise state exists");
-        *promise_state =
-            PromiseState::Waiting(vec![Continuation::capture(frame(0), 3, RegisterId(0))]);
+        *promise_state = PromiseState::Waiting(vec![PromiseWaiter::Await(Continuation::capture(
+            frame(0),
+            3,
+            RegisterId(0),
+        ))]);
 
         let mut runtime = RuntimeState {
             ready: VecDeque::new(),
             promise_states,
+            select_states: SelectStates::new(),
             effect_counter: EffectNumber(0),
         };
 
@@ -303,5 +339,125 @@ mod tests {
             exception.details,
             PromiseValue::Ready(TestReadyValue::Int(41))
         );
+    }
+
+    fn runtime_state(
+        promise_states: PromiseStates<&'static str, usize, TestValue>,
+    ) -> RuntimeState<&'static str, usize, TestValue> {
+        RuntimeState {
+            ready: VecDeque::new(),
+            promise_states,
+            select_states: SelectStates::new(),
+            effect_counter: EffectNumber(0),
+        }
+    }
+
+    #[test]
+    fn resolve_promise_claims_the_select_and_delivers_to_the_arm() {
+        let mut promise_states = PromiseStates::<&'static str, usize, TestValue>::new();
+        let source = promise_states.prepare();
+
+        let mut select_states = SelectStates::new();
+        let handle = select_states.insert(Continuation::capture_select(frame(0)));
+
+        *promise_states.get_mut(source).expect("source exists") =
+            PromiseState::Waiting(vec![PromiseWaiter::Select(handle.arm(RegisterId(1), 7))]);
+
+        let mut runtime = RuntimeState {
+            ready: VecDeque::new(),
+            promise_states,
+            select_states,
+            effect_counter: EffectNumber(0),
+        };
+
+        runtime
+            .resolve_promise(source, PromiseValue::Ready(TestReadyValue::Int(41)))
+            .expect("source promise should resolve");
+
+        let resumed = runtime.ready.pop_front().expect("claimed frame is resumed");
+        assert_eq!(resumed.state, 7);
+        assert_eq!(
+            resumed.regs.get(RegisterId(1)),
+            Some(&PromiseValue::Ready(TestReadyValue::Int(41)))
+        );
+        assert!(resumed.exception.is_none());
+    }
+
+    #[test]
+    fn reject_promise_claims_the_select_and_raises_at_the_arm() {
+        let mut promise_states = PromiseStates::<&'static str, usize, TestValue>::new();
+        let source = promise_states.prepare();
+
+        let mut select_states = SelectStates::new();
+        let handle = select_states.insert(Continuation::capture_select(frame(0)));
+
+        *promise_states.get_mut(source).expect("source exists") =
+            PromiseState::Waiting(vec![PromiseWaiter::Select(handle.arm(RegisterId(1), 7))]);
+
+        let mut runtime = RuntimeState {
+            ready: VecDeque::new(),
+            promise_states,
+            select_states,
+            effect_counter: EffectNumber(0),
+        };
+
+        runtime
+            .reject_promise(
+                source,
+                Exception {
+                    type_id: "ValueError".to_owned(),
+                    details: PromiseValue::Ready(TestReadyValue::Int(41)),
+                },
+            )
+            .expect("source promise should reject");
+
+        let resumed = runtime.ready.pop_front().expect("claimed frame is resumed");
+        assert_eq!(resumed.state, 7);
+        let Some(exception) = resumed.exception else {
+            panic!("claimed frame should carry the raised exception");
+        };
+        assert_eq!(exception.type_id, "ValueError");
+    }
+
+    #[test]
+    fn losing_select_arm_is_inert_and_other_waiters_still_notify() {
+        let mut promise_states = PromiseStates::<&'static str, usize, TestValue>::new();
+        let winner_source = promise_states.prepare();
+        let loser_source = promise_states.prepare();
+
+        let mut select_states = SelectStates::new();
+        let handle = select_states.insert(Continuation::capture_select(frame(0)));
+
+        *promise_states
+            .get_mut(winner_source)
+            .expect("winner source exists") =
+            PromiseState::Waiting(vec![PromiseWaiter::Select(handle.arm(RegisterId(0), 3))]);
+        *promise_states
+            .get_mut(loser_source)
+            .expect("loser source exists") = PromiseState::Waiting(vec![
+            PromiseWaiter::Select(handle.arm(RegisterId(1), 5)),
+            PromiseWaiter::Await(continuation(RegisterId(0), 9)),
+        ]);
+
+        let mut runtime = runtime_state(promise_states);
+        runtime.select_states = select_states;
+
+        runtime
+            .resolve_promise(winner_source, PromiseValue::Ready(TestReadyValue::Int(1)))
+            .expect("winner source should resolve");
+
+        let claimed = runtime.ready.pop_front().expect("claimed frame is resumed");
+        assert_eq!(claimed.state, 3);
+        assert!(runtime.ready.is_empty());
+
+        // The loser arm finds the select already claimed and is inert;
+        // the source's other waiters are still notified.
+        runtime
+            .resolve_promise(loser_source, PromiseValue::Ready(TestReadyValue::Int(2)))
+            .expect("loser source should resolve");
+
+        let resumed = runtime.ready.pop_front().expect("plain waiter is resumed");
+        assert_eq!(resumed.state, 9);
+        assert!(runtime.ready.is_empty(), "the losing arm must not resume");
     }
 }

--- a/crates/lib/vm-runtime-core/src/select_states.rs
+++ b/crates/lib/vm-runtime-core/src/select_states.rs
@@ -1,0 +1,204 @@
+use std::collections::BTreeMap;
+
+use crate::{Continuation, RegisterId, ResumeSelectArm, ResumeWithValue, SelectArm};
+
+/// An opaque identifier of a select state.
+///
+/// # Invariant: unique per VM
+///
+/// An id value belongs to at most one select over the entire lifetime of
+/// the VM that issued it - including snapshot/restore cycles. The inert
+/// handling of losing select arms rests on exactly this property: a stale
+/// arm entry finding its id absent means its select was already claimed.
+/// A reused id would let such a stale arm claim an unrelated select.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct SelectStateId(pub usize);
+
+/// A handle to an inserted select: the capability to mint its arms'
+/// claims.
+///
+/// Returned by [`SelectStates::insert`] and the only way to create
+/// [`SelectStateClaim`]s - so every planted arm provably refers to a select
+/// that was actually inserted.
+#[derive(Debug, Clone, Copy)]
+pub struct SelectStateHandle {
+    /// The select this handle mints claims for.
+    select_state_id: SelectStateId,
+}
+
+impl SelectStateHandle {
+    /// Create a claim through an arm of this select, delivering to the
+    /// `dst` register and resuming from the `resume` state.
+    pub fn arm<StateId>(&self, dst: RegisterId, resume: StateId) -> SelectStateClaim<StateId> {
+        SelectStateClaim {
+            select_state_id: self.select_state_id,
+            arm: SelectArm::new(dst, resume),
+        }
+    }
+}
+
+/// A select's claim to a promise's settlement, planted as one arm of
+/// the select.
+///
+/// Opaque: only mintable through a [`SelectStateHandle`], and only consumed by
+/// the settlement paths claiming the select.
+#[derive(Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct SelectStateClaim<StateId> {
+    /// The select this arm belongs to.
+    select_state_id: SelectStateId,
+
+    /// The arm's delivery target.
+    arm: SelectArm<StateId>,
+}
+
+/// The select continuations of a runtime, keyed by their select state ids.
+///
+/// A select continuation is inserted when its frame waits on multiple
+/// promises at once, and claimed - exactly once - by the first of its arms
+/// to settle.
+#[derive(Debug)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(bound(
+        serialize = "FunctionId: serde::Serialize, StateId: serde::Serialize, Value: serde::Serialize",
+        deserialize = "FunctionId: serde::Deserialize<'de>, StateId: serde::Deserialize<'de>, Value: serde::Deserialize<'de>",
+    ))
+)]
+pub struct SelectStates<FunctionId, StateId, Value> {
+    /// The id to assign to the next select state.
+    ///
+    /// Monotonically increasing and never rewound - upholding the
+    /// unique-per-VM invariant documented on [`SelectStateId`].
+    next_select_state_id: usize,
+
+    /// The select continuations by their ids.
+    //
+    // A `BTreeMap` keeps the serialized snapshot form deterministic.
+    continuations:
+        BTreeMap<SelectStateId, Continuation<FunctionId, StateId, Value, ResumeSelectArm>>,
+}
+
+impl<FunctionId, StateId, Value> Default for SelectStates<FunctionId, StateId, Value> {
+    fn default() -> Self {
+        Self {
+            next_select_state_id: 0,
+            continuations: BTreeMap::new(),
+        }
+    }
+}
+
+impl<FunctionId, StateId, Value> SelectStates<FunctionId, StateId, Value> {
+    /// Create a new empty select states collection.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Insert a select continuation, returning the handle that mints its
+    /// arms.
+    pub fn insert(
+        &mut self,
+        continuation: Continuation<FunctionId, StateId, Value, ResumeSelectArm>,
+    ) -> SelectStateHandle {
+        let select_state_id = SelectStateId(self.next_select_state_id);
+        self.next_select_state_id += 1;
+
+        self.continuations.insert(select_state_id, continuation);
+
+        SelectStateHandle { select_state_id }
+    }
+
+    /// Claim the select through the given arm's claim, producing the
+    /// continuation resumable through that arm.
+    ///
+    /// Returns `None` if the select has already been claimed - the normal
+    /// fate of every losing select arm.
+    pub(crate) fn claim(
+        &mut self,
+        select_state_claim: SelectStateClaim<StateId>,
+    ) -> Option<Continuation<FunctionId, StateId, Value, ResumeWithValue>> {
+        let SelectStateClaim {
+            select_state_id,
+            arm,
+        } = select_state_claim;
+
+        let continuation = self.continuations.remove(&select_state_id)?;
+        Some(continuation.into_arm(arm))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use waymark_vm_runtime_promise_value::PromiseValue;
+
+    use super::{SelectStateId, SelectStates};
+    use crate::{Continuation, ExceptionHandlers, Frame, FrameKind, Registers};
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    struct TestReadyValue;
+
+    type TestValue = PromiseValue<TestReadyValue>;
+
+    impl waymark_vm_runtime_value::RootValueAccess for TestReadyValue {
+        type RootValue = TestValue;
+    }
+
+    fn select_continuation() -> Continuation<&'static str, usize, TestValue, crate::ResumeSelectArm>
+    {
+        Continuation::capture_select(Frame {
+            func: "example",
+            state: 0,
+            regs: Registers::new(2),
+            exception: None,
+            exception_handler_blocks: ExceptionHandlers::new(),
+            kind: FrameKind::TopLevel,
+        })
+    }
+
+    #[test]
+    fn insert_mints_monotonically_increasing_ids() {
+        let mut select_states = SelectStates::new();
+
+        assert_eq!(
+            select_states.insert(select_continuation()).select_state_id,
+            SelectStateId(0)
+        );
+        assert_eq!(
+            select_states.insert(select_continuation()).select_state_id,
+            SelectStateId(1)
+        );
+    }
+
+    #[test]
+    fn claim_removes_the_select_continuation_exactly_once() {
+        let mut select_states = SelectStates::new();
+        let handle = select_states.insert(select_continuation());
+
+        assert!(
+            select_states
+                .claim(handle.arm(crate::RegisterId(0), 0))
+                .is_some()
+        );
+        assert!(
+            select_states
+                .claim(handle.arm(crate::RegisterId(0), 0))
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn ids_are_not_reused_after_claims() {
+        let mut select_states = SelectStates::new();
+        let first = select_states.insert(select_continuation());
+        select_states
+            .claim(first.arm(crate::RegisterId(0), 0))
+            .expect("first select is inserted");
+
+        assert_eq!(
+            select_states.insert(select_continuation()).select_state_id,
+            SelectStateId(1)
+        );
+    }
+}

--- a/crates/lib/vm-runtime-test/src/lib.rs
+++ b/crates/lib/vm-runtime-test/src/lib.rs
@@ -164,7 +164,9 @@ impl Interpreter for TestInterpreter {
                     .get_mut(promise_state_id)
                     .expect("prepared promise state should exist");
                 *promise_state =
-                    PromiseState::Waiting(vec![Continuation::capture(frame, resume, dst)]);
+                    PromiseState::Waiting(vec![waymark_vm_runtime_core::PromiseWaiter::Await(
+                        Continuation::capture(frame, resume, dst),
+                    )]);
                 Ok(ExecutionOutcome::ExitFrame)
             }
             TestInstruction::EmitRegister(register) => {

--- a/crates/lib/vm-runtime/src/lib.rs
+++ b/crates/lib/vm-runtime/src/lib.rs
@@ -11,7 +11,8 @@ pub mod step;
 use std::collections::VecDeque;
 
 use waymark_vm_runtime_core::{
-    ExceptionHandlers, Frame, FrameKind, PromiseStates, Registers, RuntimeState, SettlePromiseError,
+    ExceptionHandlers, Frame, FrameKind, PromiseStates, Registers, RuntimeState, SelectStates,
+    SettlePromiseError,
 };
 use waymark_vm_runtime_promise_core::PromiseStateId;
 
@@ -112,6 +113,7 @@ where
         let state = RuntimeState {
             ready,
             promise_states: PromiseStates::new(),
+            select_states: SelectStates::new(),
             effect_counter: waymark_vm_runtime_effect::EffectNumber(0),
         };
 


### PR DESCRIPTION
Goes in after #484 

Supersedes #485 

---

This PR adds `select` control flow instruction, enabling us to race promises.

It theoretically weakens the determinism guarantees of the VM runtime, however in practice we have implemented the vm-driver in such a way that the execution is still deterministic with respect to the snapshots history in relation to the promise resolutions; this means that the determinism depends on the order at which the database and rust-side internals produce the promise settlements matters.

This is important for future features like VCR; in essence this means that the level at which we have to record the VCR logs (tapes) is the promise settlements so we can record the exact same effective order those records appear (and preserve the VM runtime run()s / promise settlement batching lock-steps). This shall make the VCR feature capture all non-deterministic behaviors such that it can faithfully reproduce the life of a recorded VM on replay. ~~Todo: verify this statement.~~ In fact, this was an issue with #485, but with `select` it should no longer be an issue.