### PR TITLE
Implement wrapper functions for action calls at vm-compiler-for-ast-old

### DIFF
--- a/crates/lib/vm-compiler-for-ast-old/src/function/compiler.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/function/compiler.rs
@@ -10,6 +10,7 @@ mod env;
 mod error;
 mod r#loop;
 mod suspend;
+mod wrapper_fn;
 
 mod plan {
     //! AST planning helpers that normalize statements and expressions before

--- a/crates/lib/vm-compiler-for-ast-old/src/function/compiler/lowering/value.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/function/compiler/lowering/value.rs
@@ -207,18 +207,40 @@ where
     }
 
     /// Starts an action call into the given promise register.
+    ///
+    /// A policy-annotated call site starts a generated wrapper function
+    /// holding the policy machinery instead of the raw action call; the
+    /// wrapper's call promise takes the action promise's place.
     pub fn compile_action_call_start(
         &mut self,
         call: ActionCallPlanFor<'_, Spec>,
         dst: &Marked<RegisterHandle, PromiseMarker>,
     ) -> Result<(), ErrorFor<Spec, Lowering>> {
-        let (action_ref, kwargs) = call.into_parts();
+        let (action_ref, kwargs, action_name, policies) = call.into_parts();
         let args = compile_expr_registers(
             kwargs,
             |kwarg| &kwarg.value,
             |arg| self.compile_expr(arg, ResultTarget::Allocate),
         )?;
         let arg_registers = args.iter().map(RegisterHandle::register).collect();
+
+        if !policies.is_empty() {
+            let wrapper_function_id = super::wrapper_fn::create(
+                self.context.extra_fns,
+                action_name,
+                action_ref,
+                kwargs.len(),
+                policies,
+            )?;
+
+            self.context
+                .emitter
+                .emit_call(dst.marked(), wrapper_function_id, arg_registers);
+
+            drop(args);
+
+            return Ok(());
+        }
 
         let resume_state = self.reserve_state();
 

--- a/crates/lib/vm-compiler-for-ast-old/src/function/compiler/plan/call.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/function/compiler/plan/call.rs
@@ -1,7 +1,7 @@
 //! Call planning.
 
 use nonempty_collections::{IntoNonEmptyIterator as _, NESlice, NEVec, NonEmptyIterator as _};
-use waymark_vm_ast_old::{ActionCall, Call, Expr, FunctionCall, Kwarg, Spanned};
+use waymark_vm_ast_old::{ActionCall, Call, Expr, FunctionCall, Kwarg, PolicyBracket, Spanned};
 use waymark_vm_bytecode_core::FunctionId;
 use waymark_vm_compiler_for_ast_old_core::lowering;
 
@@ -28,6 +28,12 @@ pub struct ActionCallPlan<'a, ActionRef> {
 
     /// Keyword arguments forwarded to the action.
     kwargs: &'a [Kwarg],
+
+    /// The source action name for wrapper generation and diagnostics.
+    action_name: &'a str,
+
+    /// The policy brackets attached to this call site.
+    policies: &'a [PolicyBracket],
 }
 
 /// A normalized call plan for either a function call or an action call.
@@ -129,12 +135,20 @@ impl<'a, ActionRef> ActionCallPlan<'a, ActionRef> {
         Ok(Self {
             action_ref,
             kwargs: &call.kwargs,
+            action_name: &call.action_name,
+            policies: &call.policies,
         })
     }
 
-    /// Returns the lowered action reference and original keyword arguments.
-    pub fn into_parts(self) -> (ActionRef, &'a [Kwarg]) {
-        (self.action_ref, self.kwargs)
+    /// Returns the lowered action reference, the original keyword arguments,
+    /// the source action name, and the policy brackets of this call site.
+    pub fn into_parts(self) -> (ActionRef, &'a [Kwarg], &'a str, &'a [PolicyBracket]) {
+        (
+            self.action_ref,
+            self.kwargs,
+            self.action_name,
+            self.policies,
+        )
     }
 }
 
@@ -376,10 +390,12 @@ mod tests {
         let call = action_call("notify", Vec::new());
         let planned_call = ActionCallPlan::lower::<TestSpec, TestLowering, ()>(&call)
             .expect("supported action should lower");
-        let (action_ref, kwargs) = planned_call.into_parts();
+        let (action_ref, kwargs, action_name, policies) = planned_call.into_parts();
 
         assert!(matches!(action_ref, TestActionRef(name) if name == "notify"));
         assert!(kwargs.is_empty());
+        assert_eq!(action_name, "notify");
+        assert!(policies.is_empty());
     }
 
     #[test]

--- a/crates/lib/vm-compiler-for-ast-old/src/function/compiler/plan/unsupported.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/function/compiler/plan/unsupported.rs
@@ -47,6 +47,20 @@ pub enum Unsupported {
         count: NonZeroUsize,
     },
 
+    /// A retry policy bracket is not compiled yet.
+    #[error("retry policy on action `{action_name}` is not supported by the compiler yet")]
+    RetryPolicy {
+        /// The action the policy is attached to.
+        action_name: String,
+    },
+
+    /// A timeout policy bracket is not compiled yet.
+    #[error("timeout policy on action `{action_name}` is not supported by the compiler yet")]
+    TimeoutPolicy {
+        /// The action the policy is attached to.
+        action_name: String,
+    },
+
     /// A parallel expression assignment shape cannot be represented directly.
     #[error(
         "parallel expression with {call_count} calls and {target_count} assignment targets is not supported: {reason}"

--- a/crates/lib/vm-compiler-for-ast-old/src/function/compiler/wrapper_fn.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/function/compiler/wrapper_fn.rs
@@ -1,0 +1,209 @@
+//! Ephemeral wrapper-function generation for policy-annotated action calls.
+//!
+//! Policy brackets (retry/timeout) lower inside a dedicated per-call-site
+//! function that wraps the plain action call. Every call site - sequential
+//! or fan-out - then invokes the wrapper through an ordinary function call,
+//! so the policy machinery has exactly one lowering path and the wrapper
+//! frame owns the argument registers for the whole policy lifetime.
+
+use waymark_vm_bytecode_core::FunctionId;
+
+use crate::Marked;
+use crate::function::extras::ExtraFunctions;
+
+use super::Error;
+use super::bytecode::emitter::FunctionEmitter;
+use super::env::LocalFrame;
+use super::plan::Unsupported;
+
+/// Generates the wrapper function for one policy-annotated action call site
+/// and returns its id.
+///
+/// The wrapper takes the action's keyword arguments as positional inputs in
+/// call-site order and forwards them to the wrapped action.
+pub fn create<Spec, LiteralLoweringError, ActionLoweringError>(
+    extra_fns: &mut ExtraFunctions<Spec>,
+    action_name: &str,
+    action_ref: <Spec as waymark_vm_instructions_extcallset::Spec>::ActionRef,
+    kwarg_count: usize,
+    policies: &[waymark_vm_ast_old::PolicyBracket],
+) -> Result<FunctionId, Error<LiteralLoweringError, ActionLoweringError>>
+where
+    Spec: waymark_vm_compiler_for_ast_old_core::SpecRequirements,
+{
+    if let Some(policy) = policies.first() {
+        return Err(match policy {
+            waymark_vm_ast_old::PolicyBracket::Retry(_) => Unsupported::RetryPolicy {
+                action_name: action_name.to_owned(),
+            }
+            .into(),
+            waymark_vm_ast_old::PolicyBracket::Timeout(_) => Unsupported::TimeoutPolicy {
+                action_name: action_name.to_owned(),
+            }
+            .into(),
+        });
+    }
+
+    let mut emitter = FunctionEmitter::<Spec>::new();
+    let mut local_frame = LocalFrame::new();
+
+    // Inputs occupy the first registers of the frame in call order.
+    let arg_registers: Vec<_> = (0..kwarg_count)
+        .map(|_| local_frame.allocate_register())
+        .collect();
+
+    let promise_register = Marked::mark(local_frame.allocate_register());
+    let resume_after_call = emitter.reserve_state();
+    emitter.emit_extcall(
+        promise_register,
+        action_ref,
+        arg_registers,
+        resume_after_call,
+    );
+    emitter.switch_to(resume_after_call);
+
+    let result_register = local_frame.allocate_register();
+    let resume_after_await = emitter.reserve_state();
+    emitter.emit_await(result_register, promise_register, resume_after_await);
+    emitter.switch_to(resume_after_await);
+    emitter.emit_return(result_register);
+
+    let function = waymark_vm_bytecode::Function {
+        states: emitter.finish(),
+        num_regs: local_frame.num_registers(),
+    };
+
+    Ok(extra_fns.insert(function))
+}
+
+#[cfg(test)]
+mod tests {
+    use waymark_vm_ast_old::{DurationLiteral, PolicyBracket, RetryPolicy, TimeoutPolicy};
+    use waymark_vm_bytecode_core::{FunctionId, StateId};
+    use waymark_vm_compiler_for_ast_old_test_support::{TestActionRef, TestSpec};
+    use waymark_vm_instructions_coreset::CoreSet;
+    use waymark_vm_instructions_extcallset::ExtCallSet;
+    use waymark_vm_instructions_fullset::FullSet as InstructionSet;
+    use waymark_vm_runtime_core::RegisterId;
+
+    use super::super::{Error, Unsupported};
+    use super::create;
+    use crate::function::extras::ExtraFunctions;
+
+    #[test]
+    fn generates_the_plain_action_wrapper_body() {
+        let mut extra_fns = ExtraFunctions::<TestSpec>::new(3);
+
+        let function_id = create::<_, (), ()>(
+            &mut extra_fns,
+            "notify",
+            TestActionRef("notify".to_owned()),
+            2,
+            &[],
+        )
+        .expect("a wrapper without brackets should compile");
+        assert_eq!(function_id, FunctionId(3));
+
+        let functions = extra_fns.finish();
+        assert_eq!(functions.len(), 1);
+        let function = &functions[0];
+        assert_eq!(function.num_regs, 4);
+
+        let mut start_instructions = function.states[StateId(0)].instructions.iter();
+        assert!(matches!(
+            start_instructions.next(),
+            Some(InstructionSet::ExtCallSet(ExtCallSet::ActionCall {
+                dst,
+                action_ref: TestActionRef(action_ref),
+                args,
+                resume,
+            })) if *dst == RegisterId(2)
+                && action_ref == "notify"
+                && *args == vec![RegisterId(0), RegisterId(1)]
+                && *resume == StateId(1)
+        ));
+        assert!(start_instructions.next().is_none());
+
+        let mut await_instructions = function.states[StateId(1)].instructions.iter();
+        assert!(matches!(
+            await_instructions.next(),
+            Some(InstructionSet::CoreSet(CoreSet::Await { dst, src, resume }))
+                if *dst == RegisterId(3) && *src == RegisterId(2) && *resume == StateId(2)
+        ));
+        assert!(await_instructions.next().is_none());
+
+        let mut return_instructions = function.states[StateId(2)].instructions.iter();
+        assert!(matches!(
+            return_instructions.next(),
+            Some(InstructionSet::CoreSet(CoreSet::Return { src })) if *src == RegisterId(3)
+        ));
+        assert!(return_instructions.next().is_none());
+    }
+
+    #[test]
+    fn assigns_sequential_ids_after_the_source_functions() {
+        let mut extra_fns = ExtraFunctions::<TestSpec>::new(2);
+
+        let first = create::<_, (), ()>(
+            &mut extra_fns,
+            "first",
+            TestActionRef("first".to_owned()),
+            0,
+            &[],
+        )
+        .expect("first wrapper should compile");
+        let second = create::<_, (), ()>(
+            &mut extra_fns,
+            "second",
+            TestActionRef("second".to_owned()),
+            1,
+            &[],
+        )
+        .expect("second wrapper should compile");
+
+        assert_eq!(first, FunctionId(2));
+        assert_eq!(second, FunctionId(3));
+        assert_eq!(extra_fns.finish().len(), 2);
+    }
+
+    #[test]
+    fn rejects_policy_brackets_pending_their_lowering() {
+        let mut extra_fns = ExtraFunctions::<TestSpec>::new(0);
+
+        let retry_error = create::<_, (), ()>(
+            &mut extra_fns,
+            "notify",
+            TestActionRef("notify".to_owned()),
+            0,
+            &[PolicyBracket::Retry(RetryPolicy {
+                exception_types: Vec::new(),
+                max_retries: 2,
+                backoff: None,
+            })],
+        )
+        .expect_err("retry policies should not lower yet");
+        assert!(matches!(
+            retry_error,
+            Error::Unsupported(Unsupported::RetryPolicy { action_name })
+                if action_name == "notify"
+        ));
+
+        let timeout_error = create::<_, (), ()>(
+            &mut extra_fns,
+            "notify",
+            TestActionRef("notify".to_owned()),
+            0,
+            &[PolicyBracket::Timeout(TimeoutPolicy {
+                timeout: DurationLiteral { seconds: 30 },
+            })],
+        )
+        .expect_err("timeout policies should not lower yet");
+        assert!(matches!(
+            timeout_error,
+            Error::Unsupported(Unsupported::TimeoutPolicy { action_name })
+                if action_name == "notify"
+        ));
+
+        assert!(extra_fns.finish().is_empty());
+    }
+}

--- a/crates/lib/vm-compiler-for-ast-old/src/tests/mod.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/tests/mod.rs
@@ -12,6 +12,7 @@ mod function_table;
 mod loops;
 mod lowering_errors;
 mod parallel;
+mod policies;
 mod spreads;
 mod variables;
 

--- a/crates/lib/vm-compiler-for-ast-old/src/tests/policies.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/tests/policies.rs
@@ -1,0 +1,71 @@
+//! Tests for policy brackets on action calls.
+//!
+//! Policy-annotated action calls route through wrapper-function generation;
+//! the brackets themselves are rejected until their lowerings land.
+
+use waymark_vm_ast_old::{
+    DurationLiteral, PolicyBracket, RetryPolicy, Spanned, Statement, TimeoutPolicy,
+};
+use waymark_vm_ast_old_helpers::{action_call, function, program, spanned};
+use waymark_vm_compiler_for_ast_old_test_support::{TestLowering, TestSpec};
+
+use crate::{CompileError, compile, function::compiler};
+
+/// Builds a bare action-call statement carrying the provided policies.
+fn policy_action_stmt(policies: Vec<PolicyBracket>) -> Spanned<Statement> {
+    let mut call = action_call("notify", Vec::new());
+    call.policies = policies;
+    spanned(Statement::ActionCall { call })
+}
+
+#[test]
+fn rejects_retry_policies_pending_their_lowering() {
+    let program = program(vec![function(
+        "main",
+        &[],
+        vec![policy_action_stmt(vec![PolicyBracket::Retry(
+            RetryPolicy {
+                exception_types: Vec::new(),
+                max_retries: 2,
+                backoff: None,
+            },
+        )])],
+    )]);
+
+    let error = match compile::<TestSpec, TestLowering>(&program) {
+        Ok(_) => panic!("retry policies should fail until their lowering lands"),
+        Err(error) => error,
+    };
+
+    assert!(matches!(
+        error,
+        CompileError::FunctionCompiler(compiler::Error::Unsupported(
+            compiler::Unsupported::RetryPolicy { action_name }
+        )) if action_name == "notify"
+    ));
+}
+
+#[test]
+fn rejects_timeout_policies_pending_their_lowering() {
+    let program = program(vec![function(
+        "main",
+        &[],
+        vec![policy_action_stmt(vec![PolicyBracket::Timeout(
+            TimeoutPolicy {
+                timeout: DurationLiteral { seconds: 30 },
+            },
+        )])],
+    )]);
+
+    let error = match compile::<TestSpec, TestLowering>(&program) {
+        Ok(_) => panic!("timeout policies should fail until their lowering lands"),
+        Err(error) => error,
+    };
+
+    assert!(matches!(
+        error,
+        CompileError::FunctionCompiler(compiler::Error::Unsupported(
+            compiler::Unsupported::TimeoutPolicy { action_name }
+        )) if action_name == "notify"
+    ));
+}

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_run_action_spread.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_run_action_spread.py__bytecode.snap
@@ -1,54 +1,11 @@
 ---
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
-expression: bytecode for python/tests/fixtures_gather/gather_run_action_spread.py
+expression: "bytecode for python/tests/fixtures_gather/gather_run_action_spread.py [compilation error]"
 ---
-fn main(input: [items], output: []):
-    results = spread items:item -> @gather_run_action_spread.process_item(item=item) [retry: 2] [timeout: 30s]
-    _return_tmp = @gather_run_action_spread.combine_results(results=results)
-    return _return_tmp
----
-f0: [9 registers]
-  s0:
-    PureSet(MakeList { dst: r2, items: [] })
-    PureSet(MakeList { dst: r3, items: [] })
-    PureSet(LoadConst { dst: r4, value: Int(0) })
-    PureSet(Length { dst: r5, src: r0 })
-    CoreSet(Jump { target_state: s1 })
-  s1:
-    PureSet(Binary { kind: Lt, op: BinaryOp { dst: r6, a: r4, b: r5 } })
-    CoreSet(JumpIf { target_state: s2, cond: r6 })
-    CoreSet(Jump { target_state: s4 })
-  s2:
-    PureSet(Index { dst: r6, object: r0, index: r4 })
-    ExtCallSet(ActionCall { dst: r7, action_ref: TestActionRef("process_item"), args: [r6], resume: s5 })
-  s3:
-    PureSet(LoadConst { dst: r6, value: Int(1) })
-    PureSet(Binary { kind: Add, op: BinaryOp { dst: r4, a: r4, b: r6 } })
-    CoreSet(Jump { target_state: s1 })
-  s4:
-    PureSet(LoadConst { dst: r4, value: Int(0) })
-    CoreSet(Jump { target_state: s6 })
-  s5:
-    PureSet(ListAppend { dst: r3, list: r3, item: r7 })
-    CoreSet(Jump { target_state: s3 })
-  s6:
-    PureSet(Binary { kind: Lt, op: BinaryOp { dst: r6, a: r4, b: r5 } })
-    CoreSet(JumpIf { target_state: s7, cond: r6 })
-    CoreSet(Jump { target_state: s9 })
-  s7:
-    PureSet(Index { dst: r6, object: r3, index: r4 })
-    CoreSet(Await { dst: r6, src: r6, resume: s10 })
-  s8:
-    PureSet(LoadConst { dst: r6, value: Int(1) })
-    PureSet(Binary { kind: Add, op: BinaryOp { dst: r4, a: r4, b: r6 } })
-    CoreSet(Jump { target_state: s6 })
-  s9:
-    PureSet(Copy { dst: r1, src: r2 })
-    ExtCallSet(ActionCall { dst: r8, action_ref: TestActionRef("combine_results"), args: [r1], resume: s11 })
-  s10:
-    PureSet(ListAppend { dst: r2, list: r2, item: r6 })
-    CoreSet(Jump { target_state: s8 })
-  s11:
-    CoreSet(Await { dst: r8, src: r8, resume: s12 })
-  s12:
-    CoreSet(Return { src: r8 })
+FunctionCompiler(
+    Unsupported(
+        RetryPolicy {
+            action_name: "process_item",
+        },
+    ),
+)

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_policy__instance_attr_policies.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_policy__instance_attr_policies.py__bytecode.snap
@@ -1,25 +1,11 @@
 ---
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
-expression: bytecode for python/tests/fixtures_policy/instance_attr_policies.py
+expression: "bytecode for python/tests/fixtures_policy/instance_attr_policies.py [compilation error]"
 ---
-fn main(input: [value], output: []):
-    a = @instance_attr_policies.action_with_instance_retry(value=value) [retry: 2, backoff: 10s]
-    b = @instance_attr_policies.action_with_instance_timeout(value=a) [timeout: 2m]
-    c = @instance_attr_policies.action_with_both_policies(value=b) [retry: 1] [timeout: 2m]
-    return c
----
-f0: [4 registers]
-  s0:
-    ExtCallSet(ActionCall { dst: r1, action_ref: TestActionRef("action_with_instance_retry"), args: [r0], resume: s1 })
-  s1:
-    CoreSet(Await { dst: r1, src: r1, resume: s2 })
-  s2:
-    ExtCallSet(ActionCall { dst: r2, action_ref: TestActionRef("action_with_instance_timeout"), args: [r1], resume: s3 })
-  s3:
-    CoreSet(Await { dst: r2, src: r2, resume: s4 })
-  s4:
-    ExtCallSet(ActionCall { dst: r3, action_ref: TestActionRef("action_with_both_policies"), args: [r2], resume: s5 })
-  s5:
-    CoreSet(Await { dst: r3, src: r3, resume: s6 })
-  s6:
-    CoreSet(Return { src: r3 })
+FunctionCompiler(
+    Unsupported(
+        RetryPolicy {
+            action_name: "action_with_instance_retry",
+        },
+    ),
+)

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_policy__integration_crash_recovery.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_policy__integration_crash_recovery.py__bytecode.snap
@@ -1,31 +1,11 @@
 ---
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
-expression: bytecode for python/tests/fixtures_policy/integration_crash_recovery.py
+expression: "bytecode for python/tests/fixtures_policy/integration_crash_recovery.py [compilation error]"
 ---
-fn main(input: [], output: []):
-    a = @integration_crash_recovery.step_one(value="start") [timeout: 2s]
-    b = @integration_crash_recovery.step_two(value=a) [timeout: 2s]
-    c = @integration_crash_recovery.step_three(value=b) [timeout: 2s]
-    d = @integration_crash_recovery.step_four(value=c) [timeout: 2s]
-    return d
----
-f0: [5 registers]
-  s0:
-    PureSet(LoadConst { dst: r1, value: String("start") })
-    ExtCallSet(ActionCall { dst: r0, action_ref: TestActionRef("step_one"), args: [r1], resume: s1 })
-  s1:
-    CoreSet(Await { dst: r0, src: r0, resume: s2 })
-  s2:
-    ExtCallSet(ActionCall { dst: r2, action_ref: TestActionRef("step_two"), args: [r0], resume: s3 })
-  s3:
-    CoreSet(Await { dst: r2, src: r2, resume: s4 })
-  s4:
-    ExtCallSet(ActionCall { dst: r3, action_ref: TestActionRef("step_three"), args: [r2], resume: s5 })
-  s5:
-    CoreSet(Await { dst: r3, src: r3, resume: s6 })
-  s6:
-    ExtCallSet(ActionCall { dst: r4, action_ref: TestActionRef("step_four"), args: [r3], resume: s7 })
-  s7:
-    CoreSet(Await { dst: r4, src: r4, resume: s8 })
-  s8:
-    CoreSet(Return { src: r4 })
+FunctionCompiler(
+    Unsupported(
+        TimeoutPolicy {
+            action_name: "step_one",
+        },
+    ),
+)

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_policy__integration_exception_custom.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_policy__integration_exception_custom.py__bytecode.snap
@@ -1,35 +1,11 @@
 ---
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
-assertion_line: 113
-expression: bytecode for python/tests/fixtures_policy/integration_exception_custom.py
+expression: "bytecode for python/tests/fixtures_policy/integration_exception_custom.py [compilation error]"
 ---
-fn main(input: [], output: []):
-    try:
-        number = @integration_exception_custom.provide_value()
-        @integration_exception_custom.explode_custom(value=number) [retry: 0]
-    except CustomError:
-        result = @integration_exception_custom.cleanup(label="custom_fallback")
-    return result
----
-f0: [3 registers]
-  s0:
-    CoreSet(PushExceptionHandlers { handlers: [ExceptionHandler { handler_state: s2, exception_types: ["CustomError"], exception_dst: None }] })
-    ExtCallSet(ActionCall { dst: r0, action_ref: TestActionRef("provide_value"), args: [], resume: s3 })
-  s1:
-    CoreSet(Return { src: r2 })
-  s2:
-    PureSet(LoadConst { dst: r1, value: String("custom_fallback") })
-    ExtCallSet(ActionCall { dst: r2, action_ref: TestActionRef("cleanup"), args: [r1], resume: s7 })
-  s3:
-    CoreSet(Await { dst: r0, src: r0, resume: s4 })
-  s4:
-    ExtCallSet(ActionCall { dst: r1, action_ref: TestActionRef("explode_custom"), args: [r0], resume: s5 })
-  s5:
-    CoreSet(Await { dst: r1, src: r1, resume: s6 })
-  s6:
-    CoreSet(PopExceptionHandlers { count: 1 })
-    CoreSet(Jump { target_state: s1 })
-  s7:
-    CoreSet(Await { dst: r2, src: r2, resume: s8 })
-  s8:
-    CoreSet(Jump { target_state: s1 })
+FunctionCompiler(
+    Unsupported(
+        RetryPolicy {
+            action_name: "explode_custom",
+        },
+    ),
+)

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_policy__policy_variations.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_policy__policy_variations.py__bytecode.snap
@@ -1,45 +1,11 @@
 ---
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
-expression: bytecode for python/tests/fixtures_policy/policy_variations.py
+expression: "bytecode for python/tests/fixtures_policy/policy_variations.py [compilation error]"
 ---
-fn main(input: [value], output: []):
-    a = @policy_variations.action_with_timeout_int(value=value) [timeout: 1m]
-    b = @policy_variations.action_with_timeout_minutes(value=a) [timeout: 2m]
-    c = @policy_variations.action_with_retry_backoff(value=b) [retry: 2, backoff: 5s]
-    d = @policy_variations.action_with_retry_exceptions(value=c) [ValueError, KeyError -> retry: 1]
-    d_retry_default = @policy_variations.action_with_retry_default(value=d) [retry: 100]
-    e = @policy_variations.action_with_timeout_hours(value=d_retry_default) [timeout: 1h]
-    f = @policy_variations.action_with_timeout_days(value=e) [timeout: 24h]
-    return f
----
-f0: [8 registers]
-  s0:
-    ExtCallSet(ActionCall { dst: r1, action_ref: TestActionRef("action_with_timeout_int"), args: [r0], resume: s1 })
-  s1:
-    CoreSet(Await { dst: r1, src: r1, resume: s2 })
-  s2:
-    ExtCallSet(ActionCall { dst: r2, action_ref: TestActionRef("action_with_timeout_minutes"), args: [r1], resume: s3 })
-  s3:
-    CoreSet(Await { dst: r2, src: r2, resume: s4 })
-  s4:
-    ExtCallSet(ActionCall { dst: r3, action_ref: TestActionRef("action_with_retry_backoff"), args: [r2], resume: s5 })
-  s5:
-    CoreSet(Await { dst: r3, src: r3, resume: s6 })
-  s6:
-    ExtCallSet(ActionCall { dst: r4, action_ref: TestActionRef("action_with_retry_exceptions"), args: [r3], resume: s7 })
-  s7:
-    CoreSet(Await { dst: r4, src: r4, resume: s8 })
-  s8:
-    ExtCallSet(ActionCall { dst: r5, action_ref: TestActionRef("action_with_retry_default"), args: [r4], resume: s9 })
-  s9:
-    CoreSet(Await { dst: r5, src: r5, resume: s10 })
-  s10:
-    ExtCallSet(ActionCall { dst: r6, action_ref: TestActionRef("action_with_timeout_hours"), args: [r5], resume: s11 })
-  s11:
-    CoreSet(Await { dst: r6, src: r6, resume: s12 })
-  s12:
-    ExtCallSet(ActionCall { dst: r7, action_ref: TestActionRef("action_with_timeout_days"), args: [r6], resume: s13 })
-  s13:
-    CoreSet(Await { dst: r7, src: r7, resume: s14 })
-  s14:
-    CoreSet(Return { src: r7 })
+FunctionCompiler(
+    Unsupported(
+        TimeoutPolicy {
+            action_name: "action_with_timeout_int",
+        },
+    ),
+)


### PR DESCRIPTION
Goes in after #490.

Superseded by a re-split in #490 & #489 

---

This PR introduces "extra functions" that can be added to the executable by the compiler and the machinery for wrapping existing functions; this will be used for implementing retries in the subsequent work.