### PR TITLE
Implement timeouts and retries at the vm compiler side

### DIFF
--- a/crates/lib/vm-compiler-for-ast-old/src/function/compiler.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/function/compiler.rs
@@ -10,6 +10,7 @@ mod env;
 mod error;
 mod r#loop;
 mod suspend;
+mod wrapper_fn;
 
 mod plan {
     //! AST planning helpers that normalize statements and expressions before

--- a/crates/lib/vm-compiler-for-ast-old/src/function/compiler/bytecode/emitter.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/function/compiler/bytecode/emitter.rs
@@ -86,6 +86,23 @@ where
         self.emit(waymark_vm_instructions_pureset::PureSet::MakeDict { dst, entries }.into());
     }
 
+    /// Emits an exception-construction instruction.
+    pub fn emit_make_exception(
+        &mut self,
+        dst: RegisterId,
+        type_id: RegisterId,
+        details: RegisterId,
+    ) {
+        self.emit(
+            waymark_vm_instructions_pureset::PureSet::MakeException {
+                dst,
+                type_id,
+                details,
+            }
+            .into(),
+        );
+    }
+
     /// Emits an indexed-access instruction.
     pub fn emit_index(&mut self, dst: RegisterId, object: RegisterId, index: RegisterId) {
         self.emit(waymark_vm_instructions_pureset::PureSet::Index { dst, object, index }.into());
@@ -183,6 +200,14 @@ where
         );
     }
 
+    /// Emits a select instruction over several promise arms.
+    pub fn emit_select(
+        &mut self,
+        arms: Vec<waymark_vm_instructions_coreset::SelectArm<RegisterId, StateId>>,
+    ) {
+        self.emit(waymark_vm_instructions_coreset::CoreSet::Select { arms }.into());
+    }
+
     /// Emits a push of one exception-handler block.
     pub fn emit_push_exception_handlers(
         &mut self,
@@ -206,6 +231,12 @@ where
     /// Emits an unconditional jump and terminates the current state.
     pub fn emit_jump(&mut self, target_state: StateId) {
         self.emit(waymark_vm_instructions_coreset::CoreSet::Jump { target_state }.into());
+        self.function_states.terminate();
+    }
+
+    /// Emits a raise and terminates the current state.
+    pub fn emit_raise(&mut self, src: RegisterId) {
+        self.emit(waymark_vm_instructions_coreset::CoreSet::Raise { src }.into());
         self.function_states.terminate();
     }
 

--- a/crates/lib/vm-compiler-for-ast-old/src/function/compiler/error.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/function/compiler/error.rs
@@ -50,6 +50,16 @@ pub enum Error<LiteralLoweringError, ActionLoweringError> {
         actual: usize,
     },
 
+    /// A timeout policy duration cannot be represented in bytecode.
+    #[error("timeout duration {seconds}s on action `{action_name}` is out of range")]
+    TimeoutDurationOutOfRange {
+        /// The action the timeout policy is attached to.
+        action_name: String,
+
+        /// The out-of-range duration in seconds.
+        seconds: u64,
+    },
+
     /// Lowering a literal into the target VM constant type failed.
     #[error("literal lowering failed")]
     LiteralLowering(#[source] LiteralLoweringError),

--- a/crates/lib/vm-compiler-for-ast-old/src/function/compiler/error.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/function/compiler/error.rs
@@ -60,6 +60,16 @@ pub enum Error<LiteralLoweringError, ActionLoweringError> {
         seconds: u64,
     },
 
+    /// A retry backoff duration cannot be represented in bytecode.
+    #[error("backoff duration {seconds}s on action `{action_name}` is out of range")]
+    BackoffDurationOutOfRange {
+        /// The action the retry policy is attached to.
+        action_name: String,
+
+        /// The out-of-range duration in seconds.
+        seconds: u64,
+    },
+
     /// Lowering a literal into the target VM constant type failed.
     #[error("literal lowering failed")]
     LiteralLowering(#[source] LiteralLoweringError),

--- a/crates/lib/vm-compiler-for-ast-old/src/function/compiler/lowering/value.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/function/compiler/lowering/value.rs
@@ -207,18 +207,40 @@ where
     }
 
     /// Starts an action call into the given promise register.
+    ///
+    /// A policy-annotated call site starts a generated wrapper function
+    /// holding the policy machinery instead of the raw action call; the
+    /// wrapper's call promise takes the action promise's place.
     pub fn compile_action_call_start(
         &mut self,
         call: ActionCallPlanFor<'_, Spec>,
         dst: &Marked<RegisterHandle, PromiseMarker>,
     ) -> Result<(), ErrorFor<Spec, Lowering>> {
-        let (action_ref, kwargs) = call.into_parts();
+        let (action_ref, kwargs, action_name, policies) = call.into_parts();
         let args = compile_expr_registers(
             kwargs,
             |kwarg| &kwarg.value,
             |arg| self.compile_expr(arg, ResultTarget::Allocate),
         )?;
         let arg_registers = args.iter().map(RegisterHandle::register).collect();
+
+        if !policies.is_empty() {
+            let wrapper_function_id = super::wrapper_fn::create(
+                self.context.extra_fns,
+                action_name,
+                action_ref,
+                kwargs.len(),
+                policies,
+            )?;
+
+            self.context
+                .emitter
+                .emit_call(dst.marked(), wrapper_function_id, arg_registers);
+
+            drop(args);
+
+            return Ok(());
+        }
 
         let resume_state = self.reserve_state();
 

--- a/crates/lib/vm-compiler-for-ast-old/src/function/compiler/lowering/value.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/function/compiler/lowering/value.rs
@@ -225,7 +225,7 @@ where
         let arg_registers = args.iter().map(RegisterHandle::register).collect();
 
         if !policies.is_empty() {
-            let wrapper_function_id = super::wrapper_fn::create(
+            let wrapper_function_id = super::wrapper_fn::create::<Spec, Lowering>(
                 self.context.extra_fns,
                 action_name,
                 action_ref,

--- a/crates/lib/vm-compiler-for-ast-old/src/function/compiler/plan/call.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/function/compiler/plan/call.rs
@@ -1,7 +1,7 @@
 //! Call planning.
 
 use nonempty_collections::{IntoNonEmptyIterator as _, NESlice, NEVec, NonEmptyIterator as _};
-use waymark_vm_ast_old::{ActionCall, Call, Expr, FunctionCall, Kwarg, Spanned};
+use waymark_vm_ast_old::{ActionCall, Call, Expr, FunctionCall, Kwarg, PolicyBracket, Spanned};
 use waymark_vm_bytecode_core::FunctionId;
 use waymark_vm_compiler_for_ast_old_core::lowering;
 
@@ -28,6 +28,12 @@ pub struct ActionCallPlan<'a, ActionRef> {
 
     /// Keyword arguments forwarded to the action.
     kwargs: &'a [Kwarg],
+
+    /// The source action name for wrapper generation and diagnostics.
+    action_name: &'a str,
+
+    /// The policy brackets attached to this call site.
+    policies: &'a [PolicyBracket],
 }
 
 /// A normalized call plan for either a function call or an action call.
@@ -129,12 +135,20 @@ impl<'a, ActionRef> ActionCallPlan<'a, ActionRef> {
         Ok(Self {
             action_ref,
             kwargs: &call.kwargs,
+            action_name: &call.action_name,
+            policies: &call.policies,
         })
     }
 
-    /// Returns the lowered action reference and original keyword arguments.
-    pub fn into_parts(self) -> (ActionRef, &'a [Kwarg]) {
-        (self.action_ref, self.kwargs)
+    /// Returns the lowered action reference, the original keyword arguments,
+    /// the source action name, and the policy brackets of this call site.
+    pub fn into_parts(self) -> (ActionRef, &'a [Kwarg], &'a str, &'a [PolicyBracket]) {
+        (
+            self.action_ref,
+            self.kwargs,
+            self.action_name,
+            self.policies,
+        )
     }
 }
 
@@ -376,10 +390,12 @@ mod tests {
         let call = action_call("notify", Vec::new());
         let planned_call = ActionCallPlan::lower::<TestSpec, TestLowering, ()>(&call)
             .expect("supported action should lower");
-        let (action_ref, kwargs) = planned_call.into_parts();
+        let (action_ref, kwargs, action_name, policies) = planned_call.into_parts();
 
         assert!(matches!(action_ref, TestActionRef(name) if name == "notify"));
         assert!(kwargs.is_empty());
+        assert_eq!(action_name, "notify");
+        assert!(policies.is_empty());
     }
 
     #[test]

--- a/crates/lib/vm-compiler-for-ast-old/src/function/compiler/plan/unsupported.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/function/compiler/plan/unsupported.rs
@@ -54,13 +54,6 @@ pub enum Unsupported {
         action_name: String,
     },
 
-    /// A timeout policy bracket is not compiled yet.
-    #[error("timeout policy on action `{action_name}` is not supported by the compiler yet")]
-    TimeoutPolicy {
-        /// The action the policy is attached to.
-        action_name: String,
-    },
-
     /// A parallel expression assignment shape cannot be represented directly.
     #[error(
         "parallel expression with {call_count} calls and {target_count} assignment targets is not supported: {reason}"

--- a/crates/lib/vm-compiler-for-ast-old/src/function/compiler/plan/unsupported.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/function/compiler/plan/unsupported.rs
@@ -47,6 +47,20 @@ pub enum Unsupported {
         count: NonZeroUsize,
     },
 
+    /// A retry policy bracket is not compiled yet.
+    #[error("retry policy on action `{action_name}` is not supported by the compiler yet")]
+    RetryPolicy {
+        /// The action the policy is attached to.
+        action_name: String,
+    },
+
+    /// A timeout policy bracket is not compiled yet.
+    #[error("timeout policy on action `{action_name}` is not supported by the compiler yet")]
+    TimeoutPolicy {
+        /// The action the policy is attached to.
+        action_name: String,
+    },
+
     /// A parallel expression assignment shape cannot be represented directly.
     #[error(
         "parallel expression with {call_count} calls and {target_count} assignment targets is not supported: {reason}"

--- a/crates/lib/vm-compiler-for-ast-old/src/function/compiler/plan/unsupported.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/function/compiler/plan/unsupported.rs
@@ -47,13 +47,6 @@ pub enum Unsupported {
         count: NonZeroUsize,
     },
 
-    /// A retry policy bracket is not compiled yet.
-    #[error("retry policy on action `{action_name}` is not supported by the compiler yet")]
-    RetryPolicy {
-        /// The action the policy is attached to.
-        action_name: String,
-    },
-
     /// A parallel expression assignment shape cannot be represented directly.
     #[error(
         "parallel expression with {call_count} calls and {target_count} assignment targets is not supported: {reason}"

--- a/crates/lib/vm-compiler-for-ast-old/src/function/compiler/wrapper_fn.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/function/compiler/wrapper_fn.rs
@@ -9,6 +9,7 @@
 use waymark_vm_ast_old::Literal;
 use waymark_vm_bytecode_core::FunctionId;
 use waymark_vm_instructions_coreset::SelectArm;
+use waymark_vm_instructions_pureset::BinaryOpKind;
 use waymark_vm_runtime_core::RegisterId;
 
 use crate::Marked;
@@ -16,20 +17,71 @@ use crate::function::extras::ExtraFunctions;
 
 use super::bytecode::emitter::FunctionEmitter;
 use super::env::LocalFrame;
-use super::plan::Unsupported;
 use super::suspend::PromiseMarker;
 use super::{Error, ErrorFor};
 
 /// The exception type id raised when a per-attempt timeout fires.
 const ACTION_TIMEOUT_TYPE_ID: &str = "ActionTimeout";
 
+/// One digested retry bracket.
+struct RetryPlan {
+    /// The exception types this bracket retries; empty retries everything.
+    exception_types: Vec<String>,
+
+    /// The retry budget: extra attempts beyond the first.
+    max_retries: u32,
+
+    /// The fixed backoff to sleep before each retry, in seconds.
+    backoff_seconds: Option<u64>,
+}
+
+impl RetryPlan {
+    /// Digests one retry bracket, normalizing the catch-all filter the same
+    /// way `try`/`except` normalizes `Exception`.
+    fn digest(retry_policy: &waymark_vm_ast_old::RetryPolicy) -> Self {
+        let exception_types = if retry_policy.exception_types == ["Exception"] {
+            Vec::new()
+        } else {
+            retry_policy.exception_types.clone()
+        };
+        let backoff_seconds = retry_policy
+            .backoff
+            .as_ref()
+            .map(|backoff| backoff.seconds)
+            .filter(|&seconds| seconds != 0);
+
+        Self {
+            exception_types,
+            max_retries: retry_policy.max_retries,
+            backoff_seconds,
+        }
+    }
+
+    /// Returns whether this bracket statically retries the compiled-in
+    /// `ActionTimeout` exception.
+    ///
+    /// The catch-all filter deliberately does not: with no cancellation the
+    /// timed-out attempt may still be running, so retrying timeouts requires
+    /// an explicit opt-in - matching the legacy runner semantics.
+    fn retries_timeouts(&self) -> bool {
+        self.exception_types
+            .iter()
+            .any(|exception_type| exception_type == ACTION_TIMEOUT_TYPE_ID)
+    }
+}
+
 /// Generates the wrapper function for one policy-annotated action call site
 /// and returns its id.
 ///
 /// The wrapper takes the action's keyword arguments as positional inputs in
-/// call-site order and forwards them to the wrapped action. All timeout
-/// brackets collapse into one per-attempt duration by minimum over nonzero
-/// seconds; zero-second brackets are ignored.
+/// call-site order and forwards them to the wrapped action.
+///
+/// The policy brackets are an order-insensitive flat bag with the legacy
+/// runner semantics: all timeout brackets collapse into one per-attempt
+/// duration by minimum over nonzero seconds (zero-second brackets are
+/// ignored), and retry brackets aggregate by matching the raised exception
+/// against each bracket in descending `max_retries` order against a shared
+/// attempt counter.
 pub fn create<Spec, Lowering>(
     extra_fns: &mut ExtraFunctions<Spec>,
     action_name: &str,
@@ -42,13 +94,11 @@ where
     Lowering: waymark_vm_compiler_for_ast_old_core::lowering::FullSet<Spec>,
 {
     let mut timeout_seconds: Option<u64> = None;
+    let mut retry_plans: Vec<RetryPlan> = Vec::new();
     for policy in policies {
         match policy {
-            waymark_vm_ast_old::PolicyBracket::Retry(_) => {
-                return Err(Unsupported::RetryPolicy {
-                    action_name: action_name.to_owned(),
-                }
-                .into());
+            waymark_vm_ast_old::PolicyBracket::Retry(retry_policy) => {
+                retry_plans.push(RetryPlan::digest(retry_policy));
             }
             waymark_vm_ast_old::PolicyBracket::Timeout(timeout_policy) => {
                 let seconds = timeout_policy.timeout.seconds;
@@ -62,6 +112,9 @@ where
             }
         }
     }
+    // Descending budgets with first-match-wins handler dispatch reproduce
+    // the legacy max-of-matching-brackets aggregation.
+    retry_plans.sort_by_key(|retry_plan| core::cmp::Reverse(retry_plan.max_retries));
 
     let mut emitter = FunctionEmitter::<Spec>::new();
     let mut local_frame = LocalFrame::new();
@@ -71,25 +124,37 @@ where
         .map(|_| local_frame.allocate_register())
         .collect();
 
-    let promise_register = Marked::mark(local_frame.allocate_register());
-    let resume_after_call = emitter.reserve_state();
-    emitter.emit_extcall(
-        promise_register,
-        action_ref,
-        arg_registers,
-        resume_after_call,
-    );
-    emitter.switch_to(resume_after_call);
+    if retry_plans.is_empty() {
+        let promise_register = Marked::mark(local_frame.allocate_register());
+        let resume_after_call = emitter.reserve_state();
+        emitter.emit_extcall(
+            promise_register,
+            action_ref,
+            arg_registers,
+            resume_after_call,
+        );
+        emitter.switch_to(resume_after_call);
 
-    match timeout_seconds {
-        None => emit_plain_tail(&mut emitter, &mut local_frame, promise_register),
-        Some(seconds) => emit_timed_tail::<Spec, Lowering>(
+        match timeout_seconds {
+            None => emit_plain_tail(&mut emitter, &mut local_frame, promise_register),
+            Some(seconds) => emit_timed_tail::<Spec, Lowering>(
+                &mut emitter,
+                &mut local_frame,
+                promise_register,
+                action_name,
+                seconds,
+            )?,
+        }
+    } else {
+        emit_retry_loop::<Spec, Lowering>(
             &mut emitter,
             &mut local_frame,
-            promise_register,
             action_name,
-            seconds,
-        )?,
+            action_ref,
+            arg_registers,
+            timeout_seconds,
+            &retry_plans,
+        )?;
     }
 
     let function = waymark_vm_bytecode::Function {
@@ -165,6 +230,20 @@ where
     emitter.emit_return(result_register);
 
     emitter.switch_to(resume_on_timeout);
+    emit_action_timeout_raise::<Spec, Lowering>(emitter, local_frame)?;
+
+    Ok(())
+}
+
+/// Emits the construction and raise of the `ActionTimeout` exception.
+fn emit_action_timeout_raise<Spec, Lowering>(
+    emitter: &mut FunctionEmitter<Spec>,
+    local_frame: &mut LocalFrame,
+) -> Result<(), ErrorFor<Spec, Lowering>>
+where
+    Spec: waymark_vm_compiler_for_ast_old_core::SpecRequirements,
+    Lowering: waymark_vm_compiler_for_ast_old_core::lowering::FullSet<Spec>,
+{
     let type_id_value =
         Lowering::lower_literal(&Literal::String(ACTION_TIMEOUT_TYPE_ID.to_owned()))
             .map_err(Error::LiteralLowering)?;
@@ -182,19 +261,246 @@ where
     Ok(())
 }
 
+/// Emits the retrying wrapper body: an attempt loop with the retry brackets
+/// as exception handlers around each attempt, and the optional per-attempt
+/// timeout raced inside the protected region.
+///
+/// A shared attempt counter is checked against each bracket's budget at the
+/// bracket's own handler, and each bracket sleeps its own fixed backoff -
+/// outside the protected region, so a failure during backoff propagates
+/// instead of counting as an attempt. The timeout select arm routes at
+/// compile time: into the retry bookkeeping of the first bracket statically
+/// listing `ActionTimeout`, or straight to the raise - after popping the
+/// attempt's handler block, so the routing never re-enters the handlers at
+/// runtime.
+fn emit_retry_loop<Spec, Lowering>(
+    emitter: &mut FunctionEmitter<Spec>,
+    local_frame: &mut LocalFrame,
+    action_name: &str,
+    action_ref: <Spec as waymark_vm_instructions_extcallset::Spec>::ActionRef,
+    arg_registers: Vec<RegisterId>,
+    timeout_seconds: Option<u64>,
+    retry_plans: &[RetryPlan],
+) -> Result<(), ErrorFor<Spec, Lowering>>
+where
+    Spec: waymark_vm_compiler_for_ast_old_core::SpecRequirements,
+    Lowering: waymark_vm_compiler_for_ast_old_core::lowering::FullSet<Spec>,
+{
+    let used_register = local_frame.allocate_register();
+    let one_register = local_frame.allocate_register();
+    let exception_register = local_frame.allocate_register();
+    let promise_register = Marked::mark(local_frame.allocate_register());
+
+    // Attempt counter setup; the counter and the increment constant live
+    // across all attempts.
+    let zero_value = Lowering::lower_literal(&Literal::Int(0)).map_err(Error::LiteralLowering)?;
+    emitter.emit_load_const(used_register, zero_value);
+    let one_value = Lowering::lower_literal(&Literal::Int(1)).map_err(Error::LiteralLowering)?;
+    emitter.emit_load_const(one_register, one_value);
+
+    let attempt_state = emitter.reserve_state();
+    emitter.emit_jump(attempt_state);
+    emitter.switch_to(attempt_state);
+
+    // One handler and one retry-bookkeeping state per bracket.
+    let handler_states: Vec<_> = retry_plans
+        .iter()
+        .map(|_| emitter.reserve_state())
+        .collect();
+    let retry_states: Vec<_> = retry_plans
+        .iter()
+        .map(|_| emitter.reserve_state())
+        .collect();
+
+    let handlers = retry_plans
+        .iter()
+        .zip(handler_states.iter().copied())
+        .map(
+            |(retry_plan, handler_state)| waymark_vm_exception_handler::ExceptionHandler {
+                handler_state,
+                exception_types: retry_plan.exception_types.clone(),
+                exception_dst: Some(exception_register),
+            },
+        )
+        .collect();
+    emitter.emit_push_exception_handlers(handlers);
+
+    let resume_after_call = emitter.reserve_state();
+    emitter.emit_extcall(
+        promise_register,
+        action_ref,
+        arg_registers,
+        resume_after_call,
+    );
+    emitter.switch_to(resume_after_call);
+
+    let ok_state = emitter.reserve_state();
+    let max_register;
+    let cond_register;
+
+    match timeout_seconds {
+        None => {
+            let result_register = local_frame.allocate_register();
+            max_register = local_frame.allocate_register();
+            cond_register = local_frame.allocate_register();
+
+            emitter.emit_await(result_register, promise_register, ok_state);
+
+            emitter.switch_to(ok_state);
+            emitter.emit_pop_exception_handlers(1);
+            emitter.emit_return(result_register);
+        }
+        Some(seconds) => {
+            let seconds_literal =
+                i64::try_from(seconds).map_err(|_| Error::TimeoutDurationOutOfRange {
+                    action_name: action_name.to_owned(),
+                    seconds,
+                })?;
+            let duration_value = Lowering::lower_literal(&Literal::Int(seconds_literal))
+                .map_err(Error::LiteralLowering)?;
+            let duration_register = local_frame.allocate_register();
+            emitter.emit_load_const(duration_register, duration_value);
+
+            let sleep_register = Marked::mark(local_frame.allocate_register());
+            let resume_after_sleep = emitter.reserve_state();
+            emitter.emit_sleep(sleep_register, duration_register, resume_after_sleep, true);
+            emitter.switch_to(resume_after_sleep);
+
+            let result_register = local_frame.allocate_register();
+            let sleep_result_register = local_frame.allocate_register();
+            max_register = local_frame.allocate_register();
+            cond_register = local_frame.allocate_register();
+            let timeout_state = emitter.reserve_state();
+            emitter.emit_select(vec![
+                SelectArm {
+                    src: *promise_register,
+                    dst: result_register,
+                    resume: ok_state,
+                },
+                SelectArm {
+                    src: *sleep_register,
+                    dst: sleep_result_register,
+                    resume: timeout_state,
+                },
+            ]);
+
+            emitter.switch_to(ok_state);
+            emitter.emit_pop_exception_handlers(1);
+            emitter.emit_return(result_register);
+
+            // The timeout arm resumed normally, so the attempt's handler
+            // block is still active - pop it first: the compile-time routing
+            // below must never be caught by the attempt's own handlers.
+            emitter.switch_to(timeout_state);
+            emitter.emit_pop_exception_handlers(1);
+            let routed_retry = retry_plans.iter().position(RetryPlan::retries_timeouts);
+            match routed_retry {
+                Some(position) => {
+                    let max_value = Lowering::lower_literal(&Literal::Int(i64::from(
+                        retry_plans[position].max_retries,
+                    )))
+                    .map_err(Error::LiteralLowering)?;
+                    emitter.emit_load_const(max_register, max_value);
+                    emitter.emit_binary(
+                        BinaryOpKind::Lt,
+                        cond_register,
+                        used_register,
+                        max_register,
+                    );
+                    emitter.emit_jump_if(retry_states[position], cond_register);
+                    emit_action_timeout_raise::<Spec, Lowering>(emitter, local_frame)?;
+                }
+                None => {
+                    emit_action_timeout_raise::<Spec, Lowering>(emitter, local_frame)?;
+                }
+            }
+        }
+    }
+
+    // Per-bracket handlers: check the shared counter against this bracket's
+    // budget; retry or re-raise the caught exception on exhaustion. The
+    // handler block was already popped by the raise transfer.
+    let mut backoff_registers: Option<(RegisterId, Marked<RegisterId, PromiseMarker>, RegisterId)> =
+        None;
+    for (retry_plan, (handler_state, retry_state)) in retry_plans
+        .iter()
+        .zip(handler_states.into_iter().zip(retry_states))
+    {
+        emitter.switch_to(handler_state);
+        let max_value = Lowering::lower_literal(&Literal::Int(i64::from(retry_plan.max_retries)))
+            .map_err(Error::LiteralLowering)?;
+        emitter.emit_load_const(max_register, max_value);
+        emitter.emit_binary(BinaryOpKind::Lt, cond_register, used_register, max_register);
+        emitter.emit_jump_if(retry_state, cond_register);
+        emitter.emit_raise(exception_register);
+
+        emitter.switch_to(retry_state);
+        emitter.emit_binary(
+            BinaryOpKind::Add,
+            used_register,
+            used_register,
+            one_register,
+        );
+        if let Some(seconds) = retry_plan.backoff_seconds {
+            let seconds_literal =
+                i64::try_from(seconds).map_err(|_| Error::BackoffDurationOutOfRange {
+                    action_name: action_name.to_owned(),
+                    seconds,
+                })?;
+            let backoff_value = Lowering::lower_literal(&Literal::Int(seconds_literal))
+                .map_err(Error::LiteralLowering)?;
+            let (backoff_duration, backoff_promise, backoff_result) = *backoff_registers
+                .get_or_insert_with(|| {
+                    (
+                        local_frame.allocate_register(),
+                        Marked::mark(local_frame.allocate_register()),
+                        local_frame.allocate_register(),
+                    )
+                });
+            emitter.emit_load_const(backoff_duration, backoff_value);
+            let resume_after_backoff = emitter.reserve_state();
+            emitter.emit_sleep(
+                backoff_promise,
+                backoff_duration,
+                resume_after_backoff,
+                false,
+            );
+            emitter.switch_to(resume_after_backoff);
+            let resume_after_backoff_await = emitter.reserve_state();
+            emitter.emit_await(backoff_result, backoff_promise, resume_after_backoff_await);
+            emitter.switch_to(resume_after_backoff_await);
+        }
+        emitter.emit_jump(attempt_state);
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use waymark_vm_ast_old::{DurationLiteral, PolicyBracket, RetryPolicy, TimeoutPolicy};
     use waymark_vm_bytecode_core::FunctionId;
     use waymark_vm_compiler_for_ast_old_test_support::{TestActionRef, TestLowering, TestSpec};
 
-    use super::super::{Error, Unsupported};
+    use super::super::Error;
     use super::create;
     use crate::function::extras::ExtraFunctions;
 
     fn timeout_policy(seconds: u64) -> PolicyBracket {
         PolicyBracket::Timeout(TimeoutPolicy {
             timeout: DurationLiteral { seconds },
+        })
+    }
+
+    fn retry_policy(
+        max_retries: u32,
+        exception_types: Vec<&str>,
+        backoff_seconds: Option<u64>,
+    ) -> PolicyBracket {
+        PolicyBracket::Retry(RetryPolicy {
+            exception_types: exception_types.into_iter().map(ToOwned::to_owned).collect(),
+            max_retries,
+            backoff: backoff_seconds.map(|seconds| DurationLiteral { seconds }),
         })
     }
 
@@ -284,6 +590,226 @@ mod tests {
     }
 
     #[test]
+    fn generates_the_retrying_wrapper_body() {
+        insta::assert_snapshot!(
+            display_wrapper(1, &[retry_policy(2, Vec::new(), None)]),
+            @r#"
+        s0:
+          PureSet(LoadConst { dst: r1, value: Int(0) })
+          PureSet(LoadConst { dst: r2, value: Int(1) })
+          CoreSet(Jump { target_state: s1 })
+        s1:
+          CoreSet(PushExceptionHandlers { handlers: [ExceptionHandler { handler_state: s2, exception_types: [], exception_dst: Some(r3) }] })
+          ExtCallSet(ActionCall { dst: r4, action_ref: TestActionRef("notify"), args: [r0], resume: s4 })
+        s2:
+          PureSet(LoadConst { dst: r6, value: Int(2) })
+          PureSet(Binary { kind: Lt, op: BinaryOp { dst: r7, a: r1, b: r6 } })
+          CoreSet(JumpIf { target_state: s3, cond: r7 })
+          CoreSet(Raise { src: r3 })
+        s3:
+          PureSet(Binary { kind: Add, op: BinaryOp { dst: r1, a: r1, b: r2 } })
+          CoreSet(Jump { target_state: s1 })
+        s4:
+          CoreSet(Await { dst: r5, src: r4, resume: s5 })
+        s5:
+          CoreSet(PopExceptionHandlers { count: 1 })
+          CoreSet(Return { src: r5 })
+        "#
+        );
+    }
+
+    #[test]
+    fn retries_sleep_their_backoff_between_attempts() {
+        insta::assert_snapshot!(
+            display_wrapper(0, &[retry_policy(2, Vec::new(), Some(5))]),
+            @r#"
+        s0:
+          PureSet(LoadConst { dst: r0, value: Int(0) })
+          PureSet(LoadConst { dst: r1, value: Int(1) })
+          CoreSet(Jump { target_state: s1 })
+        s1:
+          CoreSet(PushExceptionHandlers { handlers: [ExceptionHandler { handler_state: s2, exception_types: [], exception_dst: Some(r2) }] })
+          ExtCallSet(ActionCall { dst: r3, action_ref: TestActionRef("notify"), args: [], resume: s4 })
+        s2:
+          PureSet(LoadConst { dst: r5, value: Int(2) })
+          PureSet(Binary { kind: Lt, op: BinaryOp { dst: r6, a: r0, b: r5 } })
+          CoreSet(JumpIf { target_state: s3, cond: r6 })
+          CoreSet(Raise { src: r2 })
+        s3:
+          PureSet(Binary { kind: Add, op: BinaryOp { dst: r0, a: r0, b: r1 } })
+          PureSet(LoadConst { dst: r7, value: Int(5) })
+          ExtCallSet(Sleep { dst: r8, duration: r7, resume: s6, unskippable: false })
+        s4:
+          CoreSet(Await { dst: r4, src: r3, resume: s5 })
+        s5:
+          CoreSet(PopExceptionHandlers { count: 1 })
+          CoreSet(Return { src: r4 })
+        s6:
+          CoreSet(Await { dst: r9, src: r8, resume: s7 })
+        s7:
+          CoreSet(Jump { target_state: s1 })
+        "#
+        );
+    }
+
+    #[test]
+    fn orders_brackets_by_descending_budget_with_first_match_dispatch() {
+        insta::assert_snapshot!(
+            display_wrapper(
+                0,
+                &[
+                    retry_policy(1, vec!["ValueError"], None),
+                    retry_policy(3, Vec::new(), None),
+                ],
+            ),
+            @r#"
+        s0:
+          PureSet(LoadConst { dst: r0, value: Int(0) })
+          PureSet(LoadConst { dst: r1, value: Int(1) })
+          CoreSet(Jump { target_state: s1 })
+        s1:
+          CoreSet(PushExceptionHandlers { handlers: [ExceptionHandler { handler_state: s2, exception_types: [], exception_dst: Some(r2) }, ExceptionHandler { handler_state: s3, exception_types: ["ValueError"], exception_dst: Some(r2) }] })
+          ExtCallSet(ActionCall { dst: r3, action_ref: TestActionRef("notify"), args: [], resume: s6 })
+        s2:
+          PureSet(LoadConst { dst: r5, value: Int(3) })
+          PureSet(Binary { kind: Lt, op: BinaryOp { dst: r6, a: r0, b: r5 } })
+          CoreSet(JumpIf { target_state: s4, cond: r6 })
+          CoreSet(Raise { src: r2 })
+        s3:
+          PureSet(LoadConst { dst: r5, value: Int(1) })
+          PureSet(Binary { kind: Lt, op: BinaryOp { dst: r6, a: r0, b: r5 } })
+          CoreSet(JumpIf { target_state: s5, cond: r6 })
+          CoreSet(Raise { src: r2 })
+        s4:
+          PureSet(Binary { kind: Add, op: BinaryOp { dst: r0, a: r0, b: r1 } })
+          CoreSet(Jump { target_state: s1 })
+        s5:
+          PureSet(Binary { kind: Add, op: BinaryOp { dst: r0, a: r0, b: r1 } })
+          CoreSet(Jump { target_state: s1 })
+        s6:
+          CoreSet(Await { dst: r4, src: r3, resume: s7 })
+        s7:
+          CoreSet(PopExceptionHandlers { count: 1 })
+          CoreSet(Return { src: r4 })
+        "#
+        );
+    }
+
+    #[test]
+    fn normalizes_the_exception_catch_all_like_try_except() {
+        insta::assert_snapshot!(
+            display_wrapper(0, &[retry_policy(1, vec!["Exception"], None)]),
+            @r#"
+        s0:
+          PureSet(LoadConst { dst: r0, value: Int(0) })
+          PureSet(LoadConst { dst: r1, value: Int(1) })
+          CoreSet(Jump { target_state: s1 })
+        s1:
+          CoreSet(PushExceptionHandlers { handlers: [ExceptionHandler { handler_state: s2, exception_types: [], exception_dst: Some(r2) }] })
+          ExtCallSet(ActionCall { dst: r3, action_ref: TestActionRef("notify"), args: [], resume: s4 })
+        s2:
+          PureSet(LoadConst { dst: r5, value: Int(1) })
+          PureSet(Binary { kind: Lt, op: BinaryOp { dst: r6, a: r0, b: r5 } })
+          CoreSet(JumpIf { target_state: s3, cond: r6 })
+          CoreSet(Raise { src: r2 })
+        s3:
+          PureSet(Binary { kind: Add, op: BinaryOp { dst: r0, a: r0, b: r1 } })
+          CoreSet(Jump { target_state: s1 })
+        s4:
+          CoreSet(Await { dst: r4, src: r3, resume: s5 })
+        s5:
+          CoreSet(PopExceptionHandlers { count: 1 })
+          CoreSet(Return { src: r4 })
+        "#
+        );
+    }
+
+    #[test]
+    fn does_not_route_timeouts_into_catch_all_retries() {
+        insta::assert_snapshot!(
+            display_wrapper(0, &[retry_policy(2, Vec::new(), None), timeout_policy(30)]),
+            @r#"
+        s0:
+          PureSet(LoadConst { dst: r0, value: Int(0) })
+          PureSet(LoadConst { dst: r1, value: Int(1) })
+          CoreSet(Jump { target_state: s1 })
+        s1:
+          CoreSet(PushExceptionHandlers { handlers: [ExceptionHandler { handler_state: s2, exception_types: [], exception_dst: Some(r2) }] })
+          ExtCallSet(ActionCall { dst: r3, action_ref: TestActionRef("notify"), args: [], resume: s4 })
+        s2:
+          PureSet(LoadConst { dst: r8, value: Int(2) })
+          PureSet(Binary { kind: Lt, op: BinaryOp { dst: r9, a: r0, b: r8 } })
+          CoreSet(JumpIf { target_state: s3, cond: r9 })
+          CoreSet(Raise { src: r2 })
+        s3:
+          PureSet(Binary { kind: Add, op: BinaryOp { dst: r0, a: r0, b: r1 } })
+          CoreSet(Jump { target_state: s1 })
+        s4:
+          PureSet(LoadConst { dst: r4, value: Int(30) })
+          ExtCallSet(Sleep { dst: r5, duration: r4, resume: s6, unskippable: true })
+        s5:
+          CoreSet(PopExceptionHandlers { count: 1 })
+          CoreSet(Return { src: r6 })
+        s6:
+          CoreSet(Select { arms: [SelectArm { src: r3, dst: r6, resume: s5 }, SelectArm { src: r5, dst: r7, resume: s7 }] })
+        s7:
+          CoreSet(PopExceptionHandlers { count: 1 })
+          PureSet(LoadConst { dst: r10, value: String("ActionTimeout") })
+          PureSet(LoadConst { dst: r11, value: None })
+          PureSet(MakeException { dst: r12, type_id: r10, details: r11 })
+          CoreSet(Raise { src: r12 })
+        "#
+        );
+    }
+
+    #[test]
+    fn routes_timeouts_into_retries_on_explicit_opt_in() {
+        insta::assert_snapshot!(
+            display_wrapper(
+                0,
+                &[
+                    retry_policy(2, vec!["ActionTimeout"], None),
+                    timeout_policy(30),
+                ],
+            ),
+            @r#"
+        s0:
+          PureSet(LoadConst { dst: r0, value: Int(0) })
+          PureSet(LoadConst { dst: r1, value: Int(1) })
+          CoreSet(Jump { target_state: s1 })
+        s1:
+          CoreSet(PushExceptionHandlers { handlers: [ExceptionHandler { handler_state: s2, exception_types: ["ActionTimeout"], exception_dst: Some(r2) }] })
+          ExtCallSet(ActionCall { dst: r3, action_ref: TestActionRef("notify"), args: [], resume: s4 })
+        s2:
+          PureSet(LoadConst { dst: r8, value: Int(2) })
+          PureSet(Binary { kind: Lt, op: BinaryOp { dst: r9, a: r0, b: r8 } })
+          CoreSet(JumpIf { target_state: s3, cond: r9 })
+          CoreSet(Raise { src: r2 })
+        s3:
+          PureSet(Binary { kind: Add, op: BinaryOp { dst: r0, a: r0, b: r1 } })
+          CoreSet(Jump { target_state: s1 })
+        s4:
+          PureSet(LoadConst { dst: r4, value: Int(30) })
+          ExtCallSet(Sleep { dst: r5, duration: r4, resume: s6, unskippable: true })
+        s5:
+          CoreSet(PopExceptionHandlers { count: 1 })
+          CoreSet(Return { src: r6 })
+        s6:
+          CoreSet(Select { arms: [SelectArm { src: r3, dst: r6, resume: s5 }, SelectArm { src: r5, dst: r7, resume: s7 }] })
+        s7:
+          CoreSet(PopExceptionHandlers { count: 1 })
+          PureSet(LoadConst { dst: r8, value: Int(2) })
+          PureSet(Binary { kind: Lt, op: BinaryOp { dst: r9, a: r0, b: r8 } })
+          CoreSet(JumpIf { target_state: s3, cond: r9 })
+          PureSet(LoadConst { dst: r10, value: String("ActionTimeout") })
+          PureSet(LoadConst { dst: r11, value: None })
+          PureSet(MakeException { dst: r12, type_id: r10, details: r11 })
+          CoreSet(Raise { src: r12 })
+        "#
+        );
+    }
+
+    #[test]
     fn assigns_sequential_ids_after_the_source_functions() {
         let mut extra_fns = ExtraFunctions::<TestSpec>::new(2);
 
@@ -310,49 +836,21 @@ mod tests {
     }
 
     #[test]
-    fn rejects_retry_policies_pending_their_lowering() {
+    fn rejects_out_of_range_backoff_durations() {
         let mut extra_fns = ExtraFunctions::<TestSpec>::new(0);
 
-        let retry_error = create::<TestSpec, TestLowering>(
+        let error = create::<TestSpec, TestLowering>(
             &mut extra_fns,
             "notify",
             TestActionRef("notify".to_owned()),
             0,
-            &[PolicyBracket::Retry(RetryPolicy {
-                exception_types: Vec::new(),
-                max_retries: 2,
-                backoff: None,
-            })],
+            &[retry_policy(1, Vec::new(), Some(u64::MAX))],
         )
-        .expect_err("retry policies should not lower yet");
+        .expect_err("an unrepresentable backoff should fail");
         assert!(matches!(
-            retry_error,
-            Error::Unsupported(Unsupported::RetryPolicy { action_name })
-                if action_name == "notify"
+            error,
+            Error::BackoffDurationOutOfRange { action_name, seconds }
+                if action_name == "notify" && seconds == u64::MAX
         ));
-
-        // A retry bracket rejects even when combined with timeout brackets.
-        let mixed_error = create::<TestSpec, TestLowering>(
-            &mut extra_fns,
-            "notify",
-            TestActionRef("notify".to_owned()),
-            0,
-            &[
-                timeout_policy(30),
-                PolicyBracket::Retry(RetryPolicy {
-                    exception_types: Vec::new(),
-                    max_retries: 2,
-                    backoff: None,
-                }),
-            ],
-        )
-        .expect_err("mixed retry policies should not lower yet");
-        assert!(matches!(
-            mixed_error,
-            Error::Unsupported(Unsupported::RetryPolicy { action_name })
-                if action_name == "notify"
-        ));
-
-        assert!(extra_fns.finish().is_empty());
     }
 }

--- a/crates/lib/vm-compiler-for-ast-old/src/function/compiler/wrapper_fn.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/function/compiler/wrapper_fn.rs
@@ -6,42 +6,61 @@
 //! so the policy machinery has exactly one lowering path and the wrapper
 //! frame owns the argument registers for the whole policy lifetime.
 
+use waymark_vm_ast_old::Literal;
 use waymark_vm_bytecode_core::FunctionId;
+use waymark_vm_instructions_coreset::SelectArm;
+use waymark_vm_runtime_core::RegisterId;
 
 use crate::Marked;
 use crate::function::extras::ExtraFunctions;
 
-use super::Error;
 use super::bytecode::emitter::FunctionEmitter;
 use super::env::LocalFrame;
 use super::plan::Unsupported;
+use super::suspend::PromiseMarker;
+use super::{Error, ErrorFor};
+
+/// The exception type id raised when a per-attempt timeout fires.
+const ACTION_TIMEOUT_TYPE_ID: &str = "ActionTimeout";
 
 /// Generates the wrapper function for one policy-annotated action call site
 /// and returns its id.
 ///
 /// The wrapper takes the action's keyword arguments as positional inputs in
-/// call-site order and forwards them to the wrapped action.
-pub fn create<Spec, LiteralLoweringError, ActionLoweringError>(
+/// call-site order and forwards them to the wrapped action. All timeout
+/// brackets collapse into one per-attempt duration by minimum over nonzero
+/// seconds; zero-second brackets are ignored.
+pub fn create<Spec, Lowering>(
     extra_fns: &mut ExtraFunctions<Spec>,
     action_name: &str,
     action_ref: <Spec as waymark_vm_instructions_extcallset::Spec>::ActionRef,
     kwarg_count: usize,
     policies: &[waymark_vm_ast_old::PolicyBracket],
-) -> Result<FunctionId, Error<LiteralLoweringError, ActionLoweringError>>
+) -> Result<FunctionId, ErrorFor<Spec, Lowering>>
 where
     Spec: waymark_vm_compiler_for_ast_old_core::SpecRequirements,
+    Lowering: waymark_vm_compiler_for_ast_old_core::lowering::FullSet<Spec>,
 {
-    if let Some(policy) = policies.first() {
-        return Err(match policy {
-            waymark_vm_ast_old::PolicyBracket::Retry(_) => Unsupported::RetryPolicy {
-                action_name: action_name.to_owned(),
+    let mut timeout_seconds: Option<u64> = None;
+    for policy in policies {
+        match policy {
+            waymark_vm_ast_old::PolicyBracket::Retry(_) => {
+                return Err(Unsupported::RetryPolicy {
+                    action_name: action_name.to_owned(),
+                }
+                .into());
             }
-            .into(),
-            waymark_vm_ast_old::PolicyBracket::Timeout(_) => Unsupported::TimeoutPolicy {
-                action_name: action_name.to_owned(),
+            waymark_vm_ast_old::PolicyBracket::Timeout(timeout_policy) => {
+                let seconds = timeout_policy.timeout.seconds;
+                if seconds == 0 {
+                    continue;
+                }
+                timeout_seconds = Some(match timeout_seconds {
+                    Some(existing) => existing.min(seconds),
+                    None => seconds,
+                });
             }
-            .into(),
-        });
+        }
     }
 
     let mut emitter = FunctionEmitter::<Spec>::new();
@@ -62,11 +81,16 @@ where
     );
     emitter.switch_to(resume_after_call);
 
-    let result_register = local_frame.allocate_register();
-    let resume_after_await = emitter.reserve_state();
-    emitter.emit_await(result_register, promise_register, resume_after_await);
-    emitter.switch_to(resume_after_await);
-    emitter.emit_return(result_register);
+    match timeout_seconds {
+        None => emit_plain_tail(&mut emitter, &mut local_frame, promise_register),
+        Some(seconds) => emit_timed_tail::<Spec, Lowering>(
+            &mut emitter,
+            &mut local_frame,
+            promise_register,
+            action_name,
+            seconds,
+        )?,
+    }
 
     let function = waymark_vm_bytecode::Function {
         states: emitter.finish(),
@@ -76,75 +100,194 @@ where
     Ok(extra_fns.insert(function))
 }
 
+/// Emits the plain resolution tail: await the action promise and return its
+/// value.
+fn emit_plain_tail<Spec>(
+    emitter: &mut FunctionEmitter<Spec>,
+    local_frame: &mut LocalFrame,
+    promise_register: Marked<RegisterId, PromiseMarker>,
+) where
+    Spec: waymark_vm_compiler_for_ast_old_core::SpecRequirements,
+{
+    let result_register = local_frame.allocate_register();
+    let resume_after_await = emitter.reserve_state();
+    emitter.emit_await(result_register, promise_register, resume_after_await);
+    emitter.switch_to(resume_after_await);
+    emitter.emit_return(result_register);
+}
+
+/// Emits the timed resolution tail: race the action promise against the
+/// timeout sleep. The action arm returns the action's value; the sleep arm
+/// raises an `ActionTimeout` exception.
+fn emit_timed_tail<Spec, Lowering>(
+    emitter: &mut FunctionEmitter<Spec>,
+    local_frame: &mut LocalFrame,
+    promise_register: Marked<RegisterId, PromiseMarker>,
+    action_name: &str,
+    seconds: u64,
+) -> Result<(), ErrorFor<Spec, Lowering>>
+where
+    Spec: waymark_vm_compiler_for_ast_old_core::SpecRequirements,
+    Lowering: waymark_vm_compiler_for_ast_old_core::lowering::FullSet<Spec>,
+{
+    let seconds_literal = i64::try_from(seconds).map_err(|_| Error::TimeoutDurationOutOfRange {
+        action_name: action_name.to_owned(),
+        seconds,
+    })?;
+    let duration_value =
+        Lowering::lower_literal(&Literal::Int(seconds_literal)).map_err(Error::LiteralLowering)?;
+    let duration_register = local_frame.allocate_register();
+    emitter.emit_load_const(duration_register, duration_value);
+
+    let sleep_register = Marked::mark(local_frame.allocate_register());
+    let resume_after_sleep = emitter.reserve_state();
+    emitter.emit_sleep(sleep_register, duration_register, resume_after_sleep, true);
+    emitter.switch_to(resume_after_sleep);
+
+    let result_register = local_frame.allocate_register();
+    let sleep_result_register = local_frame.allocate_register();
+    let resume_on_action = emitter.reserve_state();
+    let resume_on_timeout = emitter.reserve_state();
+    emitter.emit_select(vec![
+        SelectArm {
+            src: *promise_register,
+            dst: result_register,
+            resume: resume_on_action,
+        },
+        SelectArm {
+            src: *sleep_register,
+            dst: sleep_result_register,
+            resume: resume_on_timeout,
+        },
+    ]);
+
+    emitter.switch_to(resume_on_action);
+    emitter.emit_return(result_register);
+
+    emitter.switch_to(resume_on_timeout);
+    let type_id_value =
+        Lowering::lower_literal(&Literal::String(ACTION_TIMEOUT_TYPE_ID.to_owned()))
+            .map_err(Error::LiteralLowering)?;
+    let type_id_register = local_frame.allocate_register();
+    emitter.emit_load_const(type_id_register, type_id_value);
+
+    let details_value = Lowering::lower_literal(&Literal::None).map_err(Error::LiteralLowering)?;
+    let details_register = local_frame.allocate_register();
+    emitter.emit_load_const(details_register, details_value);
+
+    let exception_register = local_frame.allocate_register();
+    emitter.emit_make_exception(exception_register, type_id_register, details_register);
+    emitter.emit_raise(exception_register);
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use waymark_vm_ast_old::{DurationLiteral, PolicyBracket, RetryPolicy, TimeoutPolicy};
-    use waymark_vm_bytecode_core::{FunctionId, StateId};
-    use waymark_vm_compiler_for_ast_old_test_support::{TestActionRef, TestSpec};
-    use waymark_vm_instructions_coreset::CoreSet;
-    use waymark_vm_instructions_extcallset::ExtCallSet;
-    use waymark_vm_instructions_fullset::FullSet as InstructionSet;
-    use waymark_vm_runtime_core::RegisterId;
+    use waymark_vm_bytecode_core::FunctionId;
+    use waymark_vm_compiler_for_ast_old_test_support::{TestActionRef, TestLowering, TestSpec};
 
     use super::super::{Error, Unsupported};
     use super::create;
     use crate::function::extras::ExtraFunctions;
 
-    #[test]
-    fn generates_the_plain_action_wrapper_body() {
-        let mut extra_fns = ExtraFunctions::<TestSpec>::new(3);
+    fn timeout_policy(seconds: u64) -> PolicyBracket {
+        PolicyBracket::Timeout(TimeoutPolicy {
+            timeout: DurationLiteral { seconds },
+        })
+    }
 
-        let function_id = create::<_, (), ()>(
+    /// Generates one wrapper for the policies and renders its bytecode.
+    fn display_wrapper(kwarg_count: usize, policies: &[PolicyBracket]) -> String {
+        let mut extra_fns = ExtraFunctions::<TestSpec>::new(1);
+        create::<TestSpec, TestLowering>(
             &mut extra_fns,
             "notify",
             TestActionRef("notify".to_owned()),
-            2,
-            &[],
+            kwarg_count,
+            policies,
         )
-        .expect("a wrapper without brackets should compile");
-        assert_eq!(function_id, FunctionId(3));
-
+        .expect("the wrapper should compile");
         let functions = extra_fns.finish();
-        assert_eq!(functions.len(), 1);
-        let function = &functions[0];
-        assert_eq!(function.num_regs, 4);
+        waymark_vm_bytecode_fmt::display(&functions[0]).to_string()
+    }
 
-        let mut start_instructions = function.states[StateId(0)].instructions.iter();
-        assert!(matches!(
-            start_instructions.next(),
-            Some(InstructionSet::ExtCallSet(ExtCallSet::ActionCall {
-                dst,
-                action_ref: TestActionRef(action_ref),
-                args,
-                resume,
-            })) if *dst == RegisterId(2)
-                && action_ref == "notify"
-                && *args == vec![RegisterId(0), RegisterId(1)]
-                && *resume == StateId(1)
-        ));
-        assert!(start_instructions.next().is_none());
+    #[test]
+    fn generates_the_plain_action_wrapper_body() {
+        insta::assert_snapshot!(display_wrapper(2, &[]), @r#"
+        s0:
+          ExtCallSet(ActionCall { dst: r2, action_ref: TestActionRef("notify"), args: [r0, r1], resume: s1 })
+        s1:
+          CoreSet(Await { dst: r3, src: r2, resume: s2 })
+        s2:
+          CoreSet(Return { src: r3 })
+        "#);
+    }
 
-        let mut await_instructions = function.states[StateId(1)].instructions.iter();
-        assert!(matches!(
-            await_instructions.next(),
-            Some(InstructionSet::CoreSet(CoreSet::Await { dst, src, resume }))
-                if *dst == RegisterId(3) && *src == RegisterId(2) && *resume == StateId(2)
-        ));
-        assert!(await_instructions.next().is_none());
+    #[test]
+    fn generates_the_timed_action_wrapper_body() {
+        insta::assert_snapshot!(display_wrapper(1, &[timeout_policy(30)]), @r#"
+        s0:
+          ExtCallSet(ActionCall { dst: r1, action_ref: TestActionRef("notify"), args: [r0], resume: s1 })
+        s1:
+          PureSet(LoadConst { dst: r2, value: Int(30) })
+          ExtCallSet(Sleep { dst: r3, duration: r2, resume: s2, unskippable: true })
+        s2:
+          CoreSet(Select { arms: [SelectArm { src: r1, dst: r4, resume: s3 }, SelectArm { src: r3, dst: r5, resume: s4 }] })
+        s3:
+          CoreSet(Return { src: r4 })
+        s4:
+          PureSet(LoadConst { dst: r6, value: String("ActionTimeout") })
+          PureSet(LoadConst { dst: r7, value: None })
+          PureSet(MakeException { dst: r8, type_id: r6, details: r7 })
+          CoreSet(Raise { src: r8 })
+        "#);
+    }
 
-        let mut return_instructions = function.states[StateId(2)].instructions.iter();
-        assert!(matches!(
-            return_instructions.next(),
-            Some(InstructionSet::CoreSet(CoreSet::Return { src })) if *src == RegisterId(3)
-        ));
-        assert!(return_instructions.next().is_none());
+    #[test]
+    fn collapses_multiple_timeouts_to_the_minimum_nonzero() {
+        insta::assert_snapshot!(
+            display_wrapper(
+                0,
+                &[timeout_policy(30), timeout_policy(0), timeout_policy(10)],
+            ),
+            @r#"
+        s0:
+          ExtCallSet(ActionCall { dst: r0, action_ref: TestActionRef("notify"), args: [], resume: s1 })
+        s1:
+          PureSet(LoadConst { dst: r1, value: Int(10) })
+          ExtCallSet(Sleep { dst: r2, duration: r1, resume: s2, unskippable: true })
+        s2:
+          CoreSet(Select { arms: [SelectArm { src: r0, dst: r3, resume: s3 }, SelectArm { src: r2, dst: r4, resume: s4 }] })
+        s3:
+          CoreSet(Return { src: r3 })
+        s4:
+          PureSet(LoadConst { dst: r5, value: String("ActionTimeout") })
+          PureSet(LoadConst { dst: r6, value: None })
+          PureSet(MakeException { dst: r7, type_id: r5, details: r6 })
+          CoreSet(Raise { src: r7 })
+        "#
+        );
+    }
+
+    #[test]
+    fn ignores_zero_second_timeouts_entirely() {
+        insta::assert_snapshot!(display_wrapper(0, &[timeout_policy(0)]), @r#"
+        s0:
+          ExtCallSet(ActionCall { dst: r0, action_ref: TestActionRef("notify"), args: [], resume: s1 })
+        s1:
+          CoreSet(Await { dst: r1, src: r0, resume: s2 })
+        s2:
+          CoreSet(Return { src: r1 })
+        "#);
     }
 
     #[test]
     fn assigns_sequential_ids_after_the_source_functions() {
         let mut extra_fns = ExtraFunctions::<TestSpec>::new(2);
 
-        let first = create::<_, (), ()>(
+        let first = create::<TestSpec, TestLowering>(
             &mut extra_fns,
             "first",
             TestActionRef("first".to_owned()),
@@ -152,7 +295,7 @@ mod tests {
             &[],
         )
         .expect("first wrapper should compile");
-        let second = create::<_, (), ()>(
+        let second = create::<TestSpec, TestLowering>(
             &mut extra_fns,
             "second",
             TestActionRef("second".to_owned()),
@@ -167,10 +310,10 @@ mod tests {
     }
 
     #[test]
-    fn rejects_policy_brackets_pending_their_lowering() {
+    fn rejects_retry_policies_pending_their_lowering() {
         let mut extra_fns = ExtraFunctions::<TestSpec>::new(0);
 
-        let retry_error = create::<_, (), ()>(
+        let retry_error = create::<TestSpec, TestLowering>(
             &mut extra_fns,
             "notify",
             TestActionRef("notify".to_owned()),
@@ -188,19 +331,25 @@ mod tests {
                 if action_name == "notify"
         ));
 
-        let timeout_error = create::<_, (), ()>(
+        // A retry bracket rejects even when combined with timeout brackets.
+        let mixed_error = create::<TestSpec, TestLowering>(
             &mut extra_fns,
             "notify",
             TestActionRef("notify".to_owned()),
             0,
-            &[PolicyBracket::Timeout(TimeoutPolicy {
-                timeout: DurationLiteral { seconds: 30 },
-            })],
+            &[
+                timeout_policy(30),
+                PolicyBracket::Retry(RetryPolicy {
+                    exception_types: Vec::new(),
+                    max_retries: 2,
+                    backoff: None,
+                }),
+            ],
         )
-        .expect_err("timeout policies should not lower yet");
+        .expect_err("mixed retry policies should not lower yet");
         assert!(matches!(
-            timeout_error,
-            Error::Unsupported(Unsupported::TimeoutPolicy { action_name })
+            mixed_error,
+            Error::Unsupported(Unsupported::RetryPolicy { action_name })
                 if action_name == "notify"
         ));
 

--- a/crates/lib/vm-compiler-for-ast-old/src/function/compiler/wrapper_fn.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/function/compiler/wrapper_fn.rs
@@ -1,0 +1,209 @@
+//! Ephemeral wrapper-function generation for policy-annotated action calls.
+//!
+//! Policy brackets (retry/timeout) lower inside a dedicated per-call-site
+//! function that wraps the plain action call. Every call site - sequential
+//! or fan-out - then invokes the wrapper through an ordinary function call,
+//! so the policy machinery has exactly one lowering path and the wrapper
+//! frame owns the argument registers for the whole policy lifetime.
+
+use waymark_vm_bytecode_core::FunctionId;
+
+use crate::Marked;
+use crate::function::extras::ExtraFunctions;
+
+use super::Error;
+use super::bytecode::emitter::FunctionEmitter;
+use super::env::LocalFrame;
+use super::plan::Unsupported;
+
+/// Generates the wrapper function for one policy-annotated action call site
+/// and returns its id.
+///
+/// The wrapper takes the action's keyword arguments as positional inputs in
+/// call-site order and forwards them to the wrapped action.
+pub fn create<Spec, LiteralLoweringError, ActionLoweringError>(
+    extra_fns: &mut ExtraFunctions<Spec>,
+    action_name: &str,
+    action_ref: <Spec as waymark_vm_instructions_extcallset::Spec>::ActionRef,
+    kwarg_count: usize,
+    policies: &[waymark_vm_ast_old::PolicyBracket],
+) -> Result<FunctionId, Error<LiteralLoweringError, ActionLoweringError>>
+where
+    Spec: waymark_vm_compiler_for_ast_old_core::SpecRequirements,
+{
+    if let Some(policy) = policies.first() {
+        return Err(match policy {
+            waymark_vm_ast_old::PolicyBracket::Retry(_) => Unsupported::RetryPolicy {
+                action_name: action_name.to_owned(),
+            }
+            .into(),
+            waymark_vm_ast_old::PolicyBracket::Timeout(_) => Unsupported::TimeoutPolicy {
+                action_name: action_name.to_owned(),
+            }
+            .into(),
+        });
+    }
+
+    let mut emitter = FunctionEmitter::<Spec>::new();
+    let mut local_frame = LocalFrame::new();
+
+    // Inputs occupy the first registers of the frame in call order.
+    let arg_registers: Vec<_> = (0..kwarg_count)
+        .map(|_| local_frame.allocate_register())
+        .collect();
+
+    let promise_register = Marked::mark(local_frame.allocate_register());
+    let resume_after_call = emitter.reserve_state();
+    emitter.emit_extcall(
+        promise_register,
+        action_ref,
+        arg_registers,
+        resume_after_call,
+    );
+    emitter.switch_to(resume_after_call);
+
+    let result_register = local_frame.allocate_register();
+    let resume_after_await = emitter.reserve_state();
+    emitter.emit_await(result_register, promise_register, resume_after_await);
+    emitter.switch_to(resume_after_await);
+    emitter.emit_return(result_register);
+
+    let function = waymark_vm_bytecode::Function {
+        states: emitter.finish(),
+        num_regs: local_frame.num_registers(),
+    };
+
+    Ok(extra_fns.insert(function))
+}
+
+#[cfg(test)]
+mod tests {
+    use waymark_vm_ast_old::{DurationLiteral, PolicyBracket, RetryPolicy, TimeoutPolicy};
+    use waymark_vm_bytecode_core::{FunctionId, StateId};
+    use waymark_vm_compiler_for_ast_old_test_support::{TestActionRef, TestSpec};
+    use waymark_vm_instructions_coreset::CoreSet;
+    use waymark_vm_instructions_extcallset::ExtCallSet;
+    use waymark_vm_instructions_fullset::FullSet as InstructionSet;
+    use waymark_vm_runtime_core::RegisterId;
+
+    use super::super::{Error, Unsupported};
+    use super::create;
+    use crate::function::extras::ExtraFunctions;
+
+    #[test]
+    fn generates_the_plain_action_wrapper_body() {
+        let mut extra_fns = ExtraFunctions::<TestSpec>::new(3);
+
+        let function_id = create::<_, (), ()>(
+            &mut extra_fns,
+            "notify",
+            TestActionRef("notify".to_owned()),
+            2,
+            &[],
+        )
+        .expect("a wrapper without brackets should compile");
+        assert_eq!(function_id, FunctionId(3));
+
+        let functions = extra_fns.finish();
+        assert_eq!(functions.len(), 1);
+        let function = &functions[0];
+        assert_eq!(function.num_regs, 4);
+
+        let mut start_instructions = function.states[StateId(0)].instructions.iter();
+        assert!(matches!(
+            start_instructions.next(),
+            Some(InstructionSet::ExtCallSet(ExtCallSet::ActionCall {
+                dst,
+                action_ref: TestActionRef(action_ref),
+                args,
+                resume,
+            })) if *dst == RegisterId(2)
+                && action_ref == "notify"
+                && *args == vec![RegisterId(0), RegisterId(1)]
+                && *resume == StateId(1)
+        ));
+        assert!(start_instructions.next().is_none());
+
+        let mut await_instructions = function.states[StateId(1)].instructions.iter();
+        assert!(matches!(
+            await_instructions.next(),
+            Some(InstructionSet::CoreSet(CoreSet::Await { dst, src, resume }))
+                if *dst == RegisterId(3) && *src == RegisterId(2) && *resume == StateId(2)
+        ));
+        assert!(await_instructions.next().is_none());
+
+        let mut return_instructions = function.states[StateId(2)].instructions.iter();
+        assert!(matches!(
+            return_instructions.next(),
+            Some(InstructionSet::CoreSet(CoreSet::Return { src })) if *src == RegisterId(3)
+        ));
+        assert!(return_instructions.next().is_none());
+    }
+
+    #[test]
+    fn assigns_sequential_ids_after_the_source_functions() {
+        let mut extra_fns = ExtraFunctions::<TestSpec>::new(2);
+
+        let first = create::<_, (), ()>(
+            &mut extra_fns,
+            "first",
+            TestActionRef("first".to_owned()),
+            0,
+            &[],
+        )
+        .expect("first wrapper should compile");
+        let second = create::<_, (), ()>(
+            &mut extra_fns,
+            "second",
+            TestActionRef("second".to_owned()),
+            1,
+            &[],
+        )
+        .expect("second wrapper should compile");
+
+        assert_eq!(first, FunctionId(2));
+        assert_eq!(second, FunctionId(3));
+        assert_eq!(extra_fns.finish().len(), 2);
+    }
+
+    #[test]
+    fn rejects_policy_brackets_pending_their_lowering() {
+        let mut extra_fns = ExtraFunctions::<TestSpec>::new(0);
+
+        let retry_error = create::<_, (), ()>(
+            &mut extra_fns,
+            "notify",
+            TestActionRef("notify".to_owned()),
+            0,
+            &[PolicyBracket::Retry(RetryPolicy {
+                exception_types: Vec::new(),
+                max_retries: 2,
+                backoff: None,
+            })],
+        )
+        .expect_err("retry policies should not lower yet");
+        assert!(matches!(
+            retry_error,
+            Error::Unsupported(Unsupported::RetryPolicy { action_name })
+                if action_name == "notify"
+        ));
+
+        let timeout_error = create::<_, (), ()>(
+            &mut extra_fns,
+            "notify",
+            TestActionRef("notify".to_owned()),
+            0,
+            &[PolicyBracket::Timeout(TimeoutPolicy {
+                timeout: DurationLiteral { seconds: 30 },
+            })],
+        )
+        .expect_err("timeout policies should not lower yet");
+        assert!(matches!(
+            timeout_error,
+            Error::Unsupported(Unsupported::TimeoutPolicy { action_name })
+                if action_name == "notify"
+        ));
+
+        assert!(extra_fns.finish().is_empty());
+    }
+}

--- a/crates/lib/vm-compiler-for-ast-old/src/tests/mod.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/tests/mod.rs
@@ -12,6 +12,7 @@ mod function_table;
 mod loops;
 mod lowering_errors;
 mod parallel;
+mod policies;
 mod spreads;
 mod variables;
 

--- a/crates/lib/vm-compiler-for-ast-old/src/tests/policies.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/tests/policies.rs
@@ -1,7 +1,7 @@
 //! Tests for policy brackets on action calls.
 //!
 //! Policy-annotated action calls route through wrapper-function generation;
-//! the brackets themselves are rejected until their lowerings land.
+//! brackets without a lowering yet are rejected.
 
 use waymark_vm_ast_old::{
     DurationLiteral, PolicyBracket, RetryPolicy, Spanned, Statement, TimeoutPolicy,
@@ -46,7 +46,7 @@ fn rejects_retry_policies_pending_their_lowering() {
 }
 
 #[test]
-fn rejects_timeout_policies_pending_their_lowering() {
+fn lowers_timeout_policies_through_a_wrapper_function() {
     let program = program(vec![function(
         "main",
         &[],
@@ -57,15 +57,33 @@ fn rejects_timeout_policies_pending_their_lowering() {
         )])],
     )]);
 
-    let error = match compile::<TestSpec, TestLowering>(&program) {
-        Ok(_) => panic!("timeout policies should fail until their lowering lands"),
-        Err(error) => error,
-    };
+    let executable =
+        compile::<TestSpec, TestLowering>(&program).expect("timeout policies should compile");
 
-    assert!(matches!(
-        error,
-        CompileError::FunctionCompiler(compiler::Error::Unsupported(
-            compiler::Unsupported::TimeoutPolicy { action_name }
-        )) if action_name == "notify"
-    ));
+    // The call site invokes the timed wrapper - the program's one extra
+    // function - instead of the raw action.
+    insta::assert_snapshot!(waymark_vm_bytecode_fmt::display(&executable), @r#"
+    f0: [1 registers]
+      s0:
+        CoreSet(Call { dst: r0, function_id: f1, args: [] })
+        CoreSet(Await { dst: r0, src: r0, resume: s1 })
+      s1:
+        PureSet(LoadConst { dst: r0, value: None })
+        CoreSet(Return { src: r0 })
+    f1: [8 registers]
+      s0:
+        ExtCallSet(ActionCall { dst: r0, action_ref: TestActionRef("notify"), args: [], resume: s1 })
+      s1:
+        PureSet(LoadConst { dst: r1, value: Int(30) })
+        ExtCallSet(Sleep { dst: r2, duration: r1, resume: s2, unskippable: true })
+      s2:
+        CoreSet(Select { arms: [SelectArm { src: r0, dst: r3, resume: s3 }, SelectArm { src: r2, dst: r4, resume: s4 }] })
+      s3:
+        CoreSet(Return { src: r3 })
+      s4:
+        PureSet(LoadConst { dst: r5, value: String("ActionTimeout") })
+        PureSet(LoadConst { dst: r6, value: None })
+        PureSet(MakeException { dst: r7, type_id: r5, details: r6 })
+        CoreSet(Raise { src: r7 })
+    "#);
 }

--- a/crates/lib/vm-compiler-for-ast-old/src/tests/policies.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/tests/policies.rs
@@ -1,7 +1,6 @@
 //! Tests for policy brackets on action calls.
 //!
-//! Policy-annotated action calls route through wrapper-function generation;
-//! brackets without a lowering yet are rejected.
+//! Policy-annotated action calls route through wrapper-function generation.
 
 use waymark_vm_ast_old::{
     DurationLiteral, PolicyBracket, RetryPolicy, Spanned, Statement, TimeoutPolicy,
@@ -9,7 +8,7 @@ use waymark_vm_ast_old::{
 use waymark_vm_ast_old_helpers::{action_call, function, program, spanned};
 use waymark_vm_compiler_for_ast_old_test_support::{TestLowering, TestSpec};
 
-use crate::{CompileError, compile, function::compiler};
+use crate::compile;
 
 /// Builds a bare action-call statement carrying the provided policies.
 fn policy_action_stmt(policies: Vec<PolicyBracket>) -> Spanned<Statement> {
@@ -19,30 +18,66 @@ fn policy_action_stmt(policies: Vec<PolicyBracket>) -> Spanned<Statement> {
 }
 
 #[test]
-fn rejects_retry_policies_pending_their_lowering() {
+fn lowers_retry_policies_through_a_wrapper_function() {
     let program = program(vec![function(
         "main",
         &[],
-        vec![policy_action_stmt(vec![PolicyBracket::Retry(
-            RetryPolicy {
+        vec![policy_action_stmt(vec![
+            PolicyBracket::Retry(RetryPolicy {
                 exception_types: Vec::new(),
                 max_retries: 2,
                 backoff: None,
-            },
-        )])],
+            }),
+            PolicyBracket::Timeout(TimeoutPolicy {
+                timeout: DurationLiteral { seconds: 30 },
+            }),
+        ])],
     )]);
 
-    let error = match compile::<TestSpec, TestLowering>(&program) {
-        Ok(_) => panic!("retry policies should fail until their lowering lands"),
-        Err(error) => error,
-    };
+    let executable =
+        compile::<TestSpec, TestLowering>(&program).expect("retry policies should compile");
 
-    assert!(matches!(
-        error,
-        CompileError::FunctionCompiler(compiler::Error::Unsupported(
-            compiler::Unsupported::RetryPolicy { action_name }
-        )) if action_name == "notify"
-    ));
+    // The call site invokes the retrying wrapper - the program's one extra
+    // function - instead of the raw action.
+    insta::assert_snapshot!(waymark_vm_bytecode_fmt::display(&executable), @r#"
+    f0: [1 registers]
+      s0:
+        CoreSet(Call { dst: r0, function_id: f1, args: [] })
+        CoreSet(Await { dst: r0, src: r0, resume: s1 })
+      s1:
+        PureSet(LoadConst { dst: r0, value: None })
+        CoreSet(Return { src: r0 })
+    f1: [13 registers]
+      s0:
+        PureSet(LoadConst { dst: r0, value: Int(0) })
+        PureSet(LoadConst { dst: r1, value: Int(1) })
+        CoreSet(Jump { target_state: s1 })
+      s1:
+        CoreSet(PushExceptionHandlers { handlers: [ExceptionHandler { handler_state: s2, exception_types: [], exception_dst: Some(r2) }] })
+        ExtCallSet(ActionCall { dst: r3, action_ref: TestActionRef("notify"), args: [], resume: s4 })
+      s2:
+        PureSet(LoadConst { dst: r8, value: Int(2) })
+        PureSet(Binary { kind: Lt, op: BinaryOp { dst: r9, a: r0, b: r8 } })
+        CoreSet(JumpIf { target_state: s3, cond: r9 })
+        CoreSet(Raise { src: r2 })
+      s3:
+        PureSet(Binary { kind: Add, op: BinaryOp { dst: r0, a: r0, b: r1 } })
+        CoreSet(Jump { target_state: s1 })
+      s4:
+        PureSet(LoadConst { dst: r4, value: Int(30) })
+        ExtCallSet(Sleep { dst: r5, duration: r4, resume: s6, unskippable: true })
+      s5:
+        CoreSet(PopExceptionHandlers { count: 1 })
+        CoreSet(Return { src: r6 })
+      s6:
+        CoreSet(Select { arms: [SelectArm { src: r3, dst: r6, resume: s5 }, SelectArm { src: r5, dst: r7, resume: s7 }] })
+      s7:
+        CoreSet(PopExceptionHandlers { count: 1 })
+        PureSet(LoadConst { dst: r10, value: String("ActionTimeout") })
+        PureSet(LoadConst { dst: r11, value: None })
+        PureSet(MakeException { dst: r12, type_id: r10, details: r11 })
+        CoreSet(Raise { src: r12 })
+    "#);
 }
 
 #[test]

--- a/crates/lib/vm-compiler-for-ast-old/src/tests/policies.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/tests/policies.rs
@@ -1,0 +1,71 @@
+//! Tests for policy brackets on action calls.
+//!
+//! Policy-annotated action calls route through wrapper-function generation;
+//! the brackets themselves are rejected until their lowerings land.
+
+use waymark_vm_ast_old::{
+    DurationLiteral, PolicyBracket, RetryPolicy, Spanned, Statement, TimeoutPolicy,
+};
+use waymark_vm_ast_old_helpers::{action_call, function, program, spanned};
+use waymark_vm_compiler_for_ast_old_test_support::{TestLowering, TestSpec};
+
+use crate::{CompileError, compile, function::compiler};
+
+/// Builds a bare action-call statement carrying the provided policies.
+fn policy_action_stmt(policies: Vec<PolicyBracket>) -> Spanned<Statement> {
+    let mut call = action_call("notify", Vec::new());
+    call.policies = policies;
+    spanned(Statement::ActionCall { call })
+}
+
+#[test]
+fn rejects_retry_policies_pending_their_lowering() {
+    let program = program(vec![function(
+        "main",
+        &[],
+        vec![policy_action_stmt(vec![PolicyBracket::Retry(
+            RetryPolicy {
+                exception_types: Vec::new(),
+                max_retries: 2,
+                backoff: None,
+            },
+        )])],
+    )]);
+
+    let error = match compile::<TestSpec, TestLowering>(&program) {
+        Ok(_) => panic!("retry policies should fail until their lowering lands"),
+        Err(error) => error,
+    };
+
+    assert!(matches!(
+        error,
+        CompileError::FunctionCompiler(compiler::Error::Unsupported(
+            compiler::Unsupported::RetryPolicy { action_name }
+        )) if action_name == "notify"
+    ));
+}
+
+#[test]
+fn rejects_timeout_policies_pending_their_lowering() {
+    let program = program(vec![function(
+        "main",
+        &[],
+        vec![policy_action_stmt(vec![PolicyBracket::Timeout(
+            TimeoutPolicy {
+                timeout: DurationLiteral { seconds: 30 },
+            },
+        )])],
+    )]);
+
+    let error = match compile::<TestSpec, TestLowering>(&program) {
+        Ok(_) => panic!("timeout policies should fail until their lowering lands"),
+        Err(error) => error,
+    };
+
+    assert!(matches!(
+        error,
+        CompileError::FunctionCompiler(compiler::Error::Unsupported(
+            compiler::Unsupported::TimeoutPolicy { action_name }
+        )) if action_name == "notify"
+    ));
+}

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_run_action_spread.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_run_action_spread.py__bytecode.snap
@@ -1,11 +1,83 @@
 ---
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
-expression: "bytecode for python/tests/fixtures_gather/gather_run_action_spread.py [compilation error]"
+expression: bytecode for python/tests/fixtures_gather/gather_run_action_spread.py
 ---
-FunctionCompiler(
-    Unsupported(
-        RetryPolicy {
-            action_name: "process_item",
-        },
-    ),
-)
+fn main(input: [items], output: []):
+    results = spread items:item -> @gather_run_action_spread.process_item(item=item) [retry: 2] [timeout: 30s]
+    _return_tmp = @gather_run_action_spread.combine_results(results=results)
+    return _return_tmp
+---
+f0: [9 registers]
+  s0:
+    PureSet(MakeList { dst: r2, items: [] })
+    PureSet(MakeList { dst: r3, items: [] })
+    PureSet(LoadConst { dst: r4, value: Int(0) })
+    PureSet(Length { dst: r5, src: r0 })
+    CoreSet(Jump { target_state: s1 })
+  s1:
+    PureSet(Binary { kind: Lt, op: BinaryOp { dst: r6, a: r4, b: r5 } })
+    CoreSet(JumpIf { target_state: s2, cond: r6 })
+    CoreSet(Jump { target_state: s4 })
+  s2:
+    PureSet(Index { dst: r6, object: r0, index: r4 })
+    CoreSet(Call { dst: r7, function_id: f1, args: [r6] })
+    PureSet(ListAppend { dst: r3, list: r3, item: r7 })
+    CoreSet(Jump { target_state: s3 })
+  s3:
+    PureSet(LoadConst { dst: r6, value: Int(1) })
+    PureSet(Binary { kind: Add, op: BinaryOp { dst: r4, a: r4, b: r6 } })
+    CoreSet(Jump { target_state: s1 })
+  s4:
+    PureSet(LoadConst { dst: r4, value: Int(0) })
+    CoreSet(Jump { target_state: s5 })
+  s5:
+    PureSet(Binary { kind: Lt, op: BinaryOp { dst: r6, a: r4, b: r5 } })
+    CoreSet(JumpIf { target_state: s6, cond: r6 })
+    CoreSet(Jump { target_state: s8 })
+  s6:
+    PureSet(Index { dst: r6, object: r3, index: r4 })
+    CoreSet(Await { dst: r6, src: r6, resume: s9 })
+  s7:
+    PureSet(LoadConst { dst: r6, value: Int(1) })
+    PureSet(Binary { kind: Add, op: BinaryOp { dst: r4, a: r4, b: r6 } })
+    CoreSet(Jump { target_state: s5 })
+  s8:
+    PureSet(Copy { dst: r1, src: r2 })
+    ExtCallSet(ActionCall { dst: r8, action_ref: TestActionRef("combine_results"), args: [r1], resume: s10 })
+  s9:
+    PureSet(ListAppend { dst: r2, list: r2, item: r6 })
+    CoreSet(Jump { target_state: s7 })
+  s10:
+    CoreSet(Await { dst: r8, src: r8, resume: s11 })
+  s11:
+    CoreSet(Return { src: r8 })
+f1: [14 registers]
+  s0:
+    PureSet(LoadConst { dst: r1, value: Int(0) })
+    PureSet(LoadConst { dst: r2, value: Int(1) })
+    CoreSet(Jump { target_state: s1 })
+  s1:
+    CoreSet(PushExceptionHandlers { handlers: [ExceptionHandler { handler_state: s2, exception_types: [], exception_dst: Some(r3) }] })
+    ExtCallSet(ActionCall { dst: r4, action_ref: TestActionRef("process_item"), args: [r0], resume: s4 })
+  s2:
+    PureSet(LoadConst { dst: r9, value: Int(2) })
+    PureSet(Binary { kind: Lt, op: BinaryOp { dst: r10, a: r1, b: r9 } })
+    CoreSet(JumpIf { target_state: s3, cond: r10 })
+    CoreSet(Raise { src: r3 })
+  s3:
+    PureSet(Binary { kind: Add, op: BinaryOp { dst: r1, a: r1, b: r2 } })
+    CoreSet(Jump { target_state: s1 })
+  s4:
+    PureSet(LoadConst { dst: r5, value: Int(30) })
+    ExtCallSet(Sleep { dst: r6, duration: r5, resume: s6, unskippable: true })
+  s5:
+    CoreSet(PopExceptionHandlers { count: 1 })
+    CoreSet(Return { src: r7 })
+  s6:
+    CoreSet(Select { arms: [SelectArm { src: r4, dst: r7, resume: s5 }, SelectArm { src: r6, dst: r8, resume: s7 }] })
+  s7:
+    CoreSet(PopExceptionHandlers { count: 1 })
+    PureSet(LoadConst { dst: r11, value: String("ActionTimeout") })
+    PureSet(LoadConst { dst: r12, value: None })
+    PureSet(MakeException { dst: r13, type_id: r11, details: r12 })
+    CoreSet(Raise { src: r13 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_run_action_spread.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_gather__gather_run_action_spread.py__bytecode.snap
@@ -1,54 +1,11 @@
 ---
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
-expression: bytecode for python/tests/fixtures_gather/gather_run_action_spread.py
+expression: "bytecode for python/tests/fixtures_gather/gather_run_action_spread.py [compilation error]"
 ---
-fn main(input: [items], output: []):
-    results = spread items:item -> @gather_run_action_spread.process_item(item=item) [retry: 2] [timeout: 30s]
-    _return_tmp = @gather_run_action_spread.combine_results(results=results)
-    return _return_tmp
----
-f0: [9 registers]
-  s0:
-    PureSet(MakeList { dst: r2, items: [] })
-    PureSet(MakeList { dst: r3, items: [] })
-    PureSet(LoadConst { dst: r4, value: Int(0) })
-    PureSet(Length { dst: r5, src: r0 })
-    CoreSet(Jump { target_state: s1 })
-  s1:
-    PureSet(Binary { kind: Lt, op: BinaryOp { dst: r6, a: r4, b: r5 } })
-    CoreSet(JumpIf { target_state: s2, cond: r6 })
-    CoreSet(Jump { target_state: s4 })
-  s2:
-    PureSet(Index { dst: r6, object: r0, index: r4 })
-    ExtCallSet(ActionCall { dst: r7, action_ref: TestActionRef("process_item"), args: [r6], resume: s5 })
-  s3:
-    PureSet(LoadConst { dst: r6, value: Int(1) })
-    PureSet(Binary { kind: Add, op: BinaryOp { dst: r4, a: r4, b: r6 } })
-    CoreSet(Jump { target_state: s1 })
-  s4:
-    PureSet(LoadConst { dst: r4, value: Int(0) })
-    CoreSet(Jump { target_state: s6 })
-  s5:
-    PureSet(ListAppend { dst: r3, list: r3, item: r7 })
-    CoreSet(Jump { target_state: s3 })
-  s6:
-    PureSet(Binary { kind: Lt, op: BinaryOp { dst: r6, a: r4, b: r5 } })
-    CoreSet(JumpIf { target_state: s7, cond: r6 })
-    CoreSet(Jump { target_state: s9 })
-  s7:
-    PureSet(Index { dst: r6, object: r3, index: r4 })
-    CoreSet(Await { dst: r6, src: r6, resume: s10 })
-  s8:
-    PureSet(LoadConst { dst: r6, value: Int(1) })
-    PureSet(Binary { kind: Add, op: BinaryOp { dst: r4, a: r4, b: r6 } })
-    CoreSet(Jump { target_state: s6 })
-  s9:
-    PureSet(Copy { dst: r1, src: r2 })
-    ExtCallSet(ActionCall { dst: r8, action_ref: TestActionRef("combine_results"), args: [r1], resume: s11 })
-  s10:
-    PureSet(ListAppend { dst: r2, list: r2, item: r6 })
-    CoreSet(Jump { target_state: s8 })
-  s11:
-    CoreSet(Await { dst: r8, src: r8, resume: s12 })
-  s12:
-    CoreSet(Return { src: r8 })
+FunctionCompiler(
+    Unsupported(
+        RetryPolicy {
+            action_name: "process_item",
+        },
+    ),
+)

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_policy__instance_attr_policies.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_policy__instance_attr_policies.py__bytecode.snap
@@ -1,25 +1,11 @@
 ---
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
-expression: bytecode for python/tests/fixtures_policy/instance_attr_policies.py
+expression: "bytecode for python/tests/fixtures_policy/instance_attr_policies.py [compilation error]"
 ---
-fn main(input: [value], output: []):
-    a = @instance_attr_policies.action_with_instance_retry(value=value) [retry: 2, backoff: 10s]
-    b = @instance_attr_policies.action_with_instance_timeout(value=a) [timeout: 2m]
-    c = @instance_attr_policies.action_with_both_policies(value=b) [retry: 1] [timeout: 2m]
-    return c
----
-f0: [4 registers]
-  s0:
-    ExtCallSet(ActionCall { dst: r1, action_ref: TestActionRef("action_with_instance_retry"), args: [r0], resume: s1 })
-  s1:
-    CoreSet(Await { dst: r1, src: r1, resume: s2 })
-  s2:
-    ExtCallSet(ActionCall { dst: r2, action_ref: TestActionRef("action_with_instance_timeout"), args: [r1], resume: s3 })
-  s3:
-    CoreSet(Await { dst: r2, src: r2, resume: s4 })
-  s4:
-    ExtCallSet(ActionCall { dst: r3, action_ref: TestActionRef("action_with_both_policies"), args: [r2], resume: s5 })
-  s5:
-    CoreSet(Await { dst: r3, src: r3, resume: s6 })
-  s6:
-    CoreSet(Return { src: r3 })
+FunctionCompiler(
+    Unsupported(
+        RetryPolicy {
+            action_name: "action_with_instance_retry",
+        },
+    ),
+)

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_policy__instance_attr_policies.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_policy__instance_attr_policies.py__bytecode.snap
@@ -1,11 +1,93 @@
 ---
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
-expression: "bytecode for python/tests/fixtures_policy/instance_attr_policies.py [compilation error]"
+expression: bytecode for python/tests/fixtures_policy/instance_attr_policies.py
 ---
-FunctionCompiler(
-    Unsupported(
-        RetryPolicy {
-            action_name: "action_with_instance_retry",
-        },
-    ),
-)
+fn main(input: [value], output: []):
+    a = @instance_attr_policies.action_with_instance_retry(value=value) [retry: 2, backoff: 10s]
+    b = @instance_attr_policies.action_with_instance_timeout(value=a) [timeout: 2m]
+    c = @instance_attr_policies.action_with_both_policies(value=b) [retry: 1] [timeout: 2m]
+    return c
+---
+f0: [4 registers]
+  s0:
+    CoreSet(Call { dst: r1, function_id: f1, args: [r0] })
+    CoreSet(Await { dst: r1, src: r1, resume: s1 })
+  s1:
+    CoreSet(Call { dst: r2, function_id: f2, args: [r1] })
+    CoreSet(Await { dst: r2, src: r2, resume: s2 })
+  s2:
+    CoreSet(Call { dst: r3, function_id: f3, args: [r2] })
+    CoreSet(Await { dst: r3, src: r3, resume: s3 })
+  s3:
+    CoreSet(Return { src: r3 })
+f1: [11 registers]
+  s0:
+    PureSet(LoadConst { dst: r1, value: Int(0) })
+    PureSet(LoadConst { dst: r2, value: Int(1) })
+    CoreSet(Jump { target_state: s1 })
+  s1:
+    CoreSet(PushExceptionHandlers { handlers: [ExceptionHandler { handler_state: s2, exception_types: [], exception_dst: Some(r3) }] })
+    ExtCallSet(ActionCall { dst: r4, action_ref: TestActionRef("action_with_instance_retry"), args: [r0], resume: s4 })
+  s2:
+    PureSet(LoadConst { dst: r6, value: Int(2) })
+    PureSet(Binary { kind: Lt, op: BinaryOp { dst: r7, a: r1, b: r6 } })
+    CoreSet(JumpIf { target_state: s3, cond: r7 })
+    CoreSet(Raise { src: r3 })
+  s3:
+    PureSet(Binary { kind: Add, op: BinaryOp { dst: r1, a: r1, b: r2 } })
+    PureSet(LoadConst { dst: r8, value: Int(10) })
+    ExtCallSet(Sleep { dst: r9, duration: r8, resume: s6, unskippable: false })
+  s4:
+    CoreSet(Await { dst: r5, src: r4, resume: s5 })
+  s5:
+    CoreSet(PopExceptionHandlers { count: 1 })
+    CoreSet(Return { src: r5 })
+  s6:
+    CoreSet(Await { dst: r10, src: r9, resume: s7 })
+  s7:
+    CoreSet(Jump { target_state: s1 })
+f2: [9 registers]
+  s0:
+    ExtCallSet(ActionCall { dst: r1, action_ref: TestActionRef("action_with_instance_timeout"), args: [r0], resume: s1 })
+  s1:
+    PureSet(LoadConst { dst: r2, value: Int(120) })
+    ExtCallSet(Sleep { dst: r3, duration: r2, resume: s2, unskippable: true })
+  s2:
+    CoreSet(Select { arms: [SelectArm { src: r1, dst: r4, resume: s3 }, SelectArm { src: r3, dst: r5, resume: s4 }] })
+  s3:
+    CoreSet(Return { src: r4 })
+  s4:
+    PureSet(LoadConst { dst: r6, value: String("ActionTimeout") })
+    PureSet(LoadConst { dst: r7, value: None })
+    PureSet(MakeException { dst: r8, type_id: r6, details: r7 })
+    CoreSet(Raise { src: r8 })
+f3: [14 registers]
+  s0:
+    PureSet(LoadConst { dst: r1, value: Int(0) })
+    PureSet(LoadConst { dst: r2, value: Int(1) })
+    CoreSet(Jump { target_state: s1 })
+  s1:
+    CoreSet(PushExceptionHandlers { handlers: [ExceptionHandler { handler_state: s2, exception_types: [], exception_dst: Some(r3) }] })
+    ExtCallSet(ActionCall { dst: r4, action_ref: TestActionRef("action_with_both_policies"), args: [r0], resume: s4 })
+  s2:
+    PureSet(LoadConst { dst: r9, value: Int(1) })
+    PureSet(Binary { kind: Lt, op: BinaryOp { dst: r10, a: r1, b: r9 } })
+    CoreSet(JumpIf { target_state: s3, cond: r10 })
+    CoreSet(Raise { src: r3 })
+  s3:
+    PureSet(Binary { kind: Add, op: BinaryOp { dst: r1, a: r1, b: r2 } })
+    CoreSet(Jump { target_state: s1 })
+  s4:
+    PureSet(LoadConst { dst: r5, value: Int(120) })
+    ExtCallSet(Sleep { dst: r6, duration: r5, resume: s6, unskippable: true })
+  s5:
+    CoreSet(PopExceptionHandlers { count: 1 })
+    CoreSet(Return { src: r7 })
+  s6:
+    CoreSet(Select { arms: [SelectArm { src: r4, dst: r7, resume: s5 }, SelectArm { src: r6, dst: r8, resume: s7 }] })
+  s7:
+    CoreSet(PopExceptionHandlers { count: 1 })
+    PureSet(LoadConst { dst: r11, value: String("ActionTimeout") })
+    PureSet(LoadConst { dst: r12, value: None })
+    PureSet(MakeException { dst: r13, type_id: r11, details: r12 })
+    CoreSet(Raise { src: r13 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_policy__integration_crash_recovery.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_policy__integration_crash_recovery.py__bytecode.snap
@@ -1,31 +1,11 @@
 ---
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
-expression: bytecode for python/tests/fixtures_policy/integration_crash_recovery.py
+expression: "bytecode for python/tests/fixtures_policy/integration_crash_recovery.py [compilation error]"
 ---
-fn main(input: [], output: []):
-    a = @integration_crash_recovery.step_one(value="start") [timeout: 2s]
-    b = @integration_crash_recovery.step_two(value=a) [timeout: 2s]
-    c = @integration_crash_recovery.step_three(value=b) [timeout: 2s]
-    d = @integration_crash_recovery.step_four(value=c) [timeout: 2s]
-    return d
----
-f0: [5 registers]
-  s0:
-    PureSet(LoadConst { dst: r1, value: String("start") })
-    ExtCallSet(ActionCall { dst: r0, action_ref: TestActionRef("step_one"), args: [r1], resume: s1 })
-  s1:
-    CoreSet(Await { dst: r0, src: r0, resume: s2 })
-  s2:
-    ExtCallSet(ActionCall { dst: r2, action_ref: TestActionRef("step_two"), args: [r0], resume: s3 })
-  s3:
-    CoreSet(Await { dst: r2, src: r2, resume: s4 })
-  s4:
-    ExtCallSet(ActionCall { dst: r3, action_ref: TestActionRef("step_three"), args: [r2], resume: s5 })
-  s5:
-    CoreSet(Await { dst: r3, src: r3, resume: s6 })
-  s6:
-    ExtCallSet(ActionCall { dst: r4, action_ref: TestActionRef("step_four"), args: [r3], resume: s7 })
-  s7:
-    CoreSet(Await { dst: r4, src: r4, resume: s8 })
-  s8:
-    CoreSet(Return { src: r4 })
+FunctionCompiler(
+    Unsupported(
+        TimeoutPolicy {
+            action_name: "step_one",
+        },
+    ),
+)

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_policy__integration_crash_recovery.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_policy__integration_crash_recovery.py__bytecode.snap
@@ -1,11 +1,87 @@
 ---
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
-expression: "bytecode for python/tests/fixtures_policy/integration_crash_recovery.py [compilation error]"
+expression: bytecode for python/tests/fixtures_policy/integration_crash_recovery.py
 ---
-FunctionCompiler(
-    Unsupported(
-        TimeoutPolicy {
-            action_name: "step_one",
-        },
-    ),
-)
+fn main(input: [], output: []):
+    a = @integration_crash_recovery.step_one(value="start") [timeout: 2s]
+    b = @integration_crash_recovery.step_two(value=a) [timeout: 2s]
+    c = @integration_crash_recovery.step_three(value=b) [timeout: 2s]
+    d = @integration_crash_recovery.step_four(value=c) [timeout: 2s]
+    return d
+---
+f0: [5 registers]
+  s0:
+    PureSet(LoadConst { dst: r1, value: String("start") })
+    CoreSet(Call { dst: r0, function_id: f1, args: [r1] })
+    CoreSet(Await { dst: r0, src: r0, resume: s1 })
+  s1:
+    CoreSet(Call { dst: r2, function_id: f2, args: [r0] })
+    CoreSet(Await { dst: r2, src: r2, resume: s2 })
+  s2:
+    CoreSet(Call { dst: r3, function_id: f3, args: [r2] })
+    CoreSet(Await { dst: r3, src: r3, resume: s3 })
+  s3:
+    CoreSet(Call { dst: r4, function_id: f4, args: [r3] })
+    CoreSet(Await { dst: r4, src: r4, resume: s4 })
+  s4:
+    CoreSet(Return { src: r4 })
+f1: [9 registers]
+  s0:
+    ExtCallSet(ActionCall { dst: r1, action_ref: TestActionRef("step_one"), args: [r0], resume: s1 })
+  s1:
+    PureSet(LoadConst { dst: r2, value: Int(2) })
+    ExtCallSet(Sleep { dst: r3, duration: r2, resume: s2, unskippable: true })
+  s2:
+    CoreSet(Select { arms: [SelectArm { src: r1, dst: r4, resume: s3 }, SelectArm { src: r3, dst: r5, resume: s4 }] })
+  s3:
+    CoreSet(Return { src: r4 })
+  s4:
+    PureSet(LoadConst { dst: r6, value: String("ActionTimeout") })
+    PureSet(LoadConst { dst: r7, value: None })
+    PureSet(MakeException { dst: r8, type_id: r6, details: r7 })
+    CoreSet(Raise { src: r8 })
+f2: [9 registers]
+  s0:
+    ExtCallSet(ActionCall { dst: r1, action_ref: TestActionRef("step_two"), args: [r0], resume: s1 })
+  s1:
+    PureSet(LoadConst { dst: r2, value: Int(2) })
+    ExtCallSet(Sleep { dst: r3, duration: r2, resume: s2, unskippable: true })
+  s2:
+    CoreSet(Select { arms: [SelectArm { src: r1, dst: r4, resume: s3 }, SelectArm { src: r3, dst: r5, resume: s4 }] })
+  s3:
+    CoreSet(Return { src: r4 })
+  s4:
+    PureSet(LoadConst { dst: r6, value: String("ActionTimeout") })
+    PureSet(LoadConst { dst: r7, value: None })
+    PureSet(MakeException { dst: r8, type_id: r6, details: r7 })
+    CoreSet(Raise { src: r8 })
+f3: [9 registers]
+  s0:
+    ExtCallSet(ActionCall { dst: r1, action_ref: TestActionRef("step_three"), args: [r0], resume: s1 })
+  s1:
+    PureSet(LoadConst { dst: r2, value: Int(2) })
+    ExtCallSet(Sleep { dst: r3, duration: r2, resume: s2, unskippable: true })
+  s2:
+    CoreSet(Select { arms: [SelectArm { src: r1, dst: r4, resume: s3 }, SelectArm { src: r3, dst: r5, resume: s4 }] })
+  s3:
+    CoreSet(Return { src: r4 })
+  s4:
+    PureSet(LoadConst { dst: r6, value: String("ActionTimeout") })
+    PureSet(LoadConst { dst: r7, value: None })
+    PureSet(MakeException { dst: r8, type_id: r6, details: r7 })
+    CoreSet(Raise { src: r8 })
+f4: [9 registers]
+  s0:
+    ExtCallSet(ActionCall { dst: r1, action_ref: TestActionRef("step_four"), args: [r0], resume: s1 })
+  s1:
+    PureSet(LoadConst { dst: r2, value: Int(2) })
+    ExtCallSet(Sleep { dst: r3, duration: r2, resume: s2, unskippable: true })
+  s2:
+    CoreSet(Select { arms: [SelectArm { src: r1, dst: r4, resume: s3 }, SelectArm { src: r3, dst: r5, resume: s4 }] })
+  s3:
+    CoreSet(Return { src: r4 })
+  s4:
+    PureSet(LoadConst { dst: r6, value: String("ActionTimeout") })
+    PureSet(LoadConst { dst: r7, value: None })
+    PureSet(MakeException { dst: r8, type_id: r6, details: r7 })
+    CoreSet(Raise { src: r8 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_policy__integration_exception_custom.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_policy__integration_exception_custom.py__bytecode.snap
@@ -1,11 +1,54 @@
 ---
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
-expression: "bytecode for python/tests/fixtures_policy/integration_exception_custom.py [compilation error]"
+expression: bytecode for python/tests/fixtures_policy/integration_exception_custom.py
 ---
-FunctionCompiler(
-    Unsupported(
-        RetryPolicy {
-            action_name: "explode_custom",
-        },
-    ),
-)
+fn main(input: [], output: []):
+    try:
+        number = @integration_exception_custom.provide_value()
+        @integration_exception_custom.explode_custom(value=number) [retry: 0]
+    except CustomError:
+        result = @integration_exception_custom.cleanup(label="custom_fallback")
+    return result
+---
+f0: [3 registers]
+  s0:
+    CoreSet(PushExceptionHandlers { handlers: [ExceptionHandler { handler_state: s2, exception_types: ["CustomError"], exception_dst: None }] })
+    ExtCallSet(ActionCall { dst: r0, action_ref: TestActionRef("provide_value"), args: [], resume: s3 })
+  s1:
+    CoreSet(Return { src: r2 })
+  s2:
+    PureSet(LoadConst { dst: r1, value: String("custom_fallback") })
+    ExtCallSet(ActionCall { dst: r2, action_ref: TestActionRef("cleanup"), args: [r1], resume: s6 })
+  s3:
+    CoreSet(Await { dst: r0, src: r0, resume: s4 })
+  s4:
+    CoreSet(Call { dst: r1, function_id: f1, args: [r0] })
+    CoreSet(Await { dst: r1, src: r1, resume: s5 })
+  s5:
+    CoreSet(PopExceptionHandlers { count: 1 })
+    CoreSet(Jump { target_state: s1 })
+  s6:
+    CoreSet(Await { dst: r2, src: r2, resume: s7 })
+  s7:
+    CoreSet(Jump { target_state: s1 })
+f1: [8 registers]
+  s0:
+    PureSet(LoadConst { dst: r1, value: Int(0) })
+    PureSet(LoadConst { dst: r2, value: Int(1) })
+    CoreSet(Jump { target_state: s1 })
+  s1:
+    CoreSet(PushExceptionHandlers { handlers: [ExceptionHandler { handler_state: s2, exception_types: [], exception_dst: Some(r3) }] })
+    ExtCallSet(ActionCall { dst: r4, action_ref: TestActionRef("explode_custom"), args: [r0], resume: s4 })
+  s2:
+    PureSet(LoadConst { dst: r6, value: Int(0) })
+    PureSet(Binary { kind: Lt, op: BinaryOp { dst: r7, a: r1, b: r6 } })
+    CoreSet(JumpIf { target_state: s3, cond: r7 })
+    CoreSet(Raise { src: r3 })
+  s3:
+    PureSet(Binary { kind: Add, op: BinaryOp { dst: r1, a: r1, b: r2 } })
+    CoreSet(Jump { target_state: s1 })
+  s4:
+    CoreSet(Await { dst: r5, src: r4, resume: s5 })
+  s5:
+    CoreSet(PopExceptionHandlers { count: 1 })
+    CoreSet(Return { src: r5 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_policy__integration_exception_custom.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_policy__integration_exception_custom.py__bytecode.snap
@@ -1,35 +1,11 @@
 ---
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
-assertion_line: 113
-expression: bytecode for python/tests/fixtures_policy/integration_exception_custom.py
+expression: "bytecode for python/tests/fixtures_policy/integration_exception_custom.py [compilation error]"
 ---
-fn main(input: [], output: []):
-    try:
-        number = @integration_exception_custom.provide_value()
-        @integration_exception_custom.explode_custom(value=number) [retry: 0]
-    except CustomError:
-        result = @integration_exception_custom.cleanup(label="custom_fallback")
-    return result
----
-f0: [3 registers]
-  s0:
-    CoreSet(PushExceptionHandlers { handlers: [ExceptionHandler { handler_state: s2, exception_types: ["CustomError"], exception_dst: None }] })
-    ExtCallSet(ActionCall { dst: r0, action_ref: TestActionRef("provide_value"), args: [], resume: s3 })
-  s1:
-    CoreSet(Return { src: r2 })
-  s2:
-    PureSet(LoadConst { dst: r1, value: String("custom_fallback") })
-    ExtCallSet(ActionCall { dst: r2, action_ref: TestActionRef("cleanup"), args: [r1], resume: s7 })
-  s3:
-    CoreSet(Await { dst: r0, src: r0, resume: s4 })
-  s4:
-    ExtCallSet(ActionCall { dst: r1, action_ref: TestActionRef("explode_custom"), args: [r0], resume: s5 })
-  s5:
-    CoreSet(Await { dst: r1, src: r1, resume: s6 })
-  s6:
-    CoreSet(PopExceptionHandlers { count: 1 })
-    CoreSet(Jump { target_state: s1 })
-  s7:
-    CoreSet(Await { dst: r2, src: r2, resume: s8 })
-  s8:
-    CoreSet(Jump { target_state: s1 })
+FunctionCompiler(
+    Unsupported(
+        RetryPolicy {
+            action_name: "explode_custom",
+        },
+    ),
+)

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_policy__policy_variations.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_policy__policy_variations.py__bytecode.snap
@@ -4,8 +4,8 @@ expression: "bytecode for python/tests/fixtures_policy/policy_variations.py [com
 ---
 FunctionCompiler(
     Unsupported(
-        TimeoutPolicy {
-            action_name: "action_with_timeout_int",
+        RetryPolicy {
+            action_name: "action_with_retry_backoff",
         },
     ),
 )

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_policy__policy_variations.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_policy__policy_variations.py__bytecode.snap
@@ -1,11 +1,166 @@
 ---
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
-expression: "bytecode for python/tests/fixtures_policy/policy_variations.py [compilation error]"
+expression: bytecode for python/tests/fixtures_policy/policy_variations.py
 ---
-FunctionCompiler(
-    Unsupported(
-        RetryPolicy {
-            action_name: "action_with_retry_backoff",
-        },
-    ),
-)
+fn main(input: [value], output: []):
+    a = @policy_variations.action_with_timeout_int(value=value) [timeout: 1m]
+    b = @policy_variations.action_with_timeout_minutes(value=a) [timeout: 2m]
+    c = @policy_variations.action_with_retry_backoff(value=b) [retry: 2, backoff: 5s]
+    d = @policy_variations.action_with_retry_exceptions(value=c) [ValueError, KeyError -> retry: 1]
+    d_retry_default = @policy_variations.action_with_retry_default(value=d) [retry: 100]
+    e = @policy_variations.action_with_timeout_hours(value=d_retry_default) [timeout: 1h]
+    f = @policy_variations.action_with_timeout_days(value=e) [timeout: 24h]
+    return f
+---
+f0: [8 registers]
+  s0:
+    CoreSet(Call { dst: r1, function_id: f1, args: [r0] })
+    CoreSet(Await { dst: r1, src: r1, resume: s1 })
+  s1:
+    CoreSet(Call { dst: r2, function_id: f2, args: [r1] })
+    CoreSet(Await { dst: r2, src: r2, resume: s2 })
+  s2:
+    CoreSet(Call { dst: r3, function_id: f3, args: [r2] })
+    CoreSet(Await { dst: r3, src: r3, resume: s3 })
+  s3:
+    CoreSet(Call { dst: r4, function_id: f4, args: [r3] })
+    CoreSet(Await { dst: r4, src: r4, resume: s4 })
+  s4:
+    CoreSet(Call { dst: r5, function_id: f5, args: [r4] })
+    CoreSet(Await { dst: r5, src: r5, resume: s5 })
+  s5:
+    CoreSet(Call { dst: r6, function_id: f6, args: [r5] })
+    CoreSet(Await { dst: r6, src: r6, resume: s6 })
+  s6:
+    CoreSet(Call { dst: r7, function_id: f7, args: [r6] })
+    CoreSet(Await { dst: r7, src: r7, resume: s7 })
+  s7:
+    CoreSet(Return { src: r7 })
+f1: [9 registers]
+  s0:
+    ExtCallSet(ActionCall { dst: r1, action_ref: TestActionRef("action_with_timeout_int"), args: [r0], resume: s1 })
+  s1:
+    PureSet(LoadConst { dst: r2, value: Int(60) })
+    ExtCallSet(Sleep { dst: r3, duration: r2, resume: s2, unskippable: true })
+  s2:
+    CoreSet(Select { arms: [SelectArm { src: r1, dst: r4, resume: s3 }, SelectArm { src: r3, dst: r5, resume: s4 }] })
+  s3:
+    CoreSet(Return { src: r4 })
+  s4:
+    PureSet(LoadConst { dst: r6, value: String("ActionTimeout") })
+    PureSet(LoadConst { dst: r7, value: None })
+    PureSet(MakeException { dst: r8, type_id: r6, details: r7 })
+    CoreSet(Raise { src: r8 })
+f2: [9 registers]
+  s0:
+    ExtCallSet(ActionCall { dst: r1, action_ref: TestActionRef("action_with_timeout_minutes"), args: [r0], resume: s1 })
+  s1:
+    PureSet(LoadConst { dst: r2, value: Int(120) })
+    ExtCallSet(Sleep { dst: r3, duration: r2, resume: s2, unskippable: true })
+  s2:
+    CoreSet(Select { arms: [SelectArm { src: r1, dst: r4, resume: s3 }, SelectArm { src: r3, dst: r5, resume: s4 }] })
+  s3:
+    CoreSet(Return { src: r4 })
+  s4:
+    PureSet(LoadConst { dst: r6, value: String("ActionTimeout") })
+    PureSet(LoadConst { dst: r7, value: None })
+    PureSet(MakeException { dst: r8, type_id: r6, details: r7 })
+    CoreSet(Raise { src: r8 })
+f3: [11 registers]
+  s0:
+    PureSet(LoadConst { dst: r1, value: Int(0) })
+    PureSet(LoadConst { dst: r2, value: Int(1) })
+    CoreSet(Jump { target_state: s1 })
+  s1:
+    CoreSet(PushExceptionHandlers { handlers: [ExceptionHandler { handler_state: s2, exception_types: [], exception_dst: Some(r3) }] })
+    ExtCallSet(ActionCall { dst: r4, action_ref: TestActionRef("action_with_retry_backoff"), args: [r0], resume: s4 })
+  s2:
+    PureSet(LoadConst { dst: r6, value: Int(2) })
+    PureSet(Binary { kind: Lt, op: BinaryOp { dst: r7, a: r1, b: r6 } })
+    CoreSet(JumpIf { target_state: s3, cond: r7 })
+    CoreSet(Raise { src: r3 })
+  s3:
+    PureSet(Binary { kind: Add, op: BinaryOp { dst: r1, a: r1, b: r2 } })
+    PureSet(LoadConst { dst: r8, value: Int(5) })
+    ExtCallSet(Sleep { dst: r9, duration: r8, resume: s6, unskippable: false })
+  s4:
+    CoreSet(Await { dst: r5, src: r4, resume: s5 })
+  s5:
+    CoreSet(PopExceptionHandlers { count: 1 })
+    CoreSet(Return { src: r5 })
+  s6:
+    CoreSet(Await { dst: r10, src: r9, resume: s7 })
+  s7:
+    CoreSet(Jump { target_state: s1 })
+f4: [8 registers]
+  s0:
+    PureSet(LoadConst { dst: r1, value: Int(0) })
+    PureSet(LoadConst { dst: r2, value: Int(1) })
+    CoreSet(Jump { target_state: s1 })
+  s1:
+    CoreSet(PushExceptionHandlers { handlers: [ExceptionHandler { handler_state: s2, exception_types: ["ValueError", "KeyError"], exception_dst: Some(r3) }] })
+    ExtCallSet(ActionCall { dst: r4, action_ref: TestActionRef("action_with_retry_exceptions"), args: [r0], resume: s4 })
+  s2:
+    PureSet(LoadConst { dst: r6, value: Int(1) })
+    PureSet(Binary { kind: Lt, op: BinaryOp { dst: r7, a: r1, b: r6 } })
+    CoreSet(JumpIf { target_state: s3, cond: r7 })
+    CoreSet(Raise { src: r3 })
+  s3:
+    PureSet(Binary { kind: Add, op: BinaryOp { dst: r1, a: r1, b: r2 } })
+    CoreSet(Jump { target_state: s1 })
+  s4:
+    CoreSet(Await { dst: r5, src: r4, resume: s5 })
+  s5:
+    CoreSet(PopExceptionHandlers { count: 1 })
+    CoreSet(Return { src: r5 })
+f5: [8 registers]
+  s0:
+    PureSet(LoadConst { dst: r1, value: Int(0) })
+    PureSet(LoadConst { dst: r2, value: Int(1) })
+    CoreSet(Jump { target_state: s1 })
+  s1:
+    CoreSet(PushExceptionHandlers { handlers: [ExceptionHandler { handler_state: s2, exception_types: [], exception_dst: Some(r3) }] })
+    ExtCallSet(ActionCall { dst: r4, action_ref: TestActionRef("action_with_retry_default"), args: [r0], resume: s4 })
+  s2:
+    PureSet(LoadConst { dst: r6, value: Int(100) })
+    PureSet(Binary { kind: Lt, op: BinaryOp { dst: r7, a: r1, b: r6 } })
+    CoreSet(JumpIf { target_state: s3, cond: r7 })
+    CoreSet(Raise { src: r3 })
+  s3:
+    PureSet(Binary { kind: Add, op: BinaryOp { dst: r1, a: r1, b: r2 } })
+    CoreSet(Jump { target_state: s1 })
+  s4:
+    CoreSet(Await { dst: r5, src: r4, resume: s5 })
+  s5:
+    CoreSet(PopExceptionHandlers { count: 1 })
+    CoreSet(Return { src: r5 })
+f6: [9 registers]
+  s0:
+    ExtCallSet(ActionCall { dst: r1, action_ref: TestActionRef("action_with_timeout_hours"), args: [r0], resume: s1 })
+  s1:
+    PureSet(LoadConst { dst: r2, value: Int(3600) })
+    ExtCallSet(Sleep { dst: r3, duration: r2, resume: s2, unskippable: true })
+  s2:
+    CoreSet(Select { arms: [SelectArm { src: r1, dst: r4, resume: s3 }, SelectArm { src: r3, dst: r5, resume: s4 }] })
+  s3:
+    CoreSet(Return { src: r4 })
+  s4:
+    PureSet(LoadConst { dst: r6, value: String("ActionTimeout") })
+    PureSet(LoadConst { dst: r7, value: None })
+    PureSet(MakeException { dst: r8, type_id: r6, details: r7 })
+    CoreSet(Raise { src: r8 })
+f7: [9 registers]
+  s0:
+    ExtCallSet(ActionCall { dst: r1, action_ref: TestActionRef("action_with_timeout_days"), args: [r0], resume: s1 })
+  s1:
+    PureSet(LoadConst { dst: r2, value: Int(86400) })
+    ExtCallSet(Sleep { dst: r3, duration: r2, resume: s2, unskippable: true })
+  s2:
+    CoreSet(Select { arms: [SelectArm { src: r1, dst: r4, resume: s3 }, SelectArm { src: r3, dst: r5, resume: s4 }] })
+  s3:
+    CoreSet(Return { src: r4 })
+  s4:
+    PureSet(LoadConst { dst: r6, value: String("ActionTimeout") })
+    PureSet(LoadConst { dst: r7, value: None })
+    PureSet(MakeException { dst: r8, type_id: r6, details: r7 })
+    CoreSet(Raise { src: r8 })

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_policy__policy_variations.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_policy__policy_variations.py__bytecode.snap
@@ -1,45 +1,11 @@
 ---
 source: crates/lib/vm-compiler-for-ast-old/tests/python.rs
-expression: bytecode for python/tests/fixtures_policy/policy_variations.py
+expression: "bytecode for python/tests/fixtures_policy/policy_variations.py [compilation error]"
 ---
-fn main(input: [value], output: []):
-    a = @policy_variations.action_with_timeout_int(value=value) [timeout: 1m]
-    b = @policy_variations.action_with_timeout_minutes(value=a) [timeout: 2m]
-    c = @policy_variations.action_with_retry_backoff(value=b) [retry: 2, backoff: 5s]
-    d = @policy_variations.action_with_retry_exceptions(value=c) [ValueError, KeyError -> retry: 1]
-    d_retry_default = @policy_variations.action_with_retry_default(value=d) [retry: 100]
-    e = @policy_variations.action_with_timeout_hours(value=d_retry_default) [timeout: 1h]
-    f = @policy_variations.action_with_timeout_days(value=e) [timeout: 24h]
-    return f
----
-f0: [8 registers]
-  s0:
-    ExtCallSet(ActionCall { dst: r1, action_ref: TestActionRef("action_with_timeout_int"), args: [r0], resume: s1 })
-  s1:
-    CoreSet(Await { dst: r1, src: r1, resume: s2 })
-  s2:
-    ExtCallSet(ActionCall { dst: r2, action_ref: TestActionRef("action_with_timeout_minutes"), args: [r1], resume: s3 })
-  s3:
-    CoreSet(Await { dst: r2, src: r2, resume: s4 })
-  s4:
-    ExtCallSet(ActionCall { dst: r3, action_ref: TestActionRef("action_with_retry_backoff"), args: [r2], resume: s5 })
-  s5:
-    CoreSet(Await { dst: r3, src: r3, resume: s6 })
-  s6:
-    ExtCallSet(ActionCall { dst: r4, action_ref: TestActionRef("action_with_retry_exceptions"), args: [r3], resume: s7 })
-  s7:
-    CoreSet(Await { dst: r4, src: r4, resume: s8 })
-  s8:
-    ExtCallSet(ActionCall { dst: r5, action_ref: TestActionRef("action_with_retry_default"), args: [r4], resume: s9 })
-  s9:
-    CoreSet(Await { dst: r5, src: r5, resume: s10 })
-  s10:
-    ExtCallSet(ActionCall { dst: r6, action_ref: TestActionRef("action_with_timeout_hours"), args: [r5], resume: s11 })
-  s11:
-    CoreSet(Await { dst: r6, src: r6, resume: s12 })
-  s12:
-    ExtCallSet(ActionCall { dst: r7, action_ref: TestActionRef("action_with_timeout_days"), args: [r6], resume: s13 })
-  s13:
-    CoreSet(Await { dst: r7, src: r7, resume: s14 })
-  s14:
-    CoreSet(Return { src: r7 })
+FunctionCompiler(
+    Unsupported(
+        TimeoutPolicy {
+            action_name: "action_with_timeout_int",
+        },
+    ),
+)

--- a/example_app/src/example_app/workflows.py
+++ b/example_app/src/example_app/workflows.py
@@ -982,7 +982,10 @@ class TimeoutProbeWorkflow(Workflow):
                     timeout_probe_attempt(
                         counter_path=counter_path,
                     ),
-                    retry=RetryPolicy(attempts=1),
+                    retry=RetryPolicy(
+                        attempts=1,
+                        exception_types=["ActionTimeout"],
+                    ),
                     timeout=1,
                 )
             elif max_attempts == 2:
@@ -990,31 +993,46 @@ class TimeoutProbeWorkflow(Workflow):
                     timeout_probe_attempt(
                         counter_path=counter_path,
                     ),
-                    retry=RetryPolicy(attempts=2),
+                    retry=RetryPolicy(
+                        attempts=2,
+                        exception_types=["ActionTimeout"],
+                    ),
                     timeout=1,
                 )
             elif max_attempts == 3:
                 await self.run_action(
                     timeout_probe_attempt(counter_path=counter_path),
-                    retry=RetryPolicy(attempts=3),
+                    retry=RetryPolicy(
+                        attempts=3,
+                        exception_types=["ActionTimeout"],
+                    ),
                     timeout=1,
                 )
             elif max_attempts == 4:
                 await self.run_action(
                     timeout_probe_attempt(counter_path=counter_path),
-                    retry=RetryPolicy(attempts=4),
+                    retry=RetryPolicy(
+                        attempts=4,
+                        exception_types=["ActionTimeout"],
+                    ),
                     timeout=1,
                 )
             elif max_attempts == 5:
                 await self.run_action(
                     timeout_probe_attempt(counter_path=counter_path),
-                    retry=RetryPolicy(attempts=5),
+                    retry=RetryPolicy(
+                        attempts=5,
+                        exception_types=["ActionTimeout"],
+                    ),
                     timeout=1,
                 )
             else:
                 await self.run_action(
                     timeout_probe_attempt(counter_path=counter_path),
-                    retry=RetryPolicy(attempts=6),
+                    retry=RetryPolicy(
+                        attempts=6,
+                        exception_types=["ActionTimeout"],
+                    ),
                     timeout=1,
                 )
         except Exception:


### PR DESCRIPTION
Goes in after #496.

---

This PR implements retries and timeouts at the VM compiler side; the retries and timeouts are both compiled in as regular instructions, and the very same instructions can be exposed to the users in one way or another to allow them building more advanced custom logic at the same level as we inject our built-in handling.