### PR TITLE
Implement extra functions at vm-compiler-for-ast-old

### DIFF
--- a/crates/lib/vm-compiler-for-ast-old/src/function/compiler.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/function/compiler.rs
@@ -70,6 +70,7 @@ pub use self::error::*;
 use waymark_vm_ast_old::{FunctionDef, Spanned};
 use waymark_vm_compiler_for_ast_old_core::InstructionFor;
 
+use super::extras::ExtraFunctions;
 use super::table::FunctionTable;
 
 /// Concrete function-compiler error type for a spec and lowering pair.
@@ -89,6 +90,9 @@ where
     /// Program-wide function metadata for resolving user-defined calls.
     function_table: &'a FunctionTable,
 
+    /// Program-wide extra functions introduced during lowering.
+    extra_fns: &'a mut ExtraFunctions<Spec>,
+
     /// Bytecode emitter for the function currently being lowered.
     emitter: FunctionEmitter<Spec>,
 
@@ -107,6 +111,7 @@ where
     /// Creates a compiler for one function definition.
     pub fn new(
         function_table: &'a FunctionTable,
+        extra_fns: &'a mut ExtraFunctions<Spec>,
         function: &'a Spanned<FunctionDef>,
     ) -> Result<Self, ErrorFor<Spec, Lowering>> {
         let mut local_frame = LocalFrame::new();
@@ -123,6 +128,7 @@ where
         Ok(Self {
             phantom_data: core::marker::PhantomData,
             function_table,
+            extra_fns,
             emitter: FunctionEmitter::new(),
             local_frame,
             flow_state,
@@ -163,6 +169,7 @@ where
             self.function_table,
             &mut self.emitter,
             &mut self.local_frame,
+            &mut *self.extra_fns,
             &mut self.flow_state,
         )
     }

--- a/crates/lib/vm-compiler-for-ast-old/src/function/compiler/context.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/function/compiler/context.rs
@@ -2,6 +2,7 @@
 
 use crate::function::{
     compiler::{FlowState, FunctionEmitter, LocalFrame},
+    extras::ExtraFunctions,
     table::FunctionTable,
 };
 
@@ -21,6 +22,9 @@ where
 
     /// Local-variable and register-allocation state.
     pub local_frame: &'borrow mut LocalFrame,
+
+    /// Program-wide extra functions introduced during lowering.
+    pub extra_fns: &'borrow mut ExtraFunctions<Spec>,
 
     /// Current definite-initialization state.
     pub flow_state: FlowStateRef,
@@ -44,6 +48,7 @@ where
         function_table: &'table FunctionTable,
         emitter: &'borrow mut FunctionEmitter<Spec>,
         local_frame: &'borrow mut LocalFrame,
+        extra_fns: &'borrow mut ExtraFunctions<Spec>,
         flow_state: &'borrow mut FlowState,
     ) -> Self {
         Self {
@@ -51,6 +56,7 @@ where
             function_table,
             emitter,
             local_frame,
+            extra_fns,
             flow_state,
         }
     }
@@ -62,6 +68,7 @@ where
             function_table: self.function_table,
             emitter: &mut *self.emitter,
             local_frame: &mut *self.local_frame,
+            extra_fns: &mut *self.extra_fns,
             flow_state: &mut *self.flow_state,
         }
     }
@@ -73,6 +80,7 @@ where
             function_table: self.function_table,
             emitter: &mut *self.emitter,
             local_frame: &mut *self.local_frame,
+            extra_fns: &mut *self.extra_fns,
             flow_state: &*self.flow_state,
         }
     }
@@ -85,6 +93,7 @@ where
             function_table: self.function_table,
             emitter: self.emitter,
             local_frame: self.local_frame,
+            extra_fns: self.extra_fns,
             flow_state: &*self.flow_state,
         }
     }

--- a/crates/lib/vm-compiler-for-ast-old/src/function/compiler/lowering/assignment.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/function/compiler/lowering/assignment.rs
@@ -182,6 +182,8 @@ mod tests {
     use waymark_vm_instructions_pureset::PureSet;
     use waymark_vm_runtime_core::RegisterId;
 
+    use crate::function::extras::ExtraFunctions;
+
     use crate::function::compiler::{
         CompilerContextMut,
         bytecode::emitter::FunctionEmitter,
@@ -247,6 +249,7 @@ mod tests {
         let mut emitter = FunctionEmitter::<TestSpec>::new();
         let mut local_frame = LocalFrame::new();
         let mut flow_state = FlowState::new();
+        let mut extra_fns = ExtraFunctions::<TestSpec>::new(1);
         let source_local = local_frame
             .declare_input(&mut flow_state, "source".to_owned())
             .expect("source input should declare");
@@ -257,6 +260,7 @@ mod tests {
                     &function_table,
                     &mut emitter,
                     &mut local_frame,
+                    &mut extra_fns,
                     &mut flow_state,
                 ),
                 0,

--- a/crates/lib/vm-compiler-for-ast-old/src/function/compiler/lowering/parallel.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/function/compiler/lowering/parallel.rs
@@ -150,6 +150,8 @@ mod tests {
     use waymark_vm_runtime_core::RegisterId;
 
     use crate::Marked;
+    use crate::function::extras::ExtraFunctions;
+
     use crate::function::compiler::{
         CompilerContextMut,
         bytecode::emitter::FunctionEmitter,
@@ -163,6 +165,7 @@ mod tests {
         let mut emitter = FunctionEmitter::<TestSpec>::new();
         let mut local_frame = LocalFrame::new();
         let mut flow_state = FlowState::new();
+        let mut extra_fns = ExtraFunctions::<TestSpec>::new(1);
         let assignment = ParallelAssignmentPlan::<TestSpec>::build::<TestLowering, _>(
             nonempty_collections::NESlice::try_from_slice(&["results".to_owned()]).unwrap(),
             &[],
@@ -183,6 +186,7 @@ mod tests {
                     &function_table,
                     &mut emitter,
                     &mut local_frame,
+                    &mut extra_fns,
                     &mut flow_state,
                 ));
 
@@ -214,6 +218,7 @@ mod tests {
         let mut emitter = FunctionEmitter::<TestSpec>::new();
         let mut local_frame = LocalFrame::new();
         let mut flow_state = FlowState::new();
+        let mut extra_fns = ExtraFunctions::<TestSpec>::new(1);
         let calls = [
             Call::Function(function_call("child", vec![int(1)])),
             Call::Function(function_call("child", vec![int(2)])),
@@ -238,6 +243,7 @@ mod tests {
                     &function_table,
                     &mut emitter,
                     &mut local_frame,
+                    &mut extra_fns,
                     &mut flow_state,
                 ));
 

--- a/crates/lib/vm-compiler-for-ast-old/src/function/compiler/lowering/statement.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/function/compiler/lowering/statement.rs
@@ -507,6 +507,8 @@ mod tests {
     use waymark_vm_instructions_pureset::PureSet;
     use waymark_vm_runtime_core::RegisterId;
 
+    use crate::function::extras::ExtraFunctions;
+
     use crate::function::compiler::{
         CompilerContextMut,
         bytecode::emitter::FunctionEmitter,
@@ -521,6 +523,7 @@ mod tests {
         let mut emitter = FunctionEmitter::<TestSpec>::new();
         let mut local_frame = LocalFrame::new();
         let mut flow_state = FlowState::new();
+        let mut extra_fns = ExtraFunctions::<TestSpec>::new(1);
         let flag_local = local_frame
             .declare_input(&mut flow_state, "flag".to_owned())
             .expect("flag input should declare");
@@ -532,6 +535,7 @@ mod tests {
                     &function_table,
                     &mut emitter,
                     &mut local_frame,
+                    &mut extra_fns,
                     &mut flow_state,
                 ),
                 loop_control,

--- a/crates/lib/vm-compiler-for-ast-old/src/function/compiler/lowering/value.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/function/compiler/lowering/value.rs
@@ -580,6 +580,8 @@ mod tests {
     use waymark_vm_instructions_pureset::PureSet;
     use waymark_vm_runtime_core::RegisterId;
 
+    use crate::function::extras::ExtraFunctions;
+
     use crate::function::compiler::{
         CompilerContextMut,
         bytecode::emitter::FunctionEmitter,
@@ -593,6 +595,7 @@ mod tests {
         let mut emitter = FunctionEmitter::<TestSpec>::new();
         let mut local_frame = LocalFrame::new();
         let mut flow_state = FlowState::new();
+        let mut extra_fns = ExtraFunctions::<TestSpec>::new(1);
 
         let dst = {
             let mut values = ValueCompiler::<TestSpec, TestLowering>::new(
@@ -600,6 +603,7 @@ mod tests {
                     &function_table,
                     &mut emitter,
                     &mut local_frame,
+                    &mut extra_fns,
                     &mut flow_state,
                 )
                 .into_ref(),
@@ -656,6 +660,7 @@ mod tests {
         let mut emitter = FunctionEmitter::<TestSpec>::new();
         let mut local_frame = LocalFrame::new();
         let mut flow_state = FlowState::new();
+        let mut extra_fns = ExtraFunctions::<TestSpec>::new(1);
 
         let dst = {
             let mut values = ValueCompiler::<TestSpec, TestLowering>::new(
@@ -663,6 +668,7 @@ mod tests {
                     &function_table,
                     &mut emitter,
                     &mut local_frame,
+                    &mut extra_fns,
                     &mut flow_state,
                 )
                 .into_ref(),
@@ -724,6 +730,7 @@ mod tests {
         let mut emitter = FunctionEmitter::<TestSpec>::new();
         let mut local_frame = LocalFrame::new();
         let mut flow_state = FlowState::new();
+        let mut extra_fns = ExtraFunctions::<TestSpec>::new(1);
         let duration = int(2);
 
         {
@@ -732,6 +739,7 @@ mod tests {
                     &function_table,
                     &mut emitter,
                     &mut local_frame,
+                    &mut extra_fns,
                     &mut flow_state,
                 )
                 .into_ref(),
@@ -785,6 +793,7 @@ mod tests {
         let mut emitter = FunctionEmitter::<TestSpec>::new();
         let mut local_frame = LocalFrame::new();
         let mut flow_state = FlowState::new();
+        let mut extra_fns = ExtraFunctions::<TestSpec>::new(1);
 
         {
             let mut values = ValueCompiler::<TestSpec, TestLowering>::new(
@@ -792,6 +801,7 @@ mod tests {
                     &function_table,
                     &mut emitter,
                     &mut local_frame,
+                    &mut extra_fns,
                     &mut flow_state,
                 )
                 .into_ref(),
@@ -827,6 +837,7 @@ mod tests {
         let mut local_frame = LocalFrame::new();
         let preferred_dst = local_frame.allocate_register();
         let mut flow_state = FlowState::new();
+        let mut extra_fns = ExtraFunctions::<TestSpec>::new(1);
 
         let dst = {
             let mut values = ValueCompiler::<TestSpec, TestLowering>::new(
@@ -834,6 +845,7 @@ mod tests {
                     &function_table,
                     &mut emitter,
                     &mut local_frame,
+                    &mut extra_fns,
                     &mut flow_state,
                 )
                 .into_ref(),
@@ -866,6 +878,7 @@ mod tests {
         let mut local_frame = LocalFrame::new();
         let preferred_dst = local_frame.allocate_register();
         let mut flow_state = FlowState::new();
+        let mut extra_fns = ExtraFunctions::<TestSpec>::new(1);
 
         let dst = {
             let mut values = ValueCompiler::<TestSpec, TestLowering>::new(
@@ -873,6 +886,7 @@ mod tests {
                     &function_table,
                     &mut emitter,
                     &mut local_frame,
+                    &mut extra_fns,
                     &mut flow_state,
                 )
                 .into_ref(),
@@ -925,6 +939,7 @@ mod tests {
         let mut local_frame = LocalFrame::new();
         let preferred_dst = local_frame.allocate_register();
         let mut flow_state = FlowState::new();
+        let mut extra_fns = ExtraFunctions::<TestSpec>::new(1);
 
         let dst = {
             let mut values = ValueCompiler::<TestSpec, TestLowering>::new(
@@ -932,6 +947,7 @@ mod tests {
                     &function_table,
                     &mut emitter,
                     &mut local_frame,
+                    &mut extra_fns,
                     &mut flow_state,
                 )
                 .into_ref(),
@@ -989,6 +1005,7 @@ mod tests {
         let mut local_frame = LocalFrame::new();
         let preferred_dst = local_frame.allocate_register();
         let mut flow_state = FlowState::new();
+        let mut extra_fns = ExtraFunctions::<TestSpec>::new(1);
 
         let dst = {
             let mut values = ValueCompiler::<TestSpec, TestLowering>::new(
@@ -996,6 +1013,7 @@ mod tests {
                     &function_table,
                     &mut emitter,
                     &mut local_frame,
+                    &mut extra_fns,
                     &mut flow_state,
                 )
                 .into_ref(),
@@ -1058,6 +1076,7 @@ mod tests {
         let mut emitter = FunctionEmitter::<TestSpec>::new();
         let mut local_frame = LocalFrame::new();
         let mut flow_state = FlowState::new();
+        let mut extra_fns = ExtraFunctions::<TestSpec>::new(1);
 
         {
             let mut values = ValueCompiler::<TestSpec, TestLowering>::new(
@@ -1065,6 +1084,7 @@ mod tests {
                     &function_table,
                     &mut emitter,
                     &mut local_frame,
+                    &mut extra_fns,
                     &mut flow_state,
                 )
                 .into_ref(),
@@ -1105,6 +1125,7 @@ mod tests {
         let mut emitter = FunctionEmitter::<TestSpec>::new();
         let mut local_frame = LocalFrame::new();
         let mut flow_state = FlowState::new();
+        let mut extra_fns = ExtraFunctions::<TestSpec>::new(1);
 
         {
             let mut values = ValueCompiler::<TestSpec, TestLowering>::new(
@@ -1112,6 +1133,7 @@ mod tests {
                     &function_table,
                     &mut emitter,
                     &mut local_frame,
+                    &mut extra_fns,
                     &mut flow_state,
                 )
                 .into_ref(),
@@ -1165,6 +1187,7 @@ mod tests {
         let mut emitter = FunctionEmitter::<TestSpec>::new();
         let mut local_frame = LocalFrame::new();
         let mut flow_state = FlowState::new();
+        let mut extra_fns = ExtraFunctions::<TestSpec>::new(1);
 
         {
             let mut values = ValueCompiler::<TestSpec, TestLowering>::new(
@@ -1172,6 +1195,7 @@ mod tests {
                     &function_table,
                     &mut emitter,
                     &mut local_frame,
+                    &mut extra_fns,
                     &mut flow_state,
                 )
                 .into_ref(),
@@ -1239,6 +1263,7 @@ mod tests {
         let mut emitter = FunctionEmitter::<TestSpec>::new();
         let mut local_frame = LocalFrame::new();
         let mut flow_state = FlowState::new();
+        let mut extra_fns = ExtraFunctions::<TestSpec>::new(1);
         let expr = spanned(Expr::List {
             elements: vec![int(1), int(2)],
         });
@@ -1249,6 +1274,7 @@ mod tests {
                     &function_table,
                     &mut emitter,
                     &mut local_frame,
+                    &mut extra_fns,
                     &mut flow_state,
                 )
                 .into_ref(),
@@ -1292,6 +1318,7 @@ mod tests {
         let mut emitter = FunctionEmitter::<TestSpec>::new();
         let mut local_frame = LocalFrame::new();
         let mut flow_state = FlowState::new();
+        let mut extra_fns = ExtraFunctions::<TestSpec>::new(1);
         let expr = spanned(Expr::Dict {
             entries: vec![DictEntry {
                 key: int(1),
@@ -1305,6 +1332,7 @@ mod tests {
                     &function_table,
                     &mut emitter,
                     &mut local_frame,
+                    &mut extra_fns,
                     &mut flow_state,
                 )
                 .into_ref(),
@@ -1351,6 +1379,7 @@ mod tests {
         let mut emitter = FunctionEmitter::<TestSpec>::new();
         let mut local_frame = LocalFrame::new();
         let mut flow_state = FlowState::new();
+        let mut extra_fns = ExtraFunctions::<TestSpec>::new(1);
         let expr = len_expr(spanned(Expr::List {
             elements: vec![int(1), int(2)],
         }));
@@ -1361,6 +1390,7 @@ mod tests {
                     &function_table,
                     &mut emitter,
                     &mut local_frame,
+                    &mut extra_fns,
                     &mut flow_state,
                 )
                 .into_ref(),
@@ -1409,6 +1439,7 @@ mod tests {
         let mut emitter = FunctionEmitter::<TestSpec>::new();
         let mut local_frame = LocalFrame::new();
         let mut flow_state = FlowState::new();
+        let mut extra_fns = ExtraFunctions::<TestSpec>::new(1);
         let expr = spanned(Expr::Index {
             object: Box::new(spanned(Expr::List {
                 elements: vec![int(3), int(4)],
@@ -1422,6 +1453,7 @@ mod tests {
                     &function_table,
                     &mut emitter,
                     &mut local_frame,
+                    &mut extra_fns,
                     &mut flow_state,
                 )
                 .into_ref(),
@@ -1483,6 +1515,7 @@ mod tests {
         let mut emitter = FunctionEmitter::<TestSpec>::new();
         let mut local_frame = LocalFrame::new();
         let mut flow_state = FlowState::new();
+        let mut extra_fns = ExtraFunctions::<TestSpec>::new(1);
         let expr = spanned(Expr::Dot {
             object: Box::new(spanned(Expr::Dict {
                 entries: vec![DictEntry {
@@ -1499,6 +1532,7 @@ mod tests {
                     &function_table,
                     &mut emitter,
                     &mut local_frame,
+                    &mut extra_fns,
                     &mut flow_state,
                 )
                 .into_ref(),
@@ -1555,6 +1589,7 @@ mod tests {
         let mut emitter = FunctionEmitter::<TestSpec>::new();
         let mut local_frame = LocalFrame::new();
         let mut flow_state = FlowState::new();
+        let mut extra_fns = ExtraFunctions::<TestSpec>::new(1);
 
         {
             let mut values = ValueCompiler::<TestSpec, TestLowering>::new(
@@ -1562,6 +1597,7 @@ mod tests {
                     &function_table,
                     &mut emitter,
                     &mut local_frame,
+                    &mut extra_fns,
                     &mut flow_state,
                 )
                 .into_ref(),

--- a/crates/lib/vm-compiler-for-ast-old/src/function/extras.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/function/extras.rs
@@ -1,0 +1,53 @@
+//! Program-wide collection of extra functions.
+
+use waymark_vm_bytecode_core::FunctionId;
+use waymark_vm_compiler_for_ast_old_core::InstructionFor;
+
+/// The extra functions introduced during a program compilation.
+///
+/// Extra functions have no source-level definition of their own - the
+/// compiler introduces them while lowering (e.g. the per-call-site policy
+/// wrappers). Their ids continue right after the source function ids, so
+/// they must be appended to the executable in generation order directly
+/// after the source functions.
+pub struct ExtraFunctions<Spec>
+where
+    Spec: waymark_vm_compiler_for_ast_old_core::SpecRequirements,
+{
+    /// The function id to assign to the next extra function.
+    next_function_id: usize,
+
+    /// The compiled extra functions in generation order.
+    functions: Vec<waymark_vm_bytecode::Function<InstructionFor<Spec>>>,
+}
+
+impl<Spec> ExtraFunctions<Spec>
+where
+    Spec: waymark_vm_compiler_for_ast_old_core::SpecRequirements,
+{
+    /// Creates an empty collection for a program with the given number of
+    /// source functions.
+    pub fn new(source_function_count: usize) -> Self {
+        Self {
+            next_function_id: source_function_count,
+            functions: Vec::new(),
+        }
+    }
+
+    /// Adds one compiled extra function and returns its assigned id.
+    pub fn insert(
+        &mut self,
+        function: waymark_vm_bytecode::Function<InstructionFor<Spec>>,
+    ) -> FunctionId {
+        let function_id = FunctionId(self.next_function_id);
+        self.next_function_id += 1;
+        self.functions.push(function);
+        function_id
+    }
+
+    /// Consumes the collection, returning the extra functions to append to
+    /// the executable after the source functions.
+    pub fn finish(self) -> Vec<waymark_vm_bytecode::Function<InstructionFor<Spec>>> {
+        self.functions
+    }
+}

--- a/crates/lib/vm-compiler-for-ast-old/src/function/mod.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/function/mod.rs
@@ -1,4 +1,5 @@
 //! Function compilation facilities.
 
 pub mod compiler;
+pub mod extras;
 pub mod table;

--- a/crates/lib/vm-compiler-for-ast-old/src/lib.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/lib.rs
@@ -120,12 +120,20 @@ where
     Lowering: waymark_vm_compiler_for_ast_old_core::lowering::FullSet<Spec>,
 {
     let function_table = function::table::FunctionTable::build(program)?;
+    let mut extra_functions = function::extras::ExtraFunctions::new(program.functions.len());
     let mut functions = TypedVec::with_capacity(program.functions.len());
 
     for function in &program.functions {
-        let compiler =
-            function::compiler::FunctionCompiler::<Spec, Lowering>::new(&function_table, function)?;
+        let compiler = function::compiler::FunctionCompiler::<Spec, Lowering>::new(
+            &function_table,
+            &mut extra_functions,
+            function,
+        )?;
         functions.push(compiler.compile(function)?);
+    }
+
+    for extra_function in extra_functions.finish() {
+        functions.push(extra_function);
     }
 
     let executable = waymark_vm_bytecode::Executable { functions };


### PR DESCRIPTION
Goes in after #487

---

The extra functions will be used for wrapping the action calls with retry / timeout handlers; but they're not limited to just that and may be used for something else.