### PR TITLE
Cleanup unused fields from ActionRef

### DIFF
--- a/crates/lib/action-core/src/lib.rs
+++ b/crates/lib/action-core/src/lib.rs
@@ -14,13 +14,4 @@ pub struct ActionRef {
 
     /// Ordered names of the keyword arguments expected by the action.
     pub call_args: Vec<String>,
-
-    /// Timeout in seconds, computed from the action's policies.
-    pub timeout_seconds: u32,
-
-    /// Maximum retry attempts (0 means no retries).
-    pub max_retries: u32,
-
-    /// Exception types that should trigger a retry.
-    pub exception_types: Vec<String>,
 }

--- a/crates/lib/action-effect-reconciler/src/test_support.rs
+++ b/crates/lib/action-effect-reconciler/src/test_support.rs
@@ -275,8 +275,5 @@ pub(crate) fn action_ref(name: &str) -> waymark_action_core::ActionRef {
         action_name: name.to_owned(),
         module_name: None,
         call_args: vec!["value".to_owned()],
-        timeout_seconds: 300,
-        max_retries: 0,
-        exception_types: Vec::new(),
     }
 }

--- a/crates/lib/action-runtime-worker-pool/src/requester.rs
+++ b/crates/lib/action-runtime-worker-pool/src/requester.rs
@@ -67,7 +67,7 @@ where
             action_name: request.action_ref.action_name,
             module_name: request.action_ref.module_name,
             kwargs,
-            timeout_seconds: request.action_ref.timeout_seconds,
+            timeout_seconds: 0,
             attempt_number: 1,
             dispatch_token: uuid::Uuid::new_v4(),
             metadata: encoded_metadata,
@@ -126,9 +126,6 @@ mod tests {
                     action_name: "act".to_owned(),
                     module_name: None,
                     call_args: Vec::new(),
-                    timeout_seconds: 1,
-                    max_retries: 0,
-                    exception_types: Vec::new(),
                 },
                 arguments: Vec::new(),
                 // Sixteen zero bytes are a valid correlation encoding; the

--- a/crates/lib/action-runtime-worker-stream/src/requester.rs
+++ b/crates/lib/action-runtime-worker-stream/src/requester.rs
@@ -59,9 +59,6 @@ fn build_dispatch<Metadata: Encode>(
         action_name,
         module_name,
         call_args,
-        timeout_seconds,
-        max_retries,
-        ..
     } = action_ref;
 
     let kwargs =
@@ -78,8 +75,8 @@ fn build_dispatch<Metadata: Encode>(
         action_name: action_name.clone(),
         module_name: module_name.clone().unwrap_or_default(),
         kwargs,
-        timeout_seconds: Some(timeout_seconds),
-        max_retries: Some(max_retries),
+        timeout_seconds: None,
+        max_retries: None,
         attempt_number: None,
         dispatch_token: None,
         metadata: encoded_metadata,

--- a/crates/lib/extcall-reconciler/src/tests.rs
+++ b/crates/lib/extcall-reconciler/src/tests.rs
@@ -93,9 +93,6 @@ async fn effect_handler_dispatches_action_call() {
             action_name: "test".into(),
             module_name: None,
             call_args: vec!["arg".into()],
-            timeout_seconds: 30,
-            max_retries: 0,
-            exception_types: vec![],
         },
         args: vec![waymark_vm_value::ReadyValue::String("hi".into())],
     };

--- a/crates/lib/vm-compiler-for-ast-old-action-ref/src/lib.rs
+++ b/crates/lib/vm-compiler-for-ast-old-action-ref/src/lib.rs
@@ -1,55 +1,19 @@
 //! Lowering helper: converts an AST [`waymark_vm_ast_old::ActionCall`] into
-//! an [`waymark_action_core::ActionRef`], extracting policy-derived fields.
+//! an [`waymark_action_core::ActionRef`].
+//!
+//! Policy brackets are not part of the action reference: they lower into
+//! bytecode at the call site instead.
 
 #![warn(missing_docs)]
 
 use waymark_action_core::ActionRef;
 use waymark_vm_ast_old::ActionCall;
 
-/// Lower an AST action call into an [`ActionRef`], computing timeout, retry
-/// limits, and exception-type filters from the action's policies.
+/// Lower an AST action call into an [`ActionRef`].
 pub fn lower_action_ref(call: &ActionCall) -> ActionRef {
-    let timeout_seconds = call
-        .policies
-        .iter()
-        .filter_map(|p| match p {
-            waymark_vm_ast_old::PolicyBracket::Timeout(t) => {
-                let s = t.timeout.seconds;
-                if s > 0 { Some(s) } else { None }
-            }
-            _ => None,
-        })
-        .min()
-        .map(|s| s.min(u64::from(u32::MAX)) as u32)
-        .unwrap_or(300);
-
-    let max_retries = call
-        .policies
-        .iter()
-        .filter_map(|p| match p {
-            waymark_vm_ast_old::PolicyBracket::Retry(r) => Some(r.max_retries),
-            _ => None,
-        })
-        .max()
-        .unwrap_or(0);
-
-    let mut exception_types: Vec<String> = Vec::new();
-    for p in &call.policies {
-        if let waymark_vm_ast_old::PolicyBracket::Retry(r) = p {
-            for ty in &r.exception_types {
-                if !exception_types.contains(ty) {
-                    exception_types.push(ty.clone());
-                }
-            }
-        }
-    }
-
     ActionRef {
         action_name: call.action_name.clone(),
         module_name: call.module_name.clone(),
         call_args: call.kwargs.iter().map(|k| k.name.clone()).collect(),
-        timeout_seconds,
-        max_retries,
-        exception_types,
     }
 }


### PR DESCRIPTION
Goes in after #489 

---

Now that we implement the timeouts and retries at the compiler, we don't need to push those parameters into the harness machinery.

We also don't pass the timeout with the action calls anymore; this is something we should move away from either way - and move towards arbitrary VM-issued cancellations; that said, worker-side timeouts may still be useful - so we might revisit this decision.