### PR TITLE
Implement unskippable sleep instructions

### DIFF
--- a/crates/bin/vm-cli/src/run.rs
+++ b/crates/bin/vm-cli/src/run.rs
@@ -116,11 +116,13 @@ pub async fn run(
                         waymark_vm_interpreter_extcallset::Effect::Sleep {
                             promise_state_id,
                             duration,
+                            skip_allowed,
                         } => {
                             tracing::info!(
                                 effect_number = %emitted_effect.number,
                                 ?promise_state_id,
                                 ?duration,
+                                skip_allowed,
                                 "sleep received"
                             );
 

--- a/crates/lib/extcall-reconciler-core/src/lib.rs
+++ b/crates/lib/extcall-reconciler-core/src/lib.rs
@@ -59,11 +59,15 @@ pub trait SleepEffectHandler {
     type Error: std::fmt::Debug;
 
     /// Record a sleep deadline for the given promise.
+    ///
+    /// When `skip_allowed` is false, the sleep's duration is load-bearing
+    /// and the handler must not settle the sleep early.
     fn record_sleep(
         &mut self,
         effect_number: EffectNumber,
         promise_state_id: PromiseStateId,
         duration: NonZeroDuration,
+        skip_allowed: bool,
     ) -> impl std::future::Future<Output = Result<(), Self::Error>> + Send;
 }
 

--- a/crates/lib/extcall-reconciler/src/lib.rs
+++ b/crates/lib/extcall-reconciler/src/lib.rs
@@ -118,9 +118,15 @@ where
             Effect::Sleep {
                 promise_state_id,
                 duration,
+                skip_allowed,
             } => {
                 self.sleep
-                    .record_sleep(emitted_effect.number, promise_state_id, duration)
+                    .record_sleep(
+                        emitted_effect.number,
+                        promise_state_id,
+                        duration,
+                        skip_allowed,
+                    )
                     .await
                     .map_err(HandleEffectError::Sleep)?;
             }

--- a/crates/lib/extcall-reconciler/src/tests.rs
+++ b/crates/lib/extcall-reconciler/src/tests.rs
@@ -128,6 +128,7 @@ async fn effect_handler_records_sleep() {
     let effect = Effect::Sleep {
         promise_state_id: PromiseStateId(0),
         duration: NonZeroDuration::try_from(std::time::Duration::from_nanos(1)).unwrap(),
+        skip_allowed: true,
     };
 
     let effect_number = EffectNumber(0);

--- a/crates/lib/sleep-reconciler/src/handler.rs
+++ b/crates/lib/sleep-reconciler/src/handler.rs
@@ -43,6 +43,9 @@ where
         effect_number: EffectNumber,
         promise_state_id: PromiseStateId,
         duration: NonZeroDuration,
+        // Durable execution always lets sleeps elapse in full, so the
+        // skip permission is vacuously honored.
+        _skip_allowed: bool,
     ) -> Result<(), Self::Error> {
         let wake_at = chrono::Utc::now()
             + chrono::Duration::from_std(duration.get()).unwrap_or(chrono::Duration::MAX);

--- a/crates/lib/sleep-reconciler/src/handler/tests.rs
+++ b/crates/lib/sleep-reconciler/src/handler/tests.rs
@@ -23,7 +23,7 @@ async fn records_the_absolute_wake_deadline() {
     let duration = NonZeroDuration::try_from(Duration::from_secs(60)).unwrap();
     let before = chrono::Utc::now();
     handler
-        .record_sleep(EffectNumber(7), PromiseStateId(3), duration)
+        .record_sleep(EffectNumber(7), PromiseStateId(3), duration, true)
         .await
         .expect("record");
     let after = chrono::Utc::now();
@@ -56,7 +56,7 @@ async fn record_errors_propagate() {
 
     let duration = NonZeroDuration::try_from(Duration::from_secs(1)).unwrap();
     handler
-        .record_sleep(EffectNumber(0), PromiseStateId(0), duration)
+        .record_sleep(EffectNumber(0), PromiseStateId(0), duration, true)
         .await
         .expect_err("backend failure surfaces");
     assert!(backend.inner.recorded.lock().unwrap().is_empty());

--- a/crates/lib/transient-sleep-reconciler/src/lib.rs
+++ b/crates/lib/transient-sleep-reconciler/src/lib.rs
@@ -21,8 +21,9 @@ use waymark_vm_runtime_promise_core::PromiseStateId;
 ///
 /// `SleepValueProvider` supplies the value elapsed sleeps resolve with.
 ///
-/// Set `skip_sleep` to true to force all sleeps to resolve immediately
-/// (useful for testing and debugging).
+/// Set `skip_sleep` to true to force skip-allowed sleeps to resolve
+/// immediately (useful for testing and debugging); sleeps recorded with
+/// `skip_allowed: false` elapse in full regardless.
 pub fn new<SleepValueProvider>(skip_sleep: bool) -> (Handler, Poller<SleepValueProvider>) {
     let (tx, rx) = mpsc::unbounded_channel();
     let recorded = Arc::new(std::sync::Mutex::new(RecordedSleeps::new()));
@@ -55,8 +56,8 @@ pub struct Handler {
     /// Channel to the poller.
     pub tx: mpsc::UnboundedSender<(PromiseStateId, Instant)>,
 
-    /// When true, sleep deadlines are set to now (immediate) instead of
-    /// now + duration, effectively skipping all sleeps.
+    /// When true, skip-allowed sleep deadlines are set to now (immediate)
+    /// instead of now + duration, effectively skipping those sleeps.
     pub skip_sleep: bool,
 
     /// Promises with an outstanding recorded sleep — used to ignore
@@ -71,7 +72,12 @@ impl Handler {
     /// outstanding — not yet settled and acknowledged — any re-record for
     /// the same promise is ignored and the first recorded deadline stands;
     /// re-emitted sleep effects must not walk the deadline forward.
-    pub fn record(&self, promise_state_id: PromiseStateId, duration: NonZeroDuration) {
+    pub fn record(
+        &self,
+        promise_state_id: PromiseStateId,
+        duration: NonZeroDuration,
+        skip_allowed: bool,
+    ) {
         let newly_recorded = self
             .recorded
             .lock()
@@ -81,7 +87,7 @@ impl Handler {
             tracing::debug!(?promise_state_id, "sleep already recorded, ignoring");
             return;
         }
-        let deadline = if self.skip_sleep {
+        let deadline = if self.skip_sleep && skip_allowed {
             Instant::now()
         } else {
             Instant::now() + duration.get()
@@ -90,6 +96,7 @@ impl Handler {
             ?promise_state_id,
             ?deadline,
             skip_sleep = self.skip_sleep,
+            skip_allowed,
             "recording sleep"
         );
         let _ = self.tx.send((promise_state_id, deadline));
@@ -107,8 +114,9 @@ impl waymark_extcall_reconciler_core::SleepEffectHandler for Handler {
         _effect_number: waymark_vm_runtime_effect::EffectNumber,
         promise_state_id: PromiseStateId,
         duration: NonZeroDuration,
+        skip_allowed: bool,
     ) -> Result<(), Self::Error> {
-        self.record(promise_state_id, duration);
+        self.record(promise_state_id, duration, skip_allowed);
         Ok(())
     }
 }

--- a/crates/lib/transient-sleep-reconciler/src/tests.rs
+++ b/crates/lib/transient-sleep-reconciler/src/tests.rs
@@ -16,6 +16,7 @@ async fn record_and_collect_single_sleep() {
     handler.record(
         psid,
         NonZeroDuration::try_from(Duration::from_nanos(1)).unwrap(),
+        true,
     );
 
     // Should collect immediately.
@@ -33,10 +34,12 @@ async fn multiple_sleeps_collected_in_order() {
     handler.record(
         a,
         NonZeroDuration::try_from(Duration::from_nanos(1)).unwrap(),
+        true,
     );
     handler.record(
         b,
         NonZeroDuration::try_from(Duration::from_nanos(1)).unwrap(),
+        true,
     );
 
     let settlements = poller.poll::<crate::Ack>().await.unwrap();
@@ -55,6 +58,7 @@ async fn poll_waits_for_new_sleep() {
         h.record(
             psid,
             NonZeroDuration::try_from(Duration::from_nanos(1)).unwrap(),
+            true,
         );
     });
 
@@ -86,6 +90,7 @@ async fn sleep_resolution_is_null_value() {
     handler.record(
         psid,
         NonZeroDuration::try_from(Duration::from_nanos(1)).unwrap(),
+        true,
     );
 
     let settlements = poller.poll::<crate::Ack>().await.unwrap();
@@ -107,6 +112,7 @@ async fn skip_sleep_resolves_immediately() {
     handler.record(
         psid,
         NonZeroDuration::try_from(Duration::from_secs(5)).unwrap(),
+        true,
     );
 
     let settlements = poller.poll::<crate::Ack>().await.unwrap();
@@ -123,14 +129,37 @@ async fn skip_sleep_multiple_resolve_immediately() {
     handler.record(
         a,
         NonZeroDuration::try_from(Duration::from_secs(60)).unwrap(),
+        true,
     );
     handler.record(
         b,
         NonZeroDuration::try_from(Duration::from_secs(120)).unwrap(),
+        true,
     );
 
     let settlements = poller.poll::<crate::Ack>().await.unwrap();
     assert_eq!(settlements.len().get(), 2);
+}
+
+#[tokio::test]
+async fn skip_sleep_does_not_skip_when_skip_not_allowed() {
+    let (handler, mut poller) = super::new::<ReadyValueSleepProvider>(true);
+    let psid = PromiseStateId(0);
+
+    // A 60-second sleep recorded with `skip_allowed: false` must keep its
+    // full deadline even though skip_sleep is on.
+    handler.record(
+        psid,
+        NonZeroDuration::try_from(Duration::from_secs(60)).unwrap(),
+        false,
+    );
+
+    tokio::select! {
+        _ = poller.poll::<crate::Ack>() => {
+            panic!("a skip-disallowed sleep must not settle early");
+        }
+        _ = tokio::time::sleep(Duration::from_millis(100)) => {}
+    }
 }
 
 #[tokio::test]
@@ -143,6 +172,7 @@ async fn skip_sleep_flag_is_independent_per_handler() {
     skip_handler.record(
         skip_psid,
         NonZeroDuration::try_from(Duration::from_secs(5)).unwrap(),
+        true,
     );
     let skip_settlements = skip_poller.poll::<crate::Ack>().await.unwrap();
     assert_eq!(skip_settlements[0].promise_state_id, skip_psid);
@@ -152,6 +182,7 @@ async fn skip_sleep_flag_is_independent_per_handler() {
     normal_handler.record(
         normal_psid,
         NonZeroDuration::try_from(Duration::from_nanos(1)).unwrap(),
+        true,
     );
     let normal_settlements = normal_poller.poll::<crate::Ack>().await.unwrap();
     assert_eq!(normal_settlements[0].promise_state_id, normal_psid);
@@ -167,10 +198,12 @@ async fn re_record_keeps_the_original_deadline() {
     handler.record(
         psid,
         NonZeroDuration::try_from(Duration::from_nanos(1)).unwrap(),
+        true,
     );
     handler.record(
         psid,
         NonZeroDuration::try_from(Duration::from_secs(3600)).unwrap(),
+        true,
     );
 
     tokio::select! {
@@ -195,6 +228,7 @@ async fn ack_makes_the_promise_recordable_again() {
     handler.record(
         psid,
         NonZeroDuration::try_from(Duration::from_nanos(1)).unwrap(),
+        true,
     );
 
     let settlements = poller.poll::<crate::Ack>().await.unwrap();
@@ -207,6 +241,7 @@ async fn ack_makes_the_promise_recordable_again() {
     handler.record(
         psid,
         NonZeroDuration::try_from(Duration::from_nanos(1)).unwrap(),
+        true,
     );
 
     let settlements = poller.poll::<crate::Ack>().await.unwrap();
@@ -222,10 +257,12 @@ async fn re_record_yields_a_single_settlement() {
     handler.record(
         psid,
         NonZeroDuration::try_from(Duration::from_nanos(1)).unwrap(),
+        true,
     );
     handler.record(
         psid,
         NonZeroDuration::try_from(Duration::from_nanos(1)).unwrap(),
+        true,
     );
 
     let settlements = poller.poll::<crate::Ack>().await.unwrap();

--- a/crates/lib/vm-compiler-for-ast-old/src/function/compiler/bytecode/emitter.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/function/compiler/bytecode/emitter.rs
@@ -145,17 +145,22 @@ where
     }
 
     /// Emits a sleep instruction that resumes at `resume`.
+    ///
+    /// Pass `unskippable: true` for sleeps whose duration is load-bearing —
+    /// execution modes that fast-forward sleeps must let them elapse in full.
     pub fn emit_sleep(
         &mut self,
         dst: Marked<RegisterId, PromiseMarker>,
         duration: RegisterId,
         resume: StateId,
+        unskippable: bool,
     ) {
         self.emit(
             waymark_vm_instructions_extcallset::ExtCallSet::Sleep {
                 dst: *dst,
                 duration,
                 resume,
+                unskippable,
             }
             .into(),
         );

--- a/crates/lib/vm-compiler-for-ast-old/src/function/compiler/lowering/value.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/function/compiler/lowering/value.rs
@@ -243,9 +243,12 @@ where
 
         let resume_state = self.reserve_state();
 
-        self.context
-            .emitter
-            .emit_sleep(dst.marked(), duration_register.register(), resume_state);
+        self.context.emitter.emit_sleep(
+            dst.marked(),
+            duration_register.register(),
+            resume_state,
+            false,
+        );
 
         self.context.emitter.switch_to(resume_state);
 
@@ -767,9 +770,11 @@ mod tests {
                 dst,
                 duration,
                 resume,
+                unskippable,
             })) if *dst == RegisterId(0)
                 && *duration == RegisterId(1)
                 && *resume == StateId(1)
+                && !unskippable
         ));
         assert!(start_instructions.next().is_none());
 

--- a/crates/lib/vm-compiler-for-ast-old/tests/integration.rs
+++ b/crates/lib/vm-compiler-for-ast-old/tests/integration.rs
@@ -619,8 +619,10 @@ fn compiles_sleep_statements_into_resumable_sleep_effects() {
         Effect::ExtCallSet(waymark_vm_interpreter_extcallset::Effect::Sleep {
             promise_state_id,
             duration,
+            skip_allowed,
         }) => {
             assert_eq!(duration, NonZeroDuration::from_secs(2).unwrap());
+            assert!(skip_allowed);
             promise_state_id
         }
         other => panic!("unexpected first runtime effect: {other:?}"),

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_sleep__sleep_aliased_import.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_sleep__sleep_aliased_import.py__bytecode.snap
@@ -15,7 +15,7 @@ f0: [4 registers]
     CoreSet(Await { dst: r0, src: r0, resume: s2 })
   s2:
     PureSet(LoadConst { dst: r2, value: Int(3) })
-    ExtCallSet(Sleep { dst: r1, duration: r2, resume: s3 })
+    ExtCallSet(Sleep { dst: r1, duration: r2, resume: s3, unskippable: false })
   s3:
     CoreSet(Await { dst: r1, src: r1, resume: s4 })
   s4:

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_sleep__sleep_from_import.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_sleep__sleep_from_import.py__bytecode.snap
@@ -15,7 +15,7 @@ f0: [4 registers]
     CoreSet(Await { dst: r0, src: r0, resume: s2 })
   s2:
     PureSet(LoadConst { dst: r2, value: Int(2) })
-    ExtCallSet(Sleep { dst: r1, duration: r2, resume: s3 })
+    ExtCallSet(Sleep { dst: r1, duration: r2, resume: s3, unskippable: false })
   s3:
     CoreSet(Await { dst: r1, src: r1, resume: s4 })
   s4:

--- a/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_sleep__sleep_import_asyncio.py__bytecode.snap
+++ b/crates/lib/vm-compiler-for-ast-old/tests/snapshots/python__fixtures_sleep__sleep_import_asyncio.py__bytecode.snap
@@ -15,7 +15,7 @@ f0: [4 registers]
     CoreSet(Await { dst: r0, src: r0, resume: s2 })
   s2:
     PureSet(LoadConst { dst: r2, value: Int(1) })
-    ExtCallSet(Sleep { dst: r1, duration: r2, resume: s3 })
+    ExtCallSet(Sleep { dst: r1, duration: r2, resume: s3, unskippable: false })
   s3:
     CoreSet(Await { dst: r1, src: r1, resume: s4 })
   s4:

--- a/crates/lib/vm-instructions-extcallset/src/lib.rs
+++ b/crates/lib/vm-instructions-extcallset/src/lib.rs
@@ -67,5 +67,9 @@ pub enum ExtCallSet<Spec: self::Spec> {
 
         /// The state to resume the execution from after starting the sleep.
         resume: Spec::StateId,
+
+        /// When true, execution modes that fast-forward sleeps must let
+        /// this one elapse in full.
+        unskippable: bool,
     },
 }

--- a/crates/lib/vm-interpreter-extcallset/src/lib.rs
+++ b/crates/lib/vm-interpreter-extcallset/src/lib.rs
@@ -49,6 +49,10 @@ pub enum Effect<ActionRef, ActionCallArgument> {
 
         /// Requested sleep duration.
         duration: NonZeroDuration,
+
+        /// When false, the sleep's duration is load-bearing and the
+        /// handler must not settle the sleep early.
+        skip_allowed: bool,
     },
 }
 
@@ -131,6 +135,7 @@ where
                 dst,
                 duration,
                 resume,
+                unskippable,
             } => {
                 let value = &frame.regs[*duration];
 
@@ -143,6 +148,7 @@ where
                 Ok(ExecutionOutcome::ExitFrameWithEffect(Effect::Sleep {
                     promise_state_id,
                     duration,
+                    skip_allowed: !unskippable,
                 }))
             }
         }

--- a/crates/lib/vm-interpreter-extcallset/tests/sleep/mod.rs
+++ b/crates/lib/vm-interpreter-extcallset/tests/sleep/mod.rs
@@ -20,6 +20,7 @@ fn runtime_emits_a_sleep_effect_and_queues_the_resumed_frame() {
                         dst: RegisterId(1),
                         duration: RegisterId(0),
                         resume: StateId(1),
+                        unskippable: false,
                     }
                     .into(),
                 ],
@@ -35,12 +36,14 @@ fn runtime_emits_a_sleep_effect_and_queues_the_resumed_frame() {
     let TestEffect::ExtCallSet(Effect::Sleep {
         promise_state_id,
         duration,
+        skip_allowed,
     }) = emitted_effect.effect
     else {
         panic!("first run should emit a sleep effect");
     };
 
     assert_eq!(duration, NonZeroDuration::from_secs(5).unwrap());
+    assert!(skip_allowed);
 
     let emitted_effect = runtime
         .run()
@@ -50,4 +53,32 @@ fn runtime_emits_a_sleep_effect_and_queues_the_resumed_frame() {
     };
 
     assert_eq!(resumed_promise_state_id, promise_state_id);
+}
+
+#[test]
+fn unskippable_sleep_emits_an_effect_with_skip_disallowed() {
+    let mut runtime = new_runtime_with_args(
+        executable(vec![function::<RuntimeInstruction>(
+            2,
+            vec![vec![
+                ExtCallSet::Sleep {
+                    dst: RegisterId(1),
+                    duration: RegisterId(0),
+                    resume: StateId(1),
+                    unskippable: true,
+                }
+                .into(),
+            ]],
+        )]),
+        vec![TestReadyValue(5)],
+    );
+
+    let emitted_effect = runtime
+        .run()
+        .expect("first run should emit the sleep effect");
+    let TestEffect::ExtCallSet(Effect::Sleep { skip_allowed, .. }) = emitted_effect.effect else {
+        panic!("first run should emit a sleep effect");
+    };
+
+    assert!(!skip_allowed);
 }

--- a/crates/lib/vm-interpreter-extcallset/tests/sleep_error/mod.rs
+++ b/crates/lib/vm-interpreter-extcallset/tests/sleep_error/mod.rs
@@ -20,6 +20,7 @@ fn runtime_surfaces_invalid_sleep_duration_errors_from_the_interpreter() {
                     dst: RegisterId(1),
                     duration: RegisterId(0),
                     resume: StateId(1),
+                    unskippable: false,
                 }
                 .into(),
             ]],

--- a/crates/lib/vm-interpreter-fullset/tests/sleep/mod.rs
+++ b/crates/lib/vm-interpreter-fullset/tests/sleep/mod.rs
@@ -26,6 +26,7 @@ fn runtime_resumes_sleep_effects_and_finishes_with_pure_work() {
                     dst: RegisterId(1),
                     duration: RegisterId(0),
                     resume: StateId(1),
+                    unskippable: false,
                 }
                 .into(),
             ],
@@ -58,6 +59,7 @@ fn runtime_resumes_sleep_effects_and_finishes_with_pure_work() {
         Effect::ExtCallSet(waymark_vm_interpreter_extcallset::Effect::Sleep {
             promise_state_id,
             duration,
+            skip_allowed: _,
         }) => {
             assert_eq!(duration, NonZeroDuration::from_secs(2).unwrap());
             promise_state_id


### PR DESCRIPTION
Goes in after #490 

---

This PR introduces support for marking certain sleep instructions unskippable. This will be very useful for later work on in-VM timeouts implementation.