### PR TITLE
Implement range assignments at the vm compiler

### DIFF
--- a/crates/lib/vm-compiler-for-ast-old/src/function/compiler/lowering/assignment.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/function/compiler/lowering/assignment.rs
@@ -95,6 +95,9 @@ where
             AssignmentStatementPlan::Unpack { targets, value } => {
                 self.compile_unpack_assignment(targets, value)?;
             }
+            AssignmentStatementPlan::RangeValues { target, call } => {
+                self.compile_range_values_assignment(target, call)?;
+            }
         }
 
         Ok(())
@@ -199,6 +202,30 @@ where
             target.mark_initialized(self.context.flow_state);
         }
 
+        Ok(())
+    }
+
+    /// Compiles a `range(...)` assignment into a materialized value list.
+    ///
+    /// The list accumulates in a fresh register and is copied into the
+    /// target only after the loop, so the range bounds may read the
+    /// target's previous value.
+    fn compile_range_values_assignment(
+        &mut self,
+        target: Marked<LocalSlot, AssignmentTargetMarker>,
+        call: &waymark_vm_ast_old::FunctionCall,
+    ) -> Result<(), ErrorFor<Spec, Lowering>> {
+        let accumulator_register = self.context.local_frame.allocate_register();
+        self.for_loop_compiler()
+            .compile_range_values(call, accumulator_register)?;
+
+        if accumulator_register != target.register() {
+            self.context
+                .emitter
+                .emit_copy(target.register(), accumulator_register);
+        }
+
+        target.mark_initialized(self.context.flow_state);
         Ok(())
     }
 
@@ -376,6 +403,74 @@ mod tests {
                 if *dst == RegisterId(1) && *src == RegisterId(0)
         ));
         assert!(instructions.next().is_none());
+    }
+
+    #[test]
+    fn range_assignments_materialize_a_value_list() {
+        let function_table = build_function_table();
+        let mut emitter = FunctionEmitter::<TestSpec>::new();
+        let mut local_frame = LocalFrame::new();
+        let mut flow_state = FlowState::new();
+        let mut extra_fns = ExtraFunctions::<TestSpec>::new(1);
+        local_frame
+            .declare_input(&mut flow_state, "stop".to_owned())
+            .expect("stop input should declare");
+
+        {
+            let mut assignments = AssignmentCompiler::<TestSpec, TestLowering>::new(
+                CompilerContextMut::new(
+                    &function_table,
+                    &mut emitter,
+                    &mut local_frame,
+                    &mut extra_fns,
+                    &mut flow_state,
+                ),
+                0,
+            );
+
+            let mut call =
+                waymark_vm_ast_old_helpers::function_call("range", vec![variable("stop")]);
+            call.global_function = Some(waymark_vm_ast_old::GlobalFunction::Range);
+            let value =
+                waymark_vm_ast_old_helpers::spanned(waymark_vm_ast_old::Expr::FunctionCall {
+                    call,
+                });
+
+            assignments
+                .compile_statement(&["values".to_owned()], &value)
+                .expect("range assignment should compile");
+        }
+
+        assert!(
+            local_frame
+                .resolve_initialized_local("values", &flow_state)
+                .is_some()
+        );
+
+        let function = waymark_vm_bytecode::Function {
+            states: emitter.finish(),
+            num_regs: local_frame.num_registers(),
+        };
+        insta::assert_snapshot!(waymark_vm_bytecode_fmt::display(&function).to_string(), @r"
+        s0:
+          PureSet(MakeList { dst: r2, items: [] })
+          PureSet(LoadConst { dst: r3, value: Int(0) })
+          PureSet(Copy { dst: r4, src: r0 })
+          CoreSet(Jump { target_state: s1 })
+        s1:
+          PureSet(Binary { kind: Lt, op: BinaryOp { dst: r5, a: r3, b: r4 } })
+          CoreSet(JumpIf { target_state: s2, cond: r5 })
+          CoreSet(Jump { target_state: s4 })
+        s2:
+          PureSet(ListAppend { dst: r2, list: r2, item: r3 })
+          CoreSet(Jump { target_state: s3 })
+        s3:
+          PureSet(LoadConst { dst: r5, value: Int(1) })
+          PureSet(Binary { kind: Add, op: BinaryOp { dst: r3, a: r3, b: r5 } })
+          CoreSet(Jump { target_state: s1 })
+        s4:
+          PureSet(Copy { dst: r1, src: r2 })
+        ");
     }
 
     #[test]

--- a/crates/lib/vm-compiler-for-ast-old/src/function/compiler/lowering/assignment.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/function/compiler/lowering/assignment.rs
@@ -95,6 +95,9 @@ where
             AssignmentStatementPlan::Unpack { targets, value } => {
                 self.compile_unpack_assignment(targets, value)?;
             }
+            AssignmentStatementPlan::RangeValues { target, call } => {
+                self.compile_range_values_assignment(target, call)?;
+            }
         }
 
         Ok(())
@@ -205,6 +208,30 @@ where
             target.mark_initialized(self.context.flow_state);
         }
 
+        Ok(())
+    }
+
+    /// Compiles a `range(...)` assignment into a materialized value list.
+    ///
+    /// The list accumulates in a fresh register and is copied into the
+    /// target only after the loop, so the range bounds may read the
+    /// target's previous value.
+    fn compile_range_values_assignment(
+        &mut self,
+        target: Marked<LocalSlot, AssignmentTargetMarker>,
+        call: &waymark_vm_ast_old::FunctionCall,
+    ) -> Result<(), ErrorFor<Spec, Lowering>> {
+        let accumulator_register = self.context.local_frame.allocate_register();
+        self.for_loop_compiler()
+            .compile_range_values(call, accumulator_register)?;
+
+        if accumulator_register != target.register() {
+            self.context
+                .emitter
+                .emit_copy(target.register(), accumulator_register);
+        }
+
+        target.mark_initialized(self.context.flow_state);
         Ok(())
     }
 
@@ -382,6 +409,74 @@ mod tests {
                 if *dst == RegisterId(1) && *src == RegisterId(0)
         ));
         assert!(instructions.next().is_none());
+    }
+
+    #[test]
+    fn range_assignments_materialize_a_value_list() {
+        let function_table = build_function_table();
+        let mut emitter = FunctionEmitter::<TestSpec>::new();
+        let mut local_frame = LocalFrame::new();
+        let mut flow_state = FlowState::new();
+        let mut extra_fns = ExtraFunctions::<TestSpec>::new(1);
+        local_frame
+            .declare_input(&mut flow_state, "stop".to_owned())
+            .expect("stop input should declare");
+
+        {
+            let mut assignments = AssignmentCompiler::<TestSpec, TestLowering>::new(
+                CompilerContextMut::new(
+                    &function_table,
+                    &mut emitter,
+                    &mut local_frame,
+                    &mut extra_fns,
+                    &mut flow_state,
+                ),
+                0,
+            );
+
+            let mut call =
+                waymark_vm_ast_old_helpers::function_call("range", vec![variable("stop")]);
+            call.global_function = Some(waymark_vm_ast_old::GlobalFunction::Range);
+            let value =
+                waymark_vm_ast_old_helpers::spanned(waymark_vm_ast_old::Expr::FunctionCall {
+                    call,
+                });
+
+            assignments
+                .compile_statement(&["values".to_owned()], &value)
+                .expect("range assignment should compile");
+        }
+
+        assert!(
+            local_frame
+                .resolve_initialized_local("values", &flow_state)
+                .is_some()
+        );
+
+        let function = waymark_vm_bytecode::Function {
+            states: emitter.finish(),
+            num_regs: local_frame.num_registers(),
+        };
+        insta::assert_snapshot!(waymark_vm_bytecode_fmt::display(&function).to_string(), @r"
+        s0:
+          PureSet(MakeList { dst: r2, items: [] })
+          PureSet(LoadConst { dst: r3, value: Int(0) })
+          PureSet(Copy { dst: r4, src: r0 })
+          CoreSet(Jump { target_state: s1 })
+        s1:
+          PureSet(Binary { kind: Lt, op: BinaryOp { dst: r5, a: r3, b: r4 } })
+          CoreSet(JumpIf { target_state: s2, cond: r5 })
+          CoreSet(Jump { target_state: s4 })
+        s2:
+          PureSet(ListAppend { dst: r2, list: r2, item: r3 })
+          CoreSet(Jump { target_state: s3 })
+        s3:
+          PureSet(LoadConst { dst: r5, value: Int(1) })
+          PureSet(Binary { kind: Add, op: BinaryOp { dst: r3, a: r3, b: r5 } })
+          CoreSet(Jump { target_state: s1 })
+        s4:
+          PureSet(Copy { dst: r1, src: r2 })
+        ");
     }
 
     #[test]

--- a/crates/lib/vm-compiler-for-ast-old/src/function/compiler/lowering/for_loop.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/function/compiler/lowering/for_loop.rs
@@ -110,6 +110,44 @@ enum RangeLoop<'expr> {
     },
 }
 
+impl<'expr> RangeLoop<'expr> {
+    /// Validates a `range(...)` call and classifies its argument shape.
+    fn classify<Spec, Lowering>(call: &'expr FunctionCall) -> Result<Self, ErrorFor<Spec, Lowering>>
+    where
+        Spec: waymark_vm_compiler_for_ast_old_core::SpecRequirements,
+        Lowering: waymark_vm_compiler_for_ast_old_core::lowering::FullSet<Spec>,
+    {
+        let function = builtin_call_name(call, "range");
+
+        if !call.kwargs.is_empty() {
+            return Err(Unsupported::FunctionCall {
+                name: function,
+                reason: UnsupportedFunctionCall::KeywordArguments,
+            }
+            .into());
+        }
+
+        match call.args.as_slice() {
+            [] => Err(Error::FunctionArityMismatch {
+                function,
+                expected: 1,
+                actual: 0,
+            }),
+            [end] => Ok(Self::Positive { start: None, end }),
+            [start, end] => Ok(Self::Positive {
+                start: Some(start),
+                end,
+            }),
+            [start, end, step] => Ok(Self::Stepped { start, end, step }),
+            _ => Err(Error::FunctionArityMismatch {
+                function,
+                expected: 3,
+                actual: call.args.len(),
+            }),
+        }
+    }
+}
+
 /// Persistent registers from indexed spread fan-out that the join can reuse.
 #[derive(Clone, Copy)]
 struct IndexedSpreadJoinRegisters {
@@ -154,40 +192,10 @@ impl<'expr> ResolvedForLoop<'expr> {
         Spec: waymark_vm_compiler_for_ast_old_core::SpecRequirements,
         Lowering: waymark_vm_compiler_for_ast_old_core::lowering::FullSet<Spec>,
     {
-        let function = builtin_call_name(call, "range");
-
-        if !call.kwargs.is_empty() {
-            return Err(Unsupported::FunctionCall {
-                name: function,
-                reason: UnsupportedFunctionCall::KeywordArguments,
-            }
-            .into());
-        }
-
-        let range = match call.args.as_slice() {
-            [] => {
-                return Err(Error::FunctionArityMismatch {
-                    function,
-                    expected: 1,
-                    actual: 0,
-                });
-            }
-            [end] => RangeLoop::Positive { start: None, end },
-            [start, end] => RangeLoop::Positive {
-                start: Some(start),
-                end,
-            },
-            [start, end, step] => RangeLoop::Stepped { start, end, step },
-            _ => {
-                return Err(Error::FunctionArityMismatch {
-                    function,
-                    expected: 3,
-                    actual: call.args.len(),
-                });
-            }
-        };
-
-        Ok(Self::Range { range, binding })
+        Ok(Self::Range {
+            range: RangeLoop::classify::<Spec, Lowering>(call)?,
+            binding,
+        })
     }
 
     /// Validates and classifies an `enumerate(...)` call.
@@ -589,6 +597,117 @@ where
         )
     }
 
+    /// Compiles a value-position `range(...)` call by materializing its
+    /// values into a freshly-built list in `result_register`.
+    pub fn compile_range_values(
+        &mut self,
+        call: &FunctionCall,
+        result_register: RegisterId,
+    ) -> Result<(), ErrorFor<Spec, Lowering>> {
+        let range = RangeLoop::classify::<Spec, Lowering>(call)?;
+
+        self.context
+            .emitter
+            .emit_make_list(result_register, Vec::new());
+
+        match range {
+            RangeLoop::Positive { start, end } => {
+                self.compile_positive_range_values(start, end, result_register)
+            }
+            RangeLoop::Stepped { start, end, step } => {
+                self.compile_stepped_range_values(start, end, step, result_register)
+            }
+        }
+    }
+
+    /// Materializes `range(stop)` or `range(start, stop)` into a list.
+    fn compile_positive_range_values(
+        &mut self,
+        start: Option<&Spanned<Expr>>,
+        end: &Spanned<Expr>,
+        result_register: RegisterId,
+    ) -> Result<(), ErrorFor<Spec, Lowering>> {
+        let current_register = self.context.local_frame.allocate_register();
+        match start {
+            Some(start) => self.compile_expr_into_register(start, current_register)?,
+            None => self.emit_int_literal_into_register(current_register, 0)?,
+        }
+
+        let end_register = self.context.local_frame.allocate_register();
+        self.compile_expr_into_register(end, end_register)?;
+
+        let empty_body = self.empty_block(end);
+        let exception_handler_depth = self.exception_handler_depth;
+
+        self.compile_loop_skeleton(
+            &empty_body,
+            |compiler, for_loop| {
+                compiler.emit_compare_and_branch(
+                    BinaryOpKind::Lt,
+                    current_register,
+                    end_register,
+                    for_loop.body_state(),
+                    for_loop
+                        .loop_scope(exception_handler_depth)
+                        .target(LoopControlKind::Break),
+                );
+                Ok(())
+            },
+            |compiler| {
+                compiler.append_list_item(result_register, current_register);
+                Ok(())
+            },
+            |compiler| compiler.emit_add_assign_immediate(current_register, 1),
+        )
+    }
+
+    /// Materializes `range(start, stop, step)` into a list.
+    fn compile_stepped_range_values(
+        &mut self,
+        start: &Spanned<Expr>,
+        end: &Spanned<Expr>,
+        step: &Spanned<Expr>,
+        result_register: RegisterId,
+    ) -> Result<(), ErrorFor<Spec, Lowering>> {
+        let current_register = self.context.local_frame.allocate_register();
+        self.compile_expr_into_register(start, current_register)?;
+
+        let end_register = self.context.local_frame.allocate_register();
+        self.compile_expr_into_register(end, end_register)?;
+
+        let step_register = self.context.local_frame.allocate_register();
+        self.compile_expr_into_register(step, step_register)?;
+
+        let empty_body = self.empty_block(step);
+        let exception_handler_depth = self.exception_handler_depth;
+
+        self.compile_loop_skeleton(
+            &empty_body,
+            |compiler, for_loop| {
+                compiler.emit_stepped_range_condition(
+                    for_loop,
+                    current_register,
+                    end_register,
+                    step_register,
+                    exception_handler_depth,
+                )
+            },
+            |compiler| {
+                compiler.append_list_item(result_register, current_register);
+                Ok(())
+            },
+            |compiler| {
+                compiler.context.emitter.emit_binary(
+                    BinaryOpKind::Add,
+                    current_register,
+                    current_register,
+                    step_register,
+                );
+                Ok(())
+            },
+        )
+    }
+
     /// Compiles a spread over `range(stop)` or `range(start, stop)`.
     fn compile_positive_range_spread(
         &mut self,
@@ -787,59 +906,13 @@ where
         self.compile_loop_skeleton(
             &empty_body,
             |compiler, for_loop| {
-                let break_target = for_loop
-                    .loop_scope(exception_handler_depth)
-                    .target(LoopControlKind::Break);
-                let incoming_flow = for_loop.condition_flow();
-
-                let positive_condition_state = compiler.new_state();
-                let negative_condition_state = compiler.new_state();
-
-                let zero_register = compiler.compile_temporary_int_literal(0)?;
-                let positive_register = compiler.context.local_frame.allocate_temporary_register();
-                compiler.context.emitter.emit_binary(
-                    BinaryOpKind::Gt,
-                    positive_register.register(),
-                    step_register,
-                    zero_register.register(),
-                );
-                compiler
-                    .context
-                    .emitter
-                    .emit_jump_if(positive_condition_state, positive_register.register());
-
-                let negative_register = compiler.context.local_frame.allocate_temporary_register();
-                compiler.context.emitter.emit_binary(
-                    BinaryOpKind::Lt,
-                    negative_register.register(),
-                    step_register,
-                    zero_register.register(),
-                );
-                compiler
-                    .context
-                    .emitter
-                    .emit_jump_if(negative_condition_state, negative_register.register());
-                compiler.context.emitter.emit_jump(break_target);
-
-                compiler.switch_to_with_flow(positive_condition_state, incoming_flow.clone());
-                compiler.emit_compare_and_branch(
-                    BinaryOpKind::Lt,
+                compiler.emit_stepped_range_condition(
+                    for_loop,
                     current_register,
                     end_register,
-                    for_loop.body_state(),
-                    break_target,
-                );
-
-                compiler.switch_to_with_flow(negative_condition_state, incoming_flow);
-                compiler.emit_compare_and_branch(
-                    BinaryOpKind::Gt,
-                    current_register,
-                    end_register,
-                    for_loop.body_state(),
-                    break_target,
-                );
-
-                Ok(())
+                    step_register,
+                    exception_handler_depth,
+                )
             },
             |compiler| {
                 compiler.compile_spread_fanout_iteration(
@@ -962,6 +1035,72 @@ where
 
         let (exit_state, exit_flow) = for_loop.finish();
         self.switch_to_with_flow(exit_state, exit_flow);
+
+        Ok(())
+    }
+
+    /// Emits the sign-classified `range(start, end, step)` loop condition:
+    /// the condition state routes on `sign(step)` to a `current < end` or
+    /// `current > end` bound check (or breaks on a zero step). See
+    /// [`Self::compile_stepped_range_loop`] for the full semantics
+    /// discussion.
+    fn emit_stepped_range_condition(
+        &mut self,
+        for_loop: &ForLoopPlan,
+        current_register: RegisterId,
+        end_register: RegisterId,
+        step_register: RegisterId,
+        exception_handler_depth: usize,
+    ) -> Result<(), ErrorFor<Spec, Lowering>> {
+        let break_target = for_loop
+            .loop_scope(exception_handler_depth)
+            .target(LoopControlKind::Break);
+        let incoming_flow = for_loop.condition_flow();
+
+        let positive_condition_state = self.new_state();
+        let negative_condition_state = self.new_state();
+
+        let zero_register = self.compile_temporary_int_literal(0)?;
+        let positive_register = self.context.local_frame.allocate_temporary_register();
+        self.context.emitter.emit_binary(
+            BinaryOpKind::Gt,
+            positive_register.register(),
+            step_register,
+            zero_register.register(),
+        );
+        self.context
+            .emitter
+            .emit_jump_if(positive_condition_state, positive_register.register());
+
+        let negative_register = self.context.local_frame.allocate_temporary_register();
+        self.context.emitter.emit_binary(
+            BinaryOpKind::Lt,
+            negative_register.register(),
+            step_register,
+            zero_register.register(),
+        );
+        self.context
+            .emitter
+            .emit_jump_if(negative_condition_state, negative_register.register());
+        self.context.emitter.emit_jump(break_target);
+
+        self.switch_to_with_flow(positive_condition_state, incoming_flow.clone());
+        self.emit_compare_and_branch(
+            BinaryOpKind::Lt,
+            current_register,
+            end_register,
+            for_loop.body_state(),
+            break_target,
+        );
+
+        self.switch_to_with_flow(negative_condition_state, incoming_flow);
+        self.emit_compare_and_branch(
+            BinaryOpKind::Gt,
+            current_register,
+            end_register,
+            for_loop.body_state(),
+            break_target,
+        );
 
         Ok(())
     }

--- a/crates/lib/vm-compiler-for-ast-old/src/function/compiler/plan/assignment.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/function/compiler/plan/assignment.rs
@@ -1,7 +1,7 @@
 //! Assignment planning.
 
 use nonempty_collections::NESlice;
-use waymark_vm_ast_old::{ActionCall, Expr, Spanned};
+use waymark_vm_ast_old::{ActionCall, Expr, FunctionCall, GlobalFunction, Spanned};
 
 use super::ErrorFor;
 use super::parallel::ParallelAssignmentPlan;
@@ -65,6 +65,15 @@ where
 
         /// Expression evaluated once and unpacked into the targets by index.
         value: &'a Spanned<Expr>,
+    },
+
+    /// An assignment materializing a `range(...)` call into a list.
+    RangeValues {
+        /// Assignment target that will receive the materialized list.
+        target: Marked<LocalSlot, AssignmentTargetMarker>,
+
+        /// The `range(...)` call to materialize.
+        call: &'a FunctionCall,
     },
 }
 
@@ -133,6 +142,15 @@ where
         }
 
         if targets.len().get() == 1 {
+            if let Expr::FunctionCall { call } = &value.value
+                && call.global_function == Some(GlobalFunction::Range)
+            {
+                return Ok(Self::RangeValues {
+                    target: resolve_target(&targets[0]),
+                    call,
+                });
+            }
+
             return Ok(Self::Direct {
                 target: resolve_target(&targets[0]),
                 value,
@@ -215,6 +233,9 @@ mod tests {
             }
             AssignmentStatementPlan::Unpack { .. } => {
                 panic!("single-target assignments should not build unpack plans")
+            }
+            AssignmentStatementPlan::RangeValues { .. } => {
+                panic!("literal assignments should not build range-values plans")
             }
         }
     }
@@ -341,6 +362,9 @@ mod tests {
             AssignmentStatementPlan::Unpack { .. } => {
                 panic!("parallel expressions should not build unpack plans")
             }
+            AssignmentStatementPlan::RangeValues { .. } => {
+                panic!("parallel expressions should not build range-values plans")
+            }
         }
     }
 
@@ -400,6 +424,9 @@ mod tests {
             AssignmentStatementPlan::Unpack { .. } => {
                 panic!("discard spread should not build an unpack plan")
             }
+            AssignmentStatementPlan::RangeValues { .. } => {
+                panic!("discard spread should not build a range-values plan")
+            }
         }
     }
 
@@ -453,6 +480,9 @@ mod tests {
             AssignmentStatementPlan::Unpack { .. } => {
                 panic!("targeted spread expressions should not build unpack plans")
             }
+            AssignmentStatementPlan::RangeValues { .. } => {
+                panic!("targeted spread expressions should not build range-values plans")
+            }
         }
     }
 
@@ -486,6 +516,40 @@ mod tests {
                 assert!(matches!(value.value, Expr::Variable { ref name } if name == "pair"));
             }
             other => panic!("multi-target assignments should build unpack plans, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn single_target_range_assignment_builds_range_values_plan() {
+        let function_table = build_function_table();
+        let mut local_frame = LocalFrame::new();
+        let mut flow_state = FlowState::new();
+        let targets = vec!["values".to_owned()];
+        let mut call = waymark_vm_ast_old_helpers::function_call("range", vec![int(3)]);
+        call.global_function = Some(GlobalFunction::Range);
+        let value = waymark_vm_ast_old_helpers::spanned(Expr::FunctionCall { call });
+
+        let plan = AssignmentStatementPlan::<TestSpec>::build::<TestLowering, _>(
+            &targets,
+            &value,
+            &function_table,
+            |target| {
+                Marked::<LocalSlot, AssignmentTargetMarker>::get_or_declare(
+                    &mut local_frame,
+                    &mut flow_state,
+                    target,
+                )
+            },
+        )
+        .expect("range assignment should build");
+
+        match plan {
+            AssignmentStatementPlan::RangeValues { target, call } => {
+                assert_eq!(target.register(), RegisterId(0));
+                assert_eq!(call.global_function, Some(GlobalFunction::Range));
+                assert_eq!(call.args.len(), 1);
+            }
+            other => panic!("range assignments should build range-values plans, got {other:?}"),
         }
     }
 

--- a/crates/lib/vm-compiler-for-ast-old/src/function/compiler/plan/call.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/function/compiler/plan/call.rs
@@ -1,7 +1,9 @@
 //! Call planning.
 
 use nonempty_collections::{IntoNonEmptyIterator as _, NESlice, NEVec, NonEmptyIterator as _};
-use waymark_vm_ast_old::{ActionCall, Call, Expr, FunctionCall, Kwarg, PolicyBracket, Spanned};
+use waymark_vm_ast_old::{
+    ActionCall, Call, Expr, FunctionCall, GlobalFunction, Kwarg, PolicyBracket, Spanned,
+};
 use waymark_vm_bytecode_core::FunctionId;
 use waymark_vm_compiler_for_ast_old_core::lowering;
 
@@ -74,9 +76,21 @@ impl<'a> FunctionCallPlan<'a> {
         call: &'a FunctionCall,
         function_table: &FunctionTable,
     ) -> Result<Self, Error<LiteralLoweringError, ActionLoweringError>> {
-        if call.global_function.is_some() {
+        if let Some(global_function) = &call.global_function {
+            let name = if call.name.is_empty() {
+                match global_function {
+                    GlobalFunction::Range => "range",
+                    GlobalFunction::Len => "len",
+                    GlobalFunction::Enumerate => "enumerate",
+                    GlobalFunction::IsException => "is_exception",
+                }
+                .to_owned()
+            } else {
+                call.name.clone()
+            };
+
             return Err(Unsupported::FunctionCall {
-                name: call.name.clone(),
+                name,
                 reason: UnsupportedFunctionCall::GlobalFunction,
             }
             .into());


### PR DESCRIPTION
Goes in after #504

---

This PR adds `range` assignment support via lowering it into a loop that populates an array