### PR TITLE
Work around the division-by-zero error in benchmark for now

### DIFF
--- a/crates/bin/benchmark/src/cases.rs
+++ b/crates/bin/benchmark/src/cases.rs
@@ -38,9 +38,14 @@ pub fn build_cases(base: i64) -> HashMap<String, BenchmarkCase> {
         (
             "try_except",
             build_try_except_program().expect("try_except program"),
+            // No value may equal 2: the program divides by `item - 2`, and a
+            // division-by-zero fault is not yet catchable by `except` — it
+            // kills the VM, and the released workload crash-loops forever
+            // (see "Missing feature: catchable runtime exceptions" in
+            // notes/postponed.md).
             HashMap::from([(
                 "values".to_string(),
-                serde_json::Value::Array(vec![1.into(), 2.into(), 3.into()]),
+                serde_json::Value::Array(vec![1.into(), 3.into(), 4.into()]),
             )]),
         ),
         (


### PR DESCRIPTION
Goes in after #505 

---

This is a temporary workaround: there is no error-to-exception path at the interpreters currently, and we'll add it later (it's easy).