### PR TITLE
Unconfirmed locks at action-effect-reconciler

### DIFF
--- a/crates/bin/benchmark/src/execution.rs
+++ b/crates/bin/benchmark/src/execution.rs
@@ -8,16 +8,12 @@ pub fn durable_execution_config(
 ) -> waymark_execution_bringup::Config<uuid::Uuid> {
     waymark_execution_bringup::Config {
         node_id: uuid::Uuid::new_v4(),
-        // Generous lock/pinning windows: at benchmark load the renewal and
-        // refresh heartbeats lag behind their default 15s TTLs, and a lapsed
-        // lock gets relocked at revive — the renewal loop then breaches its
-        // fence (`HeldElsewhere`) and shuts the whole subsystem down.
-        action_effect_reconciler_lock_ttl: Duration::from_secs(120).try_into().unwrap(),
-        action_effect_reconciler_lock_heartbeat: Duration::from_secs(15).try_into().unwrap(),
+        action_effect_reconciler_lock_ttl: Duration::from_secs(15).try_into().unwrap(),
+        action_effect_reconciler_lock_heartbeat: Duration::from_secs(5).try_into().unwrap(),
         max_pinned,
-        pinning_ttl: Duration::from_secs(120).try_into().unwrap(),
-        pinning_heartbeat: Duration::from_secs(15).try_into().unwrap(),
-        pinning_fencing_margin: Duration::from_secs(5).try_into().unwrap(),
+        pinning_ttl: Duration::from_secs(15).try_into().unwrap(),
+        pinning_heartbeat: Duration::from_secs(5).try_into().unwrap(),
+        pinning_fencing_margin: Duration::from_secs(1).try_into().unwrap(),
         workload_poll_rate_limit: 1000.try_into().unwrap(),
         sleep_poll_interval: Duration::from_millis(250).try_into().unwrap(),
         vm_retention: Duration::from_secs(60).try_into().unwrap(),

--- a/crates/bin/benchmark/src/execution.rs
+++ b/crates/bin/benchmark/src/execution.rs
@@ -8,16 +8,12 @@ pub fn durable_execution_config(
 ) -> waymark_execution_bringup::Config<uuid::Uuid> {
     waymark_execution_bringup::Config {
         node_id: uuid::Uuid::new_v4(),
-        // Generous lock/pinning windows: at benchmark load the renewal and
-        // refresh heartbeats lag behind their default 15s TTLs, and a lapsed
-        // lock gets relocked at revive — the renewal loop then breaches its
-        // fence (`HeldElsewhere`) and shuts the whole subsystem down.
-        action_effect_reconciler_lock_ttl: Duration::from_secs(120).try_into().unwrap(),
-        action_effect_reconciler_lock_heartbeat: Duration::from_secs(15).try_into().unwrap(),
+        action_effect_reconciler_lock_ttl: Duration::from_secs(15).try_into().unwrap(),
+        action_effect_reconciler_lock_heartbeat: Duration::from_secs(5).try_into().unwrap(),
         max_pinned,
-        pinning_ttl: Duration::from_secs(120).try_into().unwrap(),
-        pinning_heartbeat: Duration::from_secs(15).try_into().unwrap(),
-        pinning_fencing_margin: Duration::from_secs(5).try_into().unwrap(),
+        pinning_ttl: Duration::from_secs(15).try_into().unwrap(),
+        pinning_heartbeat: Duration::from_secs(5).try_into().unwrap(),
+        pinning_fencing_margin: Duration::from_secs(1).try_into().unwrap(),
         workload_poll_interval: Duration::from_millis(1).try_into().unwrap(),
         sleep_poll_interval: Duration::from_millis(250).try_into().unwrap(),
         vm_retention: Duration::from_secs(60).try_into().unwrap(),

--- a/crates/lib/action-effect-reconciler-backend/src/renew_action_call_request_locks.rs
+++ b/crates/lib/action-effect-reconciler-backend/src/renew_action_call_request_locks.rs
@@ -19,6 +19,14 @@ pub trait RenewActionCallRequestLocks: HasVmId + HasLockOwnerId + HasTimestamp {
     /// purged; [`RenewalStatus::HeldElsewhere`] means the lock expired and
     /// another owner took it — the attempt may now run duplicated there
     /// (accepted at-least-once semantics).
+    ///
+    /// [`RenewalStatus::HeldElsewhere`] must be **verified against a
+    /// current read**, never concluded from state that may predate a
+    /// concurrent removal: a completion recorded while the renewal runs
+    /// must classify as [`RenewalStatus::Missing`].  When ownership is
+    /// confirmed but the expiry extension is not, the implementation
+    /// reports [`RenewalStatus::Unconfirmed`] and the caller retries at
+    /// its next heartbeat.
     fn renew_action_call_request_locks<'a>(
         &'a self,
         lock: RequestLockFor<Self>,
@@ -49,4 +57,10 @@ pub enum RenewalStatus {
     /// The row is locked by a different owner.  Prune local tracking; the
     /// attempt may run duplicated there.
     HeldElsewhere,
+
+    /// The lock is still owned by the caller, but this pass could not
+    /// confirm the expiry extension (the row changed under the renewal
+    /// statement).  Keep local tracking unchanged — the existing fence
+    /// deadline stands — and retry at the next heartbeat.
+    Unconfirmed,
 }

--- a/crates/lib/action-effect-reconciler/src/renewal.rs
+++ b/crates/lib/action-effect-reconciler/src/renewal.rs
@@ -93,8 +93,11 @@ where
 /// Tracked locks leave peacefully only via
 /// [`RenewalStatus::Missing`] — the row is gone because its completion
 /// was durably recorded (or the VM was purged).  [`RenewalStatus::HeldElsewhere`]
-/// is a breach ([`Error::HeldElsewhere`]): under an intact fence another
-/// owner cannot take an unexpired lock, and our attempt is still running.
+/// is a breach ([`Error::HeldElsewhere`]): the backend reports it only
+/// from a verified current read, and under an intact fence another owner
+/// cannot take an unexpired lock while our attempt is still running.
+/// [`RenewalStatus::Unconfirmed`] keeps the lock tracked with its
+/// existing fence deadline — the next heartbeat retries the extension.
 ///
 /// Renewal call failures are logged and retried at the next heartbeat —
 /// they only matter once they push a lock to its fence (keep the
@@ -196,6 +199,12 @@ where
                         }
                         RenewalStatus::HeldElsewhere => {
                             held_elsewhere.push(key);
+                        }
+                        RenewalStatus::Unconfirmed => {
+                            // Still ours, but this pass could not confirm
+                            // the extension — the existing fence deadline
+                            // stands and the next heartbeat retries.
+                            tracing::debug!(?key, "lock renewal unconfirmed; retrying");
                         }
                     }
                 }

--- a/crates/lib/action-effect-reconciler/src/renewal/tests.rs
+++ b/crates/lib/action-effect-reconciler/src/renewal/tests.rs
@@ -134,6 +134,51 @@ async fn locks_taken_by_another_owner_breach_the_fence() {
     assert_eq!(keys.into_iter().collect::<Vec<_>>(), vec![key(1)]);
 }
 
+/// Unconfirmed renewals keep the lock tracked with its existing fence
+/// deadline: no breach, no pruning — the next heartbeat retries, and a
+/// later confirmed renewal pushes the deadline out again.
+#[tokio::test]
+async fn unconfirmed_renewals_are_retried_within_the_fence() {
+    let backend = Arc::new(MockBackend::default());
+    seed_locked_row(&backend, key(1), 7);
+    *backend.report_unconfirmed_renewals.lock().unwrap() = true;
+
+    let (held_locks_tx, held_locks_rx) = tokio::sync::mpsc::unbounded_channel();
+    held_locks_tx.send(held(key(1))).unwrap();
+
+    let renewal = tokio::spawn(run(params(
+        &backend,
+        Duration::from_secs(60),
+        held_locks_rx,
+    )));
+
+    // Several unconfirmed passes: the lock stays tracked, nothing breaches.
+    while *backend.renew_calls.lock().unwrap() < 3 {
+        tokio::time::sleep(HEARTBEAT).await;
+    }
+
+    // Recovery: a confirmed renewal pushes the expiry out.
+    *backend.report_unconfirmed_renewals.lock().unwrap() = false;
+    let recovered_calls = *backend.renew_calls.lock().unwrap() + 1;
+    while *backend.renew_calls.lock().unwrap() < recovered_calls {
+        tokio::time::sleep(HEARTBEAT).await;
+    }
+    {
+        let rows = backend.rows.lock().unwrap();
+        let renewed_expiry = rows[&key(1)].lock_expires_at.expect("locked");
+        assert!(renewed_expiry > Utc::now() + chrono::Duration::seconds(30));
+    }
+
+    // And the loop still drains peacefully.
+    drop(held_locks_tx);
+    backend.rows.lock().unwrap().remove(&key(1));
+    tokio::time::timeout(Duration::from_secs(5), renewal)
+        .await
+        .expect("renewal loop drains once all tracked locks are gone")
+        .expect("renewal loop task")
+        .expect("no breach: unconfirmed renewals stay within the fence");
+}
+
 #[tokio::test]
 async fn renewal_failures_within_the_fence_are_survived() {
     let backend = Arc::new(MockBackend::default());

--- a/crates/lib/action-effect-reconciler/src/test_support.rs
+++ b/crates/lib/action-effect-reconciler/src/test_support.rs
@@ -45,6 +45,8 @@ pub(crate) struct MockBackend {
     pub fail_locks: Mutex<bool>,
     /// Fail every renew call when set.
     pub fail_renewals: Mutex<bool>,
+    /// Report every present row as [`RenewalStatus::Unconfirmed`] when set.
+    pub report_unconfirmed_renewals: Mutex<bool>,
     pub renew_calls: Mutex<u32>,
 }
 
@@ -208,12 +210,14 @@ impl waymark_action_effect_reconciler_backend::RenewActionCallRequestLocks for M
             return Err(MockRenewError);
         }
 
+        let report_unconfirmed = *self.report_unconfirmed_renewals.lock().unwrap();
         let mut rows = self.rows.lock().unwrap();
         let renewals = keys
             .iter()
             .map(|key| {
                 let status = match rows.get_mut(key) {
                     None => RenewalStatus::Missing,
+                    Some(_) if report_unconfirmed => RenewalStatus::Unconfirmed,
                     Some(row) if row.locked_by == Some(lock.owner) => {
                         row.lock_expires_at = Some(lock.expires_at);
                         RenewalStatus::Renewed

--- a/crates/lib/backend-postgres/src/action_call_requests/mod.rs
+++ b/crates/lib/backend-postgres/src/action_call_requests/mod.rs
@@ -352,9 +352,63 @@ impl waymark_action_effect_reconciler_backend::RenewActionCallRequestLocks for P
         .await
         .map_err(Self::Error::Sqlx)?;
 
-        let renewals = rows
-            .iter()
-            .map(|row| {
+        let mut renewals = Vec::with_capacity(rows.len());
+        let mut unrenewed_but_present = Vec::new();
+        for row in &rows {
+            let promise_state_id: i64 = row.get("promise_state_id");
+            let key = ActionCallRequestKey {
+                vm_id: row.get("vm_id"),
+                promise_state_id: PromiseStateId(
+                    usize::try_from(promise_state_id).map_err(Self::Error::OutOfRange)?,
+                ),
+            };
+            if row.get::<bool, _>("renewed") {
+                renewals.push(RequestLockRenewal {
+                    key,
+                    status: RenewalStatus::Renewed,
+                });
+            } else if row.get::<bool, _>("present") {
+                unrenewed_but_present.push(key);
+            } else {
+                renewals.push(RequestLockRenewal {
+                    key,
+                    status: RenewalStatus::Missing,
+                });
+            }
+        }
+
+        // `present` above comes from the renewal statement's snapshot,
+        // which may predate a concurrent completion's row removal — the
+        // update then skips the deleted row while the snapshot still shows
+        // it, which must NOT read as another owner taking the lock.
+        // Classify these keys from a fresh read instead: gone means the
+        // completion won (`Missing`), still ours means the extension went
+        // unconfirmed this pass (`Unconfirmed`), and only a different
+        // owner on the current row is a real `HeldElsewhere`.
+        if let Some(unverified) = NESlice::try_from_slice(&unrenewed_but_present) {
+            let columns = key_columns(unverified.iter()).map_err(Self::Error::OutOfRange)?;
+
+            Self::count_query(&self.query_counts, "select:action_call_requests_verify");
+            let verify_rows = sqlx::query(
+                r#"
+                SELECT i.vm_id, i.promise_state_id,
+                       (r.vm_id IS NOT NULL) AS present,
+                       r.locked_by
+                FROM UNNEST($1::uuid[], $2::bigint[]) AS i(vm_id, promise_state_id)
+                LEFT JOIN action_call_requests r
+                    ON r.vm_id = i.vm_id AND r.promise_state_id = i.promise_state_id
+                "#,
+            )
+            .bind(&columns.vm_ids)
+            .bind(&columns.promise_state_ids)
+            .fetch_all(&self.pool)
+            .timed(crate::query_timing_histogram!(
+                "select:action_call_requests_verify"
+            ))
+            .await
+            .map_err(Self::Error::Sqlx)?;
+
+            for row in &verify_rows {
                 let promise_state_id: i64 = row.get("promise_state_id");
                 let key = ActionCallRequestKey {
                     vm_id: row.get("vm_id"),
@@ -362,16 +416,20 @@ impl waymark_action_effect_reconciler_backend::RenewActionCallRequestLocks for P
                         usize::try_from(promise_state_id).map_err(Self::Error::OutOfRange)?,
                     ),
                 };
-                let status = if row.get::<bool, _>("renewed") {
-                    RenewalStatus::Renewed
-                } else if row.get::<bool, _>("present") {
-                    RenewalStatus::HeldElsewhere
-                } else {
+                let status = if !row.get::<bool, _>("present") {
                     RenewalStatus::Missing
+                } else {
+                    match row.get::<Option<uuid::Uuid>, _>("locked_by") {
+                        Some(locked_by) if locked_by == lock.owner => RenewalStatus::Unconfirmed,
+                        // A row we no longer own — relocked by another
+                        // owner, or unlocked and up for redelivery by
+                        // anyone. Either way our authorization is gone.
+                        Some(_) | None => RenewalStatus::HeldElsewhere,
+                    }
                 };
-                Ok(RequestLockRenewal { key, status })
-            })
-            .collect::<Result<Vec<_>, Self::Error>>()?;
+                renewals.push(RequestLockRenewal { key, status });
+            }
+        }
 
         Ok(NEVec::try_from_vec(renewals)
             .expect("the input keys are non-empty and each yields one row"))

--- a/crates/lib/backend-postgres/src/action_call_requests/tests.rs
+++ b/crates/lib/backend-postgres/src/action_call_requests/tests.rs
@@ -230,6 +230,56 @@ async fn renew_reports_per_key_status() {
     assert_eq!(status_of(3), RenewalStatus::Missing);
 }
 
+/// A completion removing the request row while the renewal statement is
+/// already running must classify as [`RenewalStatus::Missing`]: the
+/// renewal statement's snapshot still shows the row, and concluding
+/// "held elsewhere" from that stale read would breach the fence over a
+/// successfully completed call.
+#[serial(postgres)]
+#[tokio::test]
+async fn renew_racing_a_row_removal_reports_missing() {
+    let backend = setup_backend().await;
+    let vm = InstanceId::new_uuid_v4();
+    let owner = uuid::Uuid::new_v4();
+
+    let records = NEVec::try_from_vec(vec![record(vm, 1, 10, b"racing")]).unwrap();
+    backend
+        .record_action_call_requests(live_lock(owner), records.as_nonempty_slice())
+        .await
+        .expect("record request");
+
+    // Hold the row lock with an uncommitted removal — standing in for the
+    // completion trigger's DELETE — so the renewal statement blocks on the
+    // row while its snapshot predates the removal.
+    let mut removal_transaction = backend.pool().begin().await.expect("begin removal");
+    sqlx::query("DELETE FROM action_call_requests WHERE vm_id = $1 AND promise_state_id = $2")
+        .bind(vm)
+        .bind(1i64)
+        .execute(&mut *removal_transaction)
+        .await
+        .expect("delete request row");
+
+    let renew_backend = backend.clone();
+    let renew_task = tokio::spawn(async move {
+        renew_backend
+            .renew_action_call_request_locks(
+                live_lock(owner),
+                NEVec::try_from_vec(vec![key(vm, 1)])
+                    .unwrap()
+                    .as_nonempty_slice(),
+            )
+            .await
+    });
+
+    // Let the renewal reach the locked row, then let the removal win.
+    tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+    removal_transaction.commit().await.expect("commit removal");
+
+    let statuses = renew_task.await.expect("join renew").expect("renew");
+    assert_eq!(statuses.len().get(), 1);
+    assert_eq!(statuses.first().status, RenewalStatus::Missing);
+}
+
 #[serial(postgres)]
 #[tokio::test]
 async fn unlock_releases_own_locks_only() {


### PR DESCRIPTION
Goes in after #507

---

This PR improves the stability of the action effect reconciler.