### PR TITLE
Add batcher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4524,6 +4524,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "waymark-batcher"
+version = "0.1.0"
+dependencies = [
+ "nonempty-collections",
+ "thiserror",
+ "tokio",
+ "waymark-nonzero-duration",
+]
+
+[[package]]
 name = "waymark-benchmark"
 version = "0.1.0"
 dependencies = [

--- a/crates/lib/batcher/Cargo.toml
+++ b/crates/lib/batcher/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "waymark-batcher"
+edition = "2024"
+version.workspace = true
+publish.workspace = true
+
+[dependencies]
+waymark-nonzero-duration = { workspace = true }
+
+nonempty-collections = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["macros", "sync", "time"] }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt", "sync", "test-util", "time"] }

--- a/crates/lib/batcher/src/lib.rs
+++ b/crates/lib/batcher/src/lib.rs
@@ -1,0 +1,248 @@
+//! A generic coalescing primitive: many producers each `submit` one item and
+//! await its individual result, while a single background batcher groups the
+//! pending items into batches and hands each batch to a caller-supplied flush
+//! closure.
+//!
+//! It comes in two modes, differing only in how a batch is prepared and how
+//! its results are delivered — everything else (the handle, the bounded
+//! intake, the accumulate-by-size-or-delay loop, shutdown) is shared:
+//!
+//! - [`write_batcher`] — **positional**. Each submitted item is distinct and
+//!   goes to exactly one waiter; the flush closure sees every item and
+//!   returns one output per item, one-to-one. Good for batched writes
+//!   (snapshots, inserts, upserts).
+//! - [`read_batcher`] — **deduplicating** (a "DataLoader"). Producers submit
+//!   keys; if several ask for the same key in one window the flush closure is
+//!   called with that key once and its single value is cloned back to every
+//!   waiter. Good for batched loads. This is why a read key must be [`Hash`]
+//!   + [`Eq`] and its value [`Clone`], where a write needs neither.
+//!
+//! The crate is deliberately domain-agnostic. It knows nothing about
+//! databases, backends, or any project trait — the only thing that touches
+//! the outside world is the flush closure the caller provides. In both modes
+//! that closure is `FnMut(NEVec<In>) -> impl Future<Output = NEVec<Out>>`,
+//! returning one output per input **positionally**; a closure that returns a
+//! different count than it was given is a programming error and panics the
+//! batcher.
+//!
+//! # Lifecycle
+//!
+//! Each constructor returns a ([`BatcherHandle`], `impl Future`) pair. The
+//! future is the batcher task — it is **not** spawned; the caller owns it. It
+//! resolves on either of two triggers:
+//!
+//! - **All handles dropped** — the intake channel closes; the batcher
+//!   flushes whatever remains and resolves.
+//! - **The `shutdown` future resolves** — the batcher closes the intake
+//!   (further [`submit`](BatcherHandle::submit)s return [`Closed`]), drains
+//!   and flushes the still-buffered items, then resolves. Shutdown is
+//!   observed between batches, so a batch already accumulating completes
+//!   within [`Policy::max_delay`] of the signal. Pass [`std::future::pending`]
+//!   when only drop-driven shutdown is wanted.
+
+#![warn(missing_docs)]
+
+mod strategy;
+
+use std::hash::Hash;
+use std::num::NonZeroUsize;
+
+use nonempty_collections::NEVec;
+use tokio::sync::{mpsc, oneshot};
+use waymark_nonzero_duration::NonZeroDuration;
+
+use self::strategy::{BatchStrategy, Deduplicated, Positional};
+
+/// Controls when the batcher stops accumulating and flushes a batch.
+#[derive(Debug, Clone, Copy)]
+pub struct Policy {
+    /// Flush once this many items are buffered. For [`read_batcher`] these
+    /// are counted *before* deduplication.
+    pub max_batch: NonZeroUsize,
+
+    /// Flush at most this long after the batch's first item arrived, even if
+    /// [`max_batch`](Policy::max_batch) was not reached. Non-zero: a zero
+    /// window would flush after every first item and defeat batching.
+    pub max_delay: NonZeroDuration,
+}
+
+/// An item and the waiter to hand its output back to.
+type Job<In, Out> = (In, oneshot::Sender<Out>);
+
+/// Error returned by [`BatcherHandle::submit`] when the batcher can no longer
+/// produce an output — it has stopped (its task ended or was dropped), so the
+/// submitted item will never be flushed.
+#[derive(Debug, thiserror::Error)]
+#[error("batcher is closed")]
+pub struct Closed;
+
+/// A handle to a batcher: cloneable and shared by every producer. The same
+/// type serves both [`write_batcher`] and [`read_batcher`].
+///
+/// Dropping every clone closes the intake channel and lets the batcher
+/// drain-and-exit.
+pub struct BatcherHandle<In, Out> {
+    tx: mpsc::Sender<Job<In, Out>>,
+}
+
+// Derived `Clone` would demand `In: Clone` / `Out: Clone`; the handle is just
+// a channel sender, so clone it directly.
+impl<In, Out> Clone for BatcherHandle<In, Out> {
+    fn clone(&self) -> Self {
+        Self {
+            tx: self.tx.clone(),
+        }
+    }
+}
+
+impl<In, Out> BatcherHandle<In, Out> {
+    /// Enqueue one item (or key) and await the output the flush closure
+    /// produces for it.
+    ///
+    /// Awaits intake capacity first, so a burst of producers naturally
+    /// backpressures instead of growing memory without bound.
+    ///
+    /// Returns [`Closed`] if the batcher is gone and the item can never be
+    /// flushed.
+    pub async fn submit(&self, item: In) -> Result<Out, Closed> {
+        let (out_tx, out_rx) = oneshot::channel();
+        self.tx.send((item, out_tx)).await.map_err(|_| Closed)?;
+        out_rx.await.map_err(|_| Closed)
+    }
+}
+
+/// Create a **positional** batcher: a handle to submit items through, and the
+/// batcher future to drive.
+///
+/// `flush_fn` sees every submitted item and must return one output per item,
+/// in the same order. See the crate docs for the shutdown triggers.
+pub fn write_batcher<In, Out, FlushFn, Fut, Shutdown>(
+    policy: Policy,
+    flush_fn: FlushFn,
+    shutdown: Shutdown,
+) -> (BatcherHandle<In, Out>, impl Future<Output = ()>)
+where
+    FlushFn: FnMut(NEVec<In>) -> Fut,
+    Fut: Future<Output = NEVec<Out>>,
+    Shutdown: Future<Output = ()>,
+{
+    build::<In, Out, Positional, _, _, _>(policy, flush_fn, shutdown)
+}
+
+/// Create a **deduplicating** batcher (a DataLoader): a handle to submit keys
+/// through, and the batcher future to drive.
+///
+/// `flush_fn` is invoked with the non-empty, deduplicated keys of a window
+/// and must return one value per unique key, in the same order; that value is
+/// cloned back to every producer that submitted the key. See the crate docs
+/// for the shutdown triggers.
+pub fn read_batcher<Key, Value, FlushFn, Fut, Shutdown>(
+    policy: Policy,
+    flush_fn: FlushFn,
+    shutdown: Shutdown,
+) -> (BatcherHandle<Key, Value>, impl Future<Output = ()>)
+where
+    Key: Hash + Eq + Clone,
+    Value: Clone,
+    FlushFn: FnMut(NEVec<Key>) -> Fut,
+    Fut: Future<Output = NEVec<Value>>,
+    Shutdown: Future<Output = ()>,
+{
+    build::<Key, Value, Deduplicated, _, _, _>(policy, flush_fn, shutdown)
+}
+
+/// Shared wiring: bound intake channel, then the strategy-parameterized loop.
+fn build<In, Out, Strategy, FlushFn, Fut, Shutdown>(
+    policy: Policy,
+    flush_fn: FlushFn,
+    shutdown: Shutdown,
+) -> (BatcherHandle<In, Out>, impl Future<Output = ()>)
+where
+    Strategy: BatchStrategy<In, Out>,
+    FlushFn: FnMut(NEVec<In>) -> Fut,
+    Fut: Future<Output = NEVec<Out>>,
+    Shutdown: Future<Output = ()>,
+{
+    // A few batches' worth of slack: enough that producers rarely block on
+    // the send while a flush is in flight, small enough to bound memory.
+    let capacity = policy.max_batch.get().saturating_mul(4);
+    let (tx, rx) = mpsc::channel(capacity);
+    (
+        BatcherHandle { tx },
+        run::<In, Out, Strategy, _, _, _>(rx, policy, flush_fn, shutdown),
+    )
+}
+
+/// The shared batcher loop. `Strategy` supplies the two mode-specific steps:
+/// turning a window's jobs into the flush input, and delivering the flush
+/// output back to the waiters.
+async fn run<In, Out, Strategy, FlushFn, Fut, Shutdown>(
+    mut rx: mpsc::Receiver<Job<In, Out>>,
+    policy: Policy,
+    mut flush_fn: FlushFn,
+    shutdown: Shutdown,
+) where
+    Strategy: BatchStrategy<In, Out>,
+    FlushFn: FnMut(NEVec<In>) -> Fut,
+    Fut: Future<Output = NEVec<Out>>,
+    Shutdown: Future<Output = ()>,
+{
+    tokio::pin!(shutdown);
+    // Once shutdown has fired we close the intake and stop watching it —
+    // the generic future may not be safe to poll again, and `rx.recv` then
+    // simply drains the buffered jobs and ends the loop on its own.
+    let mut draining = false;
+
+    loop {
+        let first = if draining {
+            rx.recv().await
+        } else {
+            tokio::select! {
+                biased;
+                () = &mut shutdown => {
+                    rx.close();
+                    draining = true;
+                    rx.recv().await
+                }
+                job = rx.recv() => job,
+            }
+        };
+        let Some(first) = first else {
+            // Channel closed: all handles dropped, or drained after shutdown.
+            break;
+        };
+
+        // Accumulate up to `max_batch` jobs, or until the delay window —
+        // timed from the first job — elapses.  Reserving `max_batch` up
+        // front keeps the hot loop at one allocation per batch instead of
+        // growth-by-doubling.
+        let mut jobs = NEVec::with_capacity(policy.max_batch, first);
+        let deadline = tokio::time::sleep(policy.max_delay.get());
+        tokio::pin!(deadline);
+        while jobs.len().get() < policy.max_batch.get() {
+            tokio::select! {
+                biased;
+                () = &mut deadline => break,
+                job = rx.recv() => match job {
+                    Some(job) => jobs.push(job),
+                    None => break,
+                },
+            }
+        }
+
+        // Mode-specific: build the flush input and the delivery plan.
+        let (input, plan) = Strategy::prepare(jobs);
+        let expected = input.len();
+        let outputs = flush_fn(input).await;
+        assert_eq!(
+            outputs.len(),
+            expected,
+            "flush must return exactly one output per input",
+        );
+        // Mode-specific: route each output to its waiter(s).
+        Strategy::deliver(plan, outputs);
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/lib/batcher/src/lib.rs
+++ b/crates/lib/batcher/src/lib.rs
@@ -1,0 +1,302 @@
+//! A generic coalescing primitive: many producers each `submit` one item and
+//! await its individual result, while a single background batcher groups the
+//! pending items into batches and hands each batch to a caller-supplied flush
+//! closure.
+//!
+//! It comes in three modes, differing only in how a batch is prepared and how
+//! its results are delivered — everything else (the handle, the bounded
+//! intake, the accumulate-by-size-or-delay loop, shutdown) is shared:
+//!
+//! - [`write_batcher`] — **positional**. Each submitted item is distinct and
+//!   goes to exactly one waiter; the flush closure sees every item and
+//!   returns one output per item, one-to-one. Good for batched writes
+//!   (snapshots, inserts, upserts).
+//! - [`read_batcher`] — **deduplicating** (a "DataLoader"). Producers submit
+//!   keys; if several ask for the same key in one window the flush closure is
+//!   called with that key once and its single value is cloned back to every
+//!   waiter. Good for batched loads. This is why a read key must be [`Hash`]
+//!   + [`Eq`] and its value [`Clone`], where a write needs neither.
+//! - [`deduplicating_write_batcher`] — **deduplicating write**. Same-key
+//!   items in one window are folded pairwise down to a single
+//!   representative (see [`deduplicating_write::ConflictResolver`]); the
+//!   flush sees only representatives, and each folded-out waiter is
+//!   answered from its fold, delivered with the flush outputs. Good for
+//!   batched writes whose statement cannot carry the same key twice.
+//!
+//! The crate is deliberately domain-agnostic. It knows nothing about
+//! databases, backends, or any project trait — the only thing that touches
+//! the outside world is the flush closure the caller provides. In every mode
+//! that closure is `FnMut(NEVec<In>) -> impl Future<Output = NEVec<Out>>`,
+//! returning one output per input **positionally**; a closure that returns a
+//! different count than it was given is a programming error and panics the
+//! batcher.
+//!
+//! # Lifecycle
+//!
+//! Each constructor returns a ([`BatcherHandle`], `impl Future`) pair. The
+//! future is the batcher task — it is **not** spawned; the caller owns it. It
+//! resolves on either of two triggers:
+//!
+//! - **All handles dropped** — the intake channel closes; the batcher
+//!   flushes whatever remains and resolves.
+//! - **The `shutdown` future resolves** — the batcher closes the intake
+//!   (further [`submit`](BatcherHandle::submit)s return [`Closed`]), drains
+//!   and flushes the still-buffered items, then resolves. Shutdown is
+//!   observed between batches, so a batch already accumulating completes
+//!   within [`Policy::max_delay`] of the signal. Pass [`std::future::pending`]
+//!   when only drop-driven shutdown is wanted.
+
+#![warn(missing_docs)]
+
+mod strategy {
+    pub mod core;
+    pub mod deduplicating_write;
+    pub mod read;
+    pub mod write;
+}
+#[cfg(test)]
+mod test_helpers;
+
+pub use self::strategy::deduplicating_write;
+
+use std::hash::Hash;
+use std::num::NonZeroUsize;
+
+use nonempty_collections::NEVec;
+use tokio::sync::{mpsc, oneshot};
+use waymark_nonzero_duration::NonZeroDuration;
+
+/// Controls when the batcher stops accumulating and flushes a batch.
+#[derive(Debug, Clone, Copy)]
+pub struct Policy {
+    /// Flush once this many items are buffered. For [`read_batcher`] these
+    /// are counted *before* deduplication.
+    pub max_batch: NonZeroUsize,
+
+    /// Flush at most this long after the batch's first item arrived, even if
+    /// [`max_batch`](Policy::max_batch) was not reached. Non-zero: a zero
+    /// window would flush after every first item and defeat batching.
+    pub max_delay: NonZeroDuration,
+}
+
+/// An item and the waiter to hand its output back to.
+type Job<In, Out> = (In, oneshot::Sender<Out>);
+
+/// Error returned by [`BatcherHandle::submit`] when the batcher can no longer
+/// produce an output — it has stopped (its task ended or was dropped), so the
+/// submitted item will never be flushed.
+#[derive(Debug, thiserror::Error)]
+#[error("batcher is closed")]
+pub struct Closed;
+
+/// A handle to a batcher: cloneable and shared by every producer. The same
+/// type serves both [`write_batcher`] and [`read_batcher`].
+///
+/// Dropping every clone closes the intake channel and lets the batcher
+/// drain-and-exit.
+pub struct BatcherHandle<In, Out> {
+    tx: mpsc::Sender<Job<In, Out>>,
+}
+
+// Derived `Clone` would demand `In: Clone` / `Out: Clone`; the handle is just
+// a channel sender, so clone it directly.
+impl<In, Out> Clone for BatcherHandle<In, Out> {
+    fn clone(&self) -> Self {
+        Self {
+            tx: self.tx.clone(),
+        }
+    }
+}
+
+impl<In, Out> BatcherHandle<In, Out> {
+    /// Enqueue one item (or key) and await the output the flush closure
+    /// produces for it.
+    ///
+    /// Awaits intake capacity first, so a burst of producers naturally
+    /// backpressures instead of growing memory without bound.
+    ///
+    /// Returns [`Closed`] if the batcher is gone and the item can never be
+    /// flushed.
+    pub async fn submit(&self, item: In) -> Result<Out, Closed> {
+        let (out_tx, out_rx) = oneshot::channel();
+        self.tx.send((item, out_tx)).await.map_err(|_| Closed)?;
+        out_rx.await.map_err(|_| Closed)
+    }
+}
+
+/// Create a **positional** batcher: a handle to submit items through, and the
+/// batcher future to drive.
+///
+/// `flush_fn` sees every submitted item and must return one output per item,
+/// in the same order. See the crate docs for the shutdown triggers.
+pub fn write_batcher<In, Out, FlushFn, Fut, Shutdown>(
+    policy: Policy,
+    flush_fn: FlushFn,
+    shutdown: Shutdown,
+) -> (BatcherHandle<In, Out>, impl Future<Output = ()>)
+where
+    FlushFn: FnMut(NEVec<In>) -> Fut,
+    Fut: Future<Output = NEVec<Out>>,
+    Shutdown: Future<Output = ()>,
+{
+    build(policy, strategy::write::BatchStrategy, flush_fn, shutdown)
+}
+
+/// Create a **deduplicating write** batcher: a handle to submit items
+/// through, and the batcher future to drive.
+///
+/// Same-key items submitted within one window are folded pairwise, in
+/// submission order, down to a single representative — see
+/// [`deduplicating_write::ConflictResolver`] for how a fold is expressed. `flush_fn`
+/// sees only the representatives, in key-first-seen order, and must return
+/// one output per item, in the same order; each folded-out waiter receives
+/// the output its fold produced, settled against its winner's flush output
+/// ([`ConflictResolver::settle_conflict`](deduplicating_write::ConflictResolver::settle_conflict))
+/// and delivered together with the flush outputs. See the crate docs for
+/// the shutdown triggers.
+///
+/// `key_fn` must be pure: an item's key never changes, so the winner of a
+/// fold keys identically to the item it folded out. [`Policy::max_batch`]
+/// counts submitted items, before deduplication.
+pub fn deduplicating_write_batcher<In, Key, Out, KeyFn, ConflictResolver, FlushFn, Fut, Shutdown>(
+    policy: Policy,
+    key_fn: KeyFn,
+    resolver: ConflictResolver,
+    flush_fn: FlushFn,
+    shutdown: Shutdown,
+) -> (BatcherHandle<In, Out>, impl Future<Output = ()>)
+where
+    KeyFn: Fn(&In) -> Key,
+    Key: Hash + Eq,
+    ConflictResolver: deduplicating_write::ConflictResolver<In, Out>,
+    FlushFn: FnMut(NEVec<In>) -> Fut,
+    Fut: Future<Output = NEVec<Out>>,
+    Shutdown: Future<Output = ()>,
+{
+    build(
+        policy,
+        strategy::deduplicating_write::BatchStrategy { key_fn, resolver },
+        flush_fn,
+        shutdown,
+    )
+}
+
+/// Create a **deduplicating** batcher (a DataLoader): a handle to submit keys
+/// through, and the batcher future to drive.
+///
+/// `flush_fn` is invoked with the non-empty, deduplicated keys of a window
+/// and must return one value per unique key, in the same order; that value is
+/// cloned back to every producer that submitted the key. See the crate docs
+/// for the shutdown triggers.
+pub fn read_batcher<Key, Value, FlushFn, Fut, Shutdown>(
+    policy: Policy,
+    flush_fn: FlushFn,
+    shutdown: Shutdown,
+) -> (BatcherHandle<Key, Value>, impl Future<Output = ()>)
+where
+    Key: Hash + Eq + Clone,
+    Value: Clone,
+    FlushFn: FnMut(NEVec<Key>) -> Fut,
+    Fut: Future<Output = NEVec<Value>>,
+    Shutdown: Future<Output = ()>,
+{
+    build(policy, strategy::read::BatchStrategy, flush_fn, shutdown)
+}
+
+/// Shared wiring: bound intake channel, then the strategy-parameterized loop.
+fn build<In, Out, BatchStrategy, FlushFn, Fut, Shutdown>(
+    policy: Policy,
+    strategy: BatchStrategy,
+    flush_fn: FlushFn,
+    shutdown: Shutdown,
+) -> (BatcherHandle<In, Out>, impl Future<Output = ()>)
+where
+    BatchStrategy: strategy::core::BatchStrategy<In, Out>,
+    FlushFn: FnMut(NEVec<In>) -> Fut,
+    Fut: Future<Output = NEVec<Out>>,
+    Shutdown: Future<Output = ()>,
+{
+    // A few batches' worth of slack: enough that producers rarely block on
+    // the send while a flush is in flight, small enough to bound memory.
+    let capacity = policy.max_batch.get().saturating_mul(4);
+    let (tx, rx) = mpsc::channel(capacity);
+    (
+        BatcherHandle { tx },
+        run(rx, policy, strategy, flush_fn, shutdown),
+    )
+}
+
+/// The shared batcher loop. `Strategy` supplies the two mode-specific steps:
+/// turning a window's jobs into the flush input, and delivering the flush
+/// output back to the waiters.
+async fn run<In, Out, BatchStrategy, FlushFn, Fut, Shutdown>(
+    mut rx: mpsc::Receiver<Job<In, Out>>,
+    policy: Policy,
+    strategy: BatchStrategy,
+    mut flush_fn: FlushFn,
+    shutdown: Shutdown,
+) where
+    BatchStrategy: strategy::core::BatchStrategy<In, Out>,
+    FlushFn: FnMut(NEVec<In>) -> Fut,
+    Fut: Future<Output = NEVec<Out>>,
+    Shutdown: Future<Output = ()>,
+{
+    tokio::pin!(shutdown);
+    // Once shutdown has fired we close the intake and stop watching it —
+    // the generic future may not be safe to poll again, and `rx.recv` then
+    // simply drains the buffered jobs and ends the loop on its own.
+    let mut draining = false;
+
+    loop {
+        let first = if draining {
+            rx.recv().await
+        } else {
+            tokio::select! {
+                biased;
+                () = &mut shutdown => {
+                    rx.close();
+                    draining = true;
+                    rx.recv().await
+                }
+                job = rx.recv() => job,
+            }
+        };
+        let Some(first) = first else {
+            // Channel closed: all handles dropped, or drained after shutdown.
+            break;
+        };
+
+        // Accumulate up to `max_batch` jobs, or until the delay window —
+        // timed from the first job — elapses.  Reserving `max_batch` up
+        // front keeps the hot loop at one allocation per batch instead of
+        // growth-by-doubling.
+        let mut jobs = NEVec::with_capacity(policy.max_batch, first);
+        let deadline = tokio::time::sleep(policy.max_delay.get());
+        tokio::pin!(deadline);
+        while jobs.len().get() < policy.max_batch.get() {
+            tokio::select! {
+                biased;
+                () = &mut deadline => break,
+                job = rx.recv() => match job {
+                    Some(job) => jobs.push(job),
+                    None => break,
+                },
+            }
+        }
+
+        // Mode-specific: build the flush input and the delivery plan.
+        let (input, plan) = strategy.prepare(jobs);
+        let expected = input.len();
+        let outputs = flush_fn(input).await;
+        assert_eq!(
+            outputs.len(),
+            expected,
+            "flush must return exactly one output per input",
+        );
+        // Mode-specific: route each output to its waiter(s).
+        strategy.deliver(plan, outputs);
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/lib/batcher/src/strategy.rs
+++ b/crates/lib/batcher/src/strategy.rs
@@ -1,0 +1,99 @@
+//! The two mode-specific steps that distinguish a positional (write) batcher
+//! from a deduplicating (read) batcher, behind one trait the shared loop
+//! drives.
+
+use std::collections::HashMap;
+use std::collections::hash_map::Entry;
+use std::hash::Hash;
+
+use nonempty_collections::{IntoNonEmptyIterator as _, NEVec, NonEmptyIterator as _};
+use tokio::sync::oneshot;
+
+use crate::Job;
+
+/// How a batch's jobs are turned into the flush input and how the flush
+/// output is delivered back to the waiters. The shared loop knows nothing
+/// beyond these two steps.
+pub(crate) trait BatchStrategy<In, Out> {
+    /// Bookkeeping retained between building the flush input and delivering
+    /// the flush output.
+    type Plan;
+
+    /// Reduce a window's jobs to the flush input (the items or keys handed to
+    /// the flush closure) plus a plan for routing the outputs back.
+    fn prepare(jobs: NEVec<Job<In, Out>>) -> (NEVec<In>, Self::Plan);
+
+    /// Route each output — positionally aligned with the flush input — to the
+    /// waiter(s) it belongs to.
+    fn deliver(plan: Self::Plan, outputs: NEVec<Out>);
+}
+
+/// Positional, one-to-one: every submitted item is flushed and its single
+/// output goes to that item's one waiter. No key bounds, no cloning.
+pub(crate) struct Positional;
+
+impl<In, Out> BatchStrategy<In, Out> for Positional {
+    type Plan = NEVec<oneshot::Sender<Out>>;
+
+    fn prepare(jobs: NEVec<Job<In, Out>>) -> (NEVec<In>, Self::Plan) {
+        let capacity = jobs.len();
+        let ((first_item, first_waiter), rest) = jobs.into_nonempty_iter().next();
+        let mut items = NEVec::with_capacity(capacity, first_item);
+        let mut waiters = NEVec::with_capacity(capacity, first_waiter);
+        for (item, waiter) in rest {
+            items.push(item);
+            waiters.push(waiter);
+        }
+        (items, waiters)
+    }
+
+    fn deliver(waiters: Self::Plan, outputs: NEVec<Out>) {
+        for (output, waiter) in outputs.into_iter().zip(waiters) {
+            // A dropped waiter (producer gave up / was cancelled) is fine;
+            // its output is simply discarded.
+            let _ = waiter.send(output);
+        }
+    }
+}
+
+/// Deduplicating: keys seen more than once in a window are flushed once, and
+/// the single value is cloned back to every waiter that submitted the key.
+pub(crate) struct Deduplicated;
+
+impl<In, Out> BatchStrategy<In, Out> for Deduplicated
+where
+    In: Hash + Eq + Clone,
+    Out: Clone,
+{
+    type Plan = (Vec<In>, HashMap<In, Vec<oneshot::Sender<Out>>>);
+
+    fn prepare(jobs: NEVec<Job<In, Out>>) -> (NEVec<In>, Self::Plan) {
+        // One entry per key in first-seen order, gathering the waiters that
+        // asked for it.
+        let mut order: Vec<In> = Vec::new();
+        let mut waiters: HashMap<In, Vec<oneshot::Sender<Out>>> = HashMap::new();
+        for (key, waiter) in jobs {
+            match waiters.entry(key.clone()) {
+                Entry::Vacant(vacant) => {
+                    order.push(key);
+                    vacant.insert(vec![waiter]);
+                }
+                Entry::Occupied(mut occupied) => occupied.get_mut().push(waiter),
+            }
+        }
+        // `order` is non-empty: the first job's key is always present.
+        let unique = NEVec::try_from_vec(order.clone()).expect("at least the first key is present");
+        (unique, (order, waiters))
+    }
+
+    fn deliver((order, mut waiters): Self::Plan, outputs: NEVec<Out>) {
+        for (key, value) in order.into_iter().zip(outputs) {
+            let key_waiters = waiters
+                .remove(&key)
+                .expect("every unique key has at least one waiter");
+            for waiter in key_waiters {
+                let _ = waiter.send(value.clone());
+            }
+        }
+    }
+}

--- a/crates/lib/batcher/src/strategy/core.rs
+++ b/crates/lib/batcher/src/strategy/core.rs
@@ -1,0 +1,23 @@
+//! The mode seam: how a batch's jobs become the flush input, and how the
+//! flush output routes back to the waiters.
+
+use nonempty_collections::NEVec;
+
+use crate::Job;
+
+/// How a batch's jobs are turned into the flush input and how the flush
+/// output is delivered back to the waiters. The shared loop knows nothing
+/// beyond these two steps.
+pub trait BatchStrategy<In, Out> {
+    /// Bookkeeping retained between building the flush input and delivering
+    /// the flush output.
+    type Plan;
+
+    /// Reduce a window's jobs to the flush input (the items or keys handed to
+    /// the flush closure) plus a plan for routing the outputs back.
+    fn prepare(&self, jobs: NEVec<Job<In, Out>>) -> (NEVec<In>, Self::Plan);
+
+    /// Route each output — positionally aligned with the flush input — to the
+    /// waiter(s) it belongs to.
+    fn deliver(&self, plan: Self::Plan, outputs: NEVec<Out>);
+}

--- a/crates/lib/batcher/src/strategy/deduplicating_write.rs
+++ b/crates/lib/batcher/src/strategy/deduplicating_write.rs
@@ -1,0 +1,226 @@
+//! Conflict resolution for the deduplicating-write batcher: how same-key
+//! items fold before the flush.
+//!
+//! A [`deduplicating_write_batcher`](crate::deduplicating_write_batcher)
+//! groups a window's items by key; when a key is seen again, the caller's
+//! [`ConflictResolver`] folds the newcomer against the incumbent —
+//! pairwise, in submission order.  A folded-out item never reaches the
+//! statement; its fold produces a *provisional* output, which is settled
+//! against its winner's actual flush output
+//! ([`ConflictResolver::settle_conflict`]) before delivery — so a folded
+//! waiter can never be told an outcome the write attempt then failed to
+//! produce.
+//!
+//! The fold is expressed through a typestate API, so its obligations hold
+//! at the type level:
+//!
+//! - the resolver receives a [`ConflictedSlot`] — a view of the
+//!   incumbent's slot — and the newcomer by value;
+//! - it must consume the slot via [`ConflictedSlot::keep`] (the incumbent
+//!   stays; the newcomer is folded out) or [`ConflictedSlot::replace`]
+//!   (the newcomer takes the slot in place; the ousted incumbent comes
+//!   back by value, to be folded out via [`ResolvingSlot::resolve`]);
+//! - either path is the only source of the [`ConflictResolvedToken`] the
+//!   fold must return, so a fold cannot be left unresolved, and the
+//!   token's lifetime pins it to its own fold, so a token cannot be
+//!   stashed and returned for a different one.
+//!
+//! Waiters are in the machinery's custody: every submitted item's waiter
+//! is answered exactly once, from the fold or from the flush.  A
+//! folded-out *item*'s ownership passes to the resolver
+//! ([`keep`](ConflictedSlot::keep) already owns the newcomer;
+//! [`replace`](ConflictedSlot::replace) hands the incumbent back), so a
+//! resolver may move the item's data into the folded output instead of
+//! cloning.
+//!
+//! Folded-out outputs are settled and *delivered* together with the flush
+//! outputs, after the flush: the fold proposes, the flush's per-winner
+//! result disposes.
+
+use std::collections::HashMap;
+use std::collections::hash_map::Entry;
+use std::hash::Hash;
+use std::marker::PhantomData;
+
+use nonempty_collections::{IntoNonEmptyIterator as _, NEVec, NonEmptyIterator as _};
+use tokio::sync::oneshot;
+
+use crate::Job;
+
+/// The conflict resolver of one deduplicating-write batcher: what happens
+/// when two same-key items meet in one window.
+///
+/// Implemented on named types only — a resolver states both halves of
+/// the fold story: what a fold records, and how it settles.
+pub trait ConflictResolver<In, Out> {
+    /// The resolver's fold-time record for a folded-out item: what
+    /// [`resolve_conflict`](Self::resolve_conflict) leaves behind, and
+    /// what [`settle_conflict`](Self::settle_conflict) consumes against
+    /// the winner's actual flush output.
+    type Placeholder;
+
+    /// Fold a same-key conflict: the incumbent (in the slot) against the
+    /// newcomer, which arrived later in submission order.  Three or more
+    /// occurrences fold pairwise, left to right.
+    ///
+    /// Consume the slot via [`ConflictedSlot::keep`] or
+    /// [`ConflictedSlot::replace`]; the returned token proves the fold
+    /// was resolved.
+    fn resolve_conflict<'a>(
+        &self,
+        slot: ConflictedSlot<'a, In, Out, Self::Placeholder>,
+        newcomer: In,
+    ) -> ConflictResolvedToken<'a>;
+
+    /// Settle a folded-out item's placeholder against its winner's
+    /// actual flush output, producing the folded waiter's final output.
+    /// Called once per folded item, after the flush and before delivery.
+    fn settle_conflict(&self, conflicted_out: Self::Placeholder, winner_out: &Out) -> Out;
+}
+
+/// A same-key conflict, viewed from the incumbent's slot.  Must be
+/// consumed via [`keep`](Self::keep) or [`replace`](Self::replace).
+pub struct ConflictedSlot<'a, In, Out, Placeholder> {
+    incumbent: &'a mut In,
+    resolving: ResolvingSlot<'a, Out, Placeholder>,
+}
+
+impl<'a, In, Out, Placeholder> ConflictedSlot<'a, In, Out, Placeholder> {
+    /// The current incumbent, for inspection before deciding.
+    pub fn incumbent(&self) -> &In {
+        self.incumbent
+    }
+
+    /// The incumbent stays; the newcomer is folded out with
+    /// `newcomer_placeholder`.  The resolver owns the newcomer and may
+    /// move its data into the placeholder.
+    pub fn keep(self, newcomer_placeholder: Placeholder) -> ConflictResolvedToken<'a> {
+        self.resolving.folded.push((
+            self.resolving.newcomer_waiter,
+            newcomer_placeholder,
+            self.resolving.winner_slot,
+        ));
+        ConflictResolvedToken { _fold: PhantomData }
+    }
+
+    /// The newcomer takes the slot in place; the ousted incumbent comes
+    /// back by value, to be folded out via [`ResolvingSlot::resolve`].
+    pub fn replace(self, newcomer: In) -> (In, ResolvingSlot<'a, Out, Placeholder>) {
+        (std::mem::replace(self.incumbent, newcomer), self.resolving)
+    }
+}
+
+/// A fold whose incumbent was ousted, awaiting the ousted side's
+/// placeholder.
+pub struct ResolvingSlot<'a, Out, Placeholder> {
+    /// Folded-out waiters, each with its placeholder and the winner slot
+    /// it folded against.
+    folded: &'a mut Vec<(oneshot::Sender<Out>, Placeholder, usize)>,
+    /// The one record of who awaits the winner slot's flush output.
+    owner: &'a mut oneshot::Sender<Out>,
+    /// The newcomer's waiter.
+    newcomer_waiter: oneshot::Sender<Out>,
+    /// The winner slot this fold happened against.
+    winner_slot: usize,
+}
+
+impl<'a, Out, Placeholder> ResolvingSlot<'a, Out, Placeholder> {
+    /// The ousted incumbent is folded out with `incumbent_placeholder`.
+    ///
+    /// The slot's flush output moves from the incumbent's waiter to the
+    /// newcomer's in one swap — a slot has exactly one awaiting waiter
+    /// at all times.
+    pub fn resolve(self, incumbent_placeholder: Placeholder) -> ConflictResolvedToken<'a> {
+        let ousted_waiter = std::mem::replace(self.owner, self.newcomer_waiter);
+        self.folded
+            .push((ousted_waiter, incumbent_placeholder, self.winner_slot));
+        ConflictResolvedToken { _fold: PhantomData }
+    }
+}
+
+/// Proof that a fold was resolved — only [`ConflictedSlot::keep`] and
+/// [`ResolvingSlot::resolve`] mint one.  Its lifetime is the fold's, so
+/// it cannot be stashed and returned for another fold.
+pub struct ConflictResolvedToken<'a> {
+    // Invariant in `'a`: closes even theoretical lifetime coercions.
+    _fold: PhantomData<fn(&'a ()) -> &'a ()>,
+}
+
+/// The deduplicating-write [`BatchStrategy`](super::core::BatchStrategy):
+/// fold same-key jobs down to winners, flush the winners, answer
+/// folded-out waiters from their folds.
+pub(crate) struct BatchStrategy<KeyFn, ConflictResolver> {
+    pub key_fn: KeyFn,
+    pub resolver: ConflictResolver,
+}
+
+impl<In, Key, Out, KeyFn, ConflictResolver> super::core::BatchStrategy<In, Out>
+    for BatchStrategy<KeyFn, ConflictResolver>
+where
+    KeyFn: Fn(&In) -> Key,
+    Key: Hash + Eq,
+    ConflictResolver: self::ConflictResolver<In, Out>,
+{
+    type Plan = (
+        // The winners' waiters, positionally aligned with the flush input.
+        NEVec<oneshot::Sender<Out>>,
+        // The folded-out waiters, each with its placeholder and the
+        // winner slot to settle it against.
+        Vec<(oneshot::Sender<Out>, ConflictResolver::Placeholder, usize)>,
+    );
+
+    fn prepare(&self, jobs: NEVec<Job<In, Out>>) -> (NEVec<In>, Self::Plan) {
+        let capacity = jobs.len();
+        let ((first_item, first_waiter), rest) = jobs.into_nonempty_iter().next();
+        let mut index_of: HashMap<Key, usize> = HashMap::new();
+        index_of.insert((self.key_fn)(&first_item), 0);
+        let mut winners = NEVec::with_capacity(capacity, first_item);
+        let mut winner_waiters = NEVec::with_capacity(capacity, first_waiter);
+        let mut folded: Vec<(oneshot::Sender<Out>, ConflictResolver::Placeholder, usize)> =
+            Vec::new();
+
+        for (item, waiter) in rest {
+            match index_of.entry((self.key_fn)(&item)) {
+                Entry::Vacant(vacant) => {
+                    vacant.insert(winner_waiters.len().get());
+                    winners.push(item);
+                    winner_waiters.push(waiter);
+                }
+                Entry::Occupied(occupied) => {
+                    let slot = *occupied.get();
+                    self.resolver.resolve_conflict(
+                        ConflictedSlot {
+                            incumbent: &mut winners[slot],
+                            resolving: ResolvingSlot {
+                                folded: &mut folded,
+                                owner: &mut winner_waiters[slot],
+                                newcomer_waiter: waiter,
+                                winner_slot: slot,
+                            },
+                        },
+                        item,
+                    );
+                }
+            }
+        }
+
+        (winners, (winner_waiters, folded))
+    }
+
+    fn deliver(&self, (winner_waiters, folded): Self::Plan, outputs: NEVec<Out>) {
+        // A dropped waiter (producer gave up / was cancelled) is fine;
+        // its output is simply discarded.
+        for (waiter, placeholder, winner_slot) in folded {
+            let output = self
+                .resolver
+                .settle_conflict(placeholder, &outputs[winner_slot]);
+            let _ = waiter.send(output);
+        }
+        for (output, waiter) in outputs.into_iter().zip(winner_waiters) {
+            let _ = waiter.send(output);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/lib/batcher/src/strategy/deduplicating_write/tests.rs
+++ b/crates/lib/batcher/src/strategy/deduplicating_write/tests.rs
@@ -1,0 +1,332 @@
+//! Unit tests for the deduplicating write: fold semantics (keep, replace,
+//! content-chosen), pairwise fold order, key-first-seen flush order,
+//! post-flush delivery of folded-out outputs, and settling folded
+//! outputs against their winner's flush output.
+
+use std::sync::Arc;
+
+use nonempty_collections::NEVec;
+
+use super::{ConflictResolvedToken, ConflictedSlot};
+use crate::test_helpers::{nz, secs};
+use crate::{BatcherHandle, Policy, deduplicating_write_batcher};
+
+/// Items are `(key, value)`; outputs are `i64`: a flushed representative
+/// gets `value * 10`, a folded-out item gets `-value` — so every output
+/// names the item it belongs to.
+type Item = (u32, i64);
+
+fn key(item: &Item) -> u32 {
+    item.0
+}
+
+fn folded_out(value: i64) -> i64 {
+    -value
+}
+
+fn flushed(value: i64) -> i64 {
+    value * 10
+}
+
+/// First-wins: the incumbent always stays.
+struct FirstWins;
+
+impl super::ConflictResolver<Item, i64> for FirstWins {
+    type Placeholder = i64;
+
+    fn resolve_conflict<'a>(
+        &self,
+        slot: ConflictedSlot<'a, Item, i64, i64>,
+        newcomer: Item,
+    ) -> ConflictResolvedToken<'a> {
+        slot.keep(folded_out(newcomer.1))
+    }
+
+    fn settle_conflict(&self, conflicted_out: i64, _winner_out: &i64) -> i64 {
+        conflicted_out
+    }
+}
+
+/// Last-wins: the newcomer always takes the slot.
+struct LastWins;
+
+impl super::ConflictResolver<Item, i64> for LastWins {
+    type Placeholder = i64;
+
+    fn resolve_conflict<'a>(
+        &self,
+        slot: ConflictedSlot<'a, Item, i64, i64>,
+        newcomer: Item,
+    ) -> ConflictResolvedToken<'a> {
+        let (incumbent, resolving) = slot.replace(newcomer);
+        resolving.resolve(folded_out(incumbent.1))
+    }
+
+    fn settle_conflict(&self, conflicted_out: i64, _winner_out: &i64) -> i64 {
+        conflicted_out
+    }
+}
+
+/// Content-chosen: the larger value wins, regardless of arrival order.
+struct LargestWins;
+
+impl super::ConflictResolver<Item, i64> for LargestWins {
+    type Placeholder = i64;
+
+    fn resolve_conflict<'a>(
+        &self,
+        slot: ConflictedSlot<'a, Item, i64, i64>,
+        newcomer: Item,
+    ) -> ConflictResolvedToken<'a> {
+        if slot.incumbent().1 >= newcomer.1 {
+            slot.keep(folded_out(newcomer.1))
+        } else {
+            let (incumbent, resolving) = slot.replace(newcomer);
+            resolving.resolve(folded_out(incumbent.1))
+        }
+    }
+
+    fn settle_conflict(&self, conflicted_out: i64, _winner_out: &i64) -> i64 {
+        conflicted_out
+    }
+}
+
+/// First-wins whose settle adds the winner's flush output to the folded
+/// output — so a test can assert exactly which winner a folded item was
+/// settled against.
+struct FirstWinsSettling;
+
+impl super::ConflictResolver<Item, i64> for FirstWinsSettling {
+    type Placeholder = i64;
+
+    fn resolve_conflict<'a>(
+        &self,
+        slot: ConflictedSlot<'a, Item, i64, i64>,
+        newcomer: Item,
+    ) -> ConflictResolvedToken<'a> {
+        slot.keep(folded_out(newcomer.1))
+    }
+
+    fn settle_conflict(&self, conflicted_out: i64, winner_out: &i64) -> i64 {
+        conflicted_out + *winner_out
+    }
+}
+
+/// Last-wins with the same settling arithmetic as [`FirstWinsSettling`].
+struct LastWinsSettling;
+
+impl super::ConflictResolver<Item, i64> for LastWinsSettling {
+    type Placeholder = i64;
+
+    fn resolve_conflict<'a>(
+        &self,
+        slot: ConflictedSlot<'a, Item, i64, i64>,
+        newcomer: Item,
+    ) -> ConflictResolvedToken<'a> {
+        let (incumbent, resolving) = slot.replace(newcomer);
+        resolving.resolve(folded_out(incumbent.1))
+    }
+
+    fn settle_conflict(&self, conflicted_out: i64, winner_out: &i64) -> i64 {
+        conflicted_out + *winner_out
+    }
+}
+
+/// A batcher that only ever flushes on the size trigger, recording each
+/// flush input's `(key, value)` pairs.
+fn spawn_size_gated<ConflictResolver>(
+    resolver: ConflictResolver,
+    max_batch: usize,
+    statements: &Arc<std::sync::Mutex<Vec<Vec<Item>>>>,
+) -> BatcherHandle<Item, i64>
+where
+    ConflictResolver: super::ConflictResolver<Item, i64> + Send + 'static,
+    ConflictResolver::Placeholder: Send,
+{
+    let statements = Arc::clone(statements);
+    let (handle, batcher) = deduplicating_write_batcher(
+        Policy {
+            max_batch: nz(max_batch),
+            max_delay: secs(3600),
+        },
+        key,
+        resolver,
+        move |batch: NEVec<Item>| {
+            statements
+                .lock()
+                .expect("lock")
+                .push(batch.iter().copied().collect());
+            let outputs: Vec<i64> = batch.into_iter().map(|(_, value)| flushed(value)).collect();
+            std::future::ready(NEVec::try_from_vec(outputs).expect("batch was non-empty"))
+        },
+        std::future::pending(),
+    );
+    tokio::spawn(batcher);
+    handle
+}
+
+/// Submit items concurrently from one task, preserving listing order.
+macro_rules! submit_all {
+    ($handle:expr, $($item:expr),+ $(,)?) => {
+        tokio::join!($($handle.submit($item)),+)
+    };
+}
+
+#[tokio::test]
+async fn distinct_keys_behave_positionally() {
+    let statements = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let handle = spawn_size_gated(FirstWins, 3, &statements);
+
+    let (a, b, c) = submit_all!(handle, (1, 10), (2, 20), (3, 30));
+    assert_eq!(a.expect("not closed"), flushed(10));
+    assert_eq!(b.expect("not closed"), flushed(20));
+    assert_eq!(c.expect("not closed"), flushed(30));
+
+    assert_eq!(
+        *statements.lock().expect("lock"),
+        vec![vec![(1, 10), (2, 20), (3, 30)]],
+        "no folds: every item reaches the statement, in submission order"
+    );
+}
+
+#[tokio::test]
+async fn first_wins_folds_the_newcomer_out() {
+    let statements = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let handle = spawn_size_gated(FirstWins, 2, &statements);
+
+    let (first, duplicate) = submit_all!(handle, (1, 10), (1, 20));
+    assert_eq!(first.expect("not closed"), flushed(10));
+    assert_eq!(duplicate.expect("not closed"), folded_out(20));
+
+    assert_eq!(
+        *statements.lock().expect("lock"),
+        vec![vec![(1, 10)]],
+        "only the incumbent reached the statement"
+    );
+}
+
+#[tokio::test]
+async fn last_wins_replaces_in_place() {
+    let statements = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let handle = spawn_size_gated(LastWins, 3, &statements);
+
+    // The same-key newcomer takes the slot; the slot's position in the
+    // statement stays where the key was first seen.
+    let (ousted, unrelated, winner) = submit_all!(handle, (1, 10), (2, 20), (1, 30));
+    assert_eq!(ousted.expect("not closed"), folded_out(10));
+    assert_eq!(unrelated.expect("not closed"), flushed(20));
+    assert_eq!(winner.expect("not closed"), flushed(30));
+
+    assert_eq!(
+        *statements.lock().expect("lock"),
+        vec![vec![(1, 30), (2, 20)]],
+        "the winner sits at the key's first-seen position"
+    );
+}
+
+#[tokio::test]
+async fn three_occurrences_fold_pairwise_in_order() {
+    let statements = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let handle = spawn_size_gated(LargestWins, 3, &statements);
+
+    // (1,20) beats (1,10); then (1,15) loses to the interim winner.
+    let (small, large, middle) = submit_all!(handle, (1, 10), (1, 20), (1, 15));
+    assert_eq!(small.expect("not closed"), folded_out(10));
+    assert_eq!(large.expect("not closed"), flushed(20));
+    assert_eq!(middle.expect("not closed"), folded_out(15));
+
+    assert_eq!(*statements.lock().expect("lock"), vec![vec![(1, 20)]]);
+}
+
+#[tokio::test]
+async fn folded_outputs_settle_against_their_own_winners_output() {
+    let statements = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let handle = spawn_size_gated(FirstWinsSettling, 3, &statements);
+
+    // The key-1 duplicate must settle against key 1's flush output
+    // (`flushed(10)`), not key 2's.
+    let (winner, duplicate, unrelated) = submit_all!(handle, (1, 10), (1, 20), (2, 30));
+    assert_eq!(winner.expect("not closed"), flushed(10));
+    assert_eq!(
+        duplicate.expect("not closed"),
+        folded_out(20) + flushed(10),
+        "settled against its own winner's output"
+    );
+    assert_eq!(unrelated.expect("not closed"), flushed(30));
+}
+
+#[tokio::test]
+async fn settling_after_replace_uses_the_final_winners_output() {
+    let statements = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let handle = spawn_size_gated(LastWinsSettling, 2, &statements);
+
+    // The ousted incumbent settles against the output of the newcomer
+    // that replaced it — the slot's final winner.
+    let (ousted, winner) = submit_all!(handle, (1, 10), (1, 30));
+    assert_eq!(winner.expect("not closed"), flushed(30));
+    assert_eq!(
+        ousted.expect("not closed"),
+        folded_out(10) + flushed(30),
+        "settled against the final winner's output"
+    );
+}
+
+#[tokio::test]
+async fn folded_outputs_are_delivered_only_after_the_flush() {
+    let statements: Arc<std::sync::Mutex<Vec<Vec<Item>>>> =
+        Arc::new(std::sync::Mutex::new(Vec::new()));
+    let gate = Arc::new(tokio::sync::Semaphore::new(0));
+    let (handle, batcher) = deduplicating_write_batcher(
+        Policy {
+            max_batch: nz(2),
+            max_delay: secs(3600),
+        },
+        key,
+        FirstWins,
+        {
+            let statements = Arc::clone(&statements);
+            let gate = Arc::clone(&gate);
+            move |batch: NEVec<Item>| {
+                statements
+                    .lock()
+                    .expect("lock")
+                    .push(batch.iter().copied().collect());
+                let outputs: Vec<i64> = batch.iter().map(|(_, value)| flushed(*value)).collect();
+                let gate = Arc::clone(&gate);
+                async move {
+                    let _permit = gate.acquire().await.expect("gate open");
+                    NEVec::try_from_vec(outputs).expect("batch was non-empty")
+                }
+            }
+        },
+        std::future::pending(),
+    );
+    tokio::spawn(batcher);
+
+    let duplicate = {
+        let handle = handle.clone();
+        tokio::spawn(async move {
+            let (_first, duplicate) = tokio::join!(handle.submit((1, 10)), handle.submit((1, 20)));
+            duplicate
+        })
+    };
+
+    // Let the batcher accumulate, fold, and enter the gated flush; the
+    // folded-out waiter must still be pending even though its output was
+    // decided at fold time.
+    for _ in 0..32 {
+        tokio::task::yield_now().await;
+    }
+    assert!(
+        !statements.lock().expect("lock").is_empty(),
+        "the flush was entered"
+    );
+    assert!(
+        !duplicate.is_finished(),
+        "folded-out output must not be released before the flush completes"
+    );
+
+    gate.add_permits(1);
+    let duplicate = duplicate.await.expect("join").expect("not closed");
+    assert_eq!(duplicate, folded_out(20));
+}

--- a/crates/lib/batcher/src/strategy/read.rs
+++ b/crates/lib/batcher/src/strategy/read.rs
@@ -1,0 +1,55 @@
+//! The deduplicating (read) strategy.
+
+use std::collections::HashMap;
+use std::collections::hash_map::Entry;
+use std::hash::Hash;
+
+use nonempty_collections::NEVec;
+use tokio::sync::oneshot;
+
+use crate::Job;
+
+/// Deduplicating: keys seen more than once in a window are flushed once, and
+/// the single value is cloned back to every waiter that submitted the key.
+pub struct BatchStrategy;
+
+impl<In, Out> super::core::BatchStrategy<In, Out> for BatchStrategy
+where
+    In: Hash + Eq + Clone,
+    Out: Clone,
+{
+    type Plan = (Vec<In>, HashMap<In, Vec<oneshot::Sender<Out>>>);
+
+    fn prepare(&self, jobs: NEVec<Job<In, Out>>) -> (NEVec<In>, Self::Plan) {
+        // One entry per key in first-seen order, gathering the waiters that
+        // asked for it.
+        let mut order: Vec<In> = Vec::new();
+        let mut waiters: HashMap<In, Vec<oneshot::Sender<Out>>> = HashMap::new();
+        for (key, waiter) in jobs {
+            match waiters.entry(key.clone()) {
+                Entry::Vacant(vacant) => {
+                    order.push(key);
+                    vacant.insert(vec![waiter]);
+                }
+                Entry::Occupied(mut occupied) => occupied.get_mut().push(waiter),
+            }
+        }
+        // `order` is non-empty: the first job's key is always present.
+        let unique = NEVec::try_from_vec(order.clone()).expect("at least the first key is present");
+        (unique, (order, waiters))
+    }
+
+    fn deliver(&self, (order, mut waiters): Self::Plan, outputs: NEVec<Out>) {
+        for (key, value) in order.into_iter().zip(outputs) {
+            let key_waiters = waiters
+                .remove(&key)
+                .expect("every unique key has at least one waiter");
+            for waiter in key_waiters {
+                let _ = waiter.send(value.clone());
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/lib/batcher/src/strategy/read/tests.rs
+++ b/crates/lib/batcher/src/strategy/read/tests.rs
@@ -1,0 +1,71 @@
+//! Unit tests for the deduplicating (read) strategy's semantics.
+
+use std::sync::Arc;
+
+use crate::test_helpers::{nz, recording_flush, secs};
+use crate::{Policy, read_batcher};
+
+#[tokio::test]
+async fn duplicate_keys_load_once_and_fan_out() {
+    let seen = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let (handle, batcher) = read_batcher(
+        // Two raw keys fill the batch; both are the same key.
+        Policy {
+            max_batch: nz(2),
+            max_delay: secs(3600),
+        },
+        recording_flush(Arc::clone(&seen), |key: u32| key * 10),
+        std::future::pending(),
+    );
+    let batcher = tokio::spawn(batcher);
+
+    let a = {
+        let handle = handle.clone();
+        tokio::spawn(async move { handle.submit(7).await })
+    };
+    let b = {
+        let handle = handle.clone();
+        tokio::spawn(async move { handle.submit(7).await })
+    };
+
+    assert_eq!(a.await.expect("join").expect("not closed"), 70);
+    assert_eq!(b.await.expect("join").expect("not closed"), 70);
+
+    drop(handle);
+    batcher.await.expect("batcher join");
+    assert_eq!(
+        *seen.lock().expect("lock"),
+        vec![1],
+        "the shared key was loaded once, not twice",
+    );
+}
+
+#[tokio::test]
+async fn distinct_keys_each_get_their_own_value() {
+    let seen = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let (handle, batcher) = read_batcher(
+        Policy {
+            max_batch: nz(3),
+            max_delay: secs(3600),
+        },
+        recording_flush(Arc::clone(&seen), |key: u64| key * 100),
+        std::future::pending(),
+    );
+    let batcher = tokio::spawn(batcher);
+
+    let submissions: Vec<_> = (1..=3u64)
+        .map(|key| {
+            let handle = handle.clone();
+            tokio::spawn(async move { (key, handle.submit(key).await) })
+        })
+        .collect();
+
+    for submission in submissions {
+        let (key, value) = submission.await.expect("join");
+        assert_eq!(value.expect("not closed"), key * 100);
+    }
+
+    drop(handle);
+    batcher.await.expect("batcher join");
+    assert_eq!(*seen.lock().expect("lock"), vec![3], "three distinct keys");
+}

--- a/crates/lib/batcher/src/strategy/write.rs
+++ b/crates/lib/batcher/src/strategy/write.rs
@@ -1,0 +1,37 @@
+//! The positional (write) strategy.
+
+use nonempty_collections::{IntoNonEmptyIterator as _, NEVec, NonEmptyIterator as _};
+use tokio::sync::oneshot;
+
+use crate::Job;
+
+/// Positional, one-to-one: every submitted item is flushed and its single
+/// output goes to that item's one waiter. No key bounds, no cloning.
+pub struct BatchStrategy;
+
+impl<In, Out> super::core::BatchStrategy<In, Out> for BatchStrategy {
+    type Plan = NEVec<oneshot::Sender<Out>>;
+
+    fn prepare(&self, jobs: NEVec<Job<In, Out>>) -> (NEVec<In>, Self::Plan) {
+        let capacity = jobs.len();
+        let ((first_item, first_waiter), rest) = jobs.into_nonempty_iter().next();
+        let mut items = NEVec::with_capacity(capacity, first_item);
+        let mut waiters = NEVec::with_capacity(capacity, first_waiter);
+        for (item, waiter) in rest {
+            items.push(item);
+            waiters.push(waiter);
+        }
+        (items, waiters)
+    }
+
+    fn deliver(&self, waiters: Self::Plan, outputs: NEVec<Out>) {
+        for (output, waiter) in outputs.into_iter().zip(waiters) {
+            // A dropped waiter (producer gave up / was cancelled) is fine;
+            // its output is simply discarded.
+            let _ = waiter.send(output);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/lib/batcher/src/strategy/write/tests.rs
+++ b/crates/lib/batcher/src/strategy/write/tests.rs
@@ -1,0 +1,106 @@
+//! Unit tests for the positional (write) strategy's semantics.
+
+use std::sync::Arc;
+
+use crate::test_helpers::{millis, nz, recording_flush, secs};
+use crate::{Policy, write_batcher};
+
+#[tokio::test]
+async fn flushes_when_the_batch_fills() {
+    let seen = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let (handle, batcher) = write_batcher(
+        Policy {
+            max_batch: nz(3),
+            max_delay: secs(3600),
+        },
+        recording_flush(Arc::clone(&seen), |item: u32| item * 10),
+        std::future::pending(),
+    );
+    let batcher = tokio::spawn(batcher);
+
+    let submissions: Vec<_> = (0..3)
+        .map(|item| {
+            let handle = handle.clone();
+            tokio::spawn(async move { handle.submit(item).await })
+        })
+        .collect();
+
+    for (item, submission) in submissions.into_iter().enumerate() {
+        let output = submission.await.expect("join").expect("not closed");
+        assert_eq!(output, item as u32 * 10, "each item gets its own output");
+    }
+
+    drop(handle);
+    batcher.await.expect("batcher join");
+    assert_eq!(
+        *seen.lock().expect("lock"),
+        vec![3],
+        "one full batch of three"
+    );
+}
+
+#[tokio::test(start_paused = true)]
+async fn flushes_when_the_delay_elapses() {
+    let seen = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let (handle, batcher) = write_batcher(
+        Policy {
+            max_batch: nz(1000),
+            max_delay: millis(50),
+        },
+        recording_flush(Arc::clone(&seen), |item: u32| item),
+        std::future::pending(),
+    );
+    let batcher = tokio::spawn(batcher);
+
+    let a = {
+        let handle = handle.clone();
+        tokio::spawn(async move { handle.submit(1).await })
+    };
+    let b = {
+        let handle = handle.clone();
+        tokio::spawn(async move { handle.submit(2).await })
+    };
+
+    assert_eq!(a.await.expect("join").expect("not closed"), 1);
+    assert_eq!(b.await.expect("join").expect("not closed"), 2);
+
+    drop(handle);
+    batcher.await.expect("batcher join");
+    assert_eq!(
+        *seen.lock().expect("lock"),
+        vec![2],
+        "delay-triggered batch"
+    );
+}
+
+#[tokio::test]
+async fn every_submitter_gets_its_own_output() {
+    let (handle, batcher) = write_batcher(
+        Policy {
+            max_batch: nz(8),
+            max_delay: secs(3600),
+        },
+        // Identity map: the output must be the submitter's own input, which
+        // only holds if the positional zip lines up waiters and outputs.
+        recording_flush(Arc::new(std::sync::Mutex::new(Vec::new())), |item: u64| {
+            item
+        }),
+        std::future::pending(),
+    );
+    let batcher = tokio::spawn(batcher);
+
+    let submissions: Vec<_> = (0..8u64)
+        .map(|item| {
+            let handle = handle.clone();
+            tokio::spawn(async move { (item, handle.submit(item).await) })
+        })
+        .collect();
+
+    for submission in submissions {
+        let (item, output) = submission.await.expect("join");
+        assert_eq!(output.expect("not closed"), item);
+    }
+
+    drop(handle);
+    batcher.await.expect("batcher join");
+}

--- a/crates/lib/batcher/src/test_helpers.rs
+++ b/crates/lib/batcher/src/test_helpers.rs
@@ -1,0 +1,31 @@
+//! Shared construction helpers for the batcher test modules.
+
+use std::num::NonZeroUsize;
+use std::sync::Arc;
+
+use nonempty_collections::NEVec;
+use waymark_nonzero_duration::NonZeroDuration;
+
+pub fn nz(value: usize) -> NonZeroUsize {
+    NonZeroUsize::new(value).expect("non-zero")
+}
+
+pub fn secs(value: u64) -> NonZeroDuration {
+    NonZeroDuration::from_secs(value).expect("non-zero")
+}
+
+pub fn millis(value: u64) -> NonZeroDuration {
+    NonZeroDuration::from_millis(value).expect("non-zero")
+}
+
+/// A flush that records each batch's size and maps every input through `map`.
+pub fn recording_flush<In, Out>(
+    seen: Arc<std::sync::Mutex<Vec<usize>>>,
+    map: impl Fn(In) -> Out + Clone,
+) -> impl FnMut(NEVec<In>) -> std::future::Ready<NEVec<Out>> + Clone {
+    move |batch: NEVec<In>| {
+        seen.lock().expect("lock").push(batch.len().get());
+        let outputs: Vec<Out> = batch.into_iter().map(map.clone()).collect();
+        std::future::ready(NEVec::try_from_vec(outputs).expect("batch was non-empty"))
+    }
+}

--- a/crates/lib/batcher/src/tests.rs
+++ b/crates/lib/batcher/src/tests.rs
@@ -1,0 +1,79 @@
+//! Unit tests for the shared loop's lifecycle — closed intake, drop-driven
+//! drain, and signal-driven shutdown — exercised through one mode each;
+//! per-mode semantics are tested in the strategy sub-modules.
+
+use std::sync::Arc;
+
+use crate::test_helpers::{nz, recording_flush, secs};
+use crate::{Policy, read_batcher, write_batcher};
+
+#[tokio::test]
+async fn submit_after_batcher_is_gone_reports_closed() {
+    let (handle, batcher) = write_batcher(
+        Policy {
+            max_batch: nz(4),
+            max_delay: secs(3600),
+        },
+        recording_flush(Arc::new(std::sync::Mutex::new(Vec::new())), |item: u32| {
+            item
+        }),
+        std::future::pending(),
+    );
+    // The batcher never runs and is dropped, closing the intake channel.
+    drop(batcher);
+
+    let result = handle.submit(1).await;
+    assert!(
+        matches!(result, Err(crate::Closed)),
+        "submit must report Closed"
+    );
+}
+
+#[tokio::test]
+async fn dropping_all_handles_ends_the_batcher() {
+    let (handle, batcher) = write_batcher(
+        Policy {
+            max_batch: nz(4),
+            max_delay: secs(3600),
+        },
+        recording_flush(Arc::new(std::sync::Mutex::new(Vec::new())), |item: u32| {
+            item
+        }),
+        std::future::pending(),
+    );
+    let batcher = tokio::spawn(batcher);
+
+    let clone = handle.clone();
+    drop(handle);
+    drop(clone);
+
+    batcher.await.expect("batcher join");
+}
+
+#[tokio::test]
+async fn shutdown_signal_stops_the_batcher_and_closes_intake() {
+    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+    let (handle, batcher) = read_batcher(
+        Policy {
+            // Neither trigger can fire on its own — only the shutdown signal
+            // ends this batcher.
+            max_batch: nz(1000),
+            max_delay: secs(3600),
+        },
+        recording_flush(Arc::new(std::sync::Mutex::new(Vec::new())), |key: u32| key),
+        async move {
+            let _ = shutdown_rx.await;
+        },
+    );
+    let batcher = tokio::spawn(batcher);
+
+    // Signal shutdown while a handle is still alive: the batcher must exit
+    // anyway, which drop-driven shutdown alone could not do.
+    shutdown_tx.send(()).expect("send shutdown");
+    batcher.await.expect("batcher join");
+
+    assert!(
+        matches!(handle.submit(1).await, Err(crate::Closed)),
+        "submit after shutdown must report Closed",
+    );
+}

--- a/crates/lib/batcher/src/tests.rs
+++ b/crates/lib/batcher/src/tests.rs
@@ -1,0 +1,280 @@
+//! Unit tests for both batcher modes.
+//!
+//! The flush closure is a plain in-memory function that records the size of
+//! each batch it saw and maps every input to an output, so the batching,
+//! deduplication, timing, and delivery logic is exercised with no database or
+//! domain types involved.
+
+use std::num::NonZeroUsize;
+use std::sync::Arc;
+
+use nonempty_collections::NEVec;
+use waymark_nonzero_duration::NonZeroDuration;
+
+use crate::{Policy, read_batcher, write_batcher};
+
+fn nz(value: usize) -> NonZeroUsize {
+    NonZeroUsize::new(value).expect("non-zero")
+}
+
+fn secs(value: u64) -> NonZeroDuration {
+    NonZeroDuration::from_secs(value).expect("non-zero")
+}
+
+fn millis(value: u64) -> NonZeroDuration {
+    NonZeroDuration::from_millis(value).expect("non-zero")
+}
+
+/// A flush that records each batch's size and maps every input through `map`.
+fn recording_flush<In, Out>(
+    seen: Arc<std::sync::Mutex<Vec<usize>>>,
+    map: impl Fn(In) -> Out + Clone,
+) -> impl FnMut(NEVec<In>) -> std::future::Ready<NEVec<Out>> + Clone {
+    move |batch: NEVec<In>| {
+        seen.lock().expect("lock").push(batch.len().get());
+        let outputs: Vec<Out> = batch.into_iter().map(map.clone()).collect();
+        std::future::ready(NEVec::try_from_vec(outputs).expect("batch was non-empty"))
+    }
+}
+
+// ---- write_batcher (positional) -------------------------------------------
+
+#[tokio::test]
+async fn write_flushes_when_the_batch_fills() {
+    let seen = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let (handle, batcher) = write_batcher(
+        Policy {
+            max_batch: nz(3),
+            max_delay: secs(3600),
+        },
+        recording_flush(Arc::clone(&seen), |item: u32| item * 10),
+        std::future::pending(),
+    );
+    let batcher = tokio::spawn(batcher);
+
+    let submissions: Vec<_> = (0..3)
+        .map(|item| {
+            let handle = handle.clone();
+            tokio::spawn(async move { handle.submit(item).await })
+        })
+        .collect();
+
+    for (item, submission) in submissions.into_iter().enumerate() {
+        let output = submission.await.expect("join").expect("not closed");
+        assert_eq!(output, item as u32 * 10, "each item gets its own output");
+    }
+
+    drop(handle);
+    batcher.await.expect("batcher join");
+    assert_eq!(
+        *seen.lock().expect("lock"),
+        vec![3],
+        "one full batch of three"
+    );
+}
+
+#[tokio::test(start_paused = true)]
+async fn write_flushes_when_the_delay_elapses() {
+    let seen = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let (handle, batcher) = write_batcher(
+        Policy {
+            max_batch: nz(1000),
+            max_delay: millis(50),
+        },
+        recording_flush(Arc::clone(&seen), |item: u32| item),
+        std::future::pending(),
+    );
+    let batcher = tokio::spawn(batcher);
+
+    let a = {
+        let handle = handle.clone();
+        tokio::spawn(async move { handle.submit(1).await })
+    };
+    let b = {
+        let handle = handle.clone();
+        tokio::spawn(async move { handle.submit(2).await })
+    };
+
+    assert_eq!(a.await.expect("join").expect("not closed"), 1);
+    assert_eq!(b.await.expect("join").expect("not closed"), 2);
+
+    drop(handle);
+    batcher.await.expect("batcher join");
+    assert_eq!(
+        *seen.lock().expect("lock"),
+        vec![2],
+        "delay-triggered batch"
+    );
+}
+
+#[tokio::test]
+async fn write_every_submitter_gets_its_own_output() {
+    let (handle, batcher) = write_batcher(
+        Policy {
+            max_batch: nz(8),
+            max_delay: secs(3600),
+        },
+        // Identity map: the output must be the submitter's own input, which
+        // only holds if the positional zip lines up waiters and outputs.
+        recording_flush(Arc::new(std::sync::Mutex::new(Vec::new())), |item: u64| {
+            item
+        }),
+        std::future::pending(),
+    );
+    let batcher = tokio::spawn(batcher);
+
+    let submissions: Vec<_> = (0..8u64)
+        .map(|item| {
+            let handle = handle.clone();
+            tokio::spawn(async move { (item, handle.submit(item).await) })
+        })
+        .collect();
+
+    for submission in submissions {
+        let (item, output) = submission.await.expect("join");
+        assert_eq!(output.expect("not closed"), item);
+    }
+
+    drop(handle);
+    batcher.await.expect("batcher join");
+}
+
+// ---- read_batcher (deduplicating) -----------------------------------------
+
+#[tokio::test]
+async fn read_duplicate_keys_load_once_and_fan_out() {
+    let seen = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let (handle, batcher) = read_batcher(
+        // Two raw keys fill the batch; both are the same key.
+        Policy {
+            max_batch: nz(2),
+            max_delay: secs(3600),
+        },
+        recording_flush(Arc::clone(&seen), |key: u32| key * 10),
+        std::future::pending(),
+    );
+    let batcher = tokio::spawn(batcher);
+
+    let a = {
+        let handle = handle.clone();
+        tokio::spawn(async move { handle.submit(7).await })
+    };
+    let b = {
+        let handle = handle.clone();
+        tokio::spawn(async move { handle.submit(7).await })
+    };
+
+    assert_eq!(a.await.expect("join").expect("not closed"), 70);
+    assert_eq!(b.await.expect("join").expect("not closed"), 70);
+
+    drop(handle);
+    batcher.await.expect("batcher join");
+    assert_eq!(
+        *seen.lock().expect("lock"),
+        vec![1],
+        "the shared key was loaded once, not twice",
+    );
+}
+
+#[tokio::test]
+async fn read_distinct_keys_each_get_their_own_value() {
+    let seen = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let (handle, batcher) = read_batcher(
+        Policy {
+            max_batch: nz(3),
+            max_delay: secs(3600),
+        },
+        recording_flush(Arc::clone(&seen), |key: u64| key * 100),
+        std::future::pending(),
+    );
+    let batcher = tokio::spawn(batcher);
+
+    let submissions: Vec<_> = (1..=3u64)
+        .map(|key| {
+            let handle = handle.clone();
+            tokio::spawn(async move { (key, handle.submit(key).await) })
+        })
+        .collect();
+
+    for submission in submissions {
+        let (key, value) = submission.await.expect("join");
+        assert_eq!(value.expect("not closed"), key * 100);
+    }
+
+    drop(handle);
+    batcher.await.expect("batcher join");
+    assert_eq!(*seen.lock().expect("lock"), vec![3], "three distinct keys");
+}
+
+// ---- shared lifecycle (exercised through one mode) ------------------------
+
+#[tokio::test]
+async fn submit_after_batcher_is_gone_reports_closed() {
+    let (handle, batcher) = write_batcher(
+        Policy {
+            max_batch: nz(4),
+            max_delay: secs(3600),
+        },
+        recording_flush(Arc::new(std::sync::Mutex::new(Vec::new())), |item: u32| {
+            item
+        }),
+        std::future::pending(),
+    );
+    // The batcher never runs and is dropped, closing the intake channel.
+    drop(batcher);
+
+    let result = handle.submit(1).await;
+    assert!(
+        matches!(result, Err(crate::Closed)),
+        "submit must report Closed"
+    );
+}
+
+#[tokio::test]
+async fn dropping_all_handles_ends_the_batcher() {
+    let (handle, batcher) = write_batcher(
+        Policy {
+            max_batch: nz(4),
+            max_delay: secs(3600),
+        },
+        recording_flush(Arc::new(std::sync::Mutex::new(Vec::new())), |item: u32| {
+            item
+        }),
+        std::future::pending(),
+    );
+    let batcher = tokio::spawn(batcher);
+
+    let clone = handle.clone();
+    drop(handle);
+    drop(clone);
+
+    batcher.await.expect("batcher join");
+}
+
+#[tokio::test]
+async fn shutdown_signal_stops_the_batcher_and_closes_intake() {
+    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+    let (handle, batcher) = read_batcher(
+        Policy {
+            // Neither trigger can fire on its own — only the shutdown signal
+            // ends this batcher.
+            max_batch: nz(1000),
+            max_delay: secs(3600),
+        },
+        recording_flush(Arc::new(std::sync::Mutex::new(Vec::new())), |key: u32| key),
+        async move {
+            let _ = shutdown_rx.await;
+        },
+    );
+    let batcher = tokio::spawn(batcher);
+
+    // Signal shutdown while a handle is still alive: the batcher must exit
+    // anyway, which drop-driven shutdown alone could not do.
+    shutdown_tx.send(()).expect("send shutdown");
+    batcher.await.expect("batcher join");
+
+    assert!(
+        matches!(handle.submit(1).await, Err(crate::Closed)),
+        "submit after shutdown must report Closed",
+    );
+}


### PR DESCRIPTION
Goes in after #510 

---

This PR adds batcher - a buffering / flushing primitive to enable efficient batch operations at the cost of potential added latency.