### PR TITLE
Batch snapshot writes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4553,6 +4553,7 @@ dependencies = [
  "waymark-execution-bringup",
  "waymark-fn-main-common",
  "waymark-ids",
+ "waymark-nonzero-duration",
  "waymark-observability",
  "waymark-observability-setup",
  "waymark-proto",
@@ -4734,6 +4735,7 @@ dependencies = [
  "waymark-action-runtime-metadata",
  "waymark-action-runtime-metadata-compat",
  "waymark-action-runtime-worker-pool",
+ "waymark-batcher",
  "waymark-execution-driver",
  "waymark-extcall-reconciler",
  "waymark-fullset-effect-handler",
@@ -5416,11 +5418,13 @@ version = "0.1.0"
 name = "waymark-state-vm-runtimes"
 version = "0.1.0"
 dependencies = [
+ "nonempty-collections",
  "serde",
  "thiserror",
  "tokio",
  "tokio-util",
  "tracing",
+ "waymark-batcher",
  "waymark-state-manager",
  "waymark-state-manager-core",
  "waymark-state-vm-runtimes-backend",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4553,6 +4553,7 @@ dependencies = [
  "waymark-execution-bringup",
  "waymark-fn-main-common",
  "waymark-ids",
+ "waymark-nonzero-duration",
  "waymark-observability",
  "waymark-observability-setup",
  "waymark-proto",
@@ -4724,6 +4725,7 @@ name = "waymark-execution-bringup"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "nonempty-collections",
  "tokio",
  "tokio-util",
  "tracing",
@@ -4734,6 +4736,7 @@ dependencies = [
  "waymark-action-runtime-metadata",
  "waymark-action-runtime-metadata-compat",
  "waymark-action-runtime-worker-pool",
+ "waymark-batcher",
  "waymark-execution-driver",
  "waymark-extcall-reconciler",
  "waymark-fullset-effect-handler",
@@ -5421,6 +5424,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "waymark-batcher",
  "waymark-state-manager",
  "waymark-state-manager-core",
  "waymark-state-vm-runtimes-backend",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ waymark-backend-memory = { path = "crates/lib/backend-memory" }
 waymark-backend-postgres = { path = "crates/lib/backend-postgres" }
 waymark-backend-postgres-migrations = { path = "crates/lib/backend-postgres-migrations" }
 waymark-backends-core = { path = "crates/lib/backends-core" }
+waymark-batcher = { path = "crates/lib/batcher" }
 waymark-blocking-future = { path = "crates/lib/blocking-future" }
 waymark-config = { path = "crates/lib/config" }
 waymark-convert-core = { path = "crates/lib/convert-core" }

--- a/crates/bin/benchmark/Cargo.toml
+++ b/crates/bin/benchmark/Cargo.toml
@@ -11,6 +11,7 @@ waymark-convert-core = { workspace = true }
 waymark-execution-bringup = { workspace = true }
 waymark-fn-main-common = { workspace = true }
 waymark-ids = { workspace = true }
+waymark-nonzero-duration = { workspace = true }
 waymark-observability = { workspace = true }
 waymark-observability-setup = { workspace = true }
 waymark-proto = { workspace = true }

--- a/crates/bin/benchmark/src/execution.rs
+++ b/crates/bin/benchmark/src/execution.rs
@@ -3,6 +3,25 @@
 use std::num::NonZeroUsize;
 use std::time::Duration;
 
+use waymark_nonzero_duration::NonZeroDuration;
+
+/// Max snapshots coalesced per batched write (env `WAYMARK_SNAPSHOT_BATCH_MAX`).
+fn snapshot_batch_max() -> NonZeroUsize {
+    std::env::var("WAYMARK_SNAPSHOT_BATCH_MAX")
+        .ok()
+        .and_then(|value| value.trim().parse().ok())
+        .unwrap_or(NonZeroUsize::new(256).unwrap())
+}
+
+/// Snapshot batch flush window (env `WAYMARK_SNAPSHOT_BATCH_DELAY_MS`).
+fn snapshot_batch_delay() -> NonZeroDuration {
+    std::env::var("WAYMARK_SNAPSHOT_BATCH_DELAY_MS")
+        .ok()
+        .and_then(|value| value.trim().parse::<u64>().ok())
+        .and_then(NonZeroDuration::from_millis)
+        .unwrap_or(NonZeroDuration::from_millis(5).unwrap())
+}
+
 pub fn durable_execution_config(
     max_pinned: NonZeroUsize,
 ) -> waymark_execution_bringup::Config<uuid::Uuid> {
@@ -15,6 +34,8 @@ pub fn durable_execution_config(
         pinning_heartbeat: Duration::from_secs(5).try_into().unwrap(),
         pinning_fencing_margin: Duration::from_secs(1).try_into().unwrap(),
         workload_poll_interval: Duration::from_millis(1).try_into().unwrap(),
+        snapshot_batch_max: snapshot_batch_max(),
+        snapshot_batch_delay: snapshot_batch_delay(),
         sleep_poll_interval: Duration::from_millis(250).try_into().unwrap(),
         vm_retention: Duration::from_secs(60).try_into().unwrap(),
         vm_sweep_interval: Duration::from_secs(10).try_into().unwrap(),
@@ -35,6 +56,7 @@ pub async fn shutdown_execution(handles: waymark_execution_bringup::Handles) {
         durable_sleeps_poller,
         durable_sleeps_acker,
         action_effect_reconciler_lock_renewal,
+        snapshot_batcher,
     } = handles;
 
     let _ = tokio::time::timeout(Duration::from_secs(5), pinning_manager).await;
@@ -51,4 +73,5 @@ pub async fn shutdown_execution(handles: waymark_execution_bringup::Handles) {
         action_effect_reconciler_lock_renewal,
     )
     .await;
+    let _ = tokio::time::timeout(Duration::from_secs(5), snapshot_batcher).await;
 }

--- a/crates/bin/benchmark/src/execution.rs
+++ b/crates/bin/benchmark/src/execution.rs
@@ -3,6 +3,25 @@
 use std::num::NonZeroUsize;
 use std::time::Duration;
 
+use waymark_nonzero_duration::NonZeroDuration;
+
+/// Max snapshots coalesced per batched write (env `WAYMARK_SNAPSHOT_BATCH_MAX`).
+fn snapshot_batch_max() -> NonZeroUsize {
+    std::env::var("WAYMARK_SNAPSHOT_BATCH_MAX")
+        .ok()
+        .and_then(|value| value.trim().parse().ok())
+        .unwrap_or(NonZeroUsize::new(256).unwrap())
+}
+
+/// Snapshot batch flush window (env `WAYMARK_SNAPSHOT_BATCH_DELAY_MS`).
+fn snapshot_batch_delay() -> NonZeroDuration {
+    std::env::var("WAYMARK_SNAPSHOT_BATCH_DELAY_MS")
+        .ok()
+        .and_then(|value| value.trim().parse::<u64>().ok())
+        .and_then(NonZeroDuration::from_millis)
+        .unwrap_or(NonZeroDuration::from_millis(5).unwrap())
+}
+
 pub fn durable_execution_config(
     max_pinned: NonZeroUsize,
 ) -> waymark_execution_bringup::Config<uuid::Uuid> {
@@ -15,6 +34,8 @@ pub fn durable_execution_config(
         pinning_heartbeat: Duration::from_secs(5).try_into().unwrap(),
         pinning_fencing_margin: Duration::from_secs(1).try_into().unwrap(),
         workload_poll_rate_limit: 1000.try_into().unwrap(),
+        snapshot_batch_max: snapshot_batch_max(),
+        snapshot_batch_delay: snapshot_batch_delay(),
         sleep_poll_interval: Duration::from_millis(250).try_into().unwrap(),
         vm_retention: Duration::from_secs(60).try_into().unwrap(),
         vm_sweep_interval: Duration::from_secs(10).try_into().unwrap(),
@@ -35,6 +56,7 @@ pub async fn shutdown_execution(handles: waymark_execution_bringup::Handles) {
         durable_sleeps_poller,
         durable_sleeps_acker,
         action_effect_reconciler_lock_renewal,
+        snapshot_batcher,
     } = handles;
 
     let _ = tokio::time::timeout(Duration::from_secs(5), pinning_manager).await;
@@ -51,4 +73,5 @@ pub async fn shutdown_execution(handles: waymark_execution_bringup::Handles) {
         action_effect_reconciler_lock_renewal,
     )
     .await;
+    let _ = tokio::time::timeout(Duration::from_secs(5), snapshot_batcher).await;
 }

--- a/crates/bin/integration-test/src/durable.rs
+++ b/crates/bin/integration-test/src/durable.rs
@@ -150,6 +150,8 @@ fn durable_execution_config() -> waymark_execution_bringup::Config<uuid::Uuid> {
         pinning_heartbeat: Duration::from_secs(5).try_into().unwrap(),
         pinning_fencing_margin: Duration::from_secs(1).try_into().unwrap(),
         workload_poll_interval: Duration::from_millis(1).try_into().unwrap(),
+        snapshot_batch_max: 256.try_into().unwrap(),
+        snapshot_batch_delay: Duration::from_millis(5).try_into().unwrap(),
         sleep_poll_interval: Duration::from_millis(250).try_into().unwrap(),
         vm_retention: Duration::from_secs(60).try_into().unwrap(),
         vm_sweep_interval: Duration::from_secs(10).try_into().unwrap(),
@@ -170,6 +172,7 @@ async fn shutdown_execution(handles: waymark_execution_bringup::Handles) {
         durable_sleeps_poller,
         durable_sleeps_acker,
         action_effect_reconciler_lock_renewal,
+        snapshot_batcher,
     } = handles;
 
     let _ = tokio::time::timeout(Duration::from_secs(5), pinning_manager).await;
@@ -186,6 +189,7 @@ async fn shutdown_execution(handles: waymark_execution_bringup::Handles) {
         action_effect_reconciler_lock_renewal,
     )
     .await;
+    let _ = tokio::time::timeout(Duration::from_secs(5), snapshot_batcher).await;
 }
 
 async fn run_case_durable(

--- a/crates/bin/integration-test/src/durable.rs
+++ b/crates/bin/integration-test/src/durable.rs
@@ -150,6 +150,8 @@ fn durable_execution_config() -> waymark_execution_bringup::Config<uuid::Uuid> {
         pinning_heartbeat: Duration::from_secs(5).try_into().unwrap(),
         pinning_fencing_margin: Duration::from_secs(1).try_into().unwrap(),
         workload_poll_rate_limit: 1000.try_into().unwrap(),
+        snapshot_batch_max: 256.try_into().unwrap(),
+        snapshot_batch_delay: Duration::from_millis(5).try_into().unwrap(),
         sleep_poll_interval: Duration::from_millis(250).try_into().unwrap(),
         vm_retention: Duration::from_secs(60).try_into().unwrap(),
         vm_sweep_interval: Duration::from_secs(10).try_into().unwrap(),
@@ -170,6 +172,7 @@ async fn shutdown_execution(handles: waymark_execution_bringup::Handles) {
         durable_sleeps_poller,
         durable_sleeps_acker,
         action_effect_reconciler_lock_renewal,
+        snapshot_batcher,
     } = handles;
 
     let _ = tokio::time::timeout(Duration::from_secs(5), pinning_manager).await;
@@ -186,6 +189,7 @@ async fn shutdown_execution(handles: waymark_execution_bringup::Handles) {
         action_effect_reconciler_lock_renewal,
     )
     .await;
+    let _ = tokio::time::timeout(Duration::from_secs(5), snapshot_batcher).await;
 }
 
 async fn run_case_durable(

--- a/crates/bin/start-workers/src/main.rs
+++ b/crates/bin/start-workers/src/main.rs
@@ -159,6 +159,8 @@ async fn main() -> Result<()> {
         pinning_heartbeat: config.lock_heartbeat,
         pinning_fencing_margin: config.pinning_fencing_margin,
         workload_poll_interval: config.workload_poll_interval,
+        snapshot_batch_max: config.snapshot_batch_max,
+        snapshot_batch_delay: config.snapshot_batch_delay,
         sleep_poll_interval: config.sleep_poll_interval,
         vm_retention: config.vm_retention,
         vm_sweep_interval: config.vm_sweep_interval,
@@ -203,6 +205,7 @@ async fn main() -> Result<()> {
         execution_handles.action_effect_reconciler_lock_renewal,
     )
     .await;
+    let _ = tokio::time::timeout(Duration::from_secs(5), execution_handles.snapshot_batcher).await;
     let _ = tokio::time::timeout(Duration::from_secs(5), bridge_task).await;
     let _ = tokio::time::timeout(Duration::from_secs(2), status_reporter_handle).await;
 

--- a/crates/bin/start-workers/src/main.rs
+++ b/crates/bin/start-workers/src/main.rs
@@ -159,6 +159,8 @@ async fn main() -> Result<()> {
         pinning_heartbeat: config.lock_heartbeat,
         pinning_fencing_margin: config.pinning_fencing_margin,
         workload_poll_rate_limit: config.workload_poll_rate_limit,
+        snapshot_batch_max: config.snapshot_batch_max,
+        snapshot_batch_delay: config.snapshot_batch_delay,
         sleep_poll_interval: config.sleep_poll_interval,
         vm_retention: config.vm_retention,
         vm_sweep_interval: config.vm_sweep_interval,
@@ -203,6 +205,7 @@ async fn main() -> Result<()> {
         execution_handles.action_effect_reconciler_lock_renewal,
     )
     .await;
+    let _ = tokio::time::timeout(Duration::from_secs(5), execution_handles.snapshot_batcher).await;
     let _ = tokio::time::timeout(Duration::from_secs(5), bridge_task).await;
     let _ = tokio::time::timeout(Duration::from_secs(2), status_reporter_handle).await;
 

--- a/crates/lib/backend-postgres/src/vm_runtimes/error.rs
+++ b/crates/lib/backend-postgres/src/vm_runtimes/error.rs
@@ -1,17 +1,11 @@
 //! Error types for the state-vm-runtimes postgres backend.
 
-/// Error returned by [`super::PostgresBackend`] when storing a VM snapshot.
+/// Error returned by [`super::PostgresBackend`] when storing VM snapshots.
 #[derive(Debug, thiserror::Error)]
-pub enum StoreSnapshotError {
+pub enum StoreSnapshotsError {
     /// The underlying database operation failed.
     #[error("sqlx: {0}")]
     Sqlx(#[source] sqlx::Error),
-
-    /// The VM has not been registered yet. Register it via
-    /// [`waymark_workflow_service_vm_runtimes_backend::RegisterVmRuntime::register_vm_runtime`]
-    /// first.
-    #[error("vm runtime not registered: {0}")]
-    NotRegistered(waymark_ids::InstanceId),
 }
 
 /// Error returned by [`super::PostgresBackend`] when loading a VM snapshot

--- a/crates/lib/backend-postgres/src/vm_runtimes/mod.rs
+++ b/crates/lib/backend-postgres/src/vm_runtimes/mod.rs
@@ -20,36 +20,47 @@ impl waymark_state_vm_runtimes_backend::HasExecutableId for PostgresBackend {
     type ExecutableId = WorkflowVersionId;
 }
 
-impl waymark_state_vm_runtimes_backend::StoreSnapshot for PostgresBackend {
-    type Error = error::StoreSnapshotError;
+impl waymark_state_vm_runtimes_backend::StoreSnapshots for PostgresBackend {
+    type Error = error::StoreSnapshotsError;
 
     #[obs]
     #[function_name::named]
-    async fn store_snapshot<'a>(
+    async fn store_snapshots<'a>(
         &'a self,
-        vm_id: &'a InstanceId,
-        data: &'a [u8],
+        snapshots: &'a [waymark_state_vm_runtimes_backend::StoreSnapshotsItem<'a, InstanceId>],
     ) -> Result<(), Self::Error> {
         Self::count_query(&self.query_counts, "update:vm_runtime_snapshots_snapshot");
-        let result = sqlx::query(
+        Self::count_batch_size(
+            &self.batch_size_counts,
+            "update:vm_runtime_snapshots_snapshot",
+            snapshots.len(),
+        );
+
+        let mut vm_ids = Vec::with_capacity(snapshots.len());
+        let mut blobs: Vec<&[u8]> = Vec::with_capacity(snapshots.len());
+        for item in snapshots {
+            vm_ids.push(*item.vm_id);
+            blobs.push(item.snapshot);
+        }
+
+        // Missing rows (VM already completed/deleted) simply match nothing —
+        // a benign no-op, so `rows_affected` is not inspected.
+        sqlx::query(
             r#"
-            UPDATE vm_runtime_snapshots
-            SET snapshot = $2, updated_at = NOW()
-            WHERE vm_id = $1
+            UPDATE vm_runtime_snapshots AS s
+            SET snapshot = b.snapshot, updated_at = NOW()
+            FROM UNNEST($1::uuid[], $2::bytea[]) AS b(vm_id, snapshot)
+            WHERE s.vm_id = b.vm_id
             "#,
         )
-        .bind(vm_id)
-        .bind(data)
+        .bind(&vm_ids)
+        .bind(&blobs)
         .execute(&self.pool)
         .timed(crate::query_timing_histogram!(
             "update:vm_runtime_snapshots_snapshot"
         ))
         .await
-        .map_err(error::StoreSnapshotError::Sqlx)?;
-
-        if result.rows_affected() == 0 {
-            return Err(error::StoreSnapshotError::NotRegistered(*vm_id));
-        }
+        .map_err(error::StoreSnapshotsError::Sqlx)?;
 
         Ok(())
     }

--- a/crates/lib/backend-postgres/src/vm_runtimes/tests.rs
+++ b/crates/lib/backend-postgres/src/vm_runtimes/tests.rs
@@ -17,10 +17,12 @@ async fn store_and_load_snapshot_happy_path() {
     assert_eq!(payload.snapshot, TEST_VM_SNAPSHOT);
     assert_eq!(payload.executable_id, executable_id);
 
-    waymark_state_vm_runtimes_backend::StoreSnapshot::store_snapshot(
+    waymark_state_vm_runtimes_backend::StoreSnapshots::store_snapshots(
         &backend,
-        &vm_id,
-        updated_snapshot,
+        &[waymark_state_vm_runtimes_backend::StoreSnapshotsItem {
+            vm_id: &vm_id,
+            snapshot: updated_snapshot,
+        }],
     )
     .await
     .expect("store snapshot");
@@ -35,16 +37,80 @@ async fn store_and_load_snapshot_happy_path() {
 
 #[serial(postgres)]
 #[tokio::test]
-async fn store_snapshot_before_register_returns_error() {
+async fn store_snapshots_multi_item_batch_updates_each_vm() {
     let backend = setup_backend().await;
-    let vm_id = InstanceId::new_uuid_v4();
+    let (vm_a, executable_a) = register_test_vm(&backend).await;
+    let (vm_b, executable_b) = register_test_vm(&backend).await;
+    let unregistered = InstanceId::new_uuid_v4();
+
+    // One batch spanning two registered VMs plus an unregistered one; the
+    // unregistered item matches no row and must not disturb the others.
+    waymark_state_vm_runtimes_backend::StoreSnapshots::store_snapshots(
+        &backend,
+        &[
+            waymark_state_vm_runtimes_backend::StoreSnapshotsItem {
+                vm_id: &vm_a,
+                snapshot: b"snapshot-a",
+            },
+            waymark_state_vm_runtimes_backend::StoreSnapshotsItem {
+                vm_id: &vm_b,
+                snapshot: b"snapshot-b",
+            },
+            waymark_state_vm_runtimes_backend::StoreSnapshotsItem {
+                vm_id: &unregistered,
+                snapshot: b"snapshot-lost",
+            },
+        ],
+    )
+    .await
+    .expect("store snapshots");
+
+    let payload =
+        waymark_state_vm_runtimes_backend::LoadForRevive::load_for_revive(&backend, &vm_a)
+            .await
+            .expect("load for revive");
+    assert_eq!(payload.snapshot, b"snapshot-a");
+    assert_eq!(payload.executable_id, executable_a);
+
+    let payload =
+        waymark_state_vm_runtimes_backend::LoadForRevive::load_for_revive(&backend, &vm_b)
+            .await
+            .expect("load for revive");
+    assert_eq!(payload.snapshot, b"snapshot-b");
+    assert_eq!(payload.executable_id, executable_b);
 
     let result =
-        waymark_state_vm_runtimes_backend::StoreSnapshot::store_snapshot(&backend, &vm_id, b"data")
+        waymark_state_vm_runtimes_backend::LoadForRevive::load_for_revive(&backend, &unregistered)
             .await;
     assert!(matches!(
         result,
-        Err(super::error::StoreSnapshotError::NotRegistered(_))
+        Err(super::error::LoadForReviveError::NotFound(_))
+    ));
+}
+
+#[serial(postgres)]
+#[tokio::test]
+async fn store_snapshots_before_register_is_a_noop() {
+    let backend = setup_backend().await;
+    let vm_id = InstanceId::new_uuid_v4();
+
+    // An unregistered VM matches no row: the batch succeeds and stores
+    // nothing, rather than erroring.
+    waymark_state_vm_runtimes_backend::StoreSnapshots::store_snapshots(
+        &backend,
+        &[waymark_state_vm_runtimes_backend::StoreSnapshotsItem {
+            vm_id: &vm_id,
+            snapshot: b"data",
+        }],
+    )
+    .await
+    .expect("store snapshots is a no-op for an unregistered vm");
+
+    let result =
+        waymark_state_vm_runtimes_backend::LoadForRevive::load_for_revive(&backend, &vm_id).await;
+    assert!(matches!(
+        result,
+        Err(super::error::LoadForReviveError::NotFound(_))
     ));
 }
 

--- a/crates/lib/backend-postgres/src/vm_runtimes/tests.rs
+++ b/crates/lib/backend-postgres/src/vm_runtimes/tests.rs
@@ -17,10 +17,12 @@ async fn store_and_load_snapshot_happy_path() {
     assert_eq!(payload.snapshot, TEST_VM_SNAPSHOT);
     assert_eq!(payload.executable_id, executable_id);
 
-    waymark_state_vm_runtimes_backend::StoreSnapshot::store_snapshot(
+    waymark_state_vm_runtimes_backend::StoreSnapshots::store_snapshots(
         &backend,
-        &vm_id,
-        updated_snapshot,
+        &[waymark_state_vm_runtimes_backend::StoreSnapshotsItem {
+            vm_id: &vm_id,
+            snapshot: updated_snapshot,
+        }],
     )
     .await
     .expect("store snapshot");
@@ -35,16 +37,27 @@ async fn store_and_load_snapshot_happy_path() {
 
 #[serial(postgres)]
 #[tokio::test]
-async fn store_snapshot_before_register_returns_error() {
+async fn store_snapshots_before_register_is_a_noop() {
     let backend = setup_backend().await;
     let vm_id = InstanceId::new_uuid_v4();
 
+    // An unregistered VM matches no row: the batch succeeds and stores
+    // nothing, rather than erroring.
+    waymark_state_vm_runtimes_backend::StoreSnapshots::store_snapshots(
+        &backend,
+        &[waymark_state_vm_runtimes_backend::StoreSnapshotsItem {
+            vm_id: &vm_id,
+            snapshot: b"data",
+        }],
+    )
+    .await
+    .expect("store snapshots is a no-op for an unregistered vm");
+
     let result =
-        waymark_state_vm_runtimes_backend::StoreSnapshot::store_snapshot(&backend, &vm_id, b"data")
-            .await;
+        waymark_state_vm_runtimes_backend::LoadForRevive::load_for_revive(&backend, &vm_id).await;
     assert!(matches!(
         result,
-        Err(super::error::StoreSnapshotError::NotRegistered(_))
+        Err(super::error::LoadForReviveError::NotFound(_))
     ));
 }
 

--- a/crates/lib/config/src/lib.rs
+++ b/crates/lib/config/src/lib.rs
@@ -28,6 +28,8 @@ pub struct WorkerConfig {
     pub lock_heartbeat: NonZeroDuration,
     pub pinning_fencing_margin: NonZeroDuration,
     pub workload_poll_interval: NonZeroDuration,
+    pub snapshot_batch_max: NonZeroUsize,
+    pub snapshot_batch_delay: NonZeroDuration,
     pub action_effect_reconciler_lock_ttl: NonZeroDuration,
     pub action_effect_reconciler_lock_heartbeat: NonZeroDuration,
     pub evict_sleep_threshold: NonZeroDuration,
@@ -85,6 +87,11 @@ impl WorkerConfig {
         // trip takes longer, so it only floors the spin without pacing it.
         let FromNanos(workload_poll_interval) =
             envfury::or_parse("WAYMARK_WORKLOAD_POLL_INTERVAL_NS", "1000000")?;
+
+        let snapshot_batch_max = envfury::or_parse("WAYMARK_SNAPSHOT_BATCH_MAX", "256")?;
+
+        let FromMillis(snapshot_batch_delay) =
+            envfury::or_parse("WAYMARK_SNAPSHOT_BATCH_DELAY_MS", "5")?;
 
         let FromMillis(action_effect_reconciler_lock_ttl) =
             envfury::or_parse("WAYMARK_ACTION_EFFECT_RECONCILER_LOCK_TTL_MS", "15000")?;
@@ -167,6 +174,8 @@ impl WorkerConfig {
             lock_heartbeat,
             pinning_fencing_margin,
             workload_poll_interval,
+            snapshot_batch_max,
+            snapshot_batch_delay,
             action_effect_reconciler_lock_ttl,
             action_effect_reconciler_lock_heartbeat,
             evict_sleep_threshold,

--- a/crates/lib/config/src/lib.rs
+++ b/crates/lib/config/src/lib.rs
@@ -28,6 +28,8 @@ pub struct WorkerConfig {
     pub lock_heartbeat: NonZeroDuration,
     pub pinning_fencing_margin: NonZeroDuration,
     pub workload_poll_rate_limit: NonZeroU32,
+    pub snapshot_batch_max: NonZeroUsize,
+    pub snapshot_batch_delay: NonZeroDuration,
     pub action_effect_reconciler_lock_ttl: NonZeroDuration,
     pub action_effect_reconciler_lock_heartbeat: NonZeroDuration,
     pub evict_sleep_threshold: NonZeroDuration,
@@ -83,6 +85,11 @@ impl WorkerConfig {
 
         let workload_poll_rate_limit =
             envfury::or_parse("WAYMARK_WORKLOAD_POLL_RATE_LIMIT", "1000")?;
+
+        let snapshot_batch_max = envfury::or_parse("WAYMARK_SNAPSHOT_BATCH_MAX", "256")?;
+
+        let FromMillis(snapshot_batch_delay) =
+            envfury::or_parse("WAYMARK_SNAPSHOT_BATCH_DELAY_MS", "5")?;
 
         let FromMillis(action_effect_reconciler_lock_ttl) =
             envfury::or_parse("WAYMARK_ACTION_EFFECT_RECONCILER_LOCK_TTL_MS", "15000")?;
@@ -165,6 +172,8 @@ impl WorkerConfig {
             lock_heartbeat,
             pinning_fencing_margin,
             workload_poll_rate_limit,
+            snapshot_batch_max,
+            snapshot_batch_delay,
             action_effect_reconciler_lock_ttl,
             action_effect_reconciler_lock_heartbeat,
             evict_sleep_threshold,

--- a/crates/lib/execution-bringup/Cargo.toml
+++ b/crates/lib/execution-bringup/Cargo.toml
@@ -12,6 +12,7 @@ waymark-action-effect-reconciler-backend = { workspace = true }
 waymark-action-runtime-metadata = { workspace = true }
 waymark-action-runtime-metadata-compat = { workspace = true }
 waymark-action-runtime-worker-pool = { workspace = true }
+waymark-batcher = { workspace = true }
 waymark-execution-driver = { workspace = true }
 waymark-extcall-reconciler = { workspace = true }
 waymark-fullset-effect-handler = { workspace = true }

--- a/crates/lib/execution-bringup/Cargo.toml
+++ b/crates/lib/execution-bringup/Cargo.toml
@@ -12,6 +12,7 @@ waymark-action-effect-reconciler-backend = { workspace = true }
 waymark-action-runtime-metadata = { workspace = true }
 waymark-action-runtime-metadata-compat = { workspace = true }
 waymark-action-runtime-worker-pool = { workspace = true }
+waymark-batcher = { workspace = true }
 waymark-execution-driver = { workspace = true }
 waymark-extcall-reconciler = { workspace = true }
 waymark-fullset-effect-handler = { workspace = true }
@@ -36,6 +37,7 @@ waymark-workload-pinning-backend = { workspace = true }
 waymark-workload-pinning-manager = { workspace = true }
 
 chrono = { workspace = true }
+nonempty-collections = { workspace = true }
 tokio = { workspace = true, features = ["sync", "macros", "rt"] }
 tokio-util = { workspace = true }
 tracing = { workspace = true }

--- a/crates/lib/execution-bringup/src/lib.rs
+++ b/crates/lib/execution-bringup/src/lib.rs
@@ -137,7 +137,7 @@ where
     Backend: waymark_state_vm_runtimes_backend::HasVmId<VmId = waymark_ids::InstanceId>,
     <Backend as waymark_state_vm_runtimes_backend::HasVmId>::VmId:
         Eq + Hash + Clone + Send + Sync + core::fmt::Debug + 'static,
-    Backend: waymark_state_vm_runtimes_backend::StoreSnapshot,
+    Backend: waymark_state_vm_runtimes_backend::StoreSnapshots,
     Backend: waymark_state_vm_runtimes_backend::LoadForRevive,
     Backend: waymark_state_vm_runtimes_backend::HasExecutableId<
             ExecutableId = waymark_ids::WorkflowVersionId,
@@ -185,7 +185,7 @@ where
     <Backend as waymark_workload_pinning_backend::PollUnpinnedWorkloads>::Error: Send,
     <Backend as waymark_workload_pinning_backend::KeepalivePinnings>::Error: Send,
     <Backend as waymark_workload_pinning_backend::UnpinWorkloads>::Error: Send,
-    <Backend as waymark_state_vm_runtimes_backend::StoreSnapshot>::Error: Send + 'static,
+    <Backend as waymark_state_vm_runtimes_backend::StoreSnapshots>::Error: Send + 'static,
     <Backend as waymark_state_vm_runtimes_backend::LoadForRevive>::Error: Send + 'static,
     <Backend as waymark_workflow_completion_backend::RecordCompletion>::Error: Send + 'static,
     <Backend as waymark_workflow_completion_backend::RecordException>::Error: Send + 'static,

--- a/crates/lib/execution-bringup/src/lib.rs
+++ b/crates/lib/execution-bringup/src/lib.rs
@@ -139,7 +139,7 @@ where
     Backend: waymark_state_vm_runtimes_backend::HasVmId<VmId = waymark_ids::InstanceId>,
     <Backend as waymark_state_vm_runtimes_backend::HasVmId>::VmId:
         Eq + Hash + Clone + Send + Sync + core::fmt::Debug + 'static,
-    Backend: waymark_state_vm_runtimes_backend::StoreSnapshot,
+    Backend: waymark_state_vm_runtimes_backend::StoreSnapshots,
     Backend: waymark_state_vm_runtimes_backend::LoadForRevive,
     Backend: waymark_state_vm_runtimes_backend::HasExecutableId<
             ExecutableId = waymark_ids::WorkflowVersionId,
@@ -187,7 +187,7 @@ where
     <Backend as waymark_workload_pinning_backend::PollUnpinnedWorkloads>::Error: Send,
     <Backend as waymark_workload_pinning_backend::KeepalivePinnings>::Error: Send,
     <Backend as waymark_workload_pinning_backend::UnpinWorkloads>::Error: Send,
-    <Backend as waymark_state_vm_runtimes_backend::StoreSnapshot>::Error: Send + 'static,
+    <Backend as waymark_state_vm_runtimes_backend::StoreSnapshots>::Error: Send + 'static,
     <Backend as waymark_state_vm_runtimes_backend::LoadForRevive>::Error: Send + 'static,
     <Backend as waymark_workflow_completion_backend::RecordCompletion>::Error: Send + 'static,
     <Backend as waymark_workflow_completion_backend::RecordException>::Error: Send + 'static,

--- a/crates/lib/execution-bringup/src/lib.rs
+++ b/crates/lib/execution-bringup/src/lib.rs
@@ -50,6 +50,12 @@ pub struct Config<NodeId> {
     /// Polling is a spin by design; this only floors how tight it can get.
     pub workload_poll_interval: NonZeroDuration,
 
+    /// Maximum number of VM snapshots coalesced into one batched write.
+    pub snapshot_batch_max: NonZeroUsize,
+
+    /// Longest a snapshot waits to be batched before its write is flushed.
+    pub snapshot_batch_delay: NonZeroDuration,
+
     /// How long the durable-sleeps demand poller waits between polls
     /// while demand is registered.
     pub sleep_poll_interval: NonZeroDuration,
@@ -98,6 +104,9 @@ pub struct Handles {
 
     /// Join handle for the action-call request lock renewal heartbeat.
     pub action_effect_reconciler_lock_renewal: tokio::task::JoinHandle<()>,
+
+    /// Join handle for the VM snapshot write batcher.
+    pub snapshot_batcher: tokio::task::JoinHandle<()>,
 }
 
 /// Start the execution subsystem.
@@ -202,6 +211,8 @@ where
         pinning_heartbeat,
         pinning_fencing_margin,
         workload_poll_interval,
+        snapshot_batch_max,
+        snapshot_batch_delay,
         sleep_poll_interval,
         vm_retention,
         vm_sweep_interval,
@@ -464,12 +475,26 @@ where
         }
     });
 
+    let (snapshot_batcher, snapshot_batcher_loop) = waymark_state_vm_runtimes::snapshot_batcher(
+        Arc::clone(&backend),
+        waymark_batcher::Policy {
+            max_batch: snapshot_batch_max,
+            max_delay: snapshot_batch_delay,
+        },
+        {
+            let shutdown = shutdown_token.child_token();
+            async move { shutdown.cancelled_owned().await }
+        },
+    );
+    let snapshot_batcher_handle = tokio::spawn(snapshot_batcher_loop);
+
     let vm_runtimes_factory = waymark_state_vm_runtimes::SpawningFactory::new(
         Arc::clone(&backend),
         Arc::clone(&codec),
         executable_state,
         interpreter_provider,
         effector_provider,
+        snapshot_batcher,
     );
 
     // Reconcile-before-produce: at VM revival, pending request rows whose
@@ -548,6 +573,7 @@ where
         durable_sleeps_poller: durable_sleeps_poller_handle,
         durable_sleeps_acker: durable_sleeps_acker_handle,
         action_effect_reconciler_lock_renewal: action_effect_reconciler_lock_renewal_handle,
+        snapshot_batcher: snapshot_batcher_handle,
     })
 }
 

--- a/crates/lib/execution-bringup/src/lib.rs
+++ b/crates/lib/execution-bringup/src/lib.rs
@@ -48,6 +48,12 @@ pub struct Config<NodeId> {
     /// Maximum number of unpinned-workload poll queries per second.
     pub workload_poll_rate_limit: NonZeroU32,
 
+    /// Maximum number of VM snapshots coalesced into one batched write.
+    pub snapshot_batch_max: NonZeroUsize,
+
+    /// Longest a snapshot waits to be batched before its write is flushed.
+    pub snapshot_batch_delay: NonZeroDuration,
+
     /// How long the durable-sleeps demand poller waits between polls
     /// while demand is registered.
     pub sleep_poll_interval: NonZeroDuration,
@@ -96,6 +102,9 @@ pub struct Handles {
 
     /// Join handle for the action-call request lock renewal heartbeat.
     pub action_effect_reconciler_lock_renewal: tokio::task::JoinHandle<()>,
+
+    /// Join handle for the VM snapshot write batcher.
+    pub snapshot_batcher: tokio::task::JoinHandle<()>,
 }
 
 /// Start the execution subsystem.
@@ -200,6 +209,8 @@ where
         pinning_heartbeat,
         pinning_fencing_margin,
         workload_poll_rate_limit,
+        snapshot_batch_max,
+        snapshot_batch_delay,
         sleep_poll_interval,
         vm_retention,
         vm_sweep_interval,
@@ -462,12 +473,52 @@ where
         }
     });
 
+    let (snapshot_batcher, snapshot_batcher_loop) = waymark_batcher::write_batcher(
+        waymark_batcher::Policy {
+            max_batch: snapshot_batch_max,
+            max_delay: snapshot_batch_delay,
+        },
+        {
+            let backend = Arc::clone(&backend);
+            move |batch: nonempty_collections::NEVec<
+                waymark_state_vm_runtimes::SnapshotJob<waymark_ids::InstanceId>,
+            >| {
+                let backend = Arc::clone(&backend);
+                async move {
+                    let outcome = {
+                        let items: Vec<_> = batch
+                            .iter()
+                            .map(|(vm_id, snapshot)| {
+                                waymark_state_vm_runtimes_backend::StoreSnapshotsItem {
+                                    vm_id,
+                                    snapshot: snapshot.as_slice(),
+                                }
+                            })
+                            .collect();
+                        backend.store_snapshots(&items).await
+                    };
+                    let result = outcome.map_err(|error| {
+                        tracing::warn!(?error, "storing a snapshot batch failed");
+                        waymark_state_vm_runtimes::SnapshotBatchError::Store
+                    });
+                    nonempty_collections::NEVec::from_elem(result, batch.len())
+                }
+            }
+        },
+        {
+            let shutdown = shutdown_token.child_token();
+            async move { shutdown.cancelled_owned().await }
+        },
+    );
+    let snapshot_batcher_handle = tokio::spawn(snapshot_batcher_loop);
+
     let vm_runtimes_factory = waymark_state_vm_runtimes::SpawningFactory::new(
         Arc::clone(&backend),
         Arc::clone(&codec),
         executable_state,
         interpreter_provider,
         effector_provider,
+        snapshot_batcher,
     );
 
     // Reconcile-before-produce: at VM revival, pending request rows whose
@@ -546,6 +597,7 @@ where
         durable_sleeps_poller: durable_sleeps_poller_handle,
         durable_sleeps_acker: durable_sleeps_acker_handle,
         action_effect_reconciler_lock_renewal: action_effect_reconciler_lock_renewal_handle,
+        snapshot_batcher: snapshot_batcher_handle,
     })
 }
 

--- a/crates/lib/state-vm-runtimes-backend/src/lib.rs
+++ b/crates/lib/state-vm-runtimes-backend/src/lib.rs
@@ -15,18 +15,38 @@ pub trait HasExecutableId {
     type ExecutableId;
 }
 
-/// Persist a snapshot for a VM.
-///
-/// Called from a driver thread — implementations may block.
-pub trait StoreSnapshot: HasVmId {
+/// One VM's snapshot to persist, passed to [`StoreSnapshots::store_snapshots`].
+#[derive(Debug)]
+pub struct StoreSnapshotsItem<'a, VmId> {
+    /// The VM whose snapshot this is.
+    pub vm_id: &'a VmId,
+
+    /// The serialized snapshot bytes.
+    pub snapshot: &'a [u8],
+}
+
+// Both fields are references, so the item is copyable for any `VmId` — no
+// `VmId: Copy`/`Clone` bound, unlike what `derive` would impose.
+impl<VmId> Clone for StoreSnapshotsItem<'_, VmId> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<VmId> Copy for StoreSnapshotsItem<'_, VmId> {}
+
+/// Persist snapshots for VMs in a batch.
+pub trait StoreSnapshots: HasVmId {
     /// Error type for store operations.
     type Error: std::fmt::Debug;
 
-    /// Persist a snapshot for the given VM.
-    fn store_snapshot<'a>(
+    /// Persist the given snapshots in one batch.
+    ///
+    /// A VM whose row is gone (already completed or deleted) is a benign
+    /// no-op; the batch as a whole succeeds or fails.
+    fn store_snapshots<'a>(
         &'a self,
-        vm_id: &'a Self::VmId,
-        data: &'a [u8],
+        snapshots: &'a [StoreSnapshotsItem<'a, Self::VmId>],
     ) -> impl Future<Output = Result<(), Self::Error>> + Send + 'a;
 }
 
@@ -59,8 +79,8 @@ pub trait LoadForRevive: HasVmId + HasExecutableId {
 
 /// Convenience trait: a backend that supports both store and load.
 ///
-/// Blanket-implemented for any type that implements both [`StoreSnapshot`]
+/// Blanket-implemented for any type that implements both [`StoreSnapshots`]
 /// and [`LoadForRevive`].
-pub trait VmRuntimesStateBackend: StoreSnapshot + LoadForRevive {}
+pub trait VmRuntimesStateBackend: StoreSnapshots + LoadForRevive {}
 
-impl<T> VmRuntimesStateBackend for T where T: StoreSnapshot + LoadForRevive {}
+impl<T> VmRuntimesStateBackend for T where T: StoreSnapshots + LoadForRevive {}

--- a/crates/lib/state-vm-runtimes-backend/src/lib.rs
+++ b/crates/lib/state-vm-runtimes-backend/src/lib.rs
@@ -15,18 +15,40 @@ pub trait HasExecutableId {
     type ExecutableId;
 }
 
-/// Persist a snapshot for a VM.
+/// One VM's snapshot to persist, passed to [`StoreSnapshots::store_snapshots`].
+#[derive(Debug)]
+pub struct StoreSnapshotsItem<'a, VmId> {
+    /// The VM whose snapshot this is.
+    pub vm_id: &'a VmId,
+
+    /// The serialized snapshot bytes.
+    pub snapshot: &'a [u8],
+}
+
+// Both fields are references, so the item is copyable for any `VmId` — no
+// `VmId: Copy`/`Clone` bound, unlike what `derive` would impose.
+impl<VmId> Clone for StoreSnapshotsItem<'_, VmId> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<VmId> Copy for StoreSnapshotsItem<'_, VmId> {}
+
+/// Persist snapshots for VMs in a batch.
 ///
-/// Called from a driver thread — implementations may block.
-pub trait StoreSnapshot: HasVmId {
+/// Called on behalf of driver threads — implementations may block.
+pub trait StoreSnapshots: HasVmId {
     /// Error type for store operations.
     type Error: std::fmt::Debug;
 
-    /// Persist a snapshot for the given VM.
-    fn store_snapshot<'a>(
+    /// Persist the given snapshots in one batch.
+    ///
+    /// A VM whose row is gone (already completed or deleted) is a benign
+    /// no-op; the batch as a whole succeeds or fails.
+    fn store_snapshots<'a>(
         &'a self,
-        vm_id: &'a Self::VmId,
-        data: &'a [u8],
+        snapshots: &'a [StoreSnapshotsItem<'a, Self::VmId>],
     ) -> impl Future<Output = Result<(), Self::Error>> + Send + 'a;
 }
 
@@ -59,8 +81,8 @@ pub trait LoadForRevive: HasVmId + HasExecutableId {
 
 /// Convenience trait: a backend that supports both store and load.
 ///
-/// Blanket-implemented for any type that implements both [`StoreSnapshot`]
+/// Blanket-implemented for any type that implements both [`StoreSnapshots`]
 /// and [`LoadForRevive`].
-pub trait VmRuntimesStateBackend: StoreSnapshot + LoadForRevive {}
+pub trait VmRuntimesStateBackend: StoreSnapshots + LoadForRevive {}
 
-impl<T> VmRuntimesStateBackend for T where T: StoreSnapshot + LoadForRevive {}
+impl<T> VmRuntimesStateBackend for T where T: StoreSnapshots + LoadForRevive {}

--- a/crates/lib/state-vm-runtimes/Cargo.toml
+++ b/crates/lib/state-vm-runtimes/Cargo.toml
@@ -5,6 +5,7 @@ version.workspace = true
 publish.workspace = true
 
 [dependencies]
+waymark-batcher = { workspace = true }
 waymark-state-manager = { workspace = true }
 waymark-state-manager-core = { workspace = true }
 waymark-state-vm-runtimes-backend = { workspace = true }
@@ -19,6 +20,7 @@ waymark-vm-runtime = { workspace = true }
 waymark-vm-runtime-core = { workspace = true }
 waymark-vm-runtime-promise-core = { workspace = true }
 
+nonempty-collections = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["sync", "macros", "rt", "time"] }

--- a/crates/lib/state-vm-runtimes/Cargo.toml
+++ b/crates/lib/state-vm-runtimes/Cargo.toml
@@ -5,6 +5,7 @@ version.workspace = true
 publish.workspace = true
 
 [dependencies]
+waymark-batcher = { workspace = true }
 waymark-state-manager = { workspace = true }
 waymark-state-manager-core = { workspace = true }
 waymark-state-vm-runtimes-backend = { workspace = true }

--- a/crates/lib/state-vm-runtimes/src/lib.rs
+++ b/crates/lib/state-vm-runtimes/src/lib.rs
@@ -16,7 +16,9 @@ mod once_receiver;
 mod snapshot_adapter;
 mod spawner;
 
-pub use self::snapshot_adapter::SnapshotAdapter;
+pub use self::snapshot_adapter::{
+    SnapshotAdapter, SnapshotBatchError, SnapshotJob, SnapshotOutcome,
+};
 pub use self::spawner::{ErrorFor, Evicted, Spawned};
 
 use std::hash::Hash;
@@ -53,12 +55,19 @@ pub struct SpawningFactory<
     InterpreterProvider,
     EffectorProvider,
     Value,
-> {
+> where
+    Backend: waymark_state_vm_runtimes_backend::HasVmId,
+{
     backend: Arc<Backend>,
     codec: Arc<Codec>,
     executable_provider: ExecutableProvider,
     interpreter_provider: InterpreterProvider,
     effector_provider: EffectorProvider,
+    /// Shared batcher that coalesces snapshot writes across all VMs.
+    snapshot_batcher: waymark_batcher::BatcherHandle<
+        snapshot_adapter::SnapshotJob<Backend::VmId>,
+        snapshot_adapter::SnapshotOutcome,
+    >,
     _phantom_data: PhantomData<Value>,
 }
 
@@ -71,6 +80,8 @@ impl<Backend, Codec, ExecutableProvider, InterpreterProvider, EffectorProvider, 
         EffectorProvider,
         Value,
     >
+where
+    Backend: waymark_state_vm_runtimes_backend::HasVmId,
 {
     /// Create a new spawning factory.
     pub fn new(
@@ -79,6 +90,10 @@ impl<Backend, Codec, ExecutableProvider, InterpreterProvider, EffectorProvider, 
         executable_provider: ExecutableProvider,
         interpreter_provider: InterpreterProvider,
         effector_provider: EffectorProvider,
+        snapshot_batcher: waymark_batcher::BatcherHandle<
+            snapshot_adapter::SnapshotJob<Backend::VmId>,
+            snapshot_adapter::SnapshotOutcome,
+        >,
     ) -> Self {
         Self {
             backend,
@@ -86,6 +101,7 @@ impl<Backend, Codec, ExecutableProvider, InterpreterProvider, EffectorProvider, 
             executable_provider,
             interpreter_provider,
             effector_provider,
+            snapshot_batcher,
             _phantom_data: PhantomData,
         }
     }
@@ -104,11 +120,8 @@ impl<Backend, Codec, ExecutableProvider, InterpreterProvider, EffectorProvider, 
 where
     Backend: waymark_state_vm_runtimes_backend::HasVmId,
     Backend::VmId: Hash + Eq + Clone + Send + Sync + core::fmt::Debug + 'static,
-    Backend: waymark_state_vm_runtimes_backend::StoreSnapshots,
     Backend: waymark_state_vm_runtimes_backend::LoadForRevive,
     Backend: Send + Sync + 'static,
-    <Backend as waymark_state_vm_runtimes_backend::StoreSnapshots>::Error:
-        std::fmt::Debug + Send + 'static,
     <Backend as waymark_state_vm_runtimes_backend::LoadForRevive>::Error:
         std::fmt::Debug + Send + 'static,
     Codec: waymark_vm_codec_core::SerializerProvider<Ok = ()>,
@@ -186,7 +199,7 @@ where
             ErrorFor<
                 InterpreterProvider::Interpreter,
                 Codec,
-                SnapshotAdapter<Backend::VmId, Backend>,
+                SnapshotAdapter<Backend::VmId>,
                 EffectorProvider::Effector,
             >,
         >,
@@ -229,7 +242,7 @@ where
 
         let snapshotter = snapshot_adapter::SnapshotAdapter {
             vm_id: key.clone(),
-            backend: Arc::clone(&self.backend),
+            batcher: self.snapshot_batcher.clone(),
         };
 
         let spawned = spawner::spawn(

--- a/crates/lib/state-vm-runtimes/src/lib.rs
+++ b/crates/lib/state-vm-runtimes/src/lib.rs
@@ -14,9 +14,13 @@
 
 mod once_receiver;
 mod snapshot_adapter;
+mod snapshot_batcher;
 mod spawner;
 
 pub use self::snapshot_adapter::SnapshotAdapter;
+pub use self::snapshot_batcher::{
+    SnapshotBatchError, SnapshotJob, SnapshotOutcome, snapshot_batcher,
+};
 pub use self::spawner::{ErrorFor, Evicted, Spawned};
 
 use std::hash::Hash;
@@ -53,12 +57,16 @@ pub struct SpawningFactory<
     InterpreterProvider,
     EffectorProvider,
     Value,
-> {
+> where
+    Backend: waymark_state_vm_runtimes_backend::HasVmId,
+{
     backend: Arc<Backend>,
     codec: Arc<Codec>,
     executable_provider: ExecutableProvider,
     interpreter_provider: InterpreterProvider,
     effector_provider: EffectorProvider,
+    /// Shared batcher that coalesces snapshot writes across all VMs.
+    snapshot_batcher: snapshot_batcher::SnapshotBatcherHandle<Backend::VmId>,
     _phantom_data: PhantomData<Value>,
 }
 
@@ -71,6 +79,8 @@ impl<Backend, Codec, ExecutableProvider, InterpreterProvider, EffectorProvider, 
         EffectorProvider,
         Value,
     >
+where
+    Backend: waymark_state_vm_runtimes_backend::HasVmId,
 {
     /// Create a new spawning factory.
     pub fn new(
@@ -79,6 +89,7 @@ impl<Backend, Codec, ExecutableProvider, InterpreterProvider, EffectorProvider, 
         executable_provider: ExecutableProvider,
         interpreter_provider: InterpreterProvider,
         effector_provider: EffectorProvider,
+        snapshot_batcher: snapshot_batcher::SnapshotBatcherHandle<Backend::VmId>,
     ) -> Self {
         Self {
             backend,
@@ -86,6 +97,7 @@ impl<Backend, Codec, ExecutableProvider, InterpreterProvider, EffectorProvider, 
             executable_provider,
             interpreter_provider,
             effector_provider,
+            snapshot_batcher,
             _phantom_data: PhantomData,
         }
     }
@@ -104,11 +116,8 @@ impl<Backend, Codec, ExecutableProvider, InterpreterProvider, EffectorProvider, 
 where
     Backend: waymark_state_vm_runtimes_backend::HasVmId,
     Backend::VmId: Hash + Eq + Clone + Send + Sync + core::fmt::Debug + 'static,
-    Backend: waymark_state_vm_runtimes_backend::StoreSnapshots,
     Backend: waymark_state_vm_runtimes_backend::LoadForRevive,
     Backend: Send + Sync + 'static,
-    <Backend as waymark_state_vm_runtimes_backend::StoreSnapshots>::Error:
-        std::fmt::Debug + Send + 'static,
     <Backend as waymark_state_vm_runtimes_backend::LoadForRevive>::Error:
         std::fmt::Debug + Send + 'static,
     Codec: waymark_vm_codec_core::SerializerProvider<Ok = ()>,
@@ -186,7 +195,7 @@ where
             ErrorFor<
                 InterpreterProvider::Interpreter,
                 Codec,
-                SnapshotAdapter<Backend::VmId, Backend>,
+                SnapshotAdapter<Backend::VmId>,
                 EffectorProvider::Effector,
             >,
         >,
@@ -229,7 +238,7 @@ where
 
         let snapshotter = snapshot_adapter::SnapshotAdapter {
             vm_id: key.clone(),
-            backend: Arc::clone(&self.backend),
+            batcher: self.snapshot_batcher.clone(),
         };
 
         let spawned = spawner::spawn(

--- a/crates/lib/state-vm-runtimes/src/lib.rs
+++ b/crates/lib/state-vm-runtimes/src/lib.rs
@@ -104,10 +104,10 @@ impl<Backend, Codec, ExecutableProvider, InterpreterProvider, EffectorProvider, 
 where
     Backend: waymark_state_vm_runtimes_backend::HasVmId,
     Backend::VmId: Hash + Eq + Clone + Send + Sync + core::fmt::Debug + 'static,
-    Backend: waymark_state_vm_runtimes_backend::StoreSnapshot,
+    Backend: waymark_state_vm_runtimes_backend::StoreSnapshots,
     Backend: waymark_state_vm_runtimes_backend::LoadForRevive,
     Backend: Send + Sync + 'static,
-    <Backend as waymark_state_vm_runtimes_backend::StoreSnapshot>::Error:
+    <Backend as waymark_state_vm_runtimes_backend::StoreSnapshots>::Error:
         std::fmt::Debug + Send + 'static,
     <Backend as waymark_state_vm_runtimes_backend::LoadForRevive>::Error:
         std::fmt::Debug + Send + 'static,

--- a/crates/lib/state-vm-runtimes/src/snapshot_adapter.rs
+++ b/crates/lib/state-vm-runtimes/src/snapshot_adapter.rs
@@ -1,28 +1,54 @@
-use std::sync::Arc;
+use waymark_batcher::BatcherHandle;
 
-/// Adapter that binds a VM id to a shared backend.
-pub struct SnapshotAdapter<VmId, Backend> {
+/// The batcher item: a VM id and its owned snapshot bytes. The bytes must be
+/// owned because the batcher holds them until the batch flushes.
+pub type SnapshotJob<VmId> = (VmId, Vec<u8>);
+
+/// The per-submission result the snapshot batcher hands back.
+pub type SnapshotOutcome = Result<(), SnapshotBatchError>;
+
+/// Error from persisting a snapshot through the shared batcher.
+///
+/// The concrete backend error is logged in full at the flush — the one
+/// place that has it — and the waiters receive the category: their drive
+/// loops fail and the workloads re-pin either way.
+#[derive(Debug, Clone, Copy, thiserror::Error)]
+pub enum SnapshotBatchError {
+    /// The batched store failed; nothing of the batch was persisted.
+    #[error("batched snapshot store failed")]
+    Store,
+
+    /// The snapshot batcher has shut down and can no longer persist.
+    #[error("snapshot batcher is closed")]
+    Closed,
+}
+
+/// Adapter that submits a VM's snapshots to the shared snapshot batcher.
+pub struct SnapshotAdapter<VmId> {
     /// The VM whose snapshots this adapter persists.
     pub vm_id: VmId,
 
-    /// The backend the snapshots are persisted to.
-    pub backend: Arc<Backend>,
+    /// Handle to the shared snapshot batcher.
+    pub batcher: BatcherHandle<SnapshotJob<VmId>, SnapshotOutcome>,
 }
 
-impl<VmId, Backend> waymark_vm_driver_core::SnapshotPersister for SnapshotAdapter<VmId, Backend>
+impl<VmId> waymark_vm_driver_core::SnapshotPersister for SnapshotAdapter<VmId>
 where
-    Backend: waymark_state_vm_runtimes_backend::StoreSnapshots<VmId = VmId> + Send + Sync,
-    <Backend as waymark_state_vm_runtimes_backend::StoreSnapshots>::Error: std::fmt::Debug,
-    VmId: Sync,
+    VmId: Clone + Send + Sync + 'static,
 {
-    type Error = <Backend as waymark_state_vm_runtimes_backend::StoreSnapshots>::Error;
+    type Error = SnapshotBatchError;
 
     async fn persist_snapshot<'a>(&'a self, data: &'a [u8]) -> Result<(), Self::Error> {
-        self.backend
-            .store_snapshots(&[waymark_state_vm_runtimes_backend::StoreSnapshotsItem {
-                vm_id: &self.vm_id,
-                snapshot: data,
-            }])
+        // The batcher owns the bytes until flush, so they must be copied here.
+        // Each driver still awaits its own submission, preserving
+        // persist-before-continue.
+        match self
+            .batcher
+            .submit((self.vm_id.clone(), data.to_vec()))
             .await
+        {
+            Ok(outcome) => outcome,
+            Err(waymark_batcher::Closed) => Err(SnapshotBatchError::Closed),
+        }
     }
 }

--- a/crates/lib/state-vm-runtimes/src/snapshot_adapter.rs
+++ b/crates/lib/state-vm-runtimes/src/snapshot_adapter.rs
@@ -11,13 +11,18 @@ pub struct SnapshotAdapter<VmId, Backend> {
 
 impl<VmId, Backend> waymark_vm_driver_core::SnapshotPersister for SnapshotAdapter<VmId, Backend>
 where
-    Backend: waymark_state_vm_runtimes_backend::StoreSnapshot<VmId = VmId> + Send + Sync,
-    <Backend as waymark_state_vm_runtimes_backend::StoreSnapshot>::Error: std::fmt::Debug,
+    Backend: waymark_state_vm_runtimes_backend::StoreSnapshots<VmId = VmId> + Send + Sync,
+    <Backend as waymark_state_vm_runtimes_backend::StoreSnapshots>::Error: std::fmt::Debug,
     VmId: Sync,
 {
-    type Error = <Backend as waymark_state_vm_runtimes_backend::StoreSnapshot>::Error;
+    type Error = <Backend as waymark_state_vm_runtimes_backend::StoreSnapshots>::Error;
 
     async fn persist_snapshot<'a>(&'a self, data: &'a [u8]) -> Result<(), Self::Error> {
-        self.backend.store_snapshot(&self.vm_id, data).await
+        self.backend
+            .store_snapshots(&[waymark_state_vm_runtimes_backend::StoreSnapshotsItem {
+                vm_id: &self.vm_id,
+                snapshot: data,
+            }])
+            .await
     }
 }

--- a/crates/lib/state-vm-runtimes/src/snapshot_adapter.rs
+++ b/crates/lib/state-vm-runtimes/src/snapshot_adapter.rs
@@ -1,28 +1,33 @@
-use std::sync::Arc;
+//! The per-VM adapter feeding the shared snapshot batcher.
 
-/// Adapter that binds a VM id to a shared backend.
-pub struct SnapshotAdapter<VmId, Backend> {
+use crate::snapshot_batcher::{SnapshotBatchError, SnapshotBatcherHandle};
+
+/// Adapter that submits a VM's snapshots to the shared snapshot batcher.
+pub struct SnapshotAdapter<VmId> {
     /// The VM whose snapshots this adapter persists.
     pub vm_id: VmId,
 
-    /// The backend the snapshots are persisted to.
-    pub backend: Arc<Backend>,
+    /// Handle to the shared snapshot batcher.
+    pub batcher: SnapshotBatcherHandle<VmId>,
 }
 
-impl<VmId, Backend> waymark_vm_driver_core::SnapshotPersister for SnapshotAdapter<VmId, Backend>
+impl<VmId> waymark_vm_driver_core::SnapshotPersister for SnapshotAdapter<VmId>
 where
-    Backend: waymark_state_vm_runtimes_backend::StoreSnapshots<VmId = VmId> + Send + Sync,
-    <Backend as waymark_state_vm_runtimes_backend::StoreSnapshots>::Error: std::fmt::Debug,
-    VmId: Sync,
+    VmId: Clone + Send + Sync + 'static,
 {
-    type Error = <Backend as waymark_state_vm_runtimes_backend::StoreSnapshots>::Error;
+    type Error = SnapshotBatchError;
 
     async fn persist_snapshot<'a>(&'a self, data: &'a [u8]) -> Result<(), Self::Error> {
-        self.backend
-            .store_snapshots(&[waymark_state_vm_runtimes_backend::StoreSnapshotsItem {
-                vm_id: &self.vm_id,
-                snapshot: data,
-            }])
+        // The batcher owns the bytes until flush, so they must be copied here.
+        // Each driver still awaits its own submission, preserving
+        // persist-before-continue.
+        match self
+            .batcher
+            .submit((self.vm_id.clone(), data.to_vec()))
             .await
+        {
+            Ok(outcome) => outcome,
+            Err(waymark_batcher::Closed) => Err(SnapshotBatchError::Closed),
+        }
     }
 }

--- a/crates/lib/state-vm-runtimes/src/snapshot_batcher.rs
+++ b/crates/lib/state-vm-runtimes/src/snapshot_batcher.rs
@@ -1,0 +1,130 @@
+//! Batched durable storing of VM runtime snapshots.
+//!
+//! Every VM's [`SnapshotAdapter`](crate::SnapshotAdapter) submits its
+//! snapshot into one shared
+//! [`deduplicating_write_batcher`](waymark_batcher::deduplicating_write_batcher)
+//! keyed by the vm id and awaits its own outcome, so persist-before-ack
+//! still holds per VM while many single-row updates coalesce into one
+//! multi-row [`store_snapshots`](waymark_state_vm_runtimes_backend::StoreSnapshots::store_snapshots)
+//! statement.
+//!
+//! The concrete backend error is logged in full at the flush — the one
+//! place that has it — and the waiters receive the
+//! [`SnapshotBatchError`] category: their drive loops fail and the
+//! workloads re-pin either way.
+
+use std::hash::Hash;
+use std::sync::Arc;
+
+/// The batcher item: a VM id and its owned snapshot bytes. The bytes must be
+/// owned because the batcher holds them until the batch flushes.
+pub type SnapshotJob<VmId> = (VmId, Vec<u8>);
+
+/// The per-submission result the snapshot batcher hands back.
+pub type SnapshotOutcome = Result<(), SnapshotBatchError>;
+
+/// Handle for submitting snapshots to the shared snapshot batcher.
+pub type SnapshotBatcherHandle<VmId> =
+    waymark_batcher::BatcherHandle<SnapshotJob<VmId>, SnapshotOutcome>;
+
+/// Error from persisting a snapshot through the shared batcher.
+#[derive(Debug, Clone, Copy, thiserror::Error)]
+pub enum SnapshotBatchError {
+    /// The batched store failed; nothing of the batch was persisted.
+    #[error("batched snapshot store failed")]
+    Store,
+
+    /// The snapshot batcher has shut down and can no longer persist.
+    #[error("snapshot batcher is closed")]
+    Closed,
+}
+
+/// The snapshot batcher's conflict resolver: the newest snapshot wins.
+///
+/// A same-vm duplicate within one window cannot happen today — a driver
+/// awaits each submission inline — but if one ever arrives, sequential
+/// semantics must hold: the newest snapshot is what a later unbatched
+/// store would have persisted, and the arbitrary-row behavior of a
+/// duplicate-key `UPDATE ... FROM` must never pick the older one.  The
+/// newcomer takes the slot; the ousted earlier submission settles to the
+/// winner's verdict — in the sequential story its own store succeeded
+/// and was then overwritten, so its fate is the fate of the write that
+/// superseded it.
+struct NewestSnapshotWins;
+
+impl<VmId>
+    waymark_batcher::deduplicating_write::ConflictResolver<SnapshotJob<VmId>, SnapshotOutcome>
+    for NewestSnapshotWins
+{
+    type Placeholder = ();
+
+    fn resolve_conflict<'a>(
+        &self,
+        slot: waymark_batcher::deduplicating_write::ConflictedSlot<
+            'a,
+            SnapshotJob<VmId>,
+            SnapshotOutcome,
+            (),
+        >,
+        newcomer: SnapshotJob<VmId>,
+    ) -> waymark_batcher::deduplicating_write::ConflictResolvedToken<'a> {
+        let (_superseded, resolving) = slot.replace(newcomer);
+        resolving.resolve(())
+    }
+
+    fn settle_conflict(
+        &self,
+        _conflicted_out: (),
+        winner_out: &SnapshotOutcome,
+    ) -> SnapshotOutcome {
+        *winner_out
+    }
+}
+
+/// Create the shared snapshot batcher: a handle for the per-VM
+/// [`SnapshotAdapter`](crate::SnapshotAdapter)s, and the batcher future
+/// for the caller to spawn.
+///
+/// The future resolves once `shutdown` fires (or every handle is
+/// dropped) and the last buffered batch has been flushed.
+pub fn snapshot_batcher<Backend>(
+    backend: Arc<Backend>,
+    policy: waymark_batcher::Policy,
+    shutdown: impl Future<Output = ()>,
+) -> (
+    SnapshotBatcherHandle<Backend::VmId>,
+    impl Future<Output = ()>,
+)
+where
+    Backend: waymark_state_vm_runtimes_backend::StoreSnapshots,
+    Backend::VmId: Clone + Hash + Eq,
+{
+    waymark_batcher::deduplicating_write_batcher(
+        policy,
+        |(vm_id, _): &SnapshotJob<Backend::VmId>| vm_id.clone(),
+        NewestSnapshotWins,
+        move |batch: nonempty_collections::NEVec<SnapshotJob<Backend::VmId>>| {
+            let backend = Arc::clone(&backend);
+            async move {
+                let outcome = {
+                    let items: Vec<_> = batch
+                        .iter()
+                        .map(|(vm_id, snapshot)| {
+                            waymark_state_vm_runtimes_backend::StoreSnapshotsItem {
+                                vm_id,
+                                snapshot: snapshot.as_slice(),
+                            }
+                        })
+                        .collect();
+                    backend.store_snapshots(&items).await
+                };
+                let result = outcome.map_err(|error| {
+                    tracing::warn!(?error, "storing a snapshot batch failed");
+                    SnapshotBatchError::Store
+                });
+                nonempty_collections::NEVec::from_elem(result, batch.len())
+            }
+        },
+        shutdown,
+    )
+}


### PR DESCRIPTION
Goes in after #511.

---

This PR makes VM runtime snapshot writes batch. This was something that was intended in the design but not implemented until now. Gives us huge perf gains.

After this, other operation will also have to be converted to batches in order to improve the performance (according to the PoC findings).