### PR TITLE
Tidy the workload-pinnings-related glossary and naming in preparation for scheduling

### DIFF
--- a/crates/lib/backend-postgres-migrations/migrations/0018_rename_workload_pinnings_to_runnable_workloads.sql
+++ b/crates/lib/backend-postgres-migrations/migrations/0018_rename_workload_pinnings_to_runnable_workloads.sql
@@ -1,0 +1,15 @@
+-- Rename workload_pinnings to runnable_workloads.
+--
+-- The table states two orthogonal facts and the old name only covered
+-- one of them: row presence means the workload is runnable (in the set
+-- of things that should run), while the nullable node_id/expires_at
+-- columns hold its current pinning to a node.  The workload vocabulary
+-- also replaces the ambiguous "instance" in the key column.
+
+ALTER TABLE workload_pinnings RENAME TO runnable_workloads;
+ALTER TABLE runnable_workloads RENAME COLUMN instance_id TO workload_id;
+ALTER TABLE runnable_workloads RENAME CONSTRAINT workload_pinnings_node_expiry_paired
+    TO runnable_workloads_node_expiry_paired;
+ALTER TABLE runnable_workloads RENAME CONSTRAINT workload_pinnings_instance_id_fkey
+    TO runnable_workloads_workload_id_fkey;
+ALTER INDEX workload_pinnings_pkey RENAME TO runnable_workloads_pkey;

--- a/crates/lib/backend-postgres/src/test_helpers.rs
+++ b/crates/lib/backend-postgres/src/test_helpers.rs
@@ -14,7 +14,7 @@ pub(super) async fn setup_backend() -> PostgresBackend {
 /// Snapshot bytes written by [`register_test_vm`].
 pub(super) const TEST_VM_SNAPSHOT: &[u8] = b"test-snapshot";
 
-/// Register a VM runtime (its snapshot and workload pinning rows) through the
+/// Register a VM runtime (its snapshot and runnable-workload rows) through the
 /// production [`RegisterVmRuntime`] path and return its identifiers, so tests
 /// share exactly the registration behavior they exercise.
 pub(super) async fn register_test_vm(backend: &PostgresBackend) -> (InstanceId, WorkflowVersionId) {
@@ -39,7 +39,7 @@ pub(super) async fn reset_database(pool: &PgPool) {
                  vm_runtime_snapshots,
                  workflow_schedules,
                  workflow_versions,
-                 workload_pinnings,
+                 runnable_workloads,
                  worker_status
         RESTART IDENTITY CASCADE
         "#,

--- a/crates/lib/backend-postgres/src/workflow_service_vm_runtimes/mod.rs
+++ b/crates/lib/backend-postgres/src/workflow_service_vm_runtimes/mod.rs
@@ -66,7 +66,7 @@ impl waymark_workflow_service_vm_runtimes_backend::RegisterVmRuntime for Postgre
 
         sqlx::query(
             r#"
-            INSERT INTO workload_pinnings (instance_id)
+            INSERT INTO runnable_workloads (workload_id)
             VALUES ($1)
             "#,
         )

--- a/crates/lib/backend-postgres/src/workload_pinning/error.rs
+++ b/crates/lib/backend-postgres/src/workload_pinning/error.rs
@@ -1,6 +1,6 @@
 //! Error types for the workload-pinning postgres backend.
 
-/// Error returned by [`super::PostgresBackend`] when polling for unpinned instances.
+/// Error returned by [`super::PostgresBackend`] when polling for unpinned workloads.
 #[derive(Debug, thiserror::Error)]
 pub enum PollError {
     /// The underlying database operation failed.

--- a/crates/lib/backend-postgres/src/workload_pinning/mod.rs
+++ b/crates/lib/backend-postgres/src/workload_pinning/mod.rs
@@ -1,7 +1,7 @@
 //! Postgres backend for workload pinning.
 //!
 //! Implements [`waymark_workload_pinning_backend::Backend`] so that the
-//! workload pinning manager can claim, refresh, and release instance
+//! workload pinning manager can pin, refresh, and release workload
 //! pinnings via Postgres.
 
 pub mod error;
@@ -31,21 +31,21 @@ impl waymark_workload_pinning_backend::HasNodeId for PostgresBackend {
     type NodeId = uuid::Uuid;
 }
 
-impl waymark_workload_pinning_backend::HasInstanceId for PostgresBackend {
-    type InstanceId = InstanceId;
+impl waymark_workload_pinning_backend::HasWorkloadId for PostgresBackend {
+    type WorkloadId = InstanceId;
 }
 
-impl waymark_workload_pinning_backend::PollUnpinnedInstances for PostgresBackend {
+impl waymark_workload_pinning_backend::PollUnpinnedWorkloads for PostgresBackend {
     type Error = error::PollError;
 
     #[obs]
     #[function_name::named]
-    async fn poll_unlocked(
+    async fn poll_unpinned(
         &self,
         now: Self::Timestamp,
         pinning: Pinning<Self::NodeId, Self::Timestamp>,
         max_items: NonZeroUsize,
-    ) -> Result<Option<NEVec<Self::InstanceId>>, Self::Error> {
+    ) -> Result<Option<NEVec<Self::WorkloadId>>, Self::Error> {
         Self::count_query(&self.query_counts, "update:workload_pinnings_poll");
         let rows = sqlx::query(
             r#"
@@ -81,7 +81,7 @@ impl waymark_workload_pinning_backend::PollUnpinnedInstances for PostgresBackend
     }
 }
 
-impl waymark_workload_pinning_backend::KeepaliveInstancePinnings for PostgresBackend {
+impl waymark_workload_pinning_backend::KeepalivePinnings for PostgresBackend {
     type Error = error::RefreshError;
 
     #[obs]
@@ -91,15 +91,15 @@ impl waymark_workload_pinning_backend::KeepaliveInstancePinnings for PostgresBac
         // TODO: the trait should be updated to drop this param
         _now: Self::Timestamp,
         pinning: Pinning<Self::NodeId, Self::Timestamp>,
-        instance_ids: impl nonempty_collections::IntoNonEmptyIterator<Item = Self::InstanceId> + 'a,
+        workload_ids: impl nonempty_collections::IntoNonEmptyIterator<Item = Self::WorkloadId> + 'a,
     ) -> impl Future<
         Output = Result<
-            NEVec<PinningStatus<Self::InstanceId, Pinning<Self::NodeId, Self::Timestamp>>>,
+            NEVec<PinningStatus<Self::WorkloadId, Pinning<Self::NodeId, Self::Timestamp>>>,
             Self::Error,
         >,
     > + Send
     + 'a {
-        let ids: NEVec<InstanceId> = instance_ids.into_nonempty_iter().collect();
+        let ids: NEVec<InstanceId> = workload_ids.into_nonempty_iter().collect();
         async move {
             Self::count_query(&self.query_counts, "update:workload_pinnings_refresh");
             // Re-fence every row still owned by this node, even if it has
@@ -135,7 +135,7 @@ impl waymark_workload_pinning_backend::KeepaliveInstancePinnings for PostgresBac
             let statuses = ids
                 .into_nonempty_iter()
                 .map(|id| PinningStatus {
-                    instance_id: id,
+                    workload_id: id,
                     pinning: if refreshed.contains(&id) {
                         Some(Pinning {
                             node_id: pinning.node_id,
@@ -160,9 +160,9 @@ impl waymark_workload_pinning_backend::ReleasePinnings for PostgresBackend {
     fn release_pinnings<'a>(
         &'a self,
         node_id: Self::NodeId,
-        instance_ids: impl nonempty_collections::IntoNonEmptyIterator<Item = Self::InstanceId> + 'a,
+        workload_ids: impl nonempty_collections::IntoNonEmptyIterator<Item = Self::WorkloadId> + 'a,
     ) -> impl Future<Output = Result<(), Self::Error>> + Send + 'a {
-        let ids: Vec<InstanceId> = instance_ids.into_iter().collect();
+        let ids: Vec<InstanceId> = workload_ids.into_iter().collect();
         async move {
             Self::count_query(&self.query_counts, "update:workload_pinnings_release");
             sqlx::query(

--- a/crates/lib/backend-postgres/src/workload_pinning/mod.rs
+++ b/crates/lib/backend-postgres/src/workload_pinning/mod.rs
@@ -46,20 +46,20 @@ impl waymark_workload_pinning_backend::PollUnpinnedWorkloads for PostgresBackend
         pinning: Pinning<Self::NodeId, Self::Timestamp>,
         max_items: NonZeroUsize,
     ) -> Result<Option<NEVec<Self::WorkloadId>>, Self::Error> {
-        Self::count_query(&self.query_counts, "update:workload_pinnings_poll");
+        Self::count_query(&self.query_counts, "update:runnable_workloads_poll");
         let rows = sqlx::query(
             r#"
-            UPDATE workload_pinnings
+            UPDATE runnable_workloads
             SET node_id = $3, expires_at = $4, updated_at = NOW()
-            WHERE instance_id IN (
-                SELECT instance_id
-                FROM workload_pinnings
+            WHERE workload_id IN (
+                SELECT workload_id
+                FROM runnable_workloads
                 WHERE node_id IS NULL OR expires_at <= $1
                 ORDER BY updated_at
                 LIMIT $2
                 FOR UPDATE SKIP LOCKED
             )
-            RETURNING instance_id
+            RETURNING workload_id
             "#,
         )
         .bind(now)
@@ -68,7 +68,7 @@ impl waymark_workload_pinning_backend::PollUnpinnedWorkloads for PostgresBackend
         .bind(pinning.expires_at)
         .fetch_all(&self.pool)
         .timed(crate::query_timing_histogram!(
-            "update:workload_pinnings_poll"
+            "update:runnable_workloads_poll"
         ))
         .await
         .map_err(error::PollError::Sqlx)?;
@@ -77,7 +77,7 @@ impl waymark_workload_pinning_backend::PollUnpinnedWorkloads for PostgresBackend
             return Ok(None);
         };
 
-        Ok(Some(rows.map(|row| row.get("instance_id")).collect()))
+        Ok(Some(rows.map(|row| row.get("workload_id")).collect()))
     }
 }
 
@@ -101,7 +101,7 @@ impl waymark_workload_pinning_backend::KeepalivePinnings for PostgresBackend {
     + 'a {
         let ids: NEVec<InstanceId> = workload_ids.into_nonempty_iter().collect();
         async move {
-            Self::count_query(&self.query_counts, "update:workload_pinnings_refresh");
+            Self::count_query(&self.query_counts, "update:runnable_workloads_refresh");
             // Re-fence every row still owned by this node, even if it has
             // already lapsed past `expires_at`. Ownership (`node_id`) is the
             // source of truth: a steal by another node rewrites `node_id` and a
@@ -113,10 +113,10 @@ impl waymark_workload_pinning_backend::KeepalivePinnings for PostgresBackend {
             // just because a heartbeat landed late.
             let rows = sqlx::query(
                 r#"
-                UPDATE workload_pinnings
+                UPDATE runnable_workloads
                 SET expires_at = $3, updated_at = NOW()
-                WHERE node_id = $1 AND instance_id = ANY($2)
-                RETURNING instance_id
+                WHERE node_id = $1 AND workload_id = ANY($2)
+                RETURNING workload_id
                 "#,
             )
             .bind(pinning.node_id)
@@ -124,13 +124,13 @@ impl waymark_workload_pinning_backend::KeepalivePinnings for PostgresBackend {
             .bind(pinning.expires_at)
             .fetch_all(&self.pool)
             .timed(crate::query_timing_histogram!(
-                "update:workload_pinnings_refresh"
+                "update:runnable_workloads_refresh"
             ))
             .await
             .map_err(error::RefreshError::Sqlx)?;
 
             let refreshed: std::collections::HashSet<InstanceId> =
-                rows.iter().map(|row| row.get("instance_id")).collect();
+                rows.iter().map(|row| row.get("workload_id")).collect();
 
             let statuses = ids
                 .into_nonempty_iter()
@@ -164,19 +164,19 @@ impl waymark_workload_pinning_backend::ReleasePinnings for PostgresBackend {
     ) -> impl Future<Output = Result<(), Self::Error>> + Send + 'a {
         let ids: Vec<InstanceId> = workload_ids.into_iter().collect();
         async move {
-            Self::count_query(&self.query_counts, "update:workload_pinnings_release");
+            Self::count_query(&self.query_counts, "update:runnable_workloads_release");
             sqlx::query(
                 r#"
-                UPDATE workload_pinnings
+                UPDATE runnable_workloads
                 SET node_id = NULL, expires_at = NULL, updated_at = NOW()
-                WHERE node_id = $1 AND instance_id = ANY($2)
+                WHERE node_id = $1 AND workload_id = ANY($2)
                 "#,
             )
             .bind(node_id)
             .bind(&ids)
             .execute(&self.pool)
             .timed(crate::query_timing_histogram!(
-                "update:workload_pinnings_release"
+                "update:runnable_workloads_release"
             ))
             .await
             .map_err(error::ReleaseError::Sqlx)?;

--- a/crates/lib/backend-postgres/src/workload_pinning/tests.rs
+++ b/crates/lib/backend-postgres/src/workload_pinning/tests.rs
@@ -26,19 +26,19 @@ fn test_max_items() -> NonZeroUsize {
 
 #[serial(postgres)]
 #[tokio::test]
-async fn poll_claims_newly_registered_vm() {
+async fn poll_pins_newly_registered_vm() {
     let backend = setup_backend().await;
     let (vm_id, _executable_id) = register_test_vm(&backend).await;
 
-    let result = waymark_workload_pinning_backend::PollUnpinnedInstances::poll_unlocked(
+    let result = waymark_workload_pinning_backend::PollUnpinnedWorkloads::poll_unpinned(
         &backend,
         test_now(),
         test_pinning(Uuid::new_v4()),
         test_max_items(),
     )
     .await
-    .expect("poll unlocked")
-    .expect("instances available");
+    .expect("poll unpinned")
+    .expect("workloads available");
 
     let ids: Vec<InstanceId> = result.into_iter().collect();
     assert_eq!(ids, vec![vm_id]);
@@ -50,8 +50,8 @@ async fn poll_skips_already_pinned_vm() {
     let backend = setup_backend().await;
     let (_vm_id, _executable_id) = register_test_vm(&backend).await;
 
-    // First poll claims the VM.
-    let result = waymark_workload_pinning_backend::PollUnpinnedInstances::poll_unlocked(
+    // First poll pins the VM.
+    let result = waymark_workload_pinning_backend::PollUnpinnedWorkloads::poll_unpinned(
         &backend,
         test_now(),
         test_pinning(Uuid::new_v4()),
@@ -59,11 +59,11 @@ async fn poll_skips_already_pinned_vm() {
     )
     .await
     .expect("first poll")
-    .expect("instances available");
+    .expect("workloads available");
     assert_eq!(result.len().get(), 1);
 
     // Second poll should find nothing.
-    let result = waymark_workload_pinning_backend::PollUnpinnedInstances::poll_unlocked(
+    let result = waymark_workload_pinning_backend::PollUnpinnedWorkloads::poll_unpinned(
         &backend,
         test_now(),
         test_pinning(Uuid::new_v4()),
@@ -80,23 +80,23 @@ async fn poll_picks_up_expired_pinning() {
     let node_id = Uuid::new_v4();
     let (vm_id, _executable_id) = register_test_vm(&backend).await;
 
-    // Claim with a short expiry.
+    // Pin with a short expiry.
     let short_pinning = waymark_workload_pinning_backend::Pinning {
         node_id,
         expires_at: test_now() - Duration::seconds(1),
     };
-    waymark_workload_pinning_backend::PollUnpinnedInstances::poll_unlocked(
+    waymark_workload_pinning_backend::PollUnpinnedWorkloads::poll_unpinned(
         &backend,
         test_now(),
         short_pinning,
         test_max_items(),
     )
     .await
-    .expect("claim with short expiry")
-    .expect("instances available");
+    .expect("pin with short expiry")
+    .expect("workloads available");
 
     // Now poll — the expired pinning should be picked up.
-    let result = waymark_workload_pinning_backend::PollUnpinnedInstances::poll_unlocked(
+    let result = waymark_workload_pinning_backend::PollUnpinnedWorkloads::poll_unpinned(
         &backend,
         test_now(),
         test_pinning(node_id),
@@ -104,7 +104,7 @@ async fn poll_picks_up_expired_pinning() {
     )
     .await
     .expect("poll after expiry")
-    .expect("instances available");
+    .expect("workloads available");
     let ids: Vec<InstanceId> = result.into_iter().collect();
     assert_eq!(ids, vec![vm_id]);
 }
@@ -116,27 +116,27 @@ async fn refresh_updates_expiry() {
     let node_id = Uuid::new_v4();
     let (vm_id, _executable_id) = register_test_vm(&backend).await;
 
-    // Claim the VM.
+    // Pin the VM.
     let original_pinning = waymark_workload_pinning_backend::Pinning {
         node_id,
         expires_at: test_now() + Duration::seconds(10),
     };
-    waymark_workload_pinning_backend::PollUnpinnedInstances::poll_unlocked(
+    waymark_workload_pinning_backend::PollUnpinnedWorkloads::poll_unpinned(
         &backend,
         test_now(),
         original_pinning,
         test_max_items(),
     )
     .await
-    .expect("claim vm")
-    .expect("instances available");
+    .expect("pin vm")
+    .expect("workloads available");
 
     // Refresh with a later expiry.
     let new_pinning = waymark_workload_pinning_backend::Pinning {
         node_id,
         expires_at: test_now() + Duration::seconds(60),
     };
-    let statuses = waymark_workload_pinning_backend::KeepaliveInstancePinnings::refresh_pinnings(
+    let statuses = waymark_workload_pinning_backend::KeepalivePinnings::refresh_pinnings(
         &backend,
         test_now(),
         new_pinning,
@@ -156,21 +156,21 @@ async fn refresh_re_fences_expired_but_still_owned_pinning() {
     let node_id = Uuid::new_v4();
     let (vm_id, _executable_id) = register_test_vm(&backend).await;
 
-    // Claim the VM with an already-lapsed expiry, but let nobody steal it —
+    // Pin the VM with an already-lapsed expiry, but let nobody steal it —
     // the pinning is expired yet still owned by this node.
     let expired_pinning = waymark_workload_pinning_backend::Pinning {
         node_id,
         expires_at: test_now() - Duration::seconds(1),
     };
-    waymark_workload_pinning_backend::PollUnpinnedInstances::poll_unlocked(
+    waymark_workload_pinning_backend::PollUnpinnedWorkloads::poll_unpinned(
         &backend,
         test_now(),
         expired_pinning,
         test_max_items(),
     )
     .await
-    .expect("claim vm")
-    .expect("instances available");
+    .expect("pin vm")
+    .expect("workloads available");
 
     // A late heartbeat must still be able to re-fence it, since ownership was
     // never contested.
@@ -178,7 +178,7 @@ async fn refresh_re_fences_expired_but_still_owned_pinning() {
         node_id,
         expires_at: test_now() + Duration::seconds(60),
     };
-    let statuses = waymark_workload_pinning_backend::KeepaliveInstancePinnings::refresh_pinnings(
+    let statuses = waymark_workload_pinning_backend::KeepalivePinnings::refresh_pinnings(
         &backend,
         test_now(),
         renewed_pinning,
@@ -189,8 +189,8 @@ async fn refresh_re_fences_expired_but_still_owned_pinning() {
     assert!(statuses.first().pinning.is_some());
 
     // Re-fenced with the future expiry, so a subsequent poll can no longer
-    // claim it.
-    let poll = waymark_workload_pinning_backend::PollUnpinnedInstances::poll_unlocked(
+    // pin it.
+    let poll = waymark_workload_pinning_backend::PollUnpinnedWorkloads::poll_unpinned(
         &backend,
         test_now(),
         test_pinning(Uuid::new_v4()),
@@ -208,34 +208,34 @@ async fn refresh_returns_none_for_lost_pinning() {
     let node_b = Uuid::new_v4();
     let (vm_id, _executable_id) = register_test_vm(&backend).await;
 
-    // Node A claims the VM with a short expiry.
+    // Node A pins the VM with a short expiry.
     let short_pinning = waymark_workload_pinning_backend::Pinning {
         node_id: node_a,
         expires_at: test_now() - Duration::seconds(1),
     };
-    waymark_workload_pinning_backend::PollUnpinnedInstances::poll_unlocked(
+    waymark_workload_pinning_backend::PollUnpinnedWorkloads::poll_unpinned(
         &backend,
         test_now(),
         short_pinning,
         test_max_items(),
     )
     .await
-    .expect("node a claim")
-    .expect("instances available");
+    .expect("node a pin")
+    .expect("workloads available");
 
     // Node B steals it.
-    waymark_workload_pinning_backend::PollUnpinnedInstances::poll_unlocked(
+    waymark_workload_pinning_backend::PollUnpinnedWorkloads::poll_unpinned(
         &backend,
         test_now(),
         test_pinning(node_b),
         test_max_items(),
     )
     .await
-    .expect("node b claim")
-    .expect("instances available");
+    .expect("node b pin")
+    .expect("workloads available");
 
     // Node A tries to refresh — should get None.
-    let statuses = waymark_workload_pinning_backend::KeepaliveInstancePinnings::refresh_pinnings(
+    let statuses = waymark_workload_pinning_backend::KeepalivePinnings::refresh_pinnings(
         &backend,
         test_now(),
         test_pinning(node_a),
@@ -254,16 +254,16 @@ async fn refresh_returns_mixed_statuses_for_refreshed_and_lost() {
     let (vm_a, _executable_a) = register_test_vm(&backend).await;
     let (vm_b, _executable_b) = register_test_vm(&backend).await;
 
-    // Claim both VMs.
-    waymark_workload_pinning_backend::PollUnpinnedInstances::poll_unlocked(
+    // Pin both VMs.
+    waymark_workload_pinning_backend::PollUnpinnedWorkloads::poll_unpinned(
         &backend,
         test_now(),
         test_pinning(node_id),
         NonZeroUsize::new(5).unwrap(),
     )
     .await
-    .expect("claim both vms")
-    .expect("instances available");
+    .expect("pin both vms")
+    .expect("workloads available");
 
     // Release vm_b so it loses its pinning.
     waymark_workload_pinning_backend::ReleasePinnings::release_pinnings(
@@ -277,7 +277,7 @@ async fn refresh_returns_mixed_statuses_for_refreshed_and_lost() {
     // Refresh both — vm_a should stay pinned, vm_b should be None.
     let mut ids = nonempty_collections::NEVec::new(vm_a);
     ids.push(vm_b);
-    let statuses = waymark_workload_pinning_backend::KeepaliveInstancePinnings::refresh_pinnings(
+    let statuses = waymark_workload_pinning_backend::KeepalivePinnings::refresh_pinnings(
         &backend,
         test_now(),
         test_pinning(node_id),
@@ -289,7 +289,7 @@ async fn refresh_returns_mixed_statuses_for_refreshed_and_lost() {
     assert_eq!(statuses.len().get(), 2);
     let by_id: std::collections::HashMap<_, _> = statuses
         .into_iter()
-        .map(|s| (s.instance_id, s.pinning))
+        .map(|s| (s.workload_id, s.pinning))
         .collect();
     assert!(by_id[&vm_a].is_some());
     assert!(by_id[&vm_b].is_none());
@@ -302,16 +302,16 @@ async fn release_clears_pinning() {
     let node_id = Uuid::new_v4();
     let (vm_id, _executable_id) = register_test_vm(&backend).await;
 
-    // Claim the VM.
-    waymark_workload_pinning_backend::PollUnpinnedInstances::poll_unlocked(
+    // Pin the VM.
+    waymark_workload_pinning_backend::PollUnpinnedWorkloads::poll_unpinned(
         &backend,
         test_now(),
         test_pinning(node_id),
         test_max_items(),
     )
     .await
-    .expect("claim vm")
-    .expect("instances available");
+    .expect("pin vm")
+    .expect("workloads available");
 
     // Release it.
     waymark_workload_pinning_backend::ReleasePinnings::release_pinnings(
@@ -323,7 +323,7 @@ async fn release_clears_pinning() {
     .expect("release pinning");
 
     // Poll again — should pick it up since it's released.
-    let result = waymark_workload_pinning_backend::PollUnpinnedInstances::poll_unlocked(
+    let result = waymark_workload_pinning_backend::PollUnpinnedWorkloads::poll_unpinned(
         &backend,
         test_now(),
         test_pinning(node_id),
@@ -331,7 +331,7 @@ async fn release_clears_pinning() {
     )
     .await
     .expect("poll after release")
-    .expect("instances available");
+    .expect("workloads available");
     let ids: Vec<InstanceId> = result.into_iter().collect();
     assert_eq!(ids, vec![vm_id]);
 }
@@ -348,7 +348,7 @@ async fn deregister_removes_vm_from_poll() {
         .await
         .expect("delete vm runtime snapshot");
 
-    let result = waymark_workload_pinning_backend::PollUnpinnedInstances::poll_unlocked(
+    let result = waymark_workload_pinning_backend::PollUnpinnedWorkloads::poll_unpinned(
         &backend,
         test_now(),
         test_pinning(Uuid::new_v4()),

--- a/crates/lib/execution-bringup/src/lib.rs
+++ b/crates/lib/execution-bringup/src/lib.rs
@@ -18,7 +18,7 @@ use waymark_worker_core::{BaseWorkerPool, WorkerPoolError};
 
 /// Configuration for [`start`].
 pub struct Config<NodeId> {
-    /// The node identifier for this executor instance.
+    /// The identifier of this node.
     ///
     /// Also the identity this process owns action-call request locks
     /// under.
@@ -92,7 +92,7 @@ pub struct Handles {
 /// in that case.
 ///
 /// `shutdown_token` requests a graceful stop — new workloads are refused while
-/// the maintenance loop keeps running until all active instances drain.
+/// the maintenance loop keeps running until all active workloads drain.
 /// `force_shutdown_token` breaks out of that drain immediately, so shutdown
 /// can't hang forever on a workload that never evicts.
 pub async fn start<Backend, WorkerPool>(
@@ -103,8 +103,8 @@ pub async fn start<Backend, WorkerPool>(
     force_shutdown_token: CancellationToken,
 ) -> Result<Handles, WorkerPoolError>
 where
-    Backend: waymark_workload_pinning_backend::PollUnpinnedInstances,
-    Backend: waymark_workload_pinning_backend::KeepaliveInstancePinnings,
+    Backend: waymark_workload_pinning_backend::PollUnpinnedWorkloads,
+    Backend: waymark_workload_pinning_backend::KeepalivePinnings,
     Backend: waymark_workload_pinning_backend::ReleasePinnings,
     Backend:
         waymark_workload_pinning_backend::HasTimestamp<Timestamp = chrono::DateTime<chrono::Utc>>,
@@ -112,8 +112,8 @@ where
     <Backend as waymark_state_vm_executables_backend::LoadExecutable>::Error: Send + 'static,
     Backend: Send + Sync + 'static,
     Backend::NodeId: Clone + Send + Sync + 'static,
-    Backend: waymark_workload_pinning_backend::HasInstanceId<
-            InstanceId = <Backend as waymark_state_vm_runtimes_backend::HasVmId>::VmId,
+    Backend: waymark_workload_pinning_backend::HasWorkloadId<
+            WorkloadId = <Backend as waymark_state_vm_runtimes_backend::HasVmId>::VmId,
         >,
     Backend: waymark_state_vm_runtimes_backend::HasVmId<VmId = waymark_ids::InstanceId>,
     <Backend as waymark_state_vm_runtimes_backend::HasVmId>::VmId:
@@ -154,8 +154,8 @@ where
     Backend: waymark_workflow_completion_backend::HasVmId<
             VmId = <Backend as waymark_state_vm_runtimes_backend::HasVmId>::VmId,
         >,
-    <Backend as waymark_workload_pinning_backend::PollUnpinnedInstances>::Error: Send,
-    <Backend as waymark_workload_pinning_backend::KeepaliveInstancePinnings>::Error: Send,
+    <Backend as waymark_workload_pinning_backend::PollUnpinnedWorkloads>::Error: Send,
+    <Backend as waymark_workload_pinning_backend::KeepalivePinnings>::Error: Send,
     <Backend as waymark_workload_pinning_backend::ReleasePinnings>::Error: Send,
     <Backend as waymark_state_vm_runtimes_backend::StoreSnapshot>::Error: Send + 'static,
     <Backend as waymark_state_vm_runtimes_backend::LoadForRevive>::Error: Send + 'static,

--- a/crates/lib/workload-pinning-backend/src/common.rs
+++ b/crates/lib/workload-pinning-backend/src/common.rs
@@ -12,30 +12,30 @@ pub trait HasNodeId {
     type NodeId;
 }
 
-/// Shared Instance ID type used across all backend traits.
-pub trait HasInstanceId {
-    /// The Instance ID used by this backend.
-    type InstanceId;
+/// Shared Workload ID type used across all backend traits.
+pub trait HasWorkloadId {
+    /// The Workload ID used by this backend.
+    type WorkloadId;
 }
 
-/// The pinning to apply.
+/// A node's hold on a workload.
 #[derive(Clone, Debug)]
 pub struct Pinning<NodeId, Timestamp> {
     /// The id of the node owning this pinning.
     pub node_id: NodeId,
 
-    /// Timestamp at which this claim stops being valid unless refreshed.
+    /// Timestamp at which this pinning stops being valid unless refreshed.
     pub expires_at: Timestamp,
 }
 
-/// The status of the instance pinning.
+/// The status of the workload pinning.
 #[derive(Clone, Debug)]
-pub struct PinningStatus<InstanceId, Pinning> {
-    /// Instance this pinning status is for.
-    pub instance_id: InstanceId,
+pub struct PinningStatus<WorkloadId, Pinning> {
+    /// Workload this pinning status is for.
+    pub workload_id: WorkloadId,
 
-    /// Current pinning after the operation, or `None` if the instance
-    /// is unpinned.
+    /// Current pinning after the operation, or `None` if the operating
+    /// node no longer holds a pinning on the workload.
     pub pinning: Option<Pinning>,
 }
 
@@ -45,4 +45,4 @@ pub type PinningFor<T> =
 
 /// Shorthand for a [`PinningStatus`] using the associated types of `T`.
 pub type PinningStatusFor<T> =
-    PinningStatus<<T as crate::HasInstanceId>::InstanceId, PinningFor<T>>;
+    PinningStatus<<T as crate::HasWorkloadId>::WorkloadId, PinningFor<T>>;

--- a/crates/lib/workload-pinning-backend/src/keepalive.rs
+++ b/crates/lib/workload-pinning-backend/src/keepalive.rs
@@ -1,19 +1,19 @@
-//! Keepalive (refresh) pinnings on instances.
+//! Keepalive (refresh) pinnings on workloads.
 
 use nonempty_collections::{IntoNonEmptyIterator, NEVec};
 
-use crate::{HasInstanceId, HasNodeId, HasTimestamp, PinningFor, PinningStatusFor};
+use crate::{HasNodeId, HasTimestamp, HasWorkloadId, PinningFor, PinningStatusFor};
 
-/// The ability to maintain pins on instances.
-pub trait KeepaliveInstancePinnings: HasNodeId + HasInstanceId + HasTimestamp {
+/// The ability to maintain pinnings on workloads.
+pub trait KeepalivePinnings: HasNodeId + HasWorkloadId + HasTimestamp {
     /// Error returned when refreshing pinning fails.
     type Error: std::fmt::Debug;
 
-    /// Refresh pinning expiry for owned instances.
+    /// Refresh pinning expiry for owned workloads.
     fn refresh_pinnings<'a>(
         &'a self,
         now: Self::Timestamp,
         pinning: PinningFor<Self>,
-        instance_ids: impl IntoNonEmptyIterator<Item = Self::InstanceId> + 'a,
+        workload_ids: impl IntoNonEmptyIterator<Item = Self::WorkloadId> + 'a,
     ) -> impl Future<Output = Result<NEVec<PinningStatusFor<Self>>, Self::Error>> + Send + 'a;
 }

--- a/crates/lib/workload-pinning-backend/src/lib.rs
+++ b/crates/lib/workload-pinning-backend/src/lib.rs
@@ -15,11 +15,11 @@ pub mod release;
 
 pub use self::common::*;
 
-pub use self::keepalive::KeepaliveInstancePinnings;
-pub use self::poll::PollUnpinnedInstances;
+pub use self::keepalive::KeepalivePinnings;
+pub use self::poll::PollUnpinnedWorkloads;
 pub use self::release::ReleasePinnings;
 
 /// All workload pinning backend traits.
-pub trait Backend: PollUnpinnedInstances + KeepaliveInstancePinnings + ReleasePinnings {}
+pub trait Backend: PollUnpinnedWorkloads + KeepalivePinnings + ReleasePinnings {}
 
-impl<T> Backend for T where T: PollUnpinnedInstances + KeepaliveInstancePinnings + ReleasePinnings {}
+impl<T> Backend for T where T: PollUnpinnedWorkloads + KeepalivePinnings + ReleasePinnings {}

--- a/crates/lib/workload-pinning-backend/src/poll.rs
+++ b/crates/lib/workload-pinning-backend/src/poll.rs
@@ -1,30 +1,31 @@
-//! Poll for unpinned instances.
+//! Poll for unpinned workloads.
 
 use std::num::NonZeroUsize;
 
 use nonempty_collections::NEVec;
 
-use crate::{HasInstanceId, HasNodeId, HasTimestamp, PinningFor};
+use crate::{HasNodeId, HasTimestamp, HasWorkloadId, PinningFor};
 
-/// The ability to poll and pin the instances that are present in
-/// the system but are not pinned to a particular node, effectively claiming
-/// them.
-pub trait PollUnpinnedInstances: HasTimestamp + HasNodeId + HasInstanceId {
+/// The ability to poll and pin the workloads that no node effectively
+/// holds: those that are not pinned to any node, and those whose pinning
+/// expired without a refresh. Polling takes such workloads over, pinning
+/// them to the polling node.
+pub trait PollUnpinnedWorkloads: HasTimestamp + HasNodeId + HasWorkloadId {
     /// An error that can occur while polling.
     type Error: std::fmt::Debug;
 
-    /// Return up to `max_items` instances without blocking.
+    /// Return up to `max_items` workloads without blocking.
     ///
-    /// Instances are guaranteed to be freshly pinned with
+    /// Workloads are guaranteed to be freshly pinned with
     /// the provided `pinning`.
     ///
     /// `now` is used for expiration checks of stale pinnings.
     ///
-    /// Returns `Ok(None)` if no instances were available.
-    fn poll_unlocked(
+    /// Returns `Ok(None)` if no workloads were available.
+    fn poll_unpinned(
         &self,
         now: Self::Timestamp,
         pinning: PinningFor<Self>,
         max_items: NonZeroUsize,
-    ) -> impl Future<Output = Result<Option<NEVec<Self::InstanceId>>, Self::Error>> + Send + '_;
+    ) -> impl Future<Output = Result<Option<NEVec<Self::WorkloadId>>, Self::Error>> + Send + '_;
 }

--- a/crates/lib/workload-pinning-backend/src/release.rs
+++ b/crates/lib/workload-pinning-backend/src/release.rs
@@ -1,18 +1,18 @@
-//! Release pinnings from instances.
+//! Release pinnings from workloads.
 
 use nonempty_collections::IntoNonEmptyIterator;
 
-use crate::{HasInstanceId, HasNodeId};
+use crate::{HasNodeId, HasWorkloadId};
 
-/// The ability to release held pinnings on workload queue entries.
-pub trait ReleasePinnings: HasNodeId + HasInstanceId {
+/// The ability to release held pinnings on workloads.
+pub trait ReleasePinnings: HasNodeId + HasWorkloadId {
     /// Error returned when releasing pinning fails.
     type Error: std::fmt::Debug;
 
-    /// Release instance pinnings when evicting workloads.
+    /// Release workload pinnings when evicting workloads.
     fn release_pinnings<'a>(
         &'a self,
         node_id: Self::NodeId,
-        instance_ids: impl IntoNonEmptyIterator<Item = Self::InstanceId> + 'a,
+        workload_ids: impl IntoNonEmptyIterator<Item = Self::WorkloadId> + 'a,
     ) -> impl Future<Output = Result<(), Self::Error>> + Send + 'a;
 }

--- a/crates/lib/workload-pinning-manager/src/lib.rs
+++ b/crates/lib/workload-pinning-manager/src/lib.rs
@@ -30,14 +30,14 @@ use waymark_nonzero_duration::NonZeroDuration;
 pub struct Params<Backend>
 where
     Backend: waymark_workload_pinning_backend::HasNodeId,
-    Backend: waymark_workload_pinning_backend::HasInstanceId,
+    Backend: waymark_workload_pinning_backend::HasWorkloadId,
 {
     /// Token to signal graceful shutdown of the poll loop.
     ///
     /// Cancelling this token stops accepting new workloads (polling ceases)
     /// while in-flight work is allowed to complete naturally — the
     /// maintenance loop keeps heartbeating and processing evictions
-    /// until all active instances drain.
+    /// until all active workloads drain.
     ///
     /// For an immediate stop of everything, use
     /// [`force_shutdown_token`](Params::force_shutdown_token).
@@ -55,11 +55,11 @@ where
     /// Backend for database operations (poll, pin, unpin).
     pub backend: Arc<Backend>,
 
-    /// The node identifier for this executor instance.
+    /// The identifier of this node.
     pub node_id: Backend::NodeId,
 
     /// Channel for sending newly pinned handles to external consumers.
-    pub pinned_tx: tokio::sync::mpsc::Sender<NEVec<PinnedHandle<Backend::InstanceId>>>,
+    pub pinned_tx: tokio::sync::mpsc::Sender<NEVec<PinnedHandle<Backend::WorkloadId>>>,
 
     /// Maximum number of workloads to run concurrently.
     pub max_pinned: NonZeroUsize,
@@ -80,16 +80,15 @@ pub async fn run<Backend>(params: Params<Backend>) -> RunOutcomeFor<Backend>
 where
     Backend:
         waymark_workload_pinning_backend::HasTimestamp<Timestamp = chrono::DateTime<chrono::Utc>>,
-    Backend: waymark_workload_pinning_backend::PollUnpinnedInstances,
-    Backend: waymark_workload_pinning_backend::KeepaliveInstancePinnings,
+    Backend: waymark_workload_pinning_backend::PollUnpinnedWorkloads,
+    Backend: waymark_workload_pinning_backend::KeepalivePinnings,
     Backend: waymark_workload_pinning_backend::ReleasePinnings,
     Backend: Send + Sync + 'static,
-    <Backend as waymark_workload_pinning_backend::PollUnpinnedInstances>::Error: std::fmt::Debug,
-    <Backend as waymark_workload_pinning_backend::KeepaliveInstancePinnings>::Error:
-        std::fmt::Debug,
+    <Backend as waymark_workload_pinning_backend::PollUnpinnedWorkloads>::Error: std::fmt::Debug,
+    <Backend as waymark_workload_pinning_backend::KeepalivePinnings>::Error: std::fmt::Debug,
     <Backend as waymark_workload_pinning_backend::ReleasePinnings>::Error: std::fmt::Debug,
     Backend::NodeId: Clone,
-    Backend::InstanceId: Clone + std::hash::Hash + Eq,
+    Backend::WorkloadId: Clone + std::hash::Hash + Eq,
 {
     let Params {
         shutdown_token,
@@ -113,7 +112,7 @@ where
 
     // Poll → Maintain: dispatch newly-pinned IDs with a oneshot to get back the count.
     let (batch_tx, batch_rx) = tokio::sync::mpsc::channel::<(
-        NEVec<Backend::InstanceId>,
+        NEVec<Backend::WorkloadId>,
         tokio::sync::oneshot::Sender<usize>,
     )>(1);
     // Maintain → Poll: push updated count after evictions.

--- a/crates/lib/workload-pinning-manager/src/maintenance/error.rs
+++ b/crates/lib/workload-pinning-manager/src/maintenance/error.rs
@@ -18,6 +18,6 @@ pub enum MaintenanceError<KeepaliveError, ReleaseError> {
 
 /// Convenience alias for [`MaintenanceError`] parameterized on a backend.
 pub type MaintenanceErrorFor<Backend> = MaintenanceError<
-    <Backend as waymark_workload_pinning_backend::KeepaliveInstancePinnings>::Error,
+    <Backend as waymark_workload_pinning_backend::KeepalivePinnings>::Error,
     <Backend as waymark_workload_pinning_backend::ReleasePinnings>::Error,
 >;

--- a/crates/lib/workload-pinning-manager/src/maintenance/mod.rs
+++ b/crates/lib/workload-pinning-manager/src/maintenance/mod.rs
@@ -6,8 +6,8 @@
 //! Work exists whenever **either** condition holds:
 //!
 //! - `batch_rx` is still open — the poll loop is alive and may dispatch
-//!   newly-pinned instance IDs at any time.
-//! - `active_ids` is non-empty — there are in-flight instances whose
+//!   newly-pinned workload IDs at any time.
+//! - `active_ids` is non-empty — there are in-flight workloads whose
 //!   pinnings must be refreshed and whose evictions must be processed.
 //!
 //! The **terminal state** is reached when **both** conditions are false:
@@ -47,15 +47,15 @@ use waymark_nonzero_duration::NonZeroDuration;
 pub(super) struct MaintainParams<Backend>
 where
     Backend: waymark_workload_pinning_backend::HasNodeId,
-    Backend: waymark_workload_pinning_backend::HasInstanceId,
+    Backend: waymark_workload_pinning_backend::HasWorkloadId,
 {
     pub backend: Arc<Backend>,
     pub node_id: Backend::NodeId,
     pub batch_rx: tokio::sync::mpsc::Receiver<(
-        NEVec<Backend::InstanceId>,
+        NEVec<Backend::WorkloadId>,
         tokio::sync::oneshot::Sender<usize>,
     )>,
-    pub evict_rx: tokio::sync::mpsc::UnboundedReceiver<Backend::InstanceId>,
+    pub evict_rx: tokio::sync::mpsc::UnboundedReceiver<Backend::WorkloadId>,
     pub count_tx: tokio::sync::mpsc::UnboundedSender<usize>,
     pub shutdown_token: CancellationToken,
     pub pinning_heartbeat: NonZeroDuration,
@@ -64,15 +64,15 @@ where
 
 pub(super) async fn run_maintenance_loop<Backend>(
     params: MaintainParams<Backend>,
-) -> Result<(), (MaintenanceErrorFor<Backend>, HashSet<Backend::InstanceId>)>
+) -> Result<(), (MaintenanceErrorFor<Backend>, HashSet<Backend::WorkloadId>)>
 where
-    Backend: waymark_workload_pinning_backend::PollUnpinnedInstances,
-    Backend: waymark_workload_pinning_backend::KeepaliveInstancePinnings<
+    Backend: waymark_workload_pinning_backend::PollUnpinnedWorkloads,
+    Backend: waymark_workload_pinning_backend::KeepalivePinnings<
             Timestamp = chrono::DateTime<chrono::Utc>,
         >,
     Backend: waymark_workload_pinning_backend::ReleasePinnings,
     Backend::NodeId: Clone,
-    Backend::InstanceId: Clone + std::hash::Hash + Eq,
+    Backend::WorkloadId: Clone + std::hash::Hash + Eq,
 {
     let MaintainParams {
         backend,
@@ -85,7 +85,7 @@ where
         pinning_ttl,
     } = params;
 
-    let mut active_ids: HashSet<Backend::InstanceId> = HashSet::new();
+    let mut active_ids: HashSet<Backend::WorkloadId> = HashSet::new();
     let mut poll_exited = false;
     let shutdown = shutdown_token.child_token().cancelled_owned();
     let mut shutdown = std::pin::pin!(shutdown);
@@ -152,11 +152,11 @@ pub(super) async fn refresh_active_pinnings<Backend>(
     backend: &Backend,
     now: chrono::DateTime<chrono::Utc>,
     node_id: Backend::NodeId,
-    ids: impl nonempty_collections::IntoNonEmptyIterator<Item = Backend::InstanceId>,
+    ids: impl nonempty_collections::IntoNonEmptyIterator<Item = Backend::WorkloadId>,
     pinning_ttl: NonZeroDuration,
-) -> Result<(), <Backend as waymark_workload_pinning_backend::KeepaliveInstancePinnings>::Error>
+) -> Result<(), <Backend as waymark_workload_pinning_backend::KeepalivePinnings>::Error>
 where
-    Backend: waymark_workload_pinning_backend::KeepaliveInstancePinnings<
+    Backend: waymark_workload_pinning_backend::KeepalivePinnings<
             Timestamp = chrono::DateTime<chrono::Utc>,
         >,
 {

--- a/crates/lib/workload-pinning-manager/src/maintenance/tests.rs
+++ b/crates/lib/workload-pinning-manager/src/maintenance/tests.rs
@@ -70,7 +70,7 @@ async fn maintain_loop_continues_until_last_eviction_after_batch_closed() {
         .returning(move |_, _, _| {
             let pinning = test_pinning(node_id, 1);
             Box::pin(std::future::ready(Ok(nev![PinningStatus {
-                instance_id: id,
+                workload_id: id,
                 pinning: Some(pinning),
             }])))
         });
@@ -148,7 +148,7 @@ async fn maintain_loop_heartbeats_fire_for_active_ids() {
         .returning(move |_, _, _| {
             refresh_tx.send(()).ok();
             Box::pin(std::future::ready(Ok(nev![PinningStatus {
-                instance_id: id,
+                workload_id: id,
                 pinning: Some(pinning.clone()),
             }])))
         });
@@ -240,7 +240,7 @@ async fn maintain_loop_heartbeats_after_batch_closed() {
         .returning(move |_, _, _| {
             refresh_tx.send(()).ok();
             Box::pin(std::future::ready(Ok(nev![PinningStatus {
-                instance_id: id,
+                workload_id: id,
                 pinning: Some(pinning.clone()),
             }])))
         });
@@ -317,7 +317,7 @@ async fn manager_refreshes_pinnings_on_active_vms() {
 
     let mut backend = MockBackend::new();
     backend
-        .expect_poll_unlocked()
+        .expect_poll_unpinned()
         .with(
             predicate::always(),
             predicate::always(),
@@ -334,7 +334,7 @@ async fn manager_refreshes_pinnings_on_active_vms() {
         .return_once(move |_, _, _| {
             let pinning = test_pinning(test_node_id(), 1);
             let statuses = nev![PinningStatus {
-                instance_id: id,
+                workload_id: id,
                 pinning: Some(pinning),
             }];
             Box::pin(std::future::ready(Ok(statuses)))
@@ -348,7 +348,7 @@ async fn manager_refreshes_pinnings_on_active_vms() {
     )
     .await
     .expect("poll and pin")
-    .expect("instances available");
+    .expect("workloads available");
 
     refresh_active_pinnings(
         &backend,
@@ -367,7 +367,7 @@ async fn refresh_pinnings_propagates_error() {
 
     let mut backend = MockBackend::new();
     backend
-        .expect_poll_unlocked()
+        .expect_poll_unpinned()
         .with(
             predicate::always(),
             predicate::always(),
@@ -393,7 +393,7 @@ async fn refresh_pinnings_propagates_error() {
     )
     .await
     .expect("poll and pin")
-    .expect("instances available");
+    .expect("workloads available");
 
     let result = refresh_active_pinnings(
         &backend,
@@ -427,7 +427,7 @@ async fn maintain_loop_exits_on_release_error() {
         .returning(move |_, _, _| {
             let pinning = test_pinning(node_id, 1);
             Box::pin(std::future::ready(Ok(nev![PinningStatus {
-                instance_id: id,
+                workload_id: id,
                 pinning: Some(pinning),
             }])))
         });
@@ -503,7 +503,7 @@ async fn maintain_loop_exits_on_force_shutdown() {
         .returning(move |_, _, _| {
             let pinning = test_pinning(node_id, 1);
             Box::pin(std::future::ready(Ok(nev![PinningStatus {
-                instance_id: id,
+                workload_id: id,
                 pinning: Some(pinning),
             }])))
         });

--- a/crates/lib/workload-pinning-manager/src/outcome.rs
+++ b/crates/lib/workload-pinning-manager/src/outcome.rs
@@ -25,8 +25,8 @@ pub struct RunOutcome<PollError, KeepaliveError, ReleaseError> {
 
 /// Convenience alias for [`RunOutcome`] parameterized on a backend.
 pub type RunOutcomeFor<Backend> = RunOutcome<
-    <Backend as waymark_workload_pinning_backend::PollUnpinnedInstances>::Error,
-    <Backend as waymark_workload_pinning_backend::KeepaliveInstancePinnings>::Error,
+    <Backend as waymark_workload_pinning_backend::PollUnpinnedWorkloads>::Error,
+    <Backend as waymark_workload_pinning_backend::KeepalivePinnings>::Error,
     <Backend as waymark_workload_pinning_backend::ReleasePinnings>::Error,
 >;
 

--- a/crates/lib/workload-pinning-manager/src/pinned_handle.rs
+++ b/crates/lib/workload-pinning-manager/src/pinned_handle.rs
@@ -1,22 +1,22 @@
-//! Handle for a pinned instance.
+//! Handle for a pinned workload.
 //!
 //! See [`PinnedHandle`].
 
-/// A handle to a pinned instance.
+/// A handle to a pinned workload.
 ///
-/// When dropped, the instance ID is sent back to the workload manager
+/// When dropped, the workload ID is sent back to the workload manager
 /// for unpinning.
 #[must_use]
-pub struct PinnedHandle<InstanceId> {
-    id: Option<InstanceId>,
-    evict_tx: tokio::sync::mpsc::UnboundedSender<InstanceId>,
+pub struct PinnedHandle<WorkloadId> {
+    id: Option<WorkloadId>,
+    evict_tx: tokio::sync::mpsc::UnboundedSender<WorkloadId>,
 }
 
-impl<InstanceId> PinnedHandle<InstanceId> {
+impl<WorkloadId> PinnedHandle<WorkloadId> {
     /// Create a new pinned handle.
     pub(crate) fn new(
-        id: InstanceId,
-        evict_tx: tokio::sync::mpsc::UnboundedSender<InstanceId>,
+        id: WorkloadId,
+        evict_tx: tokio::sync::mpsc::UnboundedSender<WorkloadId>,
     ) -> Self {
         Self {
             id: Some(id),
@@ -24,14 +24,14 @@ impl<InstanceId> PinnedHandle<InstanceId> {
         }
     }
 
-    /// Return a reference to the wrapped instance ID.
-    pub fn id(&self) -> &InstanceId {
+    /// Return a reference to the wrapped workload ID.
+    pub fn id(&self) -> &WorkloadId {
         // SAFETY: `PinnedHandle` is not dropped, so the `id` must be present.
         unsafe { self.id.as_ref().unwrap_unchecked() }
     }
 }
 
-impl<InstanceId> Drop for PinnedHandle<InstanceId> {
+impl<WorkloadId> Drop for PinnedHandle<WorkloadId> {
     fn drop(&mut self) {
         if let Some(id) = self.id.take() {
             let _ = self.evict_tx.send(id);
@@ -39,7 +39,7 @@ impl<InstanceId> Drop for PinnedHandle<InstanceId> {
     }
 }
 
-impl<InstanceId: std::fmt::Debug> std::fmt::Debug for PinnedHandle<InstanceId> {
+impl<WorkloadId: std::fmt::Debug> std::fmt::Debug for PinnedHandle<WorkloadId> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("PinnedHandle")
             .field("id", self.id())

--- a/crates/lib/workload-pinning-manager/src/poll/error.rs
+++ b/crates/lib/workload-pinning-manager/src/poll/error.rs
@@ -23,4 +23,4 @@ pub enum PollLoopError<PollError> {
 
 /// Convenience alias for [`PollLoopError`] parameterized on a backend.
 pub type PollLoopErrorFor<Backend> =
-    PollLoopError<<Backend as waymark_workload_pinning_backend::PollUnpinnedInstances>::Error>;
+    PollLoopError<<Backend as waymark_workload_pinning_backend::PollUnpinnedWorkloads>::Error>;

--- a/crates/lib/workload-pinning-manager/src/poll/mod.rs
+++ b/crates/lib/workload-pinning-manager/src/poll/mod.rs
@@ -1,4 +1,4 @@
-//! Poll loop — polls for unpinned instances and dispatches handles.
+//! Poll loop — polls for unpinned workloads and dispatches handles.
 
 mod error;
 
@@ -18,14 +18,14 @@ use crate::PinnedHandle;
 pub(super) struct PollParams<Backend>
 where
     Backend: waymark_workload_pinning_backend::HasNodeId,
-    Backend: waymark_workload_pinning_backend::HasInstanceId,
+    Backend: waymark_workload_pinning_backend::HasWorkloadId,
 {
     pub backend: Arc<Backend>,
     pub node_id: Backend::NodeId,
-    pub pinned_tx: tokio::sync::mpsc::Sender<NEVec<PinnedHandle<Backend::InstanceId>>>,
-    pub evict_tx: tokio::sync::mpsc::UnboundedSender<Backend::InstanceId>,
+    pub pinned_tx: tokio::sync::mpsc::Sender<NEVec<PinnedHandle<Backend::WorkloadId>>>,
+    pub evict_tx: tokio::sync::mpsc::UnboundedSender<Backend::WorkloadId>,
     pub batch_tx: tokio::sync::mpsc::Sender<(
-        NEVec<Backend::InstanceId>,
+        NEVec<Backend::WorkloadId>,
         tokio::sync::oneshot::Sender<usize>,
     )>,
     pub count_rx: tokio::sync::mpsc::UnboundedReceiver<usize>,
@@ -38,12 +38,12 @@ pub(super) async fn run_poll_loop<Backend>(
     params: PollParams<Backend>,
 ) -> Result<(), PollLoopErrorFor<Backend>>
 where
-    Backend: waymark_workload_pinning_backend::PollUnpinnedInstances<
+    Backend: waymark_workload_pinning_backend::PollUnpinnedWorkloads<
             Timestamp = chrono::DateTime<chrono::Utc>,
         >,
     Backend: waymark_workload_pinning_backend::HasTimestamp,
     Backend::NodeId: Clone,
-    Backend::InstanceId: Clone + std::hash::Hash + Eq,
+    Backend::WorkloadId: Clone + std::hash::Hash + Eq,
 {
     let PollParams {
         backend,
@@ -83,7 +83,7 @@ where
                 ) => {
                     match result {
                         Ok(Some(count)) => current_count = count,
-                        Ok(None) => { /* no instances — count unchanged */ }
+                        Ok(None) => { /* no workloads — count unchanged */ }
                         Err(error) => break Err(error),
                     }
                 }
@@ -104,18 +104,18 @@ where
 
 /// Poll for new workloads and pin them.
 ///
-/// Returns the newly pinned instance IDs, or `None` if no instances were available.
+/// Returns the newly pinned workload IDs, or `None` if no workloads were available.
 pub(super) async fn poll_and_pin<Backend>(
     backend: &Backend,
     node_id: Backend::NodeId,
     max_items: NonZeroUsize,
     pinning_ttl: NonZeroDuration,
 ) -> Result<
-    Option<NEVec<Backend::InstanceId>>,
-    <Backend as waymark_workload_pinning_backend::PollUnpinnedInstances>::Error,
+    Option<NEVec<Backend::WorkloadId>>,
+    <Backend as waymark_workload_pinning_backend::PollUnpinnedWorkloads>::Error,
 >
 where
-    Backend: waymark_workload_pinning_backend::PollUnpinnedInstances<
+    Backend: waymark_workload_pinning_backend::PollUnpinnedWorkloads<
             Timestamp = chrono::DateTime<chrono::Utc>,
         >,
 {
@@ -129,38 +129,38 @@ where
         expires_at,
     };
 
-    backend.poll_unlocked(now, pinning, max_items).await
+    backend.poll_unpinned(now, pinning, max_items).await
 }
 
 /// Poll, register with the maintain loop, and publish handles.
 ///
 /// Returns the updated active count from the maintain loop, or `None` if no
-/// instances were available to dispatch (count is unchanged).
+/// workloads were available to dispatch (count is unchanged).
 async fn poll_and_dispatch<Backend>(
     backend: &Backend,
     node_id: Backend::NodeId,
     max_items: NonZeroUsize,
     pinning_ttl: NonZeroDuration,
     batch_tx: &tokio::sync::mpsc::Sender<(
-        NEVec<Backend::InstanceId>,
+        NEVec<Backend::WorkloadId>,
         tokio::sync::oneshot::Sender<usize>,
     )>,
-    pinned_tx: &tokio::sync::mpsc::Sender<NEVec<PinnedHandle<Backend::InstanceId>>>,
-    evict_tx: &tokio::sync::mpsc::UnboundedSender<Backend::InstanceId>,
+    pinned_tx: &tokio::sync::mpsc::Sender<NEVec<PinnedHandle<Backend::WorkloadId>>>,
+    evict_tx: &tokio::sync::mpsc::UnboundedSender<Backend::WorkloadId>,
 ) -> Result<Option<usize>, PollLoopErrorFor<Backend>>
 where
-    Backend: waymark_workload_pinning_backend::PollUnpinnedInstances<
+    Backend: waymark_workload_pinning_backend::PollUnpinnedWorkloads<
             Timestamp = chrono::DateTime<chrono::Utc>,
         >,
     Backend: waymark_workload_pinning_backend::HasTimestamp,
-    Backend::InstanceId: Clone,
+    Backend::WorkloadId: Clone,
 {
     let ids = poll_and_pin(backend, node_id, max_items, pinning_ttl)
         .await
         .map_err(PollLoopError::Poll)?;
 
     let Some(ids) = ids else {
-        // No instances to dispatch — count unchanged.
+        // No workloads to dispatch — count unchanged.
         return Ok(None);
     };
 

--- a/crates/lib/workload-pinning-manager/src/poll/tests.rs
+++ b/crates/lib/workload-pinning-manager/src/poll/tests.rs
@@ -11,13 +11,13 @@ use crate::test_utils::helpers::{test_max_concurrent, test_node_id, test_pinning
 use crate::test_utils::mock::MockBackend;
 
 #[tokio::test]
-async fn manager_polls_and_pins_instances() {
+async fn manager_polls_and_pins_workloads() {
     let id1 = 1u64;
     let id2 = 2u64;
 
     let mut backend = MockBackend::new();
     backend
-        .expect_poll_unlocked()
+        .expect_poll_unpinned()
         .with(
             predicate::always(),
             predicate::always(),
@@ -30,7 +30,7 @@ async fn manager_polls_and_pins_instances() {
     let ids = poll_and_pin(&backend, test_node_id(), test_max_concurrent(), pinning_ttl)
         .await
         .expect("poll and pin")
-        .expect("instances available");
+        .expect("workloads available");
 
     let active_ids: HashSet<u64> = HashSet::from_iter(ids);
     assert_eq!(active_ids.len(), 2);
@@ -39,10 +39,10 @@ async fn manager_polls_and_pins_instances() {
 }
 
 #[tokio::test]
-async fn manager_polls_and_pins_instances_none_when_no_work() {
+async fn manager_polls_and_pins_workloads_none_when_no_work() {
     let mut backend = MockBackend::new();
     backend
-        .expect_poll_unlocked()
+        .expect_poll_unpinned()
         .with(
             predicate::always(),
             predicate::always(),
@@ -63,7 +63,7 @@ async fn manager_polls_and_pins_instances_none_when_no_work() {
 async fn poll_and_pin_propagates_error() {
     let mut backend = MockBackend::new();
     backend
-        .expect_poll_unlocked()
+        .expect_poll_unpinned()
         .with(
             predicate::always(),
             predicate::always(),
@@ -91,7 +91,7 @@ async fn poll_and_pin_propagates_error() {
 async fn poll_loop_continues_when_count_channel_closes() {
     let mut backend = MockBackend::new();
     backend
-        .expect_poll_unlocked()
+        .expect_poll_unpinned()
         .returning(move |_, _, _| Box::pin(std::future::ready(Ok(None))));
 
     let backend = Arc::new(backend);
@@ -132,7 +132,7 @@ async fn poll_loop_continues_when_count_channel_closes() {
 async fn poll_loop_exits_on_pinned_receiver_closed() {
     let mut backend = MockBackend::new();
     backend
-        .expect_poll_unlocked()
+        .expect_poll_unpinned()
         .return_once(move |_, _, _| Box::pin(std::future::ready(Ok(Some(nev![1u64])))));
 
     let backend = Arc::new(backend);

--- a/crates/lib/workload-pinning-manager/src/test_utils/mock.rs
+++ b/crates/lib/workload-pinning-manager/src/test_utils/mock.rs
@@ -12,7 +12,7 @@ pub struct MockError;
 
 mockall::mock! {
     pub Backend {
-        pub fn poll_unlocked(
+        pub fn poll_unpinned(
             &self,
             now: chrono::DateTime<chrono::Utc>,
             pinning: Pinning<u64, chrono::DateTime<chrono::Utc>>,
@@ -23,7 +23,7 @@ mockall::mock! {
             &self,
             now: chrono::DateTime<chrono::Utc>,
             pinning: Pinning<u64, chrono::DateTime<chrono::Utc>>,
-            instance_ids: NEVec<u64>,
+            workload_ids: NEVec<u64>,
         ) -> impl Future<
             Output = Result<
                 NEVec<PinningStatus<u64, Pinning<u64, chrono::DateTime<chrono::Utc>>>>,
@@ -34,7 +34,7 @@ mockall::mock! {
         pub fn release_pinnings(
             &self,
             node_id: u64,
-            instance_ids: NEVec<u64>,
+            workload_ids: NEVec<u64>,
         ) -> impl Future<Output = Result<(), MockError>> + Send;
     }
 }
@@ -47,31 +47,31 @@ impl waymark_workload_pinning_backend::HasNodeId for MockBackend {
     type NodeId = u64;
 }
 
-impl waymark_workload_pinning_backend::HasInstanceId for MockBackend {
-    type InstanceId = u64;
+impl waymark_workload_pinning_backend::HasWorkloadId for MockBackend {
+    type WorkloadId = u64;
 }
 
-impl waymark_workload_pinning_backend::PollUnpinnedInstances for MockBackend {
+impl waymark_workload_pinning_backend::PollUnpinnedWorkloads for MockBackend {
     type Error = MockError;
 
-    async fn poll_unlocked(
+    async fn poll_unpinned(
         &self,
         now: Self::Timestamp,
         pinning: Pinning<Self::NodeId, Self::Timestamp>,
         max_items: NonZeroUsize,
-    ) -> Result<Option<NEVec<Self::InstanceId>>, Self::Error> {
-        self.poll_unlocked(now, pinning, max_items).await
+    ) -> Result<Option<NEVec<Self::WorkloadId>>, Self::Error> {
+        self.poll_unpinned(now, pinning, max_items).await
     }
 }
 
-impl waymark_workload_pinning_backend::KeepaliveInstancePinnings for MockBackend {
+impl waymark_workload_pinning_backend::KeepalivePinnings for MockBackend {
     type Error = MockError;
 
     fn refresh_pinnings<'a>(
         &'a self,
         now: chrono::DateTime<chrono::Utc>,
         pinning: Pinning<u64, chrono::DateTime<chrono::Utc>>,
-        instance_ids: impl IntoNonEmptyIterator<Item = u64> + 'a,
+        workload_ids: impl IntoNonEmptyIterator<Item = u64> + 'a,
     ) -> impl Future<
         Output = Result<
             NEVec<PinningStatus<u64, Pinning<u64, chrono::DateTime<chrono::Utc>>>>,
@@ -79,7 +79,7 @@ impl waymark_workload_pinning_backend::KeepaliveInstancePinnings for MockBackend
         >,
     > + Send
     + 'a {
-        let ids: NEVec<u64> = instance_ids.into_nonempty_iter().collect();
+        let ids: NEVec<u64> = workload_ids.into_nonempty_iter().collect();
         self.refresh_pinnings(now, pinning, ids)
     }
 }
@@ -90,9 +90,9 @@ impl waymark_workload_pinning_backend::ReleasePinnings for MockBackend {
     fn release_pinnings<'a>(
         &'a self,
         node_id: u64,
-        instance_ids: impl IntoNonEmptyIterator<Item = u64> + 'a,
+        workload_ids: impl IntoNonEmptyIterator<Item = u64> + 'a,
     ) -> impl Future<Output = Result<(), Self::Error>> + Send + 'a {
-        let ids: NEVec<u64> = instance_ids.into_nonempty_iter().collect();
+        let ids: NEVec<u64> = workload_ids.into_nonempty_iter().collect();
         self.release_pinnings(node_id, ids)
     }
 }

--- a/crates/lib/workload-pinning-manager/src/tests.rs
+++ b/crates/lib/workload-pinning-manager/src/tests.rs
@@ -19,7 +19,7 @@ use crate::{Params, PinnedHandle, run};
 async fn run_exits_on_cancellation() {
     let mut backend = MockBackend::new();
     backend
-        .expect_poll_unlocked()
+        .expect_poll_unpinned()
         .returning(move |_, _, _| Box::pin(std::future::ready(Ok(None))));
 
     let backend = Arc::new(backend);
@@ -68,7 +68,7 @@ async fn run_propagates_poll_error() {
 
     let mut backend = MockBackend::new();
     backend
-        .expect_poll_unlocked()
+        .expect_poll_unpinned()
         .with(
             predicate::always(),
             predicate::always(),
@@ -113,9 +113,9 @@ async fn maintenance_drains_after_poll_error() {
     let pinning = test_pinning(node_id, 1);
 
     let mut backend = MockBackend::new();
-    // First poll returns an instance; second poll errors.
+    // First poll returns an workload; second poll errors.
     let mut poll_calls = 0;
-    backend.expect_poll_unlocked().returning(move |_, _, _| {
+    backend.expect_poll_unpinned().returning(move |_, _, _| {
         poll_calls += 1;
         if poll_calls == 1 {
             Box::pin(std::future::ready(Ok(Some(nev![id]))))
@@ -123,14 +123,14 @@ async fn maintenance_drains_after_poll_error() {
             Box::pin(std::future::ready(Err(MockError)))
         }
     });
-    // Heartbeat may fire while the instance is active, but the drain
+    // Heartbeat may fire while the workload is active, but the drain
     // cycle can complete before the first tick — optional expectation.
     backend
         .expect_refresh_pinnings()
         .times(0..)
         .returning(move |_, _, _| {
             Box::pin(std::future::ready(Ok(nev![PinningStatus {
-                instance_id: id,
+                workload_id: id,
                 pinning: Some(pinning.clone()),
             }])))
         });
@@ -186,7 +186,7 @@ async fn maintenance_drains_after_poll_error() {
 }
 
 /// After the poll loop dies, the maintenance loop must still execute
-/// heartbeats for in-flight instances. Three heartbeats are observed:
+/// heartbeats for in-flight workloads. Three heartbeats are observed:
 /// 1. Before poll error — proves heartbeats work normally.
 /// 2. After signalling poll error — may race with termination; discarded.
 /// 3. After poll is definitively dead — this is the proof.
@@ -207,10 +207,10 @@ async fn maintenance_heartbeats_after_poll_is_dead() {
     let mut poll_calls = 0;
     {
         let poll_error = Arc::clone(&poll_error);
-        backend.expect_poll_unlocked().returning(move |_, _, _| {
+        backend.expect_poll_unpinned().returning(move |_, _, _| {
             poll_calls += 1;
             if poll_calls == 1 {
-                // First call: hand out an instance so maintenance has
+                // First call: hand out an workload so maintenance has
                 // something to heartbeat.
                 return Box::pin(std::future::ready(Ok(Some(nev![id]))));
             }
@@ -236,7 +236,7 @@ async fn maintenance_heartbeats_after_poll_is_dead() {
                 // Record every heartbeat so the monitor can count them.
                 heartbeat_tx.send(()).ok();
                 Box::pin(std::future::ready(Ok(nev![PinningStatus {
-                    instance_id: id,
+                    workload_id: id,
                     pinning: Some(pinning.clone()),
                 }])))
             });
@@ -253,7 +253,7 @@ async fn maintenance_heartbeats_after_poll_is_dead() {
 
     let heartbeat = Duration::from_millis(10);
 
-    // The monitor owns the pinned handle — it holds the instance
+    // The monitor owns the pinned handle — it holds the workload
     // in-flight while counting three heartbeats, then drops the handle
     // to trigger eviction so maintenance can drain and run() can exit.
     let monitor = tokio::spawn(async move {


### PR DESCRIPTION
Re-submission of PR https://github.com/piercefreeman/waymark/pull/473 due to bogus merge

---

Goes in after #472.

---


This PR captures some corrections and clarifications to the workload-pinnings mental model as adjusted for providing the scheduling for the workloads; scheduling in a way that a workload can be runnable or parked, and not in the "cron-jobs sense" of the word scheduling.