### PR TITLE
Use the time instant for the backend calls at the action effect reconciler

### DIFF
--- a/crates/lib/action-effect-reconciler-backend/src/renew_action_call_request_locks.rs
+++ b/crates/lib/action-effect-reconciler-backend/src/renew_action_call_request_locks.rs
@@ -12,6 +12,12 @@ pub trait RenewActionCallRequestLocks: HasVmId + HasLockOwnerId + HasTimestamp {
     /// Extend the lock expiry to `lock.expires_at` for every key still
     /// locked by `lock.owner`.
     ///
+    /// `now` is the caller-clock instant `lock.expires_at` was computed
+    /// against.  Implementations keep expiry on the store's clock alone:
+    /// the extended expiry is stored as the store's now plus the
+    /// remaining duration `expires_at - now` — a difference of two
+    /// caller-clock values, so no cross-node clock agreement is needed.
+    ///
     /// Returns one [`RequestLockRenewal`] per input key.  Keys that could
     /// not be renewed tell the caller to prune its in-memory tracking:
     /// [`RenewalStatus::Missing`] means the row is gone — its completion
@@ -29,6 +35,7 @@ pub trait RenewActionCallRequestLocks: HasVmId + HasLockOwnerId + HasTimestamp {
     /// its next heartbeat.
     fn renew_action_call_request_locks<'a>(
         &'a self,
+        now: Self::Timestamp,
         lock: RequestLockFor<Self>,
         keys: NESlice<'a, ActionCallRequestKey<Self::VmId>>,
     ) -> impl Future<Output = Result<NEVec<RequestLockRenewal<Self::VmId>>, Self::Error>> + Send + 'a;

--- a/crates/lib/action-effect-reconciler/src/renewal.rs
+++ b/crates/lib/action-effect-reconciler/src/renewal.rs
@@ -169,9 +169,14 @@ where
                 let keys = NEVec::try_from_vec(tracked.keys().copied().collect())
                     .expect("tracked is non-empty");
 
-                let lock = fresh_lock(Utc::now(), &lock_owner_id, lock_time_to_live);
+                // One wall-clock instant for both the lock expiry and the
+                // store-clock baseline, so the store reconstructs the
+                // intended time-to-live exactly.  (Distinct from `now`
+                // above: the monotonic fence clock.)
+                let wall_now = Utc::now();
+                let lock = fresh_lock(wall_now, &lock_owner_id, lock_time_to_live);
                 let renewals = match backend
-                    .renew_action_call_request_locks(lock, keys.as_nonempty_slice())
+                    .renew_action_call_request_locks(wall_now, lock, keys.as_nonempty_slice())
                     .await
                 {
                     Ok(renewals) => renewals,

--- a/crates/lib/action-effect-reconciler/src/test_support.rs
+++ b/crates/lib/action-effect-reconciler/src/test_support.rs
@@ -210,6 +210,9 @@ impl waymark_action_effect_reconciler_backend::RenewActionCallRequestLocks for M
 
     async fn renew_action_call_request_locks(
         &self,
+        // The mock stores `lock.expires_at` verbatim rather than translating
+        // it onto a store clock, so the baseline instant goes unused.
+        _now: DateTime<Utc>,
         lock: TestLock,
         keys: NESlice<'_, TestKey>,
     ) -> Result<NEVec<RequestLockRenewal<TestVmId>>, Self::Error> {

--- a/crates/lib/backend-postgres/src/action_call_requests/mod.rs
+++ b/crates/lib/backend-postgres/src/action_call_requests/mod.rs
@@ -325,6 +325,7 @@ impl waymark_action_effect_reconciler_backend::RenewActionCallRequestLocks for P
     #[function_name::named]
     async fn renew_action_call_request_locks(
         &self,
+        now: DateTime<Utc>,
         lock: RequestLock<uuid::Uuid, DateTime<Utc>>,
         keys: NESlice<'_, ActionCallRequestKey<InstanceId>>,
     ) -> Result<NEVec<RequestLockRenewal<InstanceId>>, Self::Error> {
@@ -368,7 +369,7 @@ impl waymark_action_effect_reconciler_backend::RenewActionCallRequestLocks for P
         .bind(&columns.vm_ids)
         .bind(&columns.promise_state_ids)
         .bind(lock.owner)
-        .bind(crate::remaining_micros(Utc::now(), lock.expires_at))
+        .bind(crate::remaining_micros(now, lock.expires_at))
         .fetch_all(&self.pool)
         .timed(crate::query_timing_histogram!(
             "update:action_call_requests_renew"

--- a/crates/lib/backend-postgres/src/action_call_requests/tests.rs
+++ b/crates/lib/backend-postgres/src/action_call_requests/tests.rs
@@ -95,6 +95,7 @@ async fn record_fresh_then_identical_replay() {
     // Untouched includes the lock: the original owner still renews.
     let statuses = backend
         .renew_action_call_request_locks(
+            Utc::now(),
             live_lock(owner),
             NEVec::try_from_vec(vec![key(vm, 1), key(vm, 2)])
                 .unwrap()
@@ -229,6 +230,7 @@ async fn renew_reports_per_key_status() {
 
     let statuses = backend
         .renew_action_call_request_locks(
+            Utc::now(),
             live_lock(owner),
             NEVec::try_from_vec(vec![key(vm, 1), key(vm, 2), key(vm, 3)])
                 .unwrap()
@@ -282,6 +284,7 @@ async fn renew_racing_a_row_removal_reports_missing() {
     let renew_task = tokio::spawn(async move {
         renew_backend
             .renew_action_call_request_locks(
+                Utc::now(),
                 live_lock(owner),
                 NEVec::try_from_vec(vec![key(vm, 1)])
                     .unwrap()
@@ -376,6 +379,7 @@ async fn recording_a_completion_removes_the_request() {
 
     let statuses = backend
         .renew_action_call_request_locks(
+            Utc::now(),
             live_lock(owner),
             NEVec::try_from_vec(vec![key(vm, 1), key(vm, 2)])
                 .unwrap()
@@ -424,6 +428,7 @@ async fn snapshot_delete_sweeps_only_the_vms_requests() {
 
     let statuses = backend
         .renew_action_call_request_locks(
+            Utc::now(),
             live_lock(owner),
             NEVec::try_from_vec(vec![key(vm_a, 1), key(vm_b, 1)])
                 .unwrap()


### PR DESCRIPTION
Goes in after #515 

---

This PR fixes an inconsistency in the backend API, and makes the API sound and match the design patterns used at workload pinnings.