### PR TITLE
Drop anyhow from the codebase

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6229,8 +6229,9 @@ dependencies = [
 name = "waymark-webapp-bringup"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "axum 0.8.8",
+ "tera",
+ "thiserror",
  "tokio",
  "tokio-util",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4637,8 +4637,8 @@ dependencies = [
 name = "waymark-config"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "envfury",
+ "thiserror",
  "waymark-garbage-collector-config",
  "waymark-nonzero-duration",
  "waymark-scheduler-config",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4589,7 +4589,7 @@ dependencies = [
 name = "waymark-boot-singleton"
 version = "0.1.0"
 dependencies = [
- "anyhow",
+ "color-eyre",
  "tokio",
  "tonic 0.11.0",
  "tonic-health",
@@ -4601,7 +4601,7 @@ dependencies = [
 name = "waymark-bridge"
 version = "0.1.0"
 dependencies = [
- "anyhow",
+ "color-eyre",
  "envfury",
  "futures-core",
  "nonempty-collections",
@@ -4859,8 +4859,8 @@ dependencies = [
 name = "waymark-fuzzer"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "clap",
+ "color-eyre",
  "proptest",
  "serde_json",
  "tokio",
@@ -4904,8 +4904,8 @@ dependencies = [
 name = "waymark-integration-test"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "clap",
+ "color-eyre",
  "prost 0.12.6",
  "serde",
  "serde_json",
@@ -5306,8 +5306,8 @@ dependencies = [
 name = "waymark-smoke"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "clap",
+ "color-eyre",
  "tokio",
  "tokio-util",
  "tracing",
@@ -5337,9 +5337,9 @@ dependencies = [
 name = "waymark-soak-harness"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "chrono",
  "clap",
+ "color-eyre",
  "prost 0.12.6",
  "rand 0.9.3",
  "serde",
@@ -5369,7 +5369,6 @@ dependencies = [
 name = "waymark-start-workers"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "envfury",
  "metrics",
  "sqlx",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6227,8 +6227,9 @@ dependencies = [
 name = "waymark-webapp-bringup"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "axum 0.8.8",
+ "tera",
+ "thiserror",
  "tokio",
  "tokio-util",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4589,7 +4589,7 @@ dependencies = [
 name = "waymark-boot-singleton"
 version = "0.1.0"
 dependencies = [
- "anyhow",
+ "color-eyre",
  "tokio",
  "tonic 0.11.0",
  "tonic-health",
@@ -4601,7 +4601,7 @@ dependencies = [
 name = "waymark-bridge"
 version = "0.1.0"
 dependencies = [
- "anyhow",
+ "color-eyre",
  "envfury",
  "futures-core",
  "nonempty-collections",
@@ -4860,8 +4860,8 @@ dependencies = [
 name = "waymark-fuzzer"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "clap",
+ "color-eyre",
  "proptest",
  "serde_json",
  "tokio",
@@ -4905,8 +4905,8 @@ dependencies = [
 name = "waymark-integration-test"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "clap",
+ "color-eyre",
  "prost 0.12.6",
  "serde",
  "serde_json",
@@ -5307,8 +5307,8 @@ dependencies = [
 name = "waymark-smoke"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "clap",
+ "color-eyre",
  "tokio",
  "tokio-util",
  "tracing",
@@ -5338,9 +5338,9 @@ dependencies = [
 name = "waymark-soak-harness"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "chrono",
  "clap",
+ "color-eyre",
  "prost 0.12.6",
  "rand 0.9.3",
  "serde",
@@ -5370,7 +5370,6 @@ dependencies = [
 name = "waymark-start-workers"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "envfury",
  "metrics",
  "sqlx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -177,7 +177,6 @@ waymark-workload-pinning-backend = { path = "crates/lib/workload-pinning-backend
 waymark-workload-pinning-core = { path = "crates/lib/workload-pinning-core" }
 waymark-workload-pinning-manager = { path = "crates/lib/workload-pinning-manager" }
 
-anyhow = "1"
 async-stream = "0.3"
 async-walkdir = "2"
 axum = "0.8"

--- a/crates/bin/benchmark/src/main.rs
+++ b/crates/bin/benchmark/src/main.rs
@@ -132,14 +132,17 @@ async fn run_benchmark(
 
 fn main() -> Result<(), waymark_fn_main_common::Error> {
     let args = cli::BenchmarkArgs::parse();
+    // The guard is dropped on every exit path, so the chrome trace tail
+    // survives error returns too.
+    let (observability_layer, _flush_on_drop) = waymark_observability_setup::tracing_layer(
+        &waymark_observability_setup::ObservabilityOptions {
+            tokio_console: args.observe,
+            chrome_trace_path: args.trace.clone(),
+        },
+    );
     waymark_fn_main_common::init_with(waymark_fn_main_common::Params {
         tracing: waymark_fn_main_common::tracing::Params {
-            filter_bypassing_layer: waymark_observability_setup::tracing_layer(
-                &waymark_observability_setup::ObservabilityOptions {
-                    tokio_console: args.observe,
-                    chrome_trace_path: args.trace.clone(),
-                },
-            ),
+            filter_bypassing_layer: observability_layer,
             filter_wrapped_layer: waymark_fn_main_common::tracing::NO_EXTRA_LAYER,
         },
         skip_color_eyre: false,
@@ -164,6 +167,5 @@ fn main() -> Result<(), waymark_fn_main_common::Error> {
     println!("Benchmark completed in {:.2?}", stats.elapsed);
     println!("{}", report::format_query_counts(stats.query_counts));
     println!("{}", report::format_batch_size_counts(stats.batch_counts));
-    waymark_observability_setup::flush();
     Ok(())
 }

--- a/crates/bin/boot-singleton/Cargo.toml
+++ b/crates/bin/boot-singleton/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2024"
 [dependencies]
 waymark-fn-main-common = { workspace = true }
 
-anyhow = { workspace = true }
+color-eyre = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tonic = { workspace = true }
 tonic-health = { workspace = true }

--- a/crates/bin/boot-singleton/src/main.rs
+++ b/crates/bin/boot-singleton/src/main.rs
@@ -18,7 +18,7 @@ use std::{
     time::Duration,
 };
 
-use anyhow::{Context, Result, bail};
+use color_eyre::eyre::{ContextCompat as _, WrapErr as _, bail};
 use tonic::transport::Channel;
 use tonic_health::pb::HealthCheckRequest;
 use tonic_health::pb::health_client::HealthClient;
@@ -40,7 +40,7 @@ const DEFAULT_GRPC_PORT: u16 = 24117;
 const HEALTH_SERVICE_NAME: &str = "waymark.messages.WorkflowService";
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> Result<(), waymark_fn_main_common::Error> {
     waymark_fn_main_common::init()?;
 
     let args: Vec<String> = env::args().collect();
@@ -142,7 +142,7 @@ async fn check_grpc_health(host: &str, port: u16) -> bool {
     }
 }
 
-async fn spawn_server(host: &str, port: u16) -> Result<u16> {
+async fn spawn_server(host: &str, port: u16) -> Result<u16, color_eyre::eyre::Report> {
     let grpc_addr = format!("{host}:{port}");
     let server_bin = find_server_binary()?;
 
@@ -160,7 +160,7 @@ async fn spawn_server(host: &str, port: u16) -> Result<u16> {
         cmd.process_group(0);
     }
 
-    let _child = cmd.spawn().context("failed to spawn waymark-bridge")?;
+    let _child = cmd.spawn().wrap_err("failed to spawn waymark-bridge")?;
 
     let deadline = tokio::time::Instant::now() + STARTUP_WAIT;
     while tokio::time::Instant::now() < deadline {
@@ -173,8 +173,8 @@ async fn spawn_server(host: &str, port: u16) -> Result<u16> {
     bail!("server failed to start within {STARTUP_WAIT:?}")
 }
 
-fn find_server_binary() -> Result<PathBuf> {
-    let current_exe = env::current_exe().context("failed to get current executable path")?;
+fn find_server_binary() -> Result<PathBuf, color_eyre::eyre::Report> {
+    let current_exe = env::current_exe().wrap_err("failed to get current executable path")?;
     let parent = current_exe
         .parent()
         .context("failed to get parent directory")?;
@@ -211,10 +211,10 @@ fn find_server_binary() -> Result<PathBuf> {
     bail!("could not find waymark-bridge binary")
 }
 
-fn write_port_file(port_file: &Option<PathBuf>, port: u16) -> Result<()> {
+fn write_port_file(port_file: &Option<PathBuf>, port: u16) -> Result<(), color_eyre::eyre::Report> {
     if let Some(path) = port_file {
         fs::write(path, port.to_string())
-            .with_context(|| format!("failed to write port file: {}", path.display()))?;
+            .wrap_err_with(|| format!("failed to write port file: {}", path.display()))?;
         info!(path = %path.display(), port, "wrote port file");
     } else {
         println!("{port}");

--- a/crates/bin/bridge/Cargo.toml
+++ b/crates/bin/bridge/Cargo.toml
@@ -25,7 +25,7 @@ waymark-workflow-service-vm-executables = { workspace = true }
 waymark-workflow-service-vm-runtimes = { workspace = true }
 waymark-workflow-service-vm-runtimes-backend = { workspace = true }
 
-anyhow = { workspace = true }
+color-eyre = { workspace = true }
 envfury = { workspace = true }
 futures-core = { workspace = true }
 nonempty-collections = { workspace = true }

--- a/crates/bin/bridge/src/main.rs
+++ b/crates/bin/bridge/src/main.rs
@@ -17,7 +17,7 @@ use self::workflow_store::*;
 
 use std::sync::Arc;
 
-use anyhow::{Context, Result};
+use color_eyre::eyre::WrapErr as _;
 use tracing::info;
 use waymark_secret_string::SecretString;
 
@@ -38,7 +38,7 @@ impl core::str::FromStr for PermissiveBool {
 }
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> Result<(), waymark_fn_main_common::Error> {
     waymark_fn_main_common::init()?;
 
     let grpc_addr = envfury::or_parse("WAYMARK_BRIDGE_GRPC_ADDR", DEFAULT_GRPC_ADDR)?;
@@ -70,7 +70,7 @@ async fn main() -> Result<()> {
         .add_service(workflow_service)
         .serve(grpc_addr)
         .await
-        .context("bridge server exited")?;
+        .wrap_err("bridge server exited")?;
 
     Ok(())
 }

--- a/crates/bin/bridge/src/workflow_store.rs
+++ b/crates/bin/bridge/src/workflow_store.rs
@@ -2,7 +2,6 @@ use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::time::Duration;
 
-use anyhow::Result;
 use prost::Message as _;
 
 use waymark_backend_postgres::PostgresBackend;
@@ -30,7 +29,7 @@ pub struct WorkflowStore {
 }
 
 impl WorkflowStore {
-    pub async fn connect(dsn: &SecretStr) -> Result<Self> {
+    pub async fn connect(dsn: &SecretStr) -> Result<Self, color_eyre::eyre::Report> {
         let pool = sqlx::PgPool::connect(dsn.expose_secret()).await?;
         waymark_backend_postgres_migrations::run(&pool).await?;
         let backend = PostgresBackend::new(pool);
@@ -55,11 +54,14 @@ impl WorkflowStore {
     pub async fn compile_and_store(
         &self,
         registration: &proto::WorkflowRegistration,
-    ) -> Result<(
-        WorkflowVersionId,
-        Arc<waymark_system_vm::Executable>,
-        Vec<String>,
-    )> {
+    ) -> Result<
+        (
+            WorkflowVersionId,
+            Arc<waymark_system_vm::Executable>,
+            Vec<String>,
+        ),
+        color_eyre::eyre::Report,
+    > {
         let workflow_version = if registration.workflow_version.is_empty() {
             registration.ir_hash.clone()
         } else {
@@ -67,15 +69,15 @@ impl WorkflowStore {
         };
 
         let ir_program = waymark_proto::ast::Program::decode(&registration.ir[..])
-            .map_err(|err| anyhow::anyhow!("decode IR: {err}"))?;
+            .map_err(|err| color_eyre::eyre::eyre!("decode IR: {err}"))?;
         let ast_program = waymark_vm_ast_old_proto::convert(ir_program)
-            .map_err(|err| anyhow::anyhow!("convert IR to AST: {err}"))?;
+            .map_err(|err| color_eyre::eyre::eyre!("convert IR to AST: {err}"))?;
 
         let (id, executable, metadata) = self
             .executables
             .compile_and_store(&registration.workflow_name, &workflow_version, &ast_program)
             .await
-            .map_err(|err| anyhow::anyhow!("compile and store: {err}"))?;
+            .map_err(|err| color_eyre::eyre::eyre!("compile and store: {err}"))?;
 
         let entry_input_names = metadata
             .input_names(Default::default())
@@ -94,7 +96,7 @@ impl WorkflowStore {
             <waymark_system_vm::Executable as waymark_vm_executable::Functions>::FunctionId,
             waymark_system_vm::Value,
         >,
-    ) -> Result<()> {
+    ) -> Result<(), color_eyre::eyre::Report> {
         let interpreter = waymark_vm_interpreter_fullset::FullSetInterpreter::<
             waymark_system_vm::Spec,
             Arc<waymark_system_vm::Executable>,
@@ -103,12 +105,12 @@ impl WorkflowStore {
 
         let runtime: waymark_vm_runtime::Runtime<_, _, waymark_system_vm::Value> =
             waymark_vm_runtime::Runtime::with_custom_entrypoint(interpreter, executable, call_spec)
-                .map_err(|err| anyhow::anyhow!("create runtime: {err}"))?;
+                .map_err(|err| color_eyre::eyre::eyre!("create runtime: {err}"))?;
 
         self.registration
             .register_vm(vm_id, executable_id, |ser| runtime.snapshot(ser))
             .await
-            .map_err(|err| anyhow::anyhow!("register vm: {err}"))
+            .map_err(|err| color_eyre::eyre::eyre!("register vm: {err}"))
     }
 
     /// Register all instances, in chunks of at most `batch_max`.
@@ -128,7 +130,7 @@ impl WorkflowStore {
                 waymark_system_vm::Value,
             >,
         )>,
-    ) -> Result<()> {
+    ) -> Result<(), color_eyre::eyre::Report> {
         let mut vms = vms.into_iter();
         loop {
             let chunk: Vec<_> = vms.by_ref().take(batch_max.get()).collect();
@@ -149,7 +151,7 @@ impl WorkflowStore {
                         Arc::clone(&executable),
                         call_spec,
                     )
-                    .map_err(|err| anyhow::anyhow!("create runtime: {err}"))?;
+                    .map_err(|err| color_eyre::eyre::eyre!("create runtime: {err}"))?;
                 batch.push((vm_id, executable_id, runtime));
             }
 
@@ -161,7 +163,7 @@ impl WorkflowStore {
                     |runtime, serializer| runtime.snapshot(serializer),
                 )
                 .await
-                .map_err(|err| anyhow::anyhow!("register vm runtimes: {err}"))?;
+                .map_err(|err| color_eyre::eyre::eyre!("register vm runtimes: {err}"))?;
             assert!(
                 matches!(
                     success,
@@ -182,7 +184,7 @@ impl WorkflowStore {
         &self,
         instance_id: InstanceId,
         poll_interval: Duration,
-    ) -> Result<Option<proto::WorkflowArguments>> {
+    ) -> Result<Option<proto::WorkflowArguments>, color_eyre::eyre::Report> {
         let outcome = match self
             .outcome_polling
             .wait_for_outcome(&instance_id, poll_interval)
@@ -192,11 +194,11 @@ impl WorkflowStore {
             Err(waymark_workflow_service_vm_runtimes::WaitForOutcomeError::NotFound) => {
                 return Ok(None);
             }
-            Err(err) => return Err(anyhow::anyhow!("wait for outcome: {err}")),
+            Err(err) => return Err(color_eyre::eyre::eyre!("wait for outcome: {err}")),
         };
 
         let arguments = waymark_workflow_completion_convert_proto::Converter::try_convert(outcome)
-            .map_err(|err| anyhow::anyhow!("convert workflow outcome: {err}"))?;
+            .map_err(|err| color_eyre::eyre::eyre!("convert workflow outcome: {err}"))?;
 
         Ok(Some(arguments))
     }

--- a/crates/bin/bridge/src/workflow_store.rs
+++ b/crates/bin/bridge/src/workflow_store.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use anyhow::Result;
 use prost::Message as _;
 
 use waymark_backend_postgres::PostgresBackend;
@@ -32,7 +31,7 @@ pub struct WorkflowStore {
 }
 
 impl WorkflowStore {
-    pub async fn connect(dsn: &SecretStr) -> Result<Self> {
+    pub async fn connect(dsn: &SecretStr) -> Result<Self, color_eyre::eyre::Report> {
         let pool = sqlx::PgPool::connect(dsn.expose_secret()).await?;
         waymark_backend_postgres_migrations::run(&pool).await?;
         let backend = PostgresBackend::new(pool);
@@ -57,11 +56,14 @@ impl WorkflowStore {
     pub async fn compile_and_store(
         &self,
         registration: &proto::WorkflowRegistration,
-    ) -> Result<(
-        WorkflowVersionId,
-        Arc<waymark_system_vm::Executable>,
-        Vec<String>,
-    )> {
+    ) -> Result<
+        (
+            WorkflowVersionId,
+            Arc<waymark_system_vm::Executable>,
+            Vec<String>,
+        ),
+        color_eyre::eyre::Report,
+    > {
         let workflow_version = if registration.workflow_version.is_empty() {
             registration.ir_hash.clone()
         } else {
@@ -69,15 +71,15 @@ impl WorkflowStore {
         };
 
         let ir_program = waymark_proto::ast::Program::decode(&registration.ir[..])
-            .map_err(|err| anyhow::anyhow!("decode IR: {err}"))?;
+            .map_err(|err| color_eyre::eyre::eyre!("decode IR: {err}"))?;
         let ast_program = waymark_vm_ast_old_proto::convert(ir_program)
-            .map_err(|err| anyhow::anyhow!("convert IR to AST: {err}"))?;
+            .map_err(|err| color_eyre::eyre::eyre!("convert IR to AST: {err}"))?;
 
         let (id, executable, metadata) = self
             .executables
             .compile_and_store(&registration.workflow_name, &workflow_version, &ast_program)
             .await
-            .map_err(|err| anyhow::anyhow!("compile and store: {err}"))?;
+            .map_err(|err| color_eyre::eyre::eyre!("compile and store: {err}"))?;
 
         let entry_input_names = metadata
             .input_names(Default::default())
@@ -96,7 +98,7 @@ impl WorkflowStore {
             <waymark_system_vm::Executable as waymark_vm_executable::Functions>::FunctionId,
             waymark_system_vm::Value,
         >,
-    ) -> Result<()> {
+    ) -> Result<(), color_eyre::eyre::Report> {
         let interpreter = waymark_vm_interpreter_fullset::FullSetInterpreter::<
             waymark_system_vm::Spec,
             Arc<waymark_system_vm::Executable>,
@@ -105,12 +107,12 @@ impl WorkflowStore {
 
         let runtime: waymark_vm_runtime::Runtime<_, _, waymark_system_vm::Value> =
             waymark_vm_runtime::Runtime::with_custom_entrypoint(interpreter, executable, call_spec)
-                .map_err(|err| anyhow::anyhow!("create runtime: {err}"))?;
+                .map_err(|err| color_eyre::eyre::eyre!("create runtime: {err}"))?;
 
         self.registration
             .register_vm(vm_id, executable_id, |ser| runtime.snapshot(ser))
             .await
-            .map_err(|err| anyhow::anyhow!("register vm: {err}"))
+            .map_err(|err| color_eyre::eyre::eyre!("register vm: {err}"))
     }
 
     pub async fn register_vm_runtimes(
@@ -124,7 +126,7 @@ impl WorkflowStore {
                 waymark_system_vm::Value,
             >,
         )>,
-    ) -> Result<()> {
+    ) -> Result<(), color_eyre::eyre::Report> {
         let mut vms = vms.into_iter();
         loop {
             let chunk: Vec<_> = vms.by_ref().take(REGISTRATION_BATCH_MAX).collect();
@@ -145,7 +147,7 @@ impl WorkflowStore {
                         Arc::clone(&executable),
                         call_spec,
                     )
-                    .map_err(|err| anyhow::anyhow!("create runtime: {err}"))?;
+                    .map_err(|err| color_eyre::eyre::eyre!("create runtime: {err}"))?;
                 batch.push((vm_id, executable_id, runtime));
             }
 
@@ -157,7 +159,7 @@ impl WorkflowStore {
                     |runtime, serializer| runtime.snapshot(serializer),
                 )
                 .await
-                .map_err(|err| anyhow::anyhow!("register vm runtimes: {err}"))?;
+                .map_err(|err| color_eyre::eyre::eyre!("register vm runtimes: {err}"))?;
             assert!(
                 matches!(
                     success,
@@ -178,7 +180,7 @@ impl WorkflowStore {
         &self,
         instance_id: InstanceId,
         poll_interval: Duration,
-    ) -> Result<Option<proto::WorkflowArguments>> {
+    ) -> Result<Option<proto::WorkflowArguments>, color_eyre::eyre::Report> {
         let outcome = match self
             .outcome_polling
             .wait_for_outcome(&instance_id, poll_interval)
@@ -188,11 +190,11 @@ impl WorkflowStore {
             Err(waymark_workflow_service_vm_runtimes::WaitForOutcomeError::NotFound) => {
                 return Ok(None);
             }
-            Err(err) => return Err(anyhow::anyhow!("wait for outcome: {err}")),
+            Err(err) => return Err(color_eyre::eyre::eyre!("wait for outcome: {err}")),
         };
 
         let arguments = waymark_workflow_completion_convert_proto::Converter::try_convert(outcome)
-            .map_err(|err| anyhow::anyhow!("convert workflow outcome: {err}"))?;
+            .map_err(|err| color_eyre::eyre::eyre!("convert workflow outcome: {err}"))?;
 
         Ok(Some(arguments))
     }

--- a/crates/bin/fuzzer/Cargo.toml
+++ b/crates/bin/fuzzer/Cargo.toml
@@ -15,8 +15,8 @@ waymark-worker-core = { workspace = true }
 waymark-worker-inline = { workspace = true }
 waymark-workflow-completion-core = { workspace = true }
 
-anyhow = { workspace = true }
 clap = { workspace = true, features = ["derive", "env"] }
+color-eyre = { workspace = true }
 proptest = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }

--- a/crates/bin/fuzzer/src/bin/waymark-fuzz.rs
+++ b/crates/bin/fuzzer/src/bin/waymark-fuzz.rs
@@ -1,9 +1,8 @@
-use anyhow::Result;
 use clap::Parser;
 use waymark_fuzzer::{FuzzArgs, run};
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> Result<(), waymark_fn_main_common::Error> {
     waymark_fn_main_common::init()?;
 
     let args = FuzzArgs::parse();

--- a/crates/bin/fuzzer/src/harness.rs
+++ b/crates/bin/fuzzer/src/harness.rs
@@ -3,23 +3,26 @@
 use std::collections::HashMap;
 use std::time::Duration;
 
-use anyhow::{Result, bail};
+use color_eyre::eyre::bail;
 use waymark_ir_parser::parse_program;
 use waymark_worker_core::WorkerPoolError;
 use waymark_worker_inline::{ActionCallable, InlineWorkerPool};
 
 use super::generator::GeneratedCase;
 
-pub async fn run_case(case_index: usize, case: &GeneratedCase) -> Result<()> {
+pub async fn run_case(
+    case_index: usize,
+    case: &GeneratedCase,
+) -> Result<(), color_eyre::eyre::Report> {
     let program = parse_program(case.source.trim()).map_err(|err| {
-        anyhow::anyhow!(
+        color_eyre::eyre::eyre!(
             "case {case_index} failed to parse: {err}\n--- program ---\n{}",
             case.source
         )
     })?;
 
     let program = waymark_vm_ast_old_proto::convert(program).map_err(|err| {
-        anyhow::anyhow!(
+        color_eyre::eyre::eyre!(
             "case {case_index} failed to convert to the VM AST: {err}\n--- program ---\n{}",
             case.source
         )
@@ -32,7 +35,7 @@ pub async fn run_case(case_index: usize, case: &GeneratedCase) -> Result<()> {
 
     let runtime =
         waymark_transient_execution_bringup::setup_runtime(&program, inputs).map_err(|err| {
-            anyhow::anyhow!(
+            color_eyre::eyre::eyre!(
                 "case {case_index} failed to compile: {err}\n--- program ---\n{}",
                 case.source
             )
@@ -70,7 +73,7 @@ pub async fn run_case(case_index: usize, case: &GeneratedCase) -> Result<()> {
     tracing::debug!(?driver_exit, "vm driver exited");
 
     let workflow_outcome = workflow_outcome.map_err(|_recv_error| {
-        anyhow::anyhow!(
+        color_eyre::eyre::eyre!(
             "case {case_index}: vm driver exited without delivering a workflow outcome\n--- program ---\n{}",
             case.source
         )

--- a/crates/bin/fuzzer/src/lib.rs
+++ b/crates/bin/fuzzer/src/lib.rs
@@ -5,8 +5,8 @@ mod harness;
 
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use anyhow::{Result, anyhow};
 use clap::Parser;
+use color_eyre::eyre::eyre;
 use proptest::test_runner::{Config, RngSeed, TestRunner};
 
 /// CLI args for the fuzz harness.
@@ -29,7 +29,7 @@ pub struct FuzzArgs {
 
 /// Run randomized workflow fuzz cases end-to-end through parse, VM
 /// compilation, and transient execution.
-pub async fn run(args: FuzzArgs) -> Result<()> {
+pub async fn run(args: FuzzArgs) -> Result<(), color_eyre::eyre::Report> {
     let seed = args.seed.unwrap_or_else(seed_from_clock);
     let total = args.cases.max(1);
     let mut config = Config {
@@ -46,7 +46,7 @@ pub async fn run(args: FuzzArgs) -> Result<()> {
 
     for idx in 0..total {
         let case = generator::generate_case(&mut runner, args.max_steps.max(1), idx)
-            .map_err(|err| anyhow!("failed to generate case {idx}: {err}"))?;
+            .map_err(|err| eyre!("failed to generate case {idx}: {err}"))?;
         harness::run_case(idx, &case).await?;
     }
 

--- a/crates/bin/integration-test/Cargo.toml
+++ b/crates/bin/integration-test/Cargo.toml
@@ -30,8 +30,8 @@ waymark-workflow-completion-core = { workspace = true }
 waymark-workflow-service-vm-executables = { workspace = true }
 waymark-workflow-service-vm-runtimes = { workspace = true }
 
-anyhow = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
+color-eyre = { workspace = true }
 prost = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }

--- a/crates/bin/integration-test/src/cases.rs
+++ b/crates/bin/integration-test/src/cases.rs
@@ -1,6 +1,6 @@
 //! The curated fixture cases.
 
-use anyhow::{Result, bail};
+use color_eyre::eyre::bail;
 
 #[derive(Clone, Debug)]
 pub struct FixtureCase {
@@ -91,7 +91,7 @@ pub const CASES: &[FixtureCase] = &[
     },
 ];
 
-pub fn select_cases(filters: &[String]) -> Result<Vec<FixtureCase>> {
+pub fn select_cases(filters: &[String]) -> Result<Vec<FixtureCase>, color_eyre::eyre::Report> {
     if filters.is_empty() {
         return Ok(CASES.to_vec());
     }

--- a/crates/bin/integration-test/src/cli.rs
+++ b/crates/bin/integration-test/src/cli.rs
@@ -2,8 +2,8 @@
 
 use std::num::NonZeroUsize;
 
-use anyhow::{Result, bail};
 use clap::Parser;
+use color_eyre::eyre::bail;
 
 #[derive(Parser, Debug)]
 #[command(name = "integration_test")]
@@ -40,7 +40,7 @@ impl ExecutionMode {
     }
 }
 
-pub fn parse_modes(raw: &str) -> Result<Vec<ExecutionMode>> {
+pub fn parse_modes(raw: &str) -> Result<Vec<ExecutionMode>, color_eyre::eyre::Report> {
     let mut parsed = Vec::new();
     for item in raw.split(',') {
         let trimmed = item.trim();

--- a/crates/bin/integration-test/src/durable.rs
+++ b/crates/bin/integration-test/src/durable.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
 
-use anyhow::{Context, Result, anyhow};
+use color_eyre::eyre::{WrapErr as _, eyre};
 use waymark_secret_string::SecretString;
 use waymark_support_integration::{LOCAL_POSTGRES_DSN, connect_pool, ensure_local_postgres};
 
@@ -41,7 +41,7 @@ pub async fn run_durable_mode(
     prepared_cases: &[PreparedCase],
     worker_count: NonZeroUsize,
     timeout: Duration,
-) -> Result<Vec<String>> {
+) -> Result<Vec<String>, color_eyre::eyre::Report> {
     let stack = connect_durable_stack().await?;
 
     let shutdown_token = tokio_util::sync::CancellationToken::new();
@@ -53,7 +53,7 @@ pub async fn run_durable_mode(
         worker_count,
     )
     .await
-    .context("start durable worker pool")?;
+    .wrap_err("start durable worker pool")?;
 
     // The execution subsystem launches the worker pool itself.
     let execution_handles = waymark_execution_bringup::start(
@@ -64,7 +64,7 @@ pub async fn run_durable_mode(
         force_shutdown_token.child_token(),
     )
     .await
-    .context("start durable execution subsystem")?;
+    .wrap_err("start durable execution subsystem")?;
 
     let mut failures = Vec::new();
     for prepared in prepared_cases {
@@ -84,7 +84,7 @@ pub async fn run_durable_mode(
     Ok(failures)
 }
 
-async fn connect_durable_stack() -> Result<DurableStack> {
+async fn connect_durable_stack() -> Result<DurableStack, color_eyre::eyre::Report> {
     let dsn = std::env::var("WAYMARK_DATABASE_URL")
         .map(SecretString::from)
         .unwrap_or_else(|_| SecretString::from(LOCAL_POSTGRES_DSN));
@@ -92,15 +92,15 @@ async fn connect_durable_stack() -> Result<DurableStack> {
     if dsn.expose_secret() == LOCAL_POSTGRES_DSN.expose_secret() {
         ensure_local_postgres()
             .await
-            .context("auto-bootstrap local postgres for integration runner")?;
+            .wrap_err("auto-bootstrap local postgres for integration runner")?;
     }
 
     let pool = connect_pool(&dsn)
         .await
-        .with_context(|| format!("connect postgres backend: {dsn}"))?;
+        .wrap_err_with(|| format!("connect postgres backend: {dsn}"))?;
     waymark_backend_postgres_migrations::run(&pool)
         .await
-        .context("run postgres migrations for integration runner")?;
+        .wrap_err("run postgres migrations for integration runner")?;
 
     // Reset the durable-VM tables so stale runnable workloads from prior
     // (crashed) runs cannot be revived into this run's execution subsystem.
@@ -118,7 +118,7 @@ async fn connect_durable_stack() -> Result<DurableStack> {
     )
     .execute(&pool)
     .await
-    .context("truncate durable-VM tables")?;
+    .wrap_err("truncate durable-VM tables")?;
 
     let backend = waymark_backend_postgres::PostgresBackend::new(pool);
     let codec = waymark_vm_codec_rmp::RmpCodec;
@@ -216,7 +216,7 @@ async fn run_case_durable(
     prepared: &PreparedCase,
     stack: &DurableStack,
     timeout: Duration,
-) -> Result<CaseOutcome> {
+) -> Result<CaseOutcome, color_eyre::eyre::Report> {
     let (executable_id, executable, metadata) = stack
         .executables
         .compile_and_store(
@@ -226,7 +226,7 @@ async fn run_case_durable(
         )
         .await
         .map_err(|err| {
-            anyhow!(
+            eyre!(
                 "compile and store executable for case '{}': {err}",
                 prepared.case.id
             )
@@ -235,14 +235,14 @@ async fn run_case_durable(
     let call_spec = waymark_vm_runtime_builder::builder(&metadata)
         .first_fn()
         .map_err(|err| {
-            anyhow!(
+            eyre!(
                 "select entry function for case '{}': {err}",
                 prepared.case.id
             )
         })?
         .args(prepared.inputs.clone())
         .map_err(|err| {
-            anyhow!(
+            eyre!(
                 "match entry function arguments for case '{}': {err}",
                 prepared.case.id
             )
@@ -253,7 +253,7 @@ async fn run_case_durable(
         Arc::new(executable),
         call_spec,
     )
-    .map_err(|err| anyhow!("create VM runtime for case '{}': {err}", prepared.case.id))?;
+    .map_err(|err| eyre!("create VM runtime for case '{}': {err}", prepared.case.id))?;
 
     let vm_id = waymark_ids::InstanceId::new_uuid_v4();
     stack
@@ -262,7 +262,7 @@ async fn run_case_durable(
             runtime.snapshot(serializer)
         })
         .await
-        .map_err(|err| anyhow!("register VM for case '{}': {err}", prepared.case.id))?;
+        .map_err(|err| eyre!("register VM for case '{}': {err}", prepared.case.id))?;
 
     let workflow_outcome = tokio::time::timeout(
         timeout,
@@ -272,13 +272,13 @@ async fn run_case_durable(
     )
     .await
     .map_err(|_elapsed| {
-        anyhow!(
+        eyre!(
             "case '{}' timed out after {}s",
             prepared.case.id,
             timeout.as_secs()
         )
     })?
-    .map_err(|err| anyhow!("wait for outcome of case '{}': {err}", prepared.case.id))?;
+    .map_err(|err| eyre!("wait for outcome of case '{}': {err}", prepared.case.id))?;
 
     Ok(canonicalize_outcome(outcome_from_vm(workflow_outcome)?))
 }

--- a/crates/bin/integration-test/src/ground_truth.rs
+++ b/crates/bin/integration-test/src/ground_truth.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use anyhow::{Context, Result, bail};
+use color_eyre::eyre::{ContextCompat as _, WrapErr as _, bail};
 use serde::Deserialize;
 use waymark_convert_core::Convert;
 use waymark_proto::ast as ir;
@@ -34,9 +34,12 @@ pub struct PreparedCase {
     pub program: waymark_vm_ast_old::Program,
 }
 
-pub fn prepare_case(repo_root: &Path, case: FixtureCase) -> Result<PreparedCase> {
+pub fn prepare_case(
+    repo_root: &Path,
+    case: FixtureCase,
+) -> Result<PreparedCase, color_eyre::eyre::Report> {
     let kwargs_value: serde_json::Value = serde_json::from_str(case.kwargs_json)
-        .with_context(|| format!("parse kwargs JSON for case '{}'", case.id))?;
+        .wrap_err_with(|| format!("parse kwargs JSON for case '{}'", case.id))?;
     let serde_json::Value::Object(kwargs) = kwargs_value else {
         bail!("case '{}' kwargs JSON must be an object", case.id)
     };
@@ -44,13 +47,13 @@ pub fn prepare_case(repo_root: &Path, case: FixtureCase) -> Result<PreparedCase>
     let helper = run_python_helper(repo_root, &case)?;
 
     let program = <ir::Program as prost::Message>::decode(&helper.registration.ir_bytes[..])
-        .with_context(|| {
+        .wrap_err_with(|| {
             format!(
                 "decode IR bytes for case '{}' ({})",
                 case.id, case.workflow_class
             )
         })?;
-    let program = waymark_vm_ast_old_proto::convert(program).with_context(|| {
+    let program = waymark_vm_ast_old_proto::convert(program).wrap_err_with(|| {
         format!(
             "convert IR to the VM AST for case '{}' ({})",
             case.id, case.workflow_class
@@ -74,7 +77,7 @@ pub fn prepare_case(repo_root: &Path, case: FixtureCase) -> Result<PreparedCase>
     })
 }
 
-fn helper_python(repo_root: &Path) -> Result<PathBuf> {
+fn helper_python(repo_root: &Path) -> Result<PathBuf, color_eyre::eyre::Report> {
     let python = repo_root.join(".venv").join("bin").join("python");
     if python.exists() {
         Ok(python)
@@ -86,7 +89,10 @@ fn helper_python(repo_root: &Path) -> Result<PathBuf> {
     }
 }
 
-fn run_python_helper(repo_root: &Path, case: &FixtureCase) -> Result<HelperOutput> {
+fn run_python_helper(
+    repo_root: &Path,
+    case: &FixtureCase,
+) -> Result<HelperOutput, color_eyre::eyre::Report> {
     let helper_script = repo_root.join("scripts").join("fixture_ground_truth.py");
     let python = helper_python(repo_root)?;
 
@@ -100,7 +106,7 @@ fn run_python_helper(repo_root: &Path, case: &FixtureCase) -> Result<HelperOutpu
         .arg(case.kwargs_json)
         .current_dir(repo_root)
         .output()
-        .with_context(|| format!("run python helper for case '{}'", case.id))?;
+        .wrap_err_with(|| format!("run python helper for case '{}'", case.id))?;
 
     if !output.status.success() {
         bail!(
@@ -112,7 +118,7 @@ fn run_python_helper(repo_root: &Path, case: &FixtureCase) -> Result<HelperOutpu
     }
 
     let stdout = String::from_utf8(output.stdout)
-        .with_context(|| format!("decode python helper stdout for case '{}'", case.id))?;
+        .wrap_err_with(|| format!("decode python helper stdout for case '{}'", case.id))?;
     let payload = stdout
         .lines()
         .rev()
@@ -120,5 +126,5 @@ fn run_python_helper(repo_root: &Path, case: &FixtureCase) -> Result<HelperOutpu
         .with_context(|| format!("python helper produced no payload for case '{}'", case.id))?;
 
     serde_json::from_str(payload)
-        .with_context(|| format!("parse python helper JSON payload for case '{}'", case.id))
+        .wrap_err_with(|| format!("parse python helper JSON payload for case '{}'", case.id))
 }

--- a/crates/bin/integration-test/src/main.rs
+++ b/crates/bin/integration-test/src/main.rs
@@ -18,11 +18,11 @@ mod worker_pool;
 use std::path::PathBuf;
 use std::time::Duration;
 
-use anyhow::{Context, Result, bail};
 use clap::Parser as _;
+use color_eyre::eyre::{WrapErr as _, bail};
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> Result<(), waymark_fn_main_common::Error> {
     waymark_fn_main_common::init()?;
 
     let args = cli::Args::parse();
@@ -38,7 +38,7 @@ async fn main() -> Result<()> {
     let mut prepared_cases = Vec::new();
     for case in selected_cases {
         prepared_cases.push(
-            ground_truth::prepare_case(&repo_root, case.clone()).with_context(|| {
+            ground_truth::prepare_case(&repo_root, case.clone()).wrap_err_with(|| {
                 format!(
                     "prepare fixture case '{}' ({}::{})",
                     case.id, case.module_name, case.workflow_class
@@ -66,7 +66,7 @@ async fn main() -> Result<()> {
                     .await
             }
         }
-        .with_context(|| format!("run {} execution mode", mode.label()))?;
+        .wrap_err_with(|| format!("run {} execution mode", mode.label()))?;
 
         comparisons += prepared_cases.len();
         failures.extend(

--- a/crates/bin/integration-test/src/outcome.rs
+++ b/crates/bin/integration-test/src/outcome.rs
@@ -2,7 +2,7 @@
 
 use std::collections::BTreeMap;
 
-use anyhow::{Context, Result};
+use color_eyre::eyre::WrapErr as _;
 use serde::{Deserialize, Serialize};
 use waymark_convert_core::TryConvert;
 
@@ -14,7 +14,10 @@ pub struct CaseOutcome {
     pub value: serde_json::Value,
 }
 
-pub fn check_case_outcome(prepared: &PreparedCase, actual: Result<CaseOutcome>) -> Option<String> {
+pub fn check_case_outcome(
+    prepared: &PreparedCase,
+    actual: Result<CaseOutcome, color_eyre::eyre::Report>,
+) -> Option<String> {
     let mismatch = match actual {
         Ok(actual) if prepared.case.id == "timeout" => validate_timeout_outcome(&actual),
         Ok(actual) if actual != prepared.expected => Some(format!(
@@ -31,12 +34,12 @@ pub fn check_case_outcome(prepared: &PreparedCase, actual: Result<CaseOutcome>) 
 
 pub fn outcome_from_vm(
     outcome: waymark_workflow_completion_core::Outcome<waymark_system_vm::ReadyValue>,
-) -> Result<CaseOutcome> {
+) -> Result<CaseOutcome, color_eyre::eyre::Report> {
     match outcome {
         waymark_workflow_completion_core::Outcome::Completion(value) => {
             let value: serde_json::Value =
                 waymark_vm_value_convert_json::Converter::try_convert(value)
-                    .context("convert workflow completion value to JSON")?;
+                    .wrap_err("convert workflow completion value to JSON")?;
             Ok(CaseOutcome {
                 status: "ok".to_string(),
                 value,
@@ -45,7 +48,7 @@ pub fn outcome_from_vm(
         waymark_workflow_completion_core::Outcome::Exception(exception) => {
             let value: serde_json::Value =
                 waymark_vm_value_convert_json::Converter::try_convert(exception)
-                    .context("convert workflow exception to JSON")?;
+                    .wrap_err("convert workflow exception to JSON")?;
             Ok(CaseOutcome {
                 status: "error".to_string(),
                 value,

--- a/crates/bin/integration-test/src/transient.rs
+++ b/crates/bin/integration-test/src/transient.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
 
-use anyhow::{Context, Result, anyhow, bail};
+use color_eyre::eyre::{WrapErr as _, bail, eyre};
 use waymark_worker_core::BaseWorkerPool as _;
 
 use crate::ground_truth::PreparedCase;
@@ -17,7 +17,7 @@ pub async fn run_transient_mode(
     prepared_cases: &[PreparedCase],
     worker_count: NonZeroUsize,
     timeout: Duration,
-) -> Result<Vec<String>> {
+) -> Result<Vec<String>, color_eyre::eyre::Report> {
     let shutdown_token = tokio_util::sync::CancellationToken::new();
     let (worker_pool, bridge_server_task) = setup_worker_pool(
         shutdown_token.clone(),
@@ -26,11 +26,11 @@ pub async fn run_transient_mode(
         worker_count,
     )
     .await
-    .context("start transient worker pool")?;
+    .wrap_err("start transient worker pool")?;
     worker_pool
         .launch()
         .await
-        .context("launch transient worker pool")?;
+        .wrap_err("launch transient worker pool")?;
 
     let mut failures = Vec::new();
     for prepared in prepared_cases {
@@ -49,12 +49,12 @@ async fn run_case_transient(
     prepared: &PreparedCase,
     worker_pool: PythonWorkerPool,
     timeout: Duration,
-) -> Result<CaseOutcome> {
+) -> Result<CaseOutcome, color_eyre::eyre::Report> {
     let runtime = waymark_transient_execution_bringup::setup_runtime(
         &prepared.program,
         prepared.inputs.clone(),
     )
-    .with_context(|| format!("set up VM runtime for case '{}'", prepared.case.id))?;
+    .wrap_err_with(|| format!("set up VM runtime for case '{}'", prepared.case.id))?;
 
     let cancel = tokio_util::sync::CancellationToken::new();
     let waymark_transient_execution_bringup::Execution {
@@ -87,7 +87,7 @@ async fn run_case_transient(
     tracing::debug!(?driver_exit, "vm driver exited");
 
     let workflow_outcome = workflow_outcome.map_err(|_recv_error| {
-        anyhow!(
+        eyre!(
             "vm driver exited without delivering a workflow outcome for case '{}'",
             prepared.case.id
         )

--- a/crates/bin/integration-test/src/worker_pool.rs
+++ b/crates/bin/integration-test/src/worker_pool.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
 
-use anyhow::{Context, Result};
+use color_eyre::eyre::WrapErr as _;
 
 use crate::ground_truth::PreparedCase;
 
@@ -17,7 +17,7 @@ pub async fn setup_worker_pool(
     repo_root: &Path,
     cases: &[PreparedCase],
     worker_count: NonZeroUsize,
-) -> Result<(PythonWorkerPool, tokio::task::JoinHandle<()>)> {
+) -> Result<(PythonWorkerPool, tokio::task::JoinHandle<()>), color_eyre::eyre::Report> {
     let mut modules = cases
         .iter()
         .map(|prepared| prepared.case.module_name.to_string())
@@ -45,7 +45,7 @@ pub async fn setup_worker_pool(
         10.try_into().unwrap(),
     )
     .await
-    .context("create remote worker pool")?;
+    .wrap_err("create remote worker pool")?;
 
     let worker_pool = Arc::new(waymark_worker_remote_pool::RemoteWorkerPool::new(
         process_pool,

--- a/crates/bin/smoke/Cargo.toml
+++ b/crates/bin/smoke/Cargo.toml
@@ -18,8 +18,8 @@ waymark-worker-python = { workspace = true }
 waymark-worker-remote-bringup = { workspace = true }
 waymark-worker-remote-pool = { workspace = true }
 
-anyhow = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
+color-eyre = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }
 tokio-util = { workspace = true }
 tracing = { workspace = true }

--- a/crates/bin/smoke/src/main.rs
+++ b/crates/bin/smoke/src/main.rs
@@ -27,7 +27,10 @@ struct SmokeCase {
     inputs: HashMap<String, Value>,
 }
 
-async fn run_program_smoke<Pool>(case: &SmokeCase, worker_pool: Pool) -> Result<(), anyhow::Error>
+async fn run_program_smoke<Pool>(
+    case: &SmokeCase,
+    worker_pool: Pool,
+) -> Result<(), color_eyre::eyre::Report>
 where
     Pool: waymark_worker_core::BaseWorkerPool + Clone + Send + Sync + 'static,
 {
@@ -55,8 +58,9 @@ where
     let Err(driver_exit) = driver_handle.await;
     tracing::debug!(?driver_exit, "vm driver exited");
 
-    let workflow_outcome = workflow_outcome
-        .map_err(|_recv_error| anyhow::anyhow!("vm driver exited without a workflow outcome"))?;
+    let workflow_outcome = workflow_outcome.map_err(|_recv_error| {
+        color_eyre::eyre::eyre!("vm driver exited without a workflow outcome")
+    })?;
 
     println!("Workflow outcome ({}): {:?}", case.name, workflow_outcome);
     Ok(())
@@ -182,11 +186,11 @@ fn repo_root() -> std::path::PathBuf {
         .to_path_buf()
 }
 
-pub fn main() {
-    waymark_fn_main_common::init().expect("tracing setup");
+pub fn main() -> Result<(), waymark_fn_main_common::Error> {
+    waymark_fn_main_common::init()?;
 
     let args = SmokeArgs::parse();
-    let runtime = tokio::runtime::Runtime::new().expect("tokio runtime");
+    let runtime = tokio::runtime::Runtime::new()?;
     let code = runtime.block_on(run_smoke(args.base));
     std::process::exit(code);
 }

--- a/crates/bin/soak-harness/Cargo.toml
+++ b/crates/bin/soak-harness/Cargo.toml
@@ -20,9 +20,9 @@ waymark-vm-runtime-builder = { workspace = true }
 waymark-workflow-service-vm-executables = { workspace = true }
 waymark-workflow-service-vm-runtimes = { workspace = true }
 
-anyhow = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true, features = ["derive", "env"] }
+color-eyre = { workspace = true }
 prost = { workspace = true }
 rand = { workspace = true }
 serde = { workspace = true, features = ["derive"] }

--- a/crates/bin/soak-harness/src/cli.rs
+++ b/crates/bin/soak-harness/src/cli.rs
@@ -3,8 +3,8 @@ use std::{
     path::PathBuf,
 };
 
-use anyhow::{Result, bail};
 use clap::Parser;
+use color_eyre::eyre::bail;
 use serde::Serialize;
 use waymark_secret_string::{SecretStr, SecretString};
 
@@ -130,7 +130,7 @@ pub struct SoakArgs {
     pub seed: Option<u64>,
 }
 
-pub fn validate_args(args: &SoakArgs) -> Result<()> {
+pub fn validate_args(args: &SoakArgs) -> Result<(), color_eyre::eyre::Report> {
     if args.timeout_percent < 0.0 || args.failure_percent < 0.0 || args.slow_percent < 0.0 {
         bail!("workload percentages cannot be negative");
     }

--- a/crates/bin/soak-harness/src/common.rs
+++ b/crates/bin/soak-harness/src/common.rs
@@ -5,15 +5,18 @@ use std::{
     path::Path,
 };
 
-use anyhow::{Context, Result};
+use color_eyre::eyre::WrapErr as _;
 
-pub fn read_tail_lines(path: &Path, max_lines: usize) -> Result<Vec<String>> {
-    let file = File::open(path).with_context(|| format!("open {}", path.display()))?;
+pub fn read_tail_lines(
+    path: &Path,
+    max_lines: usize,
+) -> Result<Vec<String>, color_eyre::eyre::Report> {
+    let file = File::open(path).wrap_err_with(|| format!("open {}", path.display()))?;
     let reader = BufReader::new(file);
     let mut lines = VecDeque::with_capacity(max_lines.max(1));
 
     for line in reader.lines() {
-        let line = line.with_context(|| format!("read line from {}", path.display()))?;
+        let line = line.wrap_err_with(|| format!("read line from {}", path.display()))?;
         if lines.len() == max_lines {
             let _ = lines.pop_front();
         }

--- a/crates/bin/soak-harness/src/data.rs
+++ b/crates/bin/soak-harness/src/data.rs
@@ -1,5 +1,5 @@
-use anyhow::{Context, Result, anyhow, bail};
 use chrono::{DateTime, Utc};
+use color_eyre::eyre::{WrapErr as _, bail, eyre};
 use serde::Serialize;
 use sqlx::PgPool;
 use sqlx::prelude::*;
@@ -19,7 +19,9 @@ pub struct WorkloadSnapshot {
     pub oldest_ready_updated_at: Option<DateTime<Utc>>,
 }
 
-pub async fn fetch_workload_snapshot(pool: &PgPool) -> Result<WorkloadSnapshot> {
+pub async fn fetch_workload_snapshot(
+    pool: &PgPool,
+) -> Result<WorkloadSnapshot, color_eyre::eyre::Report> {
     let row = sqlx::query_as::<_, WorkloadSnapshot>(
         r#"
         SELECT
@@ -34,7 +36,7 @@ pub async fn fetch_workload_snapshot(pool: &PgPool) -> Result<WorkloadSnapshot> 
     )
     .fetch_one(pool)
     .await
-    .context("fetch workload snapshot")?;
+    .wrap_err("fetch workload snapshot")?;
 
     Ok(row)
 }
@@ -55,7 +57,9 @@ pub struct WorkerStatusSnapshot {
     pub active_instance_count: i32,
 }
 
-pub async fn fetch_latest_worker_status(pool: &PgPool) -> Result<Option<WorkerStatusSnapshot>> {
+pub async fn fetch_latest_worker_status(
+    pool: &PgPool,
+) -> Result<Option<WorkerStatusSnapshot>, color_eyre::eyre::Report> {
     let row = sqlx::query_as::<_, WorkerStatusSnapshot>(
         r#"
         SELECT
@@ -78,7 +82,7 @@ pub async fn fetch_latest_worker_status(pool: &PgPool) -> Result<Option<WorkerSt
     )
     .fetch_optional(pool)
     .await
-    .context("fetch latest worker status")?;
+    .wrap_err("fetch latest worker status")?;
 
     Ok(row)
 }
@@ -91,7 +95,10 @@ pub struct PinningOwnerRow {
     pub newest_updated_at: Option<DateTime<Utc>>,
 }
 
-pub async fn fetch_pinning_owners(pool: &PgPool, limit: i64) -> Result<Vec<PinningOwnerRow>> {
+pub async fn fetch_pinning_owners(
+    pool: &PgPool,
+    limit: i64,
+) -> Result<Vec<PinningOwnerRow>, color_eyre::eyre::Report> {
     let rows = sqlx::query_as::<_, PinningOwnerRow>(
         r#"
         SELECT
@@ -109,7 +116,7 @@ pub async fn fetch_pinning_owners(pool: &PgPool, limit: i64) -> Result<Vec<Pinni
     .bind(limit)
     .fetch_all(pool)
     .await
-    .context("fetch pinning owners")?;
+    .wrap_err("fetch pinning owners")?;
 
     Ok(rows)
 }
@@ -122,7 +129,10 @@ pub struct ExpiredPinningRow {
     pub updated_at: DateTime<Utc>,
 }
 
-pub async fn fetch_expired_pinnings(pool: &PgPool, limit: i64) -> Result<Vec<ExpiredPinningRow>> {
+pub async fn fetch_expired_pinnings(
+    pool: &PgPool,
+    limit: i64,
+) -> Result<Vec<ExpiredPinningRow>, color_eyre::eyre::Report> {
     let rows = sqlx::query_as::<_, ExpiredPinningRow>(
         r#"
         SELECT
@@ -139,7 +149,7 @@ pub async fn fetch_expired_pinnings(pool: &PgPool, limit: i64) -> Result<Vec<Exp
     .bind(limit)
     .fetch_all(pool)
     .await
-    .context("fetch expired pinnings")?;
+    .wrap_err("fetch expired pinnings")?;
 
     Ok(rows)
 }
@@ -155,7 +165,7 @@ pub struct ActionCallRequestLockOwnerRow {
 pub async fn fetch_action_call_request_lock_owners(
     pool: &PgPool,
     limit: i64,
-) -> Result<Vec<ActionCallRequestLockOwnerRow>> {
+) -> Result<Vec<ActionCallRequestLockOwnerRow>, color_eyre::eyre::Report> {
     let rows = sqlx::query_as::<_, ActionCallRequestLockOwnerRow>(
         r#"
         SELECT
@@ -172,7 +182,7 @@ pub async fn fetch_action_call_request_lock_owners(
     .bind(limit)
     .fetch_all(pool)
     .await
-    .context("fetch action-call request lock owners")?;
+    .wrap_err("fetch action-call request lock owners")?;
 
     Ok(rows)
 }
@@ -189,7 +199,7 @@ pub struct StaleActionCallRequestRow {
 pub async fn fetch_stale_action_call_request_locks(
     pool: &PgPool,
     limit: i64,
-) -> Result<Vec<StaleActionCallRequestRow>> {
+) -> Result<Vec<StaleActionCallRequestRow>, color_eyre::eyre::Report> {
     let rows = sqlx::query_as::<_, StaleActionCallRequestRow>(
         r#"
         SELECT
@@ -206,7 +216,7 @@ pub async fn fetch_stale_action_call_request_locks(
     .bind(limit)
     .fetch_all(pool)
     .await
-    .context("fetch stale action-call request locks")?;
+    .wrap_err("fetch stale action-call request locks")?;
 
     Ok(rows)
 }
@@ -221,7 +231,10 @@ pub struct ActivityRow {
     pub query: String,
 }
 
-pub async fn fetch_pg_stat_activity(pool: &PgPool, limit: i64) -> Result<Vec<ActivityRow>> {
+pub async fn fetch_pg_stat_activity(
+    pool: &PgPool,
+    limit: i64,
+) -> Result<Vec<ActivityRow>, color_eyre::eyre::Report> {
     let rows = sqlx::query_as::<_, ActivityRow>(
         r#"
         SELECT
@@ -242,7 +255,7 @@ pub async fn fetch_pg_stat_activity(pool: &PgPool, limit: i64) -> Result<Vec<Act
     .bind(limit)
     .fetch_all(pool)
     .await
-    .context("fetch pg_stat_activity")?;
+    .wrap_err("fetch pg_stat_activity")?;
 
     Ok(rows)
 }
@@ -260,13 +273,13 @@ pub struct PgStatStatementRow {
 pub async fn fetch_pg_stat_statements(
     pool: &PgPool,
     limit: i64,
-) -> Result<Vec<PgStatStatementRow>> {
+) -> Result<Vec<PgStatStatementRow>, color_eyre::eyre::Report> {
     let extension_enabled: bool = sqlx::query_scalar(
         "SELECT EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_stat_statements')",
     )
     .fetch_one(pool)
     .await
-    .context("check pg_stat_statements extension")?;
+    .wrap_err("check pg_stat_statements extension")?;
 
     if !extension_enabled {
         bail!("pg_stat_statements extension is not enabled");
@@ -310,7 +323,7 @@ pub async fn fetch_pg_stat_statements(
                 .fetch_all(pool)
                 .await
                 .map_err(|secondary_err| {
-                    anyhow!(
+                    eyre!(
                         "failed querying pg_stat_statements (new columns: {}; old columns: {})",
                         primary_err,
                         secondary_err

--- a/crates/bin/soak-harness/src/diag.rs
+++ b/crates/bin/soak-harness/src/diag.rs
@@ -2,8 +2,8 @@ use std::collections::VecDeque;
 use std::fs::{self};
 use std::path::{Path, PathBuf};
 
-use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
+use color_eyre::eyre::WrapErr as _;
 use serde::Serialize;
 use sqlx::PgPool;
 use waymark_ids::WorkflowVersionId;
@@ -36,7 +36,9 @@ struct QueryCapture<T: Serialize> {
     pub error: Option<String>,
 }
 
-fn capture_query<T: Serialize>(result: Result<Vec<T>>) -> QueryCapture<T> {
+fn capture_query<T: Serialize>(
+    result: Result<Vec<T>, color_eyre::eyre::Report>,
+) -> QueryCapture<T> {
     match result {
         Ok(rows) => QueryCapture { rows, error: None },
         Err(err) => QueryCapture {
@@ -54,7 +56,7 @@ pub async fn capture_diagnostics(
     samples: &VecDeque<HealthSample>,
     worker_log_path: Option<&Path>,
     run_dir: &Path,
-) -> Result<PathBuf> {
+) -> Result<PathBuf, color_eyre::eyre::Report> {
     let workload_snapshot = data::fetch_workload_snapshot(pool).await?;
     let worker_status = data::fetch_latest_worker_status(pool).await?;
 
@@ -105,8 +107,8 @@ pub async fn capture_diagnostics(
     };
 
     let path = run_dir.join("diagnostics.json");
-    let json = serde_json::to_vec_pretty(&bundle).context("serialize diagnostics")?;
-    fs::write(&path, json).with_context(|| format!("write {}", path.display()))?;
+    let json = serde_json::to_vec_pretty(&bundle).wrap_err("serialize diagnostics")?;
+    fs::write(&path, json).wrap_err_with(|| format!("write {}", path.display()))?;
 
     Ok(path)
 }

--- a/crates/bin/soak-harness/src/flow.rs
+++ b/crates/bin/soak-harness/src/flow.rs
@@ -5,8 +5,8 @@ use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use anyhow::{Context, Result, anyhow, bail};
 use chrono::{DateTime, Utc};
+use color_eyre::eyre::{WrapErr as _, bail, eyre};
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
 use serde::Serialize;
@@ -61,7 +61,7 @@ pub async fn run_soak_loop(
     pool: &PgPool,
     workflow: &RegisteredWorkflow,
     worker: &mut Option<crate::setup_workers::WorkerProcess>,
-) -> Result<(TerminationReason, VecDeque<HealthSample>)> {
+) -> Result<(TerminationReason, VecDeque<HealthSample>), color_eyre::eyre::Report> {
     let seed = args.seed.unwrap_or_else(rand::random);
     info!(seed, "soak workload random seed");
     let mut rng = StdRng::seed_from_u64(seed);
@@ -90,7 +90,7 @@ pub async fn run_soak_loop(
             && let Some(status) = worker_process
                 .child
                 .try_wait()
-                .context("poll worker process")?
+                .wrap_err("poll worker process")?
         {
             return Ok((
                 TerminationReason::WorkerExited(format!("worker process exited: {status}")),
@@ -253,22 +253,22 @@ async fn register_instances(
     args: &crate::cli::SoakArgs,
     count: usize,
     rng: &mut StdRng,
-) -> Result<usize> {
+) -> Result<usize, color_eyre::eyre::Report> {
     for _ in 0..count {
         let item = sample_work_item(args, rng);
         let inputs = build_instance_inputs(&item)?;
 
         let call_spec = waymark_vm_runtime_builder::builder(&workflow.metadata)
             .first_fn()
-            .map_err(|err| anyhow!("select soak entry function: {err}"))?
+            .map_err(|err| eyre!("select soak entry function: {err}"))?
             .args(inputs)
-            .map_err(|err| anyhow!("match soak entry function arguments: {err}"))?;
+            .map_err(|err| eyre!("match soak entry function arguments: {err}"))?;
         let runtime = waymark_system_vm::Runtime::with_custom_entrypoint(
             waymark_system_vm::Interpreter::default(),
             Arc::clone(&workflow.executable),
             call_spec,
         )
-        .map_err(|err| anyhow!("create soak VM runtime: {err}"))?;
+        .map_err(|err| eyre!("create soak VM runtime: {err}"))?;
 
         services
             .registration
@@ -278,7 +278,7 @@ async fn register_instances(
                 |serializer| runtime.snapshot(serializer),
             )
             .await
-            .map_err(|err| anyhow!("register soak VM: {err}"))?;
+            .map_err(|err| eyre!("register soak VM: {err}"))?;
     }
 
     Ok(count)
@@ -352,7 +352,9 @@ fn jitter_payload(base_payload: i64, rng: &mut StdRng) -> i64 {
     rng.random_range(lower..=upper)
 }
 
-fn build_instance_inputs(item: &WorkItem) -> Result<HashMap<String, waymark_system_vm::Value>> {
+fn build_instance_inputs(
+    item: &WorkItem,
+) -> Result<HashMap<String, waymark_system_vm::Value>, color_eyre::eyre::Report> {
     if item.step_delays_ms.len() != item.step_should_fail.len()
         || item.step_delays_ms.len() != item.step_payload_bytes.len()
         || item.step_delays_ms.len() != item.step_include_payload.len()

--- a/crates/bin/soak-harness/src/main.rs
+++ b/crates/bin/soak-harness/src/main.rs
@@ -20,16 +20,16 @@ use std::collections::VecDeque;
 use std::fs::{self};
 use std::time::Duration;
 
-use anyhow::{Context, Result, bail};
 use chrono::Utc;
 use clap::Parser;
+use color_eyre::eyre::{WrapErr as _, bail};
 use tracing::{error, info};
 use waymark_backend_postgres::PostgresBackend;
 
 const DB_READY_TIMEOUT: Duration = Duration::from_secs(90);
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> Result<(), color_eyre::eyre::Report> {
     waymark_fn_main_common::init()?;
 
     let args = cli::SoakArgs::parse();
@@ -38,7 +38,7 @@ async fn main() -> Result<()> {
     let run_id = Utc::now().format("%Y%m%dT%H%M%SZ").to_string();
     let run_dir = args.diagnostic_dir.join(&run_id);
     fs::create_dir_all(&run_dir)
-        .with_context(|| format!("create run directory {}", run_dir.display()))?;
+        .wrap_err_with(|| format!("create run directory {}", run_dir.display()))?;
 
     // Create a convenience symlink pointing to this run directory at
     // the `diagnostic_dir`; the goal is to allow repeating
@@ -55,7 +55,7 @@ async fn main() -> Result<()> {
     let pool = setup_db::wait_for_database(&args.dsn, DB_READY_TIMEOUT).await?;
     waymark_backend_postgres_migrations::run(&pool)
         .await
-        .context("run migrations before soak")?;
+        .wrap_err("run migrations before soak")?;
 
     let backend = PostgresBackend::new(pool.clone());
     if !args.keep_existing_data {
@@ -75,7 +75,7 @@ async fn main() -> Result<()> {
         )
         .execute(&pool)
         .await
-        .context("clear durable-VM tables")?;
+        .wrap_err("clear durable-VM tables")?;
     }
     let services = setup_workflows::soak_services(&backend);
 
@@ -174,7 +174,10 @@ async fn main() -> Result<()> {
 
 /// Creates a `last` symlink that points to the current run directory adjacent
 /// to it.
-fn symlink_last(diagnostic_dir: &std::path::Path, run_id: &str) -> Result<()> {
+fn symlink_last(
+    diagnostic_dir: &std::path::Path,
+    run_id: &str,
+) -> Result<(), color_eyre::eyre::Report> {
     symlink_if_possible(std::path::Path::new(run_id), diagnostic_dir.join("last"))?;
     Ok(())
 }
@@ -184,7 +187,7 @@ fn symlink_last(diagnostic_dir: &std::path::Path, run_id: &str) -> Result<()> {
 fn symlink_if_possible(
     target: impl AsRef<std::path::Path>,
     link: impl AsRef<std::path::Path>,
-) -> Result<()> {
+) -> Result<(), color_eyre::eyre::Report> {
     #[cfg(unix)]
     {
         let new_link = link.as_ref().with_added_extension("new");

--- a/crates/bin/soak-harness/src/setup_db.rs
+++ b/crates/bin/soak-harness/src/setup_db.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
-use anyhow::{Context, Result, anyhow, bail};
+use color_eyre::eyre::{WrapErr as _, bail, eyre};
 use sqlx::PgPool;
 use sqlx::postgres::PgPoolOptions;
 use tokio::process::Command;
@@ -9,7 +9,7 @@ use waymark_secret_string::SecretStr;
 
 const DB_RETRY_DELAY: Duration = Duration::from_millis(500);
 
-pub async fn boot_postgres() -> Result<()> {
+pub async fn boot_postgres() -> Result<(), color_eyre::eyre::Report> {
     let project_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let status = Command::new("docker")
         .arg("compose")
@@ -21,7 +21,7 @@ pub async fn boot_postgres() -> Result<()> {
         .current_dir(&project_root)
         .status()
         .await
-        .with_context(|| format!("run docker compose from {}", project_root.display()))?;
+        .wrap_err_with(|| format!("run docker compose from {}", project_root.display()))?;
 
     if !status.success() {
         bail!("docker compose up -d postgres failed with status {status}");
@@ -30,7 +30,10 @@ pub async fn boot_postgres() -> Result<()> {
     Ok(())
 }
 
-pub async fn wait_for_database(dsn: &SecretStr, timeout: Duration) -> Result<PgPool> {
+pub async fn wait_for_database(
+    dsn: &SecretStr,
+    timeout: Duration,
+) -> Result<PgPool, color_eyre::eyre::Report> {
     let deadline = Instant::now() + timeout;
     let mut last_error: Option<String> = None;
 
@@ -49,7 +52,7 @@ pub async fn wait_for_database(dsn: &SecretStr, timeout: Duration) -> Result<PgP
         }
     }
 
-    Err(anyhow!(
+    Err(eyre!(
         "timed out waiting for Postgres at {}; last error: {}",
         dsn.expose_secret(),
         last_error.unwrap_or_else(|| "unknown".to_string())

--- a/crates/bin/soak-harness/src/setup_workers.rs
+++ b/crates/bin/soak-harness/src/setup_workers.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::time::{Duration, Instant};
 
-use anyhow::{Context, Result, bail};
+use color_eyre::eyre::{WrapErr as _, bail};
 use sqlx::PgPool;
 use tokio::process::{Child, Command};
 use tracing::{info, warn};
@@ -17,7 +17,10 @@ pub struct WorkerProcess {
     pub log_path: PathBuf,
 }
 
-pub async fn start_workers(args: &crate::cli::SoakArgs, run_dir: &Path) -> Result<WorkerProcess> {
+pub async fn start_workers(
+    args: &crate::cli::SoakArgs,
+    run_dir: &Path,
+) -> Result<WorkerProcess, color_eyre::eyre::Report> {
     let webapp_enabled = !args.disable_webapp;
     let log_path = run_dir.join("start-workers.log");
     // `CARGO_MANIFEST_DIR` here is `crates/bin/soak-harness`, while the soak action module lives at
@@ -27,10 +30,10 @@ pub async fn start_workers(args: &crate::cli::SoakArgs, run_dir: &Path) -> Resul
     // remains importable even if worker-remote falls back to the caller's current directory.
     let repo_root = repo_root();
     let log_file = File::create(&log_path)
-        .with_context(|| format!("create worker log file {}", log_path.display()))?;
+        .wrap_err_with(|| format!("create worker log file {}", log_path.display()))?;
     let log_file_err = log_file
         .try_clone()
-        .with_context(|| format!("clone worker log handle {}", log_path.display()))?;
+        .wrap_err_with(|| format!("clone worker log handle {}", log_path.display()))?;
 
     let mut cmd = start_workers_command();
     cmd.current_dir(&repo_root);
@@ -64,7 +67,9 @@ pub async fn start_workers(args: &crate::cli::SoakArgs, run_dir: &Path) -> Resul
     cmd.stdout(Stdio::from(log_file));
     cmd.stderr(Stdio::from(log_file_err));
 
-    let child = cmd.spawn().context("spawn waymark-start-workers process")?;
+    let child = cmd
+        .spawn()
+        .wrap_err("spawn waymark-start-workers process")?;
     info!(
         log_path = %log_path.display(),
         webapp_enabled,
@@ -114,7 +119,7 @@ fn repo_root() -> PathBuf {
     path
 }
 
-fn soak_python_path(repo_root: &Path) -> Result<std::ffi::OsString> {
+fn soak_python_path(repo_root: &Path) -> Result<std::ffi::OsString, color_eyre::eyre::Report> {
     let mut python_paths = vec![
         repo_root.join("python"),
         repo_root.join("python").join("src"),
@@ -123,7 +128,7 @@ fn soak_python_path(repo_root: &Path) -> Result<std::ffi::OsString> {
         python_paths.extend(std::env::split_paths(&existing));
     }
 
-    std::env::join_paths(&python_paths).context("build soak PYTHONPATH")
+    std::env::join_paths(&python_paths).wrap_err("build soak PYTHONPATH")
 }
 
 fn find_executable(bin: &str) -> Option<PathBuf> {
@@ -144,11 +149,11 @@ fn find_executable(bin: &str) -> Option<PathBuf> {
     None
 }
 
-pub async fn shutdown_worker(worker: &mut WorkerProcess) -> Result<()> {
+pub async fn shutdown_worker(worker: &mut WorkerProcess) -> Result<(), color_eyre::eyre::Report> {
     if worker
         .child
         .try_wait()
-        .context("check worker process status")?
+        .wrap_err("check worker process status")?
         .is_some()
     {
         return Ok(());
@@ -158,12 +163,12 @@ pub async fn shutdown_worker(worker: &mut WorkerProcess) -> Result<()> {
     worker
         .child
         .start_kill()
-        .context("send kill signal to worker process")?;
+        .wrap_err("send kill signal to worker process")?;
 
     let status = tokio::time::timeout(Duration::from_secs(10), worker.child.wait())
         .await
-        .context("timed out waiting for worker process shutdown")?
-        .context("wait for worker process")?;
+        .wrap_err("timed out waiting for worker process shutdown")?
+        .wrap_err("wait for worker process")?;
 
     info!(status = %status, "worker process stopped");
     Ok(())
@@ -182,7 +187,7 @@ pub async fn wait_for_worker_status(
     timeout: Duration,
     startup_log_interval: Duration,
     worker: &mut WorkerProcess,
-) -> Result<()> {
+) -> Result<(), color_eyre::eyre::Report> {
     let deadline = Instant::now() + timeout;
     let started = Instant::now();
     let mut last_log_at = Instant::now();
@@ -191,7 +196,7 @@ pub async fn wait_for_worker_status(
         if let Some(status) = worker
             .child
             .try_wait()
-            .context("check worker status during startup wait")?
+            .wrap_err("check worker status during startup wait")?
         {
             let tail = crate::common::read_tail_lines(&worker.log_path, 80).unwrap_or_default();
             let tail_text = if tail.is_empty() {

--- a/crates/bin/soak-harness/src/setup_workflows.rs
+++ b/crates/bin/soak-harness/src/setup_workflows.rs
@@ -1,6 +1,6 @@
 use std::{num::NonZeroUsize, sync::Arc};
 
-use anyhow::{Result, anyhow};
+use color_eyre::eyre::eyre;
 use prost::Message as _;
 use sha2::{Digest as _, Sha256};
 use waymark_backend_postgres::PostgresBackend;
@@ -50,20 +50,20 @@ pub async fn register_workflow(
     timeout_seconds: u32,
     actions_per_workflow: NonZeroUsize,
     user_module: &str,
-) -> Result<RegisteredWorkflow> {
+) -> Result<RegisteredWorkflow, color_eyre::eyre::Report> {
     let source = workflow_source(user_module, timeout_seconds, actions_per_workflow);
 
-    let program = parse_program(source.trim()).map_err(|err| anyhow!(err.to_string()))?;
+    let program = parse_program(source.trim()).map_err(|err| eyre!(err.to_string()))?;
     let program_proto = program.encode_to_vec();
     let ir_hash = format!("{:x}", Sha256::digest(&program_proto));
     let program = waymark_vm_ast_old_proto::convert(program)
-        .map_err(|err| anyhow!("convert soak workflow to the VM AST: {err}"))?;
+        .map_err(|err| eyre!("convert soak workflow to the VM AST: {err}"))?;
 
     let (workflow_version_id, executable, metadata) = services
         .executables
         .compile_and_store(DEFAULT_WORKFLOW_NAME, &ir_hash, &program)
         .await
-        .map_err(|err| anyhow!("compile and store soak workflow: {err}"))?;
+        .map_err(|err| eyre!("compile and store soak workflow: {err}"))?;
 
     Ok(RegisteredWorkflow {
         workflow_name: DEFAULT_WORKFLOW_NAME.to_string(),

--- a/crates/bin/start-workers/Cargo.toml
+++ b/crates/bin/start-workers/Cargo.toml
@@ -18,7 +18,6 @@ waymark-worker-remote-bringup = { workspace = true }
 waymark-worker-remote-pool = { workspace = true }
 waymark-worker-status-reporter = { workspace = true }
 
-anyhow = { workspace = true }
 envfury = { workspace = true }
 metrics = { workspace = true }
 sqlx = { workspace = true }

--- a/crates/bin/start-workers/src/main.rs
+++ b/crates/bin/start-workers/src/main.rs
@@ -36,7 +36,6 @@
 use std::sync::{Arc, atomic::AtomicUsize};
 use std::time::Duration;
 
-use anyhow::Result;
 use sqlx::PgPool;
 use tokio::signal;
 use tracing::{error, info, warn};
@@ -46,7 +45,7 @@ use waymark_backend_postgres::PostgresBackend;
 use waymark_config::WorkerConfig;
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> Result<(), waymark_fn_main_common::Error> {
     waymark_fn_main_common::init()?;
 
     let metrics_addr: std::net::SocketAddr = envfury::or_parse("METRICS_ADDR", "0.0.0.0:9118")?;
@@ -238,14 +237,14 @@ async fn main() -> Result<()> {
 
     if let Some(webapp_handle) = maybe_webapp_handle {
         // Wait for graceful termination.
-        webapp_handle.await.unwrap();
+        webapp_handle.await?;
     }
 
     info!("shutdown complete");
     Ok(())
 }
 
-async fn wait_for_shutdown() -> Result<()> {
+async fn wait_for_shutdown() -> Result<(), std::io::Error> {
     #[cfg(unix)]
     {
         use tokio::signal::unix::{SignalKind, signal as unix_signal};

--- a/crates/lib/config/Cargo.toml
+++ b/crates/lib/config/Cargo.toml
@@ -11,8 +11,8 @@ waymark-scheduler-config = { workspace = true }
 waymark-secret-string = { workspace = true }
 waymark-webapp-config = { workspace = true }
 
-thiserror = { workspace = true }
 envfury = { workspace = true }
+thiserror = { workspace = true }
 
 [lib]
 test = false

--- a/crates/lib/config/Cargo.toml
+++ b/crates/lib/config/Cargo.toml
@@ -11,7 +11,7 @@ waymark-scheduler-config = { workspace = true }
 waymark-secret-string = { workspace = true }
 waymark-webapp-config = { workspace = true }
 
-anyhow = { workspace = true }
+thiserror = { workspace = true }
 envfury = { workspace = true }
 
 [lib]

--- a/crates/lib/config/src/lib.rs
+++ b/crates/lib/config/src/lib.rs
@@ -52,8 +52,32 @@ pub struct WorkerConfig {
     pub executable_sweep_interval: NonZeroDuration,
 }
 
+/// Error returned when reading a [`WorkerConfig`] from the environment.
+#[derive(Debug, thiserror::Error)]
+pub enum FromEnvError {
+    /// A required variable could not be read.
+    #[error(transparent)]
+    Must(#[from] envfury::Error<envfury::MustError<std::convert::Infallible>>),
+
+    /// A socket-address variable (with a parsed default) could not be read.
+    #[error(transparent)]
+    SocketAddrOrDefault(#[from] envfury::Error<envfury::OrParseError<std::net::AddrParseError>>),
+
+    /// An integer-backed variable (with a parsed default) could not be read.
+    #[error(transparent)]
+    IntOrDefault(#[from] envfury::Error<envfury::OrParseError<core::num::ParseIntError>>),
+
+    /// A list variable (with a parsed default) could not be read.
+    #[error(transparent)]
+    ListOrDefault(#[from] envfury::Error<envfury::OrParseError<std::convert::Infallible>>),
+
+    /// An integer-backed variable (without a parsed default) could not be read.
+    #[error(transparent)]
+    Int(#[from] envfury::Error<envfury::ValueError<core::num::ParseIntError>>),
+}
+
 impl WorkerConfig {
-    pub fn from_env() -> Result<Self, anyhow::Error> {
+    pub fn from_env() -> Result<Self, FromEnvError> {
         use self::parse::*;
 
         let database_url = envfury::must("WAYMARK_DATABASE_URL")?;

--- a/crates/lib/observability-setup/src/chrome_trace.rs
+++ b/crates/lib/observability-setup/src/chrome_trace.rs
@@ -1,36 +1,33 @@
 //! Chrome-trace file output.
 
-use std::sync::OnceLock;
-
-use tracing_chrome::FlushGuard;
 use tracing_subscriber::Registry;
 
 use crate::ObservabilityOptions;
 
-static TRACE_GUARD: OnceLock<std::sync::Mutex<Option<FlushGuard>>> = OnceLock::new();
+/// Flushes and finalizes the chrome trace file on drop, if one was being
+/// written; returned by [`crate::tracing_layer`].
+///
+/// Bind it for the duration of `main` so the trace survives error
+/// returns — the trace tail is otherwise lost precisely on the runs
+/// where it would help diagnose the failure.
+#[must_use = "the chrome trace is only flushed when this guard is dropped; bind it for the duration of the run"]
+pub struct FlushOnDrop(Option<tracing_chrome::FlushGuard>);
 
-fn store_trace_guard(guard: FlushGuard) {
-    let cell = TRACE_GUARD.get_or_init(|| std::sync::Mutex::new(None));
-    let mut slot = cell.lock().expect("trace guard lock poisoned");
-    *slot = Some(guard);
-}
-
-pub(crate) fn flush() {
-    if let Some(cell) = TRACE_GUARD.get() {
-        let mut slot = cell.lock().expect("trace guard lock poisoned");
-        slot.take();
+impl Drop for FlushOnDrop {
+    fn drop(&mut self) {
+        self.0.take();
     }
 }
 
 pub(crate) fn layer(
     options: &ObservabilityOptions,
-) -> Option<tracing_chrome::ChromeLayer<Registry>> {
-    options.chrome_trace_path.as_ref().map(|path| {
-        let (layer, guard) = tracing_chrome::ChromeLayerBuilder::new()
-            .file(path.clone())
-            .build();
-        eprintln!("tracing-chrome enabled (trace at {path})");
-        store_trace_guard(guard);
-        layer
-    })
+) -> (Option<tracing_chrome::ChromeLayer<Registry>>, FlushOnDrop) {
+    let Some(path) = options.chrome_trace_path.as_ref() else {
+        return (None, FlushOnDrop(None));
+    };
+    let (layer, guard) = tracing_chrome::ChromeLayerBuilder::new()
+        .file(path.clone())
+        .build();
+    eprintln!("tracing-chrome enabled (trace at {path})");
+    (Some(layer), FlushOnDrop(Some(guard)))
 }

--- a/crates/lib/observability-setup/src/lib.rs
+++ b/crates/lib/observability-setup/src/lib.rs
@@ -37,19 +37,22 @@ mod chrome_trace;
 mod chrome_trace {
     use super::ObservabilityOptions;
 
+    /// The no-op stand-in for the chrome-trace flush guard in builds
+    /// with chrome tracing disabled; returned by [`crate::tracing_layer`].
+    #[must_use = "the chrome trace is only flushed when this guard is dropped; bind it for the duration of the run"]
+    pub struct FlushOnDrop;
+
     pub(crate) fn layer(
         options: &ObservabilityOptions,
-    ) -> Option<tracing_subscriber::layer::Identity> {
+    ) -> (Option<tracing_subscriber::layer::Identity>, FlushOnDrop) {
         if options.chrome_trace_path.is_some() {
             eprintln!(
                 "chrome tracing disabled. Rebuild with \
                  `--cfg waymark_observability_chrome_trace` to enable it."
             );
         }
-        None
+        (None, FlushOnDrop)
     }
-
-    pub(crate) fn flush() {}
 }
 
 #[cfg(waymark_observability_tokio_console)]
@@ -72,20 +75,20 @@ mod tokio_console {
     }
 }
 
-/// Build the extra tracing layer for the requested observability options.
+pub use chrome_trace::FlushOnDrop;
+
+/// Build the extra tracing layer for the requested observability
+/// options, along with the [`FlushOnDrop`] guard that finalizes the
+/// chrome trace.
 ///
 /// Construction is effectful where the option demands it: the chrome
-/// layer registers its flush guard (see [`flush`]), and the console layer
-/// spawns its server.
+/// layer opens its trace file, and the console layer spawns its server.
 pub fn tracing_layer(
     options: &ObservabilityOptions,
-) -> impl Layer<Registry> + Send + Sync + 'static {
+) -> (impl Layer<Registry> + Send + Sync + 'static, FlushOnDrop) {
+    let (chrome_layer, flush_on_drop) = chrome_trace::layer(options);
     // The trait form: `Option`'s inherent `and_then` shadows the
     // `Layer` combinator on the method call syntax.
-    Layer::and_then(chrome_trace::layer(options), tokio_console::layer(options))
-}
-
-/// Flush and finalize the chrome trace file, if one was being written.
-pub fn flush() {
-    chrome_trace::flush();
+    let layer = Layer::and_then(chrome_layer, tokio_console::layer(options));
+    (layer, flush_on_drop)
 }

--- a/crates/lib/webapp-bringup/Cargo.toml
+++ b/crates/lib/webapp-bringup/Cargo.toml
@@ -9,8 +9,9 @@ waymark-webapp-backend = { workspace = true }
 waymark-webapp-config = { workspace = true }
 waymark-webapp-routes = { workspace = true }
 
-anyhow = { workspace = true }
 axum = { workspace = true }
+tera = { workspace = true }
+thiserror = { workspace = true }
 tokio = { workspace = true, features = ["net"] }
 tokio-util = { workspace = true }
 tracing = { workspace = true }

--- a/crates/lib/webapp-bringup/src/lib.rs
+++ b/crates/lib/webapp-bringup/src/lib.rs
@@ -2,9 +2,31 @@
 
 use std::sync::Arc;
 
-use anyhow::Context as _;
 use tokio::net::TcpListener;
 use waymark_webapp_config::WebappConfig;
+
+/// Error returned when starting the webapp server fails.
+#[derive(Debug, thiserror::Error)]
+pub enum StartError {
+    /// Binding the webapp listener failed.
+    #[error("bind webapp listener on {bind_addr}: {source}")]
+    Bind {
+        /// The address the listener was binding to.
+        bind_addr: String,
+
+        /// The underlying bind error.
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// Reading the bound listener address failed.
+    #[error("read webapp listener local address: {0}")]
+    LocalAddr(#[source] std::io::Error),
+
+    /// Initializing the webapp templates failed.
+    #[error("initialize webapp templates: {0}")]
+    Templates(#[source] tera::Error),
+}
 
 /// Start the webapp server.
 ///
@@ -13,7 +35,7 @@ pub async fn start<WebappBackend>(
     config: WebappConfig,
     database: Arc<WebappBackend>,
     shutdown_signal: tokio_util::sync::WaitForCancellationFutureOwned,
-) -> Result<Option<tokio::task::JoinHandle<()>>, anyhow::Error>
+) -> Result<Option<tokio::task::JoinHandle<()>>, StartError>
 where
     WebappBackend: ?Sized,
     WebappBackend: waymark_webapp_backend::WebappBackend,
@@ -33,12 +55,12 @@ where
     let bind_addr = config.bind_addr();
     let listener = TcpListener::bind(&bind_addr)
         .await
-        .with_context(|| format!("failed to bind webapp listener on {bind_addr}"))?;
+        .map_err(|source| StartError::Bind { bind_addr, source })?;
 
-    let actual_addr = listener.local_addr()?;
+    let actual_addr = listener.local_addr().map_err(StartError::LocalAddr)?;
 
     // Initialize templates
-    let templates = waymark_webapp_routes::init_templates()?;
+    let templates = waymark_webapp_routes::init_templates().map_err(StartError::Templates)?;
 
     let state = waymark_webapp_routes::WebappState {
         database,


### PR DESCRIPTION
Goes in after #519

---

This PR is two-fold: it eliminated anyhow in lib crates by providing proper custom errors, and it gets rid of anyhow in bin crates by switching the implementation to `color_eyre` (or to also `thiserror`-powered custom error types).