### PR TITLE
Re-add queue-batch-size flag to soak-harness

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,9 @@ $ make benchmark
 writes a tracing-chrome file, and prints a pyinstrument-style summary
 via `scripts/parse_chrome_trace.py`. Override the trace path
 with `BENCH_TRACE=...`, the summary size with `BENCH_TRACE_TOP=...`, or benchmark args with
-`BENCH_ARGS="--count 200 --batch-size 50"`. Set `BENCH_RELEASE=1` to run the benchmark binary
+`BENCH_ARGS="--count 200 --base 10"`. Registration and persistence batch sizes are environment
+knobs (`WAYMARK_REGISTRATION_BATCH_MAX`, `WAYMARK_SNAPSHOT_BATCH_MAX`, …), not CLI flags.
+Set `BENCH_RELEASE=1` to run the benchmark binary
 from the release profile. `make benchmark-trace` is an alias if you want the explicit target
 name.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5341,6 +5341,7 @@ dependencies = [
  "chrono",
  "clap",
  "color-eyre",
+ "nonempty-collections",
  "prost 0.12.6",
  "rand 0.9.3",
  "serde",
@@ -5364,6 +5365,7 @@ dependencies = [
  "waymark-vm-runtime-builder",
  "waymark-workflow-service-vm-executables",
  "waymark-workflow-service-vm-runtimes",
+ "waymark-workflow-service-vm-runtimes-backend",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5340,6 +5340,7 @@ dependencies = [
  "chrono",
  "clap",
  "color-eyre",
+ "nonempty-collections",
  "prost 0.12.6",
  "rand 0.9.3",
  "serde",
@@ -5363,6 +5364,7 @@ dependencies = [
  "waymark-vm-runtime-builder",
  "waymark-workflow-service-vm-executables",
  "waymark-workflow-service-vm-runtimes",
+ "waymark-workflow-service-vm-runtimes-backend",
 ]
 
 [[package]]

--- a/crates/bin/soak-harness/Cargo.toml
+++ b/crates/bin/soak-harness/Cargo.toml
@@ -19,10 +19,12 @@ waymark-vm-compiler-for-ast-old-core = { workspace = true }
 waymark-vm-runtime-builder = { workspace = true }
 waymark-workflow-service-vm-executables = { workspace = true }
 waymark-workflow-service-vm-runtimes = { workspace = true }
+waymark-workflow-service-vm-runtimes-backend = { workspace = true }
 
 chrono = { workspace = true }
 clap = { workspace = true, features = ["derive", "env"] }
 color-eyre = { workspace = true }
+nonempty-collections = { workspace = true }
 prost = { workspace = true }
 rand = { workspace = true }
 serde = { workspace = true, features = ["derive"] }

--- a/crates/bin/soak-harness/src/cli.rs
+++ b/crates/bin/soak-harness/src/cli.rs
@@ -72,6 +72,9 @@ pub struct SoakArgs {
     #[arg(long, default_value_t = 5.try_into().unwrap())]
     pub actions_per_workflow: NonZeroUsize,
 
+    #[arg(long, default_value_t = 500.try_into().unwrap())]
+    pub queue_batch_size: NonZeroUsize,
+
     #[arg(long, default_value_t = 50_000)]
     pub target_ready_queue: i64,
 

--- a/crates/bin/soak-harness/src/flow.rs
+++ b/crates/bin/soak-harness/src/flow.rs
@@ -254,34 +254,56 @@ async fn register_instances(
     count: usize,
     rng: &mut StdRng,
 ) -> Result<usize, color_eyre::eyre::Report> {
-    for _ in 0..count {
-        let item = sample_work_item(args, rng);
-        let inputs = build_instance_inputs(&item)?;
+    let mut registered = 0usize;
 
-        let call_spec = waymark_vm_runtime_builder::builder(&workflow.metadata)
-            .first_fn()
-            .map_err(|err| eyre!("select soak entry function: {err}"))?
-            .args(inputs)
-            .map_err(|err| eyre!("match soak entry function arguments: {err}"))?;
-        let runtime = waymark_system_vm::Runtime::with_custom_entrypoint(
-            waymark_system_vm::Interpreter::default(),
-            Arc::clone(&workflow.executable),
-            call_spec,
-        )
-        .map_err(|err| eyre!("create soak VM runtime: {err}"))?;
+    while registered < count {
+        let take = (count - registered).min(args.queue_batch_size.get());
+        let mut vms = Vec::with_capacity(take);
 
-        services
-            .registration
-            .register_vm(
+        for _ in 0..take {
+            let item = sample_work_item(args, rng);
+            let inputs = build_instance_inputs(&item)?;
+
+            let call_spec = waymark_vm_runtime_builder::builder(&workflow.metadata)
+                .first_fn()
+                .map_err(|err| eyre!("select soak entry function: {err}"))?
+                .args(inputs)
+                .map_err(|err| eyre!("match soak entry function arguments: {err}"))?;
+            let runtime = waymark_system_vm::Runtime::with_custom_entrypoint(
+                waymark_system_vm::Interpreter::default(),
+                Arc::clone(&workflow.executable),
+                call_spec,
+            )
+            .map_err(|err| eyre!("create soak VM runtime: {err}"))?;
+
+            vms.push((
                 InstanceId::new_uuid_v4(),
                 workflow.workflow_version_id,
-                |serializer| runtime.snapshot(serializer),
+                runtime,
+            ));
+        }
+
+        let success = services
+            .registration
+            .register_vms(
+                nonempty_collections::NEVec::try_from_vec(vms)
+                    .expect("the batch takes at least one instance"),
+                |runtime, serializer| runtime.snapshot(serializer),
             )
             .await
-            .map_err(|err| eyre!("register soak VM: {err}"))?;
+            .map_err(|err| eyre!("register soak VMs: {err}"))?;
+        assert!(
+            matches!(
+                success,
+                waymark_workflow_service_vm_runtimes_backend::register_vm_runtimes::RegistrationSuccess::AllRegistered,
+            ),
+            "freshly minted instance ids can never be already registered",
+        );
+
+        registered += take;
     }
 
-    Ok(count)
+    Ok(registered)
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
Goes in after #520 

---

This PR addresses an issue with missing flags still used in CI. Rather than dropping, we've re-implemented the flag so it now works just like before.