### PR TITLE
Turn some interpreter errors into catchable exceptions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5793,6 +5793,7 @@ dependencies = [
  "waymark-vm-compiler-for-ast-old-core",
  "waymark-vm-compiler-for-ast-old-test-support",
  "waymark-vm-exception-handler",
+ "waymark-vm-exception-type-ids",
  "waymark-vm-instructions-coreset",
  "waymark-vm-instructions-extcallset",
  "waymark-vm-instructions-fullset",
@@ -5927,6 +5928,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "waymark-vm-exception-type-ids"
+version = "0.1.0"
+
+[[package]]
 name = "waymark-vm-executable"
 version = "0.1.0"
 
@@ -6040,6 +6045,7 @@ dependencies = [
  "derive-where",
  "static_assertions",
  "thiserror",
+ "waymark-vm-exception-type-ids",
  "waymark-vm-instructions-pureset",
  "waymark-vm-interpreter",
  "waymark-vm-interpreter-coreset",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5795,6 +5795,7 @@ dependencies = [
  "waymark-vm-compiler-for-ast-old-core",
  "waymark-vm-compiler-for-ast-old-test-support",
  "waymark-vm-exception-handler",
+ "waymark-vm-exception-type-ids",
  "waymark-vm-instructions-coreset",
  "waymark-vm-instructions-extcallset",
  "waymark-vm-instructions-fullset",
@@ -5929,6 +5930,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "waymark-vm-exception-type-ids"
+version = "0.1.0"
+
+[[package]]
 name = "waymark-vm-executable"
 version = "0.1.0"
 
@@ -6042,6 +6047,7 @@ dependencies = [
  "derive-where",
  "static_assertions",
  "thiserror",
+ "waymark-vm-exception-type-ids",
  "waymark-vm-instructions-pureset",
  "waymark-vm-interpreter",
  "waymark-vm-interpreter-coreset",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6015,6 +6015,7 @@ dependencies = [
  "thiserror",
  "waymark-nonzero-duration",
  "waymark-vm-bytecode",
+ "waymark-vm-exception-handler",
  "waymark-vm-executable",
  "waymark-vm-instructions-coreset",
  "waymark-vm-instructions-extcallset",
@@ -6045,6 +6046,7 @@ dependencies = [
  "waymark-vm-interpreter-utils",
  "waymark-vm-runtime",
  "waymark-vm-runtime-core",
+ "waymark-vm-runtime-exception",
  "waymark-vm-runtime-test",
  "waymark-vm-runtime-value",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6017,6 +6017,7 @@ dependencies = [
  "thiserror",
  "waymark-nonzero-duration",
  "waymark-vm-bytecode",
+ "waymark-vm-exception-handler",
  "waymark-vm-executable",
  "waymark-vm-instructions-coreset",
  "waymark-vm-instructions-extcallset",
@@ -6047,6 +6048,7 @@ dependencies = [
  "waymark-vm-interpreter-utils",
  "waymark-vm-runtime",
  "waymark-vm-runtime-core",
+ "waymark-vm-runtime-exception",
  "waymark-vm-runtime-test",
  "waymark-vm-runtime-value",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,6 +117,7 @@ waymark-vm-driver = { path = "crates/lib/vm-driver" }
 waymark-vm-driver-core = { path = "crates/lib/vm-driver-core" }
 waymark-vm-driver-thread = { path = "crates/lib/vm-driver-thread" }
 waymark-vm-exception-handler = { path = "crates/lib/vm-exception-handler" }
+waymark-vm-exception-type-ids = { path = "crates/lib/vm-exception-type-ids" }
 waymark-vm-executable = { path = "crates/lib/vm-executable" }
 waymark-vm-instructions-coreset = { path = "crates/lib/vm-instructions-coreset" }
 waymark-vm-instructions-extcallset = { path = "crates/lib/vm-instructions-extcallset" }

--- a/crates/bin/benchmark/src/cases.rs
+++ b/crates/bin/benchmark/src/cases.rs
@@ -45,14 +45,9 @@ pub fn build_cases(base: i64) -> Result<HashMap<String, BenchmarkCase>, color_ey
             build_try_except_program()
                 .map_err(|err| eyre!(err))
                 .wrap_err("build try_except program")?,
-            // No value may equal 2: the program divides by `item - 2`, and a
-            // division-by-zero fault is not yet catchable by `except` — it
-            // kills the VM, and the released workload crash-loops forever
-            // (see "Missing feature: catchable runtime exceptions" in
-            // notes/postponed.md).
             HashMap::from([(
                 "values".to_string(),
-                serde_json::Value::Array(vec![1.into(), 3.into(), 4.into()]),
+                serde_json::Value::Array(vec![1.into(), 2.into(), 3.into()]),
             )]),
         ),
         (

--- a/crates/lib/vm-compiler-for-ast-old/Cargo.toml
+++ b/crates/lib/vm-compiler-for-ast-old/Cargo.toml
@@ -10,6 +10,7 @@ waymark-vm-bytecode = { workspace = true }
 waymark-vm-bytecode-core = { workspace = true }
 waymark-vm-compiler-for-ast-old-core = { workspace = true }
 waymark-vm-exception-handler = { workspace = true }
+waymark-vm-exception-type-ids = { workspace = true }
 waymark-vm-instructions-coreset = { workspace = true }
 waymark-vm-instructions-extcallset = { workspace = true }
 waymark-vm-instructions-fullset = { workspace = true }

--- a/crates/lib/vm-compiler-for-ast-old/src/function/compiler/lowering/assignment.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/function/compiler/lowering/assignment.rs
@@ -17,7 +17,7 @@ use super::plan::assignment::AssignmentStatementPlan;
 
 /// The exception type raised when an unpacked value's length does not match
 /// the assignment target count.
-const UNPACK_MISMATCH_TYPE_ID: &str = "ValueError";
+const UNPACK_MISMATCH_TYPE_ID: &str = waymark_vm_exception_type_ids::VALUE_ERROR;
 
 /// Lowers assignment statements into bytecode.
 pub struct AssignmentCompiler<'borrow, 'table, Spec, Lowering>

--- a/crates/lib/vm-compiler-for-ast-old/src/function/compiler/wrapper_fn.rs
+++ b/crates/lib/vm-compiler-for-ast-old/src/function/compiler/wrapper_fn.rs
@@ -21,7 +21,7 @@ use super::suspend::PromiseMarker;
 use super::{Error, ErrorFor};
 
 /// The exception type id raised when a per-attempt timeout fires.
-const ACTION_TIMEOUT_TYPE_ID: &str = "ActionTimeout";
+const ACTION_TIMEOUT_TYPE_ID: &str = waymark_vm_exception_type_ids::ACTION_TIMEOUT;
 
 /// One digested retry bracket.
 struct RetryPlan {

--- a/crates/lib/vm-exception-type-ids/Cargo.toml
+++ b/crates/lib/vm-exception-type-ids/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "waymark-vm-exception-type-ids"
+edition = "2024"
+version.workspace = true
+publish.workspace = true
+
+[dependencies]

--- a/crates/lib/vm-exception-type-ids/src/lib.rs
+++ b/crates/lib/vm-exception-type-ids/src/lib.rs
@@ -1,0 +1,34 @@
+//! The exception type identifiers for the built-in runtime exceptions.
+//!
+//! The single source of truth for the type id spellings shared by
+//! the producers (the compiler lowerings and the interpreters) and
+//! the exception handler matching.
+
+#![warn(missing_docs)]
+
+/// The runtime exception type identifier for a division by zero.
+pub const ZERO_DIVISION_ERROR: &str = "ZeroDivisionError";
+
+/// The runtime exception type identifier for an operation applied to values
+/// of unsupported types.
+pub const TYPE_ERROR: &str = "TypeError";
+
+/// The runtime exception type identifier for a result too large to be
+/// represented.
+pub const OVERFLOW_ERROR: &str = "OverflowError";
+
+/// The runtime exception type identifier for a sequence index out of range.
+pub const INDEX_ERROR: &str = "IndexError";
+
+/// The runtime exception type identifier for a missing mapping key.
+pub const KEY_ERROR: &str = "KeyError";
+
+/// The runtime exception type identifier for a failed attribute reference.
+pub const ATTRIBUTE_ERROR: &str = "AttributeError";
+
+/// The runtime exception type identifier for a value of the right type but
+/// an inappropriate value.
+pub const VALUE_ERROR: &str = "ValueError";
+
+/// The runtime exception type identifier for an action call that timed out.
+pub const ACTION_TIMEOUT: &str = "ActionTimeout";

--- a/crates/lib/vm-interpreter-fullset/Cargo.toml
+++ b/crates/lib/vm-interpreter-fullset/Cargo.toml
@@ -24,6 +24,7 @@ thiserror = { workspace = true }
 [dev-dependencies]
 waymark-nonzero-duration = { workspace = true }
 waymark-vm-bytecode = { workspace = true }
+waymark-vm-exception-handler = { workspace = true }
 waymark-vm-runtime = { workspace = true }
 waymark-vm-runtime-test = { workspace = true }
 waymark-vm-runtime-value = { workspace = true }

--- a/crates/lib/vm-interpreter-fullset/tests/integration.rs
+++ b/crates/lib/vm-interpreter-fullset/tests/integration.rs
@@ -10,3 +10,4 @@ mod select;
 mod sleep;
 mod state_entry;
 mod synchronous;
+mod typed_exception;

--- a/crates/lib/vm-interpreter-fullset/tests/support/mod.rs
+++ b/crates/lib/vm-interpreter-fullset/tests/support/mod.rs
@@ -83,6 +83,7 @@ pub enum TestSleepDurationError {
 pub enum TestReadyValue {
     Int(i64),
     Bool(bool),
+    Text(String),
     List(Vec<TestValue>),
     Exception(Box<Exception<TestValue>>),
 }
@@ -95,6 +96,7 @@ fn is_truthy(value: &TestReadyValue) -> bool {
     match value {
         TestReadyValue::Int(value) => *value != 0,
         TestReadyValue::Bool(value) => *value,
+        TestReadyValue::Text(value) => !value.is_empty(),
         TestReadyValue::List(items) => !items.is_empty(),
         TestReadyValue::Exception(_) => true,
     }
@@ -234,13 +236,22 @@ impl waymark_vm_interpreter_pureset::value::MakeException for TestReadyValue {
     }
 }
 
+impl waymark_vm_runtime_exception::ExceptionFromIntermediate<String> for TestReadyValue {
+    fn from_intermediate_exception(exception: Exception<String>) -> Exception<Self::RootValue> {
+        Exception {
+            type_id: exception.type_id,
+            details: TestValue::Ready(Self::Text(exception.details)),
+        }
+    }
+}
+
 impl waymark_vm_interpreter_pureset::value::Length for TestReadyValue {
     type Length = usize;
 
     fn length(&self) -> Result<usize, waymark_vm_interpreter_pureset::value::LengthError> {
         match self {
             Self::List(items) => Ok(items.len()),
-            Self::Int(_) | Self::Bool(_) | Self::Exception(_) => {
+            Self::Int(_) | Self::Bool(_) | Self::Text(_) | Self::Exception(_) => {
                 Err(waymark_vm_interpreter_pureset::value::LengthError::UnsupportedValue)
             }
         }
@@ -269,7 +280,7 @@ impl waymark_vm_interpreter_extcallset::value::SleepDuration for TestReadyValue 
                 let seconds: u64 = (*value).try_into().map_err(|_| Self::Error::Negative)?;
                 NonZeroDuration::from_secs(seconds).ok_or(Self::Error::Zero)
             }
-            Self::Bool(_) | Self::List(_) | Self::Exception(_) => {
+            Self::Bool(_) | Self::Text(_) | Self::List(_) | Self::Exception(_) => {
                 Err(Self::Error::UnsupportedValue)
             }
         }
@@ -545,6 +556,20 @@ impl waymark_vm_interpreter_pureset::value::AsExceptionTypeId for TestValue {
 impl waymark_vm_interpreter_pureset::value::MakeException for TestValue {
     fn make_exception(type_id: String, details: Self::RootValue) -> Self {
         Self::Ready(TestReadyValue::make_exception(type_id, details))
+    }
+}
+
+impl<IntermediateDetails>
+    waymark_vm_runtime_exception::ExceptionFromIntermediate<IntermediateDetails> for TestValue
+where
+    TestReadyValue: waymark_vm_runtime_exception::ExceptionFromIntermediate<IntermediateDetails>,
+{
+    fn from_intermediate_exception(
+        exception: Exception<IntermediateDetails>,
+    ) -> Exception<Self::RootValue> {
+        <TestReadyValue as waymark_vm_runtime_exception::ExceptionFromIntermediate<
+            IntermediateDetails,
+        >>::from_intermediate_exception(exception)
     }
 }
 

--- a/crates/lib/vm-interpreter-fullset/tests/typed_exception/mod.rs
+++ b/crates/lib/vm-interpreter-fullset/tests/typed_exception/mod.rs
@@ -1,0 +1,119 @@
+//! Pureset operation errors raised as catchable typed exceptions.
+//!
+//! A raising pureset instruction records the exception on the frame and
+//! continues; the coreset `after_execute` hook then bubbles it — into
+//! a handler when one matches, or up to an `UnhandledException` effect
+//! otherwise.
+
+use waymark_vm_instructions_coreset::CoreSet;
+use waymark_vm_instructions_pureset::{BinaryOp, BinaryOpKind, PureSet, UnaryOp, UnaryOpKind};
+use waymark_vm_interpreter_fullset::Effect;
+use waymark_vm_runtime_core::RegisterId;
+use waymark_vm_runtime_exception::Exception;
+use waymark_vm_runtime_test::{StateId, executable, function};
+
+use crate::support::{Instruction, TestConstValue, TestReadyValue, TestValue, new_runtime};
+
+/// A straight-line prologue that raises a `TypeError` from the pureset
+/// interpreter by adding an integer to a boolean.
+fn raising_prologue() -> Vec<Instruction> {
+    vec![
+        PureSet::LoadConst {
+            dst: RegisterId(0),
+            value: TestConstValue::Int(0),
+        }
+        .into(),
+        PureSet::Unary {
+            kind: UnaryOpKind::Not,
+            op: UnaryOp {
+                dst: RegisterId(1),
+                src: RegisterId(0),
+            },
+        }
+        .into(),
+        PureSet::Binary {
+            kind: BinaryOpKind::Add,
+            op: BinaryOp {
+                dst: RegisterId(0),
+                a: RegisterId(0),
+                b: RegisterId(1),
+            },
+        }
+        .into(),
+        // Only reached if the raise fails to bubble; completes with a value
+        // the assertions below reject.
+        CoreSet::Return { src: RegisterId(0) }.into(),
+    ]
+}
+
+fn expected_exception() -> Exception<TestValue> {
+    Exception {
+        type_id: "TypeError".to_owned(),
+        details: TestValue::Ready(TestReadyValue::Text(
+            "+ is not supported for these operands".to_owned(),
+        )),
+    }
+}
+
+#[test]
+fn raised_typed_exceptions_bubble_into_matching_handlers() {
+    let mut instructions = vec![
+        CoreSet::PushExceptionHandlers {
+            handlers: vec![waymark_vm_exception_handler::ExceptionHandler {
+                handler_state: StateId(1),
+                exception_types: vec!["TypeError".to_owned()],
+                exception_dst: Some(RegisterId(2)),
+            }],
+        }
+        .into(),
+    ];
+    instructions.extend(raising_prologue());
+
+    let executable = executable(vec![function::<Instruction>(
+        3,
+        vec![
+            instructions,
+            vec![CoreSet::Return { src: RegisterId(2) }.into()],
+        ],
+    )]);
+
+    let mut runtime = new_runtime(executable);
+
+    let emitted_effect = runtime
+        .run()
+        .expect("caught typed exception should complete through the handler");
+
+    match emitted_effect.effect {
+        Effect::CoreSet(waymark_vm_interpreter_coreset::Effect::Complete(value)) => {
+            assert_eq!(
+                value,
+                TestReadyValue::Exception(Box::new(expected_exception()))
+            );
+        }
+        effect => {
+            panic!("caught typed exception should complete with the bound exception: {effect:?}")
+        }
+    }
+}
+
+#[test]
+fn uncaught_typed_exceptions_surface_as_unhandled_exceptions() {
+    let executable = executable(vec![function::<Instruction>(2, vec![raising_prologue()])]);
+
+    let mut runtime = new_runtime(executable);
+
+    let emitted_effect = runtime
+        .run()
+        .expect("uncaught typed exception should emit an unhandled exception");
+
+    match emitted_effect.effect {
+        Effect::CoreSet(waymark_vm_interpreter_coreset::Effect::UnhandledException(exception)) => {
+            assert_eq!(exception.type_id, "TypeError");
+            assert_eq!(
+                exception.details,
+                TestReadyValue::Text("+ is not supported for these operands".to_owned())
+            );
+        }
+        effect => panic!("uncaught typed exception should not complete: {effect:?}"),
+    }
+}

--- a/crates/lib/vm-interpreter-fullset/tests/typed_exception/mod.rs
+++ b/crates/lib/vm-interpreter-fullset/tests/typed_exception/mod.rs
@@ -97,6 +97,128 @@ fn raised_typed_exceptions_bubble_into_matching_handlers() {
 }
 
 #[test]
+fn typed_exceptions_raised_in_called_functions_are_caught_by_local_handlers() {
+    let mut callee_instructions = vec![
+        CoreSet::PushExceptionHandlers {
+            handlers: vec![waymark_vm_exception_handler::ExceptionHandler {
+                handler_state: StateId(1),
+                exception_types: vec!["TypeError".to_owned()],
+                exception_dst: Some(RegisterId(2)),
+            }],
+        }
+        .into(),
+    ];
+    callee_instructions.extend(raising_prologue());
+
+    let executable = executable(vec![
+        function::<Instruction>(
+            2,
+            vec![
+                vec![
+                    CoreSet::Call {
+                        dst: RegisterId(1),
+                        function_id: waymark_vm_runtime_test::FunctionId(1),
+                        args: vec![],
+                    }
+                    .into(),
+                    CoreSet::Await {
+                        dst: RegisterId(0),
+                        src: RegisterId(1),
+                        resume: StateId(1),
+                    }
+                    .into(),
+                ],
+                vec![CoreSet::Return { src: RegisterId(0) }.into()],
+            ],
+        ),
+        function::<Instruction>(
+            3,
+            vec![
+                callee_instructions,
+                vec![CoreSet::Return { src: RegisterId(2) }.into()],
+            ],
+        ),
+    ]);
+
+    let mut runtime = new_runtime(executable);
+
+    let emitted_effect = runtime
+        .run()
+        .expect("callee-caught typed exception should complete through the call");
+
+    match emitted_effect.effect {
+        Effect::CoreSet(waymark_vm_interpreter_coreset::Effect::Complete(value)) => {
+            assert_eq!(
+                value,
+                TestReadyValue::Exception(Box::new(expected_exception()))
+            );
+        }
+        effect => {
+            panic!(
+                "callee-caught typed exception should complete with the bound exception: {effect:?}"
+            )
+        }
+    }
+}
+
+#[test]
+fn typed_exceptions_raised_in_called_functions_propagate_to_caller_handlers() {
+    let executable = executable(vec![
+        function::<Instruction>(
+            3,
+            vec![
+                vec![
+                    CoreSet::PushExceptionHandlers {
+                        handlers: vec![waymark_vm_exception_handler::ExceptionHandler {
+                            handler_state: StateId(2),
+                            exception_types: vec!["TypeError".to_owned()],
+                            exception_dst: Some(RegisterId(2)),
+                        }],
+                    }
+                    .into(),
+                    CoreSet::Call {
+                        dst: RegisterId(1),
+                        function_id: waymark_vm_runtime_test::FunctionId(1),
+                        args: vec![],
+                    }
+                    .into(),
+                    CoreSet::Await {
+                        dst: RegisterId(0),
+                        src: RegisterId(1),
+                        resume: StateId(1),
+                    }
+                    .into(),
+                ],
+                // Only reached if the rejection fails to raise in the caller.
+                vec![CoreSet::Return { src: RegisterId(0) }.into()],
+                vec![CoreSet::Return { src: RegisterId(2) }.into()],
+            ],
+        ),
+        function::<Instruction>(2, vec![raising_prologue()]),
+    ]);
+
+    let mut runtime = new_runtime(executable);
+
+    let emitted_effect = runtime
+        .run()
+        .expect("caller-caught typed exception should complete through the handler");
+
+    match emitted_effect.effect {
+        Effect::CoreSet(waymark_vm_interpreter_coreset::Effect::Complete(value)) => {
+            assert_eq!(
+                value,
+                TestReadyValue::Exception(Box::new(expected_exception()))
+            );
+        }
+        effect => {
+            panic!(
+                "caller-caught typed exception should complete with the bound exception: {effect:?}"
+            )
+        }
+    }
+}
+
+#[test]
 fn uncaught_typed_exceptions_surface_as_unhandled_exceptions() {
     let executable = executable(vec![function::<Instruction>(2, vec![raising_prologue()])]);
 

--- a/crates/lib/vm-interpreter-pureset/Cargo.toml
+++ b/crates/lib/vm-interpreter-pureset/Cargo.toml
@@ -9,6 +9,7 @@ waymark-vm-instructions-pureset = { workspace = true }
 waymark-vm-interpreter = { workspace = true }
 waymark-vm-interpreter-utils = { workspace = true }
 waymark-vm-runtime-core = { workspace = true }
+waymark-vm-runtime-exception = { workspace = true }
 waymark-vm-runtime-value = { workspace = true }
 
 derive-where = { workspace = true }

--- a/crates/lib/vm-interpreter-pureset/Cargo.toml
+++ b/crates/lib/vm-interpreter-pureset/Cargo.toml
@@ -5,6 +5,7 @@ version.workspace = true
 publish.workspace = true
 
 [dependencies]
+waymark-vm-exception-type-ids = { workspace = true }
 waymark-vm-instructions-pureset = { workspace = true }
 waymark-vm-interpreter = { workspace = true }
 waymark-vm-interpreter-utils = { workspace = true }

--- a/crates/lib/vm-interpreter-pureset/src/error.rs
+++ b/crates/lib/vm-interpreter-pureset/src/error.rs
@@ -46,20 +46,6 @@ pub enum Error {
         register: RegisterId,
     },
 
-    /// A binary instruction referenced an unusable value.
-    #[error("{operand_pos} {operation} operand is unusable: {source}")]
-    UnusableBinaryOperand {
-        /// The binary operation being evaluated.
-        operation: BinaryOpKind,
-
-        /// The operand position.
-        operand_pos: BinaryOperandPosition,
-
-        /// The underlying error.
-        #[source]
-        source: crate::AsScalarError,
-    },
-
     /// A unary instruction referenced an unset register.
     #[error("{operation} operand in register {register:?} is not initialized")]
     MissingUnaryOperand {
@@ -70,30 +56,11 @@ pub enum Error {
         register: RegisterId,
     },
 
-    /// A unary instruction referenced an unusable value.
-    #[error("{operation} operand is unusable: {source}")]
-    UnusableUnaryOperand {
-        /// The unary operation being evaluated.
-        operation: UnaryOpKind,
-
-        /// The underlying error.
-        #[source]
-        source: crate::value::AsScalarError,
-    },
-
     /// A `Length` instruction referenced an unset register.
     #[error("length value in register {register:?} is not initialized")]
     MissingLengthValue {
         /// The register that was read.
         register: RegisterId,
-    },
-
-    /// A `Length` instruction referenced an unrepresentable promise.
-    #[error("length value is unusable: {source}")]
-    UnusableLengthValue {
-        /// The underlying error.
-        #[source]
-        source: crate::LengthError,
     },
 
     /// A `MakeList` instruction referenced an unset register.
@@ -128,17 +95,6 @@ pub enum Error {
 
         /// The register that was read.
         register: RegisterId,
-    },
-
-    /// A `MakeDict` instruction referenced an unrepresentable key promise.
-    #[error("dict entry {entry_pos} key is unusable: {source}")]
-    UnusableDictKey {
-        /// The zero-based dictionary entry position.
-        entry_pos: usize,
-
-        /// The underlying representation error.
-        #[source]
-        source: crate::value::AsDictKeyError,
     },
 
     /// A `MakeDict` instruction referenced an unset value register.
@@ -195,66 +151,5 @@ pub enum Error {
 
         /// The register that was read.
         register: RegisterId,
-    },
-
-    /// Evaluating a binary instruction failed.
-    #[error("{operation}: {source}")]
-    BinaryOperation {
-        /// The binary operation that failed.
-        operation: BinaryOpKind,
-
-        /// The operation-specific failure.
-        #[source]
-        source: crate::value::BinaryOperationError,
-    },
-
-    /// Evaluating a unary instruction failed.
-    #[error("{operation}: {source}")]
-    UnaryOperation {
-        /// The unary operation that failed.
-        operation: UnaryOpKind,
-
-        /// The operation-specific failure.
-        #[source]
-        source: crate::value::UnaryOperationError,
-    },
-
-    /// Evaluating a `Length` instruction failed.
-    #[error("length: {0}")]
-    Length(#[source] crate::value::LengthError),
-
-    /// Materializing the result of a `Length` instruction failed.
-    #[error("length result: {0}")]
-    FromLength(#[source] crate::value::FromLengthError),
-
-    /// Evaluating a `MakeList` instruction failed.
-    #[error("make_list: {0}")]
-    MakeList(#[source] crate::value::MakeListError),
-
-    /// Evaluating a `ListAppend` instruction failed.
-    #[error("list_append: {0}")]
-    ListAppend(#[source] crate::value::ListAppendError),
-
-    /// Evaluating a `MakeDict` instruction failed.
-    #[error("make_dict: {0}")]
-    MakeDict(#[source] crate::value::MakeDictError),
-
-    /// Evaluating an `Index` instruction failed.
-    #[error("index: {source}")]
-    IndexOperation {
-        /// The operation-specific failure.
-        #[source]
-        source: crate::value::IndexOperationError,
-    },
-
-    /// Evaluating a `Dot` instruction failed.
-    #[error("dot attribute {attribute:?}: {source}")]
-    DotOperation {
-        /// The accessed attribute name.
-        attribute: String,
-
-        /// The operation-specific failure.
-        #[source]
-        source: crate::value::DotOperationError,
     },
 }

--- a/crates/lib/vm-interpreter-pureset/src/lib.rs
+++ b/crates/lib/vm-interpreter-pureset/src/lib.rs
@@ -94,8 +94,10 @@ where
                     |items| Value::make_list(items.by_ref()),
                 )?;
 
-                let list = make_list_result.map_err(Error::MakeList)?;
-                frame.regs.set(*dst, list);
+                match make_list_result {
+                    Ok(list) => frame.regs.set(*dst, list),
+                    Err(error) => frame.raise_typed_exception(error),
+                }
             }
             waymark_vm_instructions_pureset::PureSet::ListAppend { dst, list, item } => {
                 let list_value = frame
@@ -106,21 +108,27 @@ where
                     .regs
                     .get(*item)
                     .ok_or(Error::MissingListAppendItem { register: *item })?;
-                let grown = Value::list_append(list_value, item_value.capture_copy())
-                    .map_err(Error::ListAppend)?;
-                frame.regs.set(*dst, grown);
+                match Value::list_append(list_value, item_value.capture_copy()) {
+                    Ok(grown) => frame.regs.set(*dst, grown),
+                    Err(error) => frame.raise_typed_exception(error),
+                }
             }
             waymark_vm_instructions_pureset::PureSet::MakeDict { dst, entries } => {
                 let mut resolved_entries = Vec::with_capacity(entries.len());
+                let mut raised_key_error = None;
 
                 for (entry_pos, entry) in entries.iter().enumerate() {
                     let key = frame.regs.get(entry.key).ok_or(Error::MissingDictKey {
                         entry_pos,
                         register: entry.key,
                     })?;
-                    let key = key
-                        .as_dict_key()
-                        .map_err(|source| Error::UnusableDictKey { entry_pos, source })?;
+                    let key = match key.as_dict_key() {
+                        Ok(key) => key,
+                        Err(error) => {
+                            raised_key_error = Some(error);
+                            break;
+                        }
+                    };
 
                     let value = frame.regs.get(entry.value).ok_or(Error::MissingDictValue {
                         entry_pos,
@@ -130,8 +138,15 @@ where
                     resolved_entries.push((key.to_owned(), value.capture_copy()));
                 }
 
-                let dict = Value::make_dict(resolved_entries).map_err(Error::MakeDict)?;
-                frame.regs.set(*dst, dict);
+                if let Some(error) = raised_key_error {
+                    frame.raise_typed_exception(error);
+                    return Ok(ExecutionOutcome::Continue(frame));
+                }
+
+                match Value::make_dict(resolved_entries) {
+                    Ok(dict) => frame.regs.set(*dst, dict),
+                    Err(error) => frame.raise_typed_exception(error),
+                }
             }
             waymark_vm_instructions_pureset::PureSet::MakeException {
                 dst,
@@ -177,28 +192,28 @@ where
             operand_pos: BinaryOperandPosition::First,
             register: a,
         })?;
-        let x = x
-            .as_scalar()
-            .map_err(|source| Error::UnusableBinaryOperand {
-                operation,
-                operand_pos: BinaryOperandPosition::First,
-                source,
-            })?;
+        let x = match x.as_scalar() {
+            Ok(scalar) => scalar,
+            Err(error) => {
+                frame.raise_typed_exception(error);
+                return Ok(());
+            }
+        };
 
         let y = frame.regs.get(b).ok_or(Error::MissingBinaryOperand {
             operation,
             operand_pos: BinaryOperandPosition::Second,
             register: b,
         })?;
-        let y = y
-            .as_scalar()
-            .map_err(|source| Error::UnusableBinaryOperand {
-                operation,
-                operand_pos: BinaryOperandPosition::Second,
-                source,
-            })?;
+        let y = match y.as_scalar() {
+            Ok(scalar) => scalar,
+            Err(error) => {
+                frame.raise_typed_exception(error);
+                return Ok(());
+            }
+        };
 
-        let value = match operation {
+        let operation_result = match operation {
             BinaryOpKind::Add => Value::Scalar::add(x, y),
             BinaryOpKind::Sub => Value::Scalar::sub(x, y),
             BinaryOpKind::Mul => Value::Scalar::mul(x, y),
@@ -215,10 +230,12 @@ where
             BinaryOpKind::NotIn => Value::Scalar::not_contains(x, y),
             BinaryOpKind::And => Value::Scalar::and(x, y),
             BinaryOpKind::Or => Value::Scalar::or(x, y),
-        }
-        .map_err(|source| Error::BinaryOperation { operation, source })?;
+        };
 
-        frame.regs.set(dst, Value::from_scalar(value));
+        match operation_result {
+            Ok(value) => frame.regs.set(dst, Value::from_scalar(value)),
+            Err(error) => frame.raise_typed_exception(error),
+        }
         Ok(())
     }
 
@@ -232,17 +249,23 @@ where
             operation,
             register: src,
         })?;
-        let value = value
-            .as_scalar()
-            .map_err(|source| Error::UnusableUnaryOperand { operation, source })?;
+        let value = match value.as_scalar() {
+            Ok(scalar) => scalar,
+            Err(error) => {
+                frame.raise_typed_exception(error);
+                return Ok(());
+            }
+        };
 
-        let value = match operation {
+        let operation_result = match operation {
             UnaryOpKind::Neg => Value::Scalar::neg(value),
             UnaryOpKind::Not => Value::Scalar::not(value),
-        }
-        .map_err(|source| Error::UnaryOperation { operation, source })?;
+        };
 
-        frame.regs.set(dst, Value::from_scalar(value));
+        match operation_result {
+            Ok(value) => frame.regs.set(dst, Value::from_scalar(value)),
+            Err(error) => frame.raise_typed_exception(error),
+        }
         Ok(())
     }
 
@@ -256,10 +279,17 @@ where
             .get(src)
             .ok_or(Error::MissingLengthValue { register: src })?;
 
-        let length = <Value as value::Length>::length(value).map_err(Error::Length)?;
-        let value = <Value as value::Length>::from_length(length).map_err(Error::FromLength)?;
-
-        frame.regs.set(dst, value);
+        let length = match <Value as value::Length>::length(value) {
+            Ok(length) => length,
+            Err(error) => {
+                frame.raise_typed_exception(error);
+                return Ok(());
+            }
+        };
+        match <Value as value::Length>::from_length(length) {
+            Ok(value) => frame.regs.set(dst, value),
+            Err(error) => frame.raise_typed_exception(error),
+        }
         Ok(())
     }
 
@@ -279,10 +309,10 @@ where
             .get(index)
             .ok_or(Error::MissingIndexOperand { register: index })?;
 
-        let value = Value::index(object_value, index_value)
-            .map_err(|source| Error::IndexOperation { source })?;
-
-        frame.regs.set(dst, value);
+        match Value::index(object_value, index_value) {
+            Ok(value) => frame.regs.set(dst, value),
+            Err(error) => frame.raise_typed_exception(error),
+        }
         Ok(())
     }
 
@@ -300,12 +330,10 @@ where
                 register: object,
             })?;
 
-        let value = Value::dot(object_value, attribute).map_err(|source| Error::DotOperation {
-            attribute: attribute.to_owned(),
-            source,
-        })?;
-
-        frame.regs.set(dst, value);
+        match Value::dot(object_value, attribute) {
+            Ok(value) => frame.regs.set(dst, value),
+            Err(error) => frame.raise_typed_exception(error),
+        }
         Ok(())
     }
 }

--- a/crates/lib/vm-interpreter-pureset/src/value.rs
+++ b/crates/lib/vm-interpreter-pureset/src/value.rs
@@ -20,7 +20,6 @@ pub use self::length::*;
 pub use self::list::*;
 pub use self::load_const::*;
 pub use self::scalar::*;
-pub use self::typed_exceptions::*;
 
 /// A unifying trait for all value requirements.
 pub trait Value:

--- a/crates/lib/vm-interpreter-pureset/src/value.rs
+++ b/crates/lib/vm-interpreter-pureset/src/value.rs
@@ -9,6 +9,7 @@ mod length;
 mod list;
 mod load_const;
 mod scalar;
+mod typed_exceptions;
 
 pub use self::capture_copy::*;
 pub use self::dict::*;
@@ -19,6 +20,7 @@ pub use self::length::*;
 pub use self::list::*;
 pub use self::load_const::*;
 pub use self::scalar::*;
+pub use self::typed_exceptions::*;
 
 /// A unifying trait for all value requirements.
 pub trait Value:
@@ -34,6 +36,7 @@ pub trait Value:
     + Length
     + IndexOp
     + DotOp
+    + waymark_vm_runtime_exception::ExceptionFromIntermediate<String>
 {
 }
 
@@ -50,5 +53,6 @@ impl<T> Value for T where
         + Length
         + IndexOp
         + DotOp
+        + waymark_vm_runtime_exception::ExceptionFromIntermediate<String>
 {
 }

--- a/crates/lib/vm-interpreter-pureset/src/value/typed_exceptions.rs
+++ b/crates/lib/vm-interpreter-pureset/src/value/typed_exceptions.rs
@@ -6,26 +6,6 @@ use super::{
     UnaryOperationError,
 };
 
-/// The runtime exception type identifier for a division by zero.
-pub const ZERO_DIVISION_ERROR_TYPE_ID: &str = "ZeroDivisionError";
-
-/// The runtime exception type identifier for an operation applied to values
-/// of unsupported types.
-pub const TYPE_ERROR_TYPE_ID: &str = "TypeError";
-
-/// The runtime exception type identifier for a result too large to be
-/// represented.
-pub const OVERFLOW_ERROR_TYPE_ID: &str = "OverflowError";
-
-/// The runtime exception type identifier for a sequence index out of range.
-pub const INDEX_ERROR_TYPE_ID: &str = "IndexError";
-
-/// The runtime exception type identifier for a missing mapping key.
-pub const KEY_ERROR_TYPE_ID: &str = "KeyError";
-
-/// The runtime exception type identifier for a failed attribute reference.
-pub const ATTRIBUTE_ERROR_TYPE_ID: &str = "AttributeError";
-
 impl waymark_vm_runtime_exception::TypedException for AsScalarError {
     type IntermediateDetails = String;
 
@@ -33,7 +13,7 @@ impl waymark_vm_runtime_exception::TypedException for AsScalarError {
         self,
     ) -> waymark_vm_runtime_exception::Exception<Self::IntermediateDetails> {
         let type_id = match &self {
-            AsScalarError::NotAScalar => TYPE_ERROR_TYPE_ID,
+            AsScalarError::NotAScalar => waymark_vm_exception_type_ids::TYPE_ERROR,
         };
         waymark_vm_runtime_exception::Exception {
             type_id: type_id.to_owned(),
@@ -49,9 +29,15 @@ impl waymark_vm_runtime_exception::TypedException for BinaryOperationError {
         self,
     ) -> waymark_vm_runtime_exception::Exception<Self::IntermediateDetails> {
         let type_id = match &self {
-            BinaryOperationError::UnsupportedOperation { .. } => TYPE_ERROR_TYPE_ID,
-            BinaryOperationError::ResultOutOfBounds { .. } => OVERFLOW_ERROR_TYPE_ID,
-            BinaryOperationError::DivisionByZero { .. } => ZERO_DIVISION_ERROR_TYPE_ID,
+            BinaryOperationError::UnsupportedOperation { .. } => {
+                waymark_vm_exception_type_ids::TYPE_ERROR
+            }
+            BinaryOperationError::ResultOutOfBounds { .. } => {
+                waymark_vm_exception_type_ids::OVERFLOW_ERROR
+            }
+            BinaryOperationError::DivisionByZero { .. } => {
+                waymark_vm_exception_type_ids::ZERO_DIVISION_ERROR
+            }
         };
         waymark_vm_runtime_exception::Exception {
             type_id: type_id.to_owned(),
@@ -67,8 +53,12 @@ impl waymark_vm_runtime_exception::TypedException for UnaryOperationError {
         self,
     ) -> waymark_vm_runtime_exception::Exception<Self::IntermediateDetails> {
         let type_id = match &self {
-            UnaryOperationError::UnsupportedOperation { .. } => TYPE_ERROR_TYPE_ID,
-            UnaryOperationError::ResultOutOfBounds { .. } => OVERFLOW_ERROR_TYPE_ID,
+            UnaryOperationError::UnsupportedOperation { .. } => {
+                waymark_vm_exception_type_ids::TYPE_ERROR
+            }
+            UnaryOperationError::ResultOutOfBounds { .. } => {
+                waymark_vm_exception_type_ids::OVERFLOW_ERROR
+            }
         };
         waymark_vm_runtime_exception::Exception {
             type_id: type_id.to_owned(),
@@ -84,7 +74,7 @@ impl waymark_vm_runtime_exception::TypedException for LengthError {
         self,
     ) -> waymark_vm_runtime_exception::Exception<Self::IntermediateDetails> {
         let type_id = match &self {
-            LengthError::UnsupportedValue => TYPE_ERROR_TYPE_ID,
+            LengthError::UnsupportedValue => waymark_vm_exception_type_ids::TYPE_ERROR,
         };
         waymark_vm_runtime_exception::Exception {
             type_id: type_id.to_owned(),
@@ -100,7 +90,7 @@ impl waymark_vm_runtime_exception::TypedException for FromLengthError {
         self,
     ) -> waymark_vm_runtime_exception::Exception<Self::IntermediateDetails> {
         let type_id = match &self {
-            FromLengthError::ResultOutOfBounds => OVERFLOW_ERROR_TYPE_ID,
+            FromLengthError::ResultOutOfBounds => waymark_vm_exception_type_ids::OVERFLOW_ERROR,
         };
         waymark_vm_runtime_exception::Exception {
             type_id: type_id.to_owned(),
@@ -116,8 +106,8 @@ impl waymark_vm_runtime_exception::TypedException for MakeListError {
         self,
     ) -> waymark_vm_runtime_exception::Exception<Self::IntermediateDetails> {
         let type_id = match &self {
-            MakeListError::NotListable => TYPE_ERROR_TYPE_ID,
-            MakeListError::ResultOutOfBounds => OVERFLOW_ERROR_TYPE_ID,
+            MakeListError::NotListable => waymark_vm_exception_type_ids::TYPE_ERROR,
+            MakeListError::ResultOutOfBounds => waymark_vm_exception_type_ids::OVERFLOW_ERROR,
         };
         waymark_vm_runtime_exception::Exception {
             type_id: type_id.to_owned(),
@@ -133,8 +123,8 @@ impl waymark_vm_runtime_exception::TypedException for ListAppendError {
         self,
     ) -> waymark_vm_runtime_exception::Exception<Self::IntermediateDetails> {
         let type_id = match &self {
-            ListAppendError::NotListable => TYPE_ERROR_TYPE_ID,
-            ListAppendError::ResultOutOfBounds => OVERFLOW_ERROR_TYPE_ID,
+            ListAppendError::NotListable => waymark_vm_exception_type_ids::TYPE_ERROR,
+            ListAppendError::ResultOutOfBounds => waymark_vm_exception_type_ids::OVERFLOW_ERROR,
         };
         waymark_vm_runtime_exception::Exception {
             type_id: type_id.to_owned(),
@@ -150,7 +140,7 @@ impl waymark_vm_runtime_exception::TypedException for AsDictKeyError {
         self,
     ) -> waymark_vm_runtime_exception::Exception<Self::IntermediateDetails> {
         let type_id = match &self {
-            AsDictKeyError::UnsupportedKeyType => TYPE_ERROR_TYPE_ID,
+            AsDictKeyError::UnsupportedKeyType => waymark_vm_exception_type_ids::TYPE_ERROR,
         };
         waymark_vm_runtime_exception::Exception {
             type_id: type_id.to_owned(),
@@ -166,8 +156,8 @@ impl waymark_vm_runtime_exception::TypedException for MakeDictError {
         self,
     ) -> waymark_vm_runtime_exception::Exception<Self::IntermediateDetails> {
         let type_id = match &self {
-            MakeDictError::NotDictable => TYPE_ERROR_TYPE_ID,
-            MakeDictError::ResultOutOfBounds => OVERFLOW_ERROR_TYPE_ID,
+            MakeDictError::NotDictable => waymark_vm_exception_type_ids::TYPE_ERROR,
+            MakeDictError::ResultOutOfBounds => waymark_vm_exception_type_ids::OVERFLOW_ERROR,
         };
         waymark_vm_runtime_exception::Exception {
             type_id: type_id.to_owned(),
@@ -183,9 +173,9 @@ impl waymark_vm_runtime_exception::TypedException for IndexOperationError {
         self,
     ) -> waymark_vm_runtime_exception::Exception<Self::IntermediateDetails> {
         let type_id = match &self {
-            IndexOperationError::UnsupportedOperation => TYPE_ERROR_TYPE_ID,
-            IndexOperationError::IndexOutOfBounds => INDEX_ERROR_TYPE_ID,
-            IndexOperationError::MissingKey => KEY_ERROR_TYPE_ID,
+            IndexOperationError::UnsupportedOperation => waymark_vm_exception_type_ids::TYPE_ERROR,
+            IndexOperationError::IndexOutOfBounds => waymark_vm_exception_type_ids::INDEX_ERROR,
+            IndexOperationError::MissingKey => waymark_vm_exception_type_ids::KEY_ERROR,
         };
         waymark_vm_runtime_exception::Exception {
             type_id: type_id.to_owned(),
@@ -201,8 +191,8 @@ impl waymark_vm_runtime_exception::TypedException for DotOperationError {
         self,
     ) -> waymark_vm_runtime_exception::Exception<Self::IntermediateDetails> {
         let type_id = match &self {
-            DotOperationError::UnsupportedOperation => TYPE_ERROR_TYPE_ID,
-            DotOperationError::MissingAttribute => ATTRIBUTE_ERROR_TYPE_ID,
+            DotOperationError::UnsupportedOperation => waymark_vm_exception_type_ids::TYPE_ERROR,
+            DotOperationError::MissingAttribute => waymark_vm_exception_type_ids::ATTRIBUTE_ERROR,
         };
         waymark_vm_runtime_exception::Exception {
             type_id: type_id.to_owned(),

--- a/crates/lib/vm-interpreter-pureset/src/value/typed_exceptions.rs
+++ b/crates/lib/vm-interpreter-pureset/src/value/typed_exceptions.rs
@@ -1,0 +1,212 @@
+//! The typed exceptions for the pureset operation errors.
+
+use super::{
+    AsDictKeyError, AsScalarError, BinaryOperationError, DotOperationError, FromLengthError,
+    IndexOperationError, LengthError, ListAppendError, MakeDictError, MakeListError,
+    UnaryOperationError,
+};
+
+/// The runtime exception type identifier for a division by zero.
+pub const ZERO_DIVISION_ERROR_TYPE_ID: &str = "ZeroDivisionError";
+
+/// The runtime exception type identifier for an operation applied to values
+/// of unsupported types.
+pub const TYPE_ERROR_TYPE_ID: &str = "TypeError";
+
+/// The runtime exception type identifier for a result too large to be
+/// represented.
+pub const OVERFLOW_ERROR_TYPE_ID: &str = "OverflowError";
+
+/// The runtime exception type identifier for a sequence index out of range.
+pub const INDEX_ERROR_TYPE_ID: &str = "IndexError";
+
+/// The runtime exception type identifier for a missing mapping key.
+pub const KEY_ERROR_TYPE_ID: &str = "KeyError";
+
+/// The runtime exception type identifier for a failed attribute reference.
+pub const ATTRIBUTE_ERROR_TYPE_ID: &str = "AttributeError";
+
+impl waymark_vm_runtime_exception::TypedException for AsScalarError {
+    type IntermediateDetails = String;
+
+    fn into_intermediate_exception(
+        self,
+    ) -> waymark_vm_runtime_exception::Exception<Self::IntermediateDetails> {
+        let type_id = match &self {
+            AsScalarError::NotAScalar => TYPE_ERROR_TYPE_ID,
+        };
+        waymark_vm_runtime_exception::Exception {
+            type_id: type_id.to_owned(),
+            details: self.to_string(),
+        }
+    }
+}
+
+impl waymark_vm_runtime_exception::TypedException for BinaryOperationError {
+    type IntermediateDetails = String;
+
+    fn into_intermediate_exception(
+        self,
+    ) -> waymark_vm_runtime_exception::Exception<Self::IntermediateDetails> {
+        let type_id = match &self {
+            BinaryOperationError::UnsupportedOperation { .. } => TYPE_ERROR_TYPE_ID,
+            BinaryOperationError::ResultOutOfBounds { .. } => OVERFLOW_ERROR_TYPE_ID,
+            BinaryOperationError::DivisionByZero { .. } => ZERO_DIVISION_ERROR_TYPE_ID,
+        };
+        waymark_vm_runtime_exception::Exception {
+            type_id: type_id.to_owned(),
+            details: self.to_string(),
+        }
+    }
+}
+
+impl waymark_vm_runtime_exception::TypedException for UnaryOperationError {
+    type IntermediateDetails = String;
+
+    fn into_intermediate_exception(
+        self,
+    ) -> waymark_vm_runtime_exception::Exception<Self::IntermediateDetails> {
+        let type_id = match &self {
+            UnaryOperationError::UnsupportedOperation { .. } => TYPE_ERROR_TYPE_ID,
+            UnaryOperationError::ResultOutOfBounds { .. } => OVERFLOW_ERROR_TYPE_ID,
+        };
+        waymark_vm_runtime_exception::Exception {
+            type_id: type_id.to_owned(),
+            details: self.to_string(),
+        }
+    }
+}
+
+impl waymark_vm_runtime_exception::TypedException for LengthError {
+    type IntermediateDetails = String;
+
+    fn into_intermediate_exception(
+        self,
+    ) -> waymark_vm_runtime_exception::Exception<Self::IntermediateDetails> {
+        let type_id = match &self {
+            LengthError::UnsupportedValue => TYPE_ERROR_TYPE_ID,
+        };
+        waymark_vm_runtime_exception::Exception {
+            type_id: type_id.to_owned(),
+            details: self.to_string(),
+        }
+    }
+}
+
+impl waymark_vm_runtime_exception::TypedException for FromLengthError {
+    type IntermediateDetails = String;
+
+    fn into_intermediate_exception(
+        self,
+    ) -> waymark_vm_runtime_exception::Exception<Self::IntermediateDetails> {
+        let type_id = match &self {
+            FromLengthError::ResultOutOfBounds => OVERFLOW_ERROR_TYPE_ID,
+        };
+        waymark_vm_runtime_exception::Exception {
+            type_id: type_id.to_owned(),
+            details: self.to_string(),
+        }
+    }
+}
+
+impl waymark_vm_runtime_exception::TypedException for MakeListError {
+    type IntermediateDetails = String;
+
+    fn into_intermediate_exception(
+        self,
+    ) -> waymark_vm_runtime_exception::Exception<Self::IntermediateDetails> {
+        let type_id = match &self {
+            MakeListError::NotListable => TYPE_ERROR_TYPE_ID,
+            MakeListError::ResultOutOfBounds => OVERFLOW_ERROR_TYPE_ID,
+        };
+        waymark_vm_runtime_exception::Exception {
+            type_id: type_id.to_owned(),
+            details: self.to_string(),
+        }
+    }
+}
+
+impl waymark_vm_runtime_exception::TypedException for ListAppendError {
+    type IntermediateDetails = String;
+
+    fn into_intermediate_exception(
+        self,
+    ) -> waymark_vm_runtime_exception::Exception<Self::IntermediateDetails> {
+        let type_id = match &self {
+            ListAppendError::NotListable => TYPE_ERROR_TYPE_ID,
+            ListAppendError::ResultOutOfBounds => OVERFLOW_ERROR_TYPE_ID,
+        };
+        waymark_vm_runtime_exception::Exception {
+            type_id: type_id.to_owned(),
+            details: self.to_string(),
+        }
+    }
+}
+
+impl waymark_vm_runtime_exception::TypedException for AsDictKeyError {
+    type IntermediateDetails = String;
+
+    fn into_intermediate_exception(
+        self,
+    ) -> waymark_vm_runtime_exception::Exception<Self::IntermediateDetails> {
+        let type_id = match &self {
+            AsDictKeyError::UnsupportedKeyType => TYPE_ERROR_TYPE_ID,
+        };
+        waymark_vm_runtime_exception::Exception {
+            type_id: type_id.to_owned(),
+            details: self.to_string(),
+        }
+    }
+}
+
+impl waymark_vm_runtime_exception::TypedException for MakeDictError {
+    type IntermediateDetails = String;
+
+    fn into_intermediate_exception(
+        self,
+    ) -> waymark_vm_runtime_exception::Exception<Self::IntermediateDetails> {
+        let type_id = match &self {
+            MakeDictError::NotDictable => TYPE_ERROR_TYPE_ID,
+            MakeDictError::ResultOutOfBounds => OVERFLOW_ERROR_TYPE_ID,
+        };
+        waymark_vm_runtime_exception::Exception {
+            type_id: type_id.to_owned(),
+            details: self.to_string(),
+        }
+    }
+}
+
+impl waymark_vm_runtime_exception::TypedException for IndexOperationError {
+    type IntermediateDetails = String;
+
+    fn into_intermediate_exception(
+        self,
+    ) -> waymark_vm_runtime_exception::Exception<Self::IntermediateDetails> {
+        let type_id = match &self {
+            IndexOperationError::UnsupportedOperation => TYPE_ERROR_TYPE_ID,
+            IndexOperationError::IndexOutOfBounds => INDEX_ERROR_TYPE_ID,
+            IndexOperationError::MissingKey => KEY_ERROR_TYPE_ID,
+        };
+        waymark_vm_runtime_exception::Exception {
+            type_id: type_id.to_owned(),
+            details: self.to_string(),
+        }
+    }
+}
+
+impl waymark_vm_runtime_exception::TypedException for DotOperationError {
+    type IntermediateDetails = String;
+
+    fn into_intermediate_exception(
+        self,
+    ) -> waymark_vm_runtime_exception::Exception<Self::IntermediateDetails> {
+        let type_id = match &self {
+            DotOperationError::UnsupportedOperation => TYPE_ERROR_TYPE_ID,
+            DotOperationError::MissingAttribute => ATTRIBUTE_ERROR_TYPE_ID,
+        };
+        waymark_vm_runtime_exception::Exception {
+            type_id: type_id.to_owned(),
+            details: self.to_string(),
+        }
+    }
+}

--- a/crates/lib/vm-interpreter-pureset/tests/dict_ops/mod.rs
+++ b/crates/lib/vm-interpreter-pureset/tests/dict_ops/mod.rs
@@ -164,6 +164,54 @@ fn runtime_raises_an_attribute_error_for_a_missing_dot_attribute() {
 }
 
 #[test]
+fn runtime_raises_a_key_error_for_a_missing_dict_key() {
+    let value = run(
+        5,
+        vec![
+            PureSet::LoadConst {
+                dst: RegisterId(0),
+                value: TestConstValue::Text("present"),
+            }
+            .into(),
+            PureSet::LoadConst {
+                dst: RegisterId(1),
+                value: TestConstValue::Int(9),
+            }
+            .into(),
+            PureSet::MakeDict {
+                dst: RegisterId(2),
+                entries: vec![DictEntry {
+                    key: RegisterId(0),
+                    value: RegisterId(1),
+                }],
+            }
+            .into(),
+            PureSet::LoadConst {
+                dst: RegisterId(3),
+                value: TestConstValue::Text("missing"),
+            }
+            .into(),
+            PureSet::Index {
+                dst: RegisterId(4),
+                object: RegisterId(2),
+                index: RegisterId(3),
+            }
+            .into(),
+            RuntimeInstruction::EmitPendingException,
+        ],
+    )
+    .expect("runtime should emit the pending exception");
+
+    assert_eq!(
+        value,
+        TestValue::Exception {
+            type_id: "KeyError".to_owned(),
+            details: Box::new(TestValue::Text("key is missing".to_owned())),
+        }
+    );
+}
+
+#[test]
 fn runtime_raises_a_type_error_for_an_unusable_dict_key() {
     let value = run(
         3,

--- a/crates/lib/vm-interpreter-pureset/tests/dict_ops/mod.rs
+++ b/crates/lib/vm-interpreter-pureset/tests/dict_ops/mod.rs
@@ -3,8 +3,6 @@
 use std::collections::BTreeMap;
 
 use waymark_vm_instructions_pureset::{DictEntry, PureSet};
-use waymark_vm_interpreter_pureset::Error;
-use waymark_vm_runtime::RunError;
 use waymark_vm_runtime_core::RegisterId;
 
 use crate::support::{RuntimeInstruction, TestConstValue, TestValue, run};
@@ -41,7 +39,7 @@ fn runtime_executes_make_dict_to_a_terminal_effect() {
         value,
         TestValue::Dict(BTreeMap::from([(
             "key".to_owned(),
-            TestValue::Text("hello"),
+            TestValue::Text("hello".to_owned()),
         )]))
     );
 }
@@ -84,8 +82,8 @@ fn runtime_executes_dot_to_a_terminal_effect() {
 }
 
 #[test]
-fn runtime_surfaces_make_dict_key_type_errors_from_the_pureset_interpreter() {
-    let result = run(
+fn runtime_raises_a_type_error_for_an_unsupported_dict_key_type() {
+    let value = run(
         4,
         vec![
             PureSet::LoadConst {
@@ -106,24 +104,25 @@ fn runtime_surfaces_make_dict_key_type_errors_from_the_pureset_interpreter() {
                 }],
             }
             .into(),
-            RuntimeInstruction::EmitRegister(RegisterId(2)),
+            RuntimeInstruction::EmitPendingException,
         ],
-    );
+    )
+    .expect("runtime should emit the pending exception");
 
-    assert!(matches!(
-        result,
-        Err(RunError::Step(waymark_vm_runtime::step::Error::Execution(
-            Error::UnusableDictKey {
-                entry_pos,
-                source: waymark_vm_interpreter_pureset::value::AsDictKeyError::UnsupportedKeyType,
-            }
-        ))) if entry_pos == 0
-    ));
+    assert_eq!(
+        value,
+        TestValue::Exception {
+            type_id: "TypeError".to_owned(),
+            details: Box::new(TestValue::Text(
+                "dict keys of this type are not supported".to_owned()
+            )),
+        }
+    );
 }
 
 #[test]
-fn runtime_surfaces_missing_dot_attribute_errors_from_the_pureset_interpreter() {
-    let result = run(
+fn runtime_raises_an_attribute_error_for_a_missing_dot_attribute() {
+    let value = run(
         4,
         vec![
             PureSet::LoadConst {
@@ -150,25 +149,23 @@ fn runtime_surfaces_missing_dot_attribute_errors_from_the_pureset_interpreter() 
                 attribute: "missing".to_owned(),
             }
             .into(),
-            RuntimeInstruction::EmitRegister(RegisterId(3)),
+            RuntimeInstruction::EmitPendingException,
         ],
-    );
+    )
+    .expect("runtime should emit the pending exception");
 
-    assert!(matches!(
-        result,
-        Err(RunError::Step(waymark_vm_runtime::step::Error::Execution(
-            Error::DotOperation {
-                attribute,
-                source:
-                    waymark_vm_interpreter_pureset::value::DotOperationError::MissingAttribute,
-            }
-        ))) if attribute == "missing"
-    ));
+    assert_eq!(
+        value,
+        TestValue::Exception {
+            type_id: "AttributeError".to_owned(),
+            details: Box::new(TestValue::Text("attribute is missing".to_owned())),
+        }
+    );
 }
 
 #[test]
-fn runtime_surfaces_unusable_make_dict_key_errors_from_unusable_values() {
-    let result = run(
+fn runtime_raises_a_type_error_for_an_unusable_dict_key() {
+    let value = run(
         3,
         vec![
             RuntimeInstruction::SetUnusable { dst: RegisterId(0) },
@@ -185,17 +182,18 @@ fn runtime_surfaces_unusable_make_dict_key_errors_from_unusable_values() {
                 }],
             }
             .into(),
-            RuntimeInstruction::EmitRegister(RegisterId(2)),
+            RuntimeInstruction::EmitPendingException,
         ],
-    );
+    )
+    .expect("runtime should emit the pending exception");
 
-    assert!(matches!(
-        result,
-        Err(RunError::Step(waymark_vm_runtime::step::Error::Execution(
-            Error::UnusableDictKey {
-                entry_pos,
-                source: waymark_vm_interpreter_pureset::value::AsDictKeyError::UnsupportedKeyType,
-            }
-        ))) if entry_pos == 0
-    ));
+    assert_eq!(
+        value,
+        TestValue::Exception {
+            type_id: "TypeError".to_owned(),
+            details: Box::new(TestValue::Text(
+                "dict keys of this type are not supported".to_owned()
+            )),
+        }
+    );
 }

--- a/crates/lib/vm-interpreter-pureset/tests/length_ops/mod.rs
+++ b/crates/lib/vm-interpreter-pureset/tests/length_ops/mod.rs
@@ -1,8 +1,6 @@
 //! `Length` and its error paths (including overflow and unusable values).
 
 use waymark_vm_instructions_pureset::PureSet;
-use waymark_vm_interpreter_pureset::Error;
-use waymark_vm_runtime::RunError;
 use waymark_vm_runtime_core::RegisterId;
 
 use crate::support::{RuntimeInstruction, TestConstValue, TestValue, run};
@@ -41,8 +39,8 @@ fn runtime_executes_length_to_a_terminal_effect() {
 }
 
 #[test]
-fn runtime_surfaces_length_errors_from_the_pureset_interpreter() {
-    let result = run(
+fn runtime_raises_a_type_error_for_an_unsupported_length_value() {
+    let value = run(
         2,
         vec![
             PureSet::LoadConst {
@@ -55,21 +53,25 @@ fn runtime_surfaces_length_errors_from_the_pureset_interpreter() {
                 src: RegisterId(0),
             }
             .into(),
-            RuntimeInstruction::EmitRegister(RegisterId(1)),
+            RuntimeInstruction::EmitPendingException,
         ],
-    );
+    )
+    .expect("runtime should emit the pending exception");
 
-    assert!(matches!(
-        result,
-        Err(RunError::Step(waymark_vm_runtime::step::Error::Execution(
-            Error::Length(waymark_vm_interpreter_pureset::value::LengthError::UnsupportedValue)
-        )))
-    ));
+    assert_eq!(
+        value,
+        TestValue::Exception {
+            type_id: "TypeError".to_owned(),
+            details: Box::new(TestValue::Text(
+                "determining length is not supported for this value".to_owned()
+            )),
+        }
+    );
 }
 
 #[test]
-fn runtime_surfaces_from_length_errors_from_the_pureset_interpreter() {
-    let result = run(
+fn runtime_raises_an_overflow_error_for_an_unrepresentable_length_result() {
+    let value = run(
         2,
         vec![
             PureSet::LoadConst {
@@ -82,23 +84,23 @@ fn runtime_surfaces_from_length_errors_from_the_pureset_interpreter() {
                 src: RegisterId(0),
             }
             .into(),
-            RuntimeInstruction::EmitRegister(RegisterId(1)),
+            RuntimeInstruction::EmitPendingException,
         ],
-    );
+    )
+    .expect("runtime should emit the pending exception");
 
-    assert!(matches!(
-        result,
-        Err(RunError::Step(waymark_vm_runtime::step::Error::Execution(
-            Error::FromLength(
-                waymark_vm_interpreter_pureset::value::FromLengthError::ResultOutOfBounds
-            )
-        )))
-    ));
+    assert_eq!(
+        value,
+        TestValue::Exception {
+            type_id: "OverflowError".to_owned(),
+            details: Box::new(TestValue::Text("length result is out of bounds".to_owned())),
+        }
+    );
 }
 
 #[test]
-fn runtime_surfaces_length_errors_from_unusable_values() {
-    let result = run(
+fn runtime_raises_a_type_error_for_an_unusable_length_value() {
+    let value = run(
         2,
         vec![
             RuntimeInstruction::SetUnusable { dst: RegisterId(0) },
@@ -107,14 +109,18 @@ fn runtime_surfaces_length_errors_from_unusable_values() {
                 src: RegisterId(0),
             }
             .into(),
-            RuntimeInstruction::EmitRegister(RegisterId(1)),
+            RuntimeInstruction::EmitPendingException,
         ],
-    );
+    )
+    .expect("runtime should emit the pending exception");
 
-    assert!(matches!(
-        result,
-        Err(RunError::Step(waymark_vm_runtime::step::Error::Execution(
-            Error::Length(waymark_vm_interpreter_pureset::value::LengthError::UnsupportedValue)
-        )))
-    ));
+    assert_eq!(
+        value,
+        TestValue::Exception {
+            type_id: "TypeError".to_owned(),
+            details: Box::new(TestValue::Text(
+                "determining length is not supported for this value".to_owned()
+            )),
+        }
+    );
 }

--- a/crates/lib/vm-interpreter-pureset/tests/list_ops/mod.rs
+++ b/crates/lib/vm-interpreter-pureset/tests/list_ops/mod.rs
@@ -109,6 +109,46 @@ fn runtime_raises_a_type_error_for_an_unusable_index_operand() {
 }
 
 #[test]
+fn runtime_raises_an_index_error_for_an_out_of_bounds_index() {
+    let value = run(
+        4,
+        vec![
+            PureSet::LoadConst {
+                dst: RegisterId(0),
+                value: TestConstValue::Int(2),
+            }
+            .into(),
+            PureSet::MakeList {
+                dst: RegisterId(1),
+                items: vec![RegisterId(0)],
+            }
+            .into(),
+            PureSet::LoadConst {
+                dst: RegisterId(2),
+                value: TestConstValue::Int(1),
+            }
+            .into(),
+            PureSet::Index {
+                dst: RegisterId(3),
+                object: RegisterId(1),
+                index: RegisterId(2),
+            }
+            .into(),
+            RuntimeInstruction::EmitPendingException,
+        ],
+    )
+    .expect("runtime should emit the pending exception");
+
+    assert_eq!(
+        value,
+        TestValue::Exception {
+            type_id: "IndexError".to_owned(),
+            details: Box::new(TestValue::Text("index is out of bounds".to_owned())),
+        }
+    );
+}
+
+#[test]
 fn runtime_copies_unusable_make_list_items_to_a_terminal_effect() {
     let value = run(
         2,

--- a/crates/lib/vm-interpreter-pureset/tests/list_ops/mod.rs
+++ b/crates/lib/vm-interpreter-pureset/tests/list_ops/mod.rs
@@ -1,8 +1,6 @@
 //! `MakeList` / `Index` happy paths and failure modes.
 
 use waymark_vm_instructions_pureset::PureSet;
-use waymark_vm_interpreter_pureset::Error;
-use waymark_vm_runtime::RunError;
 use waymark_vm_runtime_core::RegisterId;
 
 use crate::support::{RuntimeInstruction, TestConstValue, TestValue, run};
@@ -34,7 +32,7 @@ fn runtime_executes_make_list_to_a_terminal_effect() {
 
     assert_eq!(
         value,
-        TestValue::List(vec![TestValue::Int(2), TestValue::Text("hello")])
+        TestValue::List(vec![TestValue::Int(2), TestValue::Text("hello".to_owned())])
     );
 }
 
@@ -73,8 +71,8 @@ fn runtime_executes_index_to_a_terminal_effect() {
 }
 
 #[test]
-fn runtime_surfaces_index_errors_from_unusable_values() {
-    let result = run(
+fn runtime_raises_a_type_error_for_an_unusable_index_operand() {
+    let value = run(
         4,
         vec![
             PureSet::LoadConst {
@@ -94,19 +92,20 @@ fn runtime_surfaces_index_errors_from_unusable_values() {
                 index: RegisterId(2),
             }
             .into(),
-            RuntimeInstruction::EmitRegister(RegisterId(3)),
+            RuntimeInstruction::EmitPendingException,
         ],
-    );
+    )
+    .expect("runtime should emit the pending exception");
 
-    assert!(matches!(
-        result,
-        Err(RunError::Step(waymark_vm_runtime::step::Error::Execution(
-            Error::IndexOperation {
-                source:
-                    waymark_vm_interpreter_pureset::value::IndexOperationError::UnsupportedOperation,
-            }
-        )))
-    ));
+    assert_eq!(
+        value,
+        TestValue::Exception {
+            type_id: "TypeError".to_owned(),
+            details: Box::new(TestValue::Text(
+                "indexed access is not supported for these operands".to_owned()
+            )),
+        }
+    );
 }
 
 #[test]

--- a/crates/lib/vm-interpreter-pureset/tests/scalar_ops/mod.rs
+++ b/crates/lib/vm-interpreter-pureset/tests/scalar_ops/mod.rs
@@ -2,8 +2,6 @@
 //! `Unary::Not`, and their failure modes.
 
 use waymark_vm_instructions_pureset::{BinaryOp, BinaryOpKind, PureSet, UnaryOp, UnaryOpKind};
-use waymark_vm_interpreter_pureset::{BinaryOperandPosition, Error};
-use waymark_vm_runtime::RunError;
 use waymark_vm_runtime_core::RegisterId;
 
 use crate::support::{RuntimeInstruction, TestConstValue, TestValue, run};
@@ -104,12 +102,12 @@ fn runtime_converts_non_numeric_constants_through_the_spec_type() {
     )
     .expect("runtime should emit the converted constant");
 
-    assert_eq!(value, TestValue::Text("hello"));
+    assert_eq!(value, TestValue::Text("hello".to_owned()));
 }
 
 #[test]
-fn runtime_surfaces_add_errors_from_the_pureset_interpreter() {
-    let result = run(
+fn runtime_raises_a_type_error_for_an_unsupported_add() {
+    let value = run(
         2,
         vec![
             PureSet::LoadConst {
@@ -131,27 +129,25 @@ fn runtime_surfaces_add_errors_from_the_pureset_interpreter() {
                 },
             }
             .into(),
-            RuntimeInstruction::EmitRegister(RegisterId(0)),
+            RuntimeInstruction::EmitPendingException,
         ],
-    );
+    )
+    .expect("runtime should emit the pending exception");
 
-    assert!(matches!(
-        result,
-        Err(RunError::Step(waymark_vm_runtime::step::Error::Execution(
-            Error::BinaryOperation {
-                operation: BinaryOpKind::Add,
-                source:
-                    waymark_vm_interpreter_pureset::value::BinaryOperationError::UnsupportedOperation {
-                        operation: BinaryOpKind::Add,
-                    },
-            }
-        )))
-    ));
+    assert_eq!(
+        value,
+        TestValue::Exception {
+            type_id: "TypeError".to_owned(),
+            details: Box::new(TestValue::Text(
+                "+ is not supported for these operands".to_owned()
+            )),
+        }
+    );
 }
 
 #[test]
-fn runtime_surfaces_unusable_add_operand_errors_from_unusable_values() {
-    let result = run(
+fn runtime_raises_a_type_error_for_an_unusable_add_operand() {
+    let value = run(
         2,
         vec![
             RuntimeInstruction::SetUnusable { dst: RegisterId(0) },
@@ -169,18 +165,16 @@ fn runtime_surfaces_unusable_add_operand_errors_from_unusable_values() {
                 },
             }
             .into(),
-            RuntimeInstruction::EmitRegister(RegisterId(0)),
+            RuntimeInstruction::EmitPendingException,
         ],
-    );
+    )
+    .expect("runtime should emit the pending exception");
 
-    assert!(matches!(
-        result,
-        Err(RunError::Step(waymark_vm_runtime::step::Error::Execution(
-            Error::UnusableBinaryOperand {
-                operation: BinaryOpKind::Add,
-                operand_pos: BinaryOperandPosition::First,
-                source: waymark_vm_interpreter_pureset::value::AsScalarError::NotAScalar,
-            }
-        )))
-    ));
+    assert_eq!(
+        value,
+        TestValue::Exception {
+            type_id: "TypeError".to_owned(),
+            details: Box::new(TestValue::Text("not a scalar".to_owned())),
+        }
+    );
 }

--- a/crates/lib/vm-interpreter-pureset/tests/support/mod.rs
+++ b/crates/lib/vm-interpreter-pureset/tests/support/mod.rs
@@ -39,7 +39,7 @@ pub enum TestConstValue {
 pub enum TestValue {
     Int(i64),
     Bool(bool),
-    Text(&'static str),
+    Text(String),
     List(Vec<TestValue>),
     Dict(BTreeMap<String, TestValue>),
     Exception {
@@ -75,7 +75,7 @@ impl waymark_vm_interpreter_pureset::value::LoadConst<&TestConstValue> for TestV
     fn load_const(const_value: &TestConstValue) -> Self {
         match const_value {
             TestConstValue::Int(value) => Self::Int(*value),
-            TestConstValue::Text(value) => Self::Text(value),
+            TestConstValue::Text(value) => Self::Text((*value).to_owned()),
             TestConstValue::OverflowLength => Self::OverflowLength,
         }
     }
@@ -243,6 +243,17 @@ impl waymark_vm_interpreter_pureset::value::MakeException for TestValue {
     }
 }
 
+impl waymark_vm_runtime_exception::ExceptionFromIntermediate<String> for TestValue {
+    fn from_intermediate_exception(
+        exception: waymark_vm_runtime_exception::Exception<String>,
+    ) -> waymark_vm_runtime_exception::Exception<Self::RootValue> {
+        waymark_vm_runtime_exception::Exception {
+            type_id: exception.type_id,
+            details: Self::Text(exception.details),
+        }
+    }
+}
+
 pub enum TestLength {
     Valid(i64),
     Overflow,
@@ -304,7 +315,7 @@ impl waymark_vm_interpreter_pureset::value::IndexOp for TestValue {
                 Ok(items[index].clone())
             }
             (Self::Dict(entries), Self::Text(key)) => entries
-                .get(*key)
+                .get(key)
                 .cloned()
                 .ok_or(waymark_vm_interpreter_pureset::value::IndexOperationError::MissingKey),
             _ => Err(
@@ -336,8 +347,17 @@ impl waymark_vm_interpreter_pureset::value::DotOp for TestValue {
 #[derive(Debug)]
 pub enum RuntimeInstruction {
     Pure(PureSet<TestSpec>),
-    SetUnusable { dst: RegisterId },
+    SetUnusable {
+        dst: RegisterId,
+    },
     EmitRegister(RegisterId),
+    /// Emit the exception pending on the frame as the terminal effect.
+    ///
+    /// The pureset interpreter raises by recording the exception on
+    /// the frame; this test runtime has no exception handling machinery,
+    /// so tests surface the pending exception for assertions with this
+    /// instruction.
+    EmitPendingException,
 }
 
 impl From<PureSet<TestSpec>> for RuntimeInstruction {
@@ -400,6 +420,18 @@ impl waymark_vm_interpreter::Interpreter for RuntimeInterpreter {
             RuntimeInstruction::EmitRegister(register) => {
                 let value = frame.regs[*register].clone();
                 Ok(ExecutionOutcome::ExitFrameWithEffect(value))
+            }
+            RuntimeInstruction::EmitPendingException => {
+                let exception = frame
+                    .exception
+                    .take()
+                    .expect("a pending exception should be present on the frame");
+                Ok(ExecutionOutcome::ExitFrameWithEffect(
+                    TestValue::Exception {
+                        type_id: exception.type_id,
+                        details: Box::new(exception.details),
+                    },
+                ))
             }
         }
     }

--- a/crates/lib/vm-runtime-core/Cargo.toml
+++ b/crates/lib/vm-runtime-core/Cargo.toml
@@ -10,6 +10,7 @@ waymark-vm-exception-handler = { workspace = true }
 waymark-vm-runtime-effect = { workspace = true }
 waymark-vm-runtime-exception = { workspace = true }
 waymark-vm-runtime-promise-core = { workspace = true }
+waymark-vm-runtime-value = { workspace = true }
 
 index_type = { workspace = true }
 serde = { workspace = true, optional = true }
@@ -29,4 +30,3 @@ serde = [
 
 [dev-dependencies]
 waymark-vm-runtime-promise-value = { workspace = true }
-waymark-vm-runtime-value = { workspace = true }

--- a/crates/lib/vm-runtime-core/src/continuation.rs
+++ b/crates/lib/vm-runtime-core/src/continuation.rs
@@ -125,7 +125,7 @@ impl<FunctionId, StateId, Value> Continuation<FunctionId, StateId, Value, Resume
 
         // Register the exception in the frame, without
         // overriding an already existing exception.
-        prepared_resume_frame.exception.get_or_insert(exception);
+        prepared_resume_frame.raise_exception(exception);
 
         prepared_resume_frame
     }
@@ -141,7 +141,7 @@ impl<FunctionId, StateId, Value> Continuation<FunctionId, StateId, Value, Resume
 
         // Register the exception in the frame, without
         // overriding an already existing exception.
-        frame.exception.get_or_insert(exception);
+        frame.raise_exception(exception);
     }
 }
 

--- a/crates/lib/vm-runtime-core/src/frame.rs
+++ b/crates/lib/vm-runtime-core/src/frame.rs
@@ -46,3 +46,29 @@ pub enum FrameKind {
         ret: PromiseStateId,
     },
 }
+
+impl<FunctionId, StateId, Value> Frame<FunctionId, StateId, Value> {
+    /// Raise a runtime exception on this frame.
+    ///
+    /// If an exception is already pending on the frame, keeps the pending
+    /// exception and discards the provided one.
+    pub fn raise_exception(&mut self, exception: Exception<Value>) {
+        self.exception.get_or_insert(exception);
+    }
+
+    /// Raise a typed runtime exception on this frame.
+    ///
+    /// See [`Frame::raise_exception`].
+    pub fn raise_typed_exception<TypedException>(&mut self, exception: TypedException)
+    where
+        TypedException: waymark_vm_runtime_exception::TypedException,
+        Value: waymark_vm_runtime_value::RootValueAccess<RootValue = Value>,
+        Value: waymark_vm_runtime_exception::ExceptionFromIntermediate<
+                TypedException::IntermediateDetails,
+            >,
+    {
+        self.raise_exception(Value::from_intermediate_exception(
+            exception.into_intermediate_exception(),
+        ));
+    }
+}

--- a/crates/lib/vm-runtime-exception/src/lib.rs
+++ b/crates/lib/vm-runtime-exception/src/lib.rs
@@ -54,3 +54,31 @@ pub trait FromException: Sized + waymark_vm_runtime_value::RootValueAccess {
     /// Wrap the provided exception as `Self`.
     fn from_exception(exception: Exception<Self::RootValue>) -> Self;
 }
+
+/// A statically-typed exception.
+///
+/// Implemented by the narrow error types whose failures are exposed to
+/// the user code as catchable runtime exceptions; the implementation
+/// determines the runtime exception type identifier and details payload.
+pub trait TypedException {
+    /// The typed details payload of the intermediate exception.
+    type IntermediateDetails;
+
+    /// Build the intermediate typed representation of the runtime exception.
+    fn into_intermediate_exception(self) -> Exception<Self::IntermediateDetails>;
+}
+
+/// Constructs a runtime exception from an intermediate typed exception.
+///
+/// Implemented by the value types; the implementation lifts the intermediate
+/// exception details into the value domain — effectively a
+/// `From<IntermediateDetails>` with the added context that the payload is
+/// an exception details payload and not just a raw value.
+pub trait ExceptionFromIntermediate<IntermediateDetails>:
+    waymark_vm_runtime_value::RootValueAccess
+{
+    /// Build the runtime exception from the provided intermediate exception.
+    fn from_intermediate_exception(
+        intermediate_exception: Exception<IntermediateDetails>,
+    ) -> Exception<Self::RootValue>;
+}

--- a/crates/lib/vm-runtime-promise-value/src/exception.rs
+++ b/crates/lib/vm-runtime-promise-value/src/exception.rs
@@ -43,3 +43,15 @@ where
         Self::Ready(T::from_exception(exception))
     }
 }
+
+impl<T, IntermediateDetails>
+    waymark_vm_runtime_exception::ExceptionFromIntermediate<IntermediateDetails> for PromiseValue<T>
+where
+    T: waymark_vm_runtime_exception::ExceptionFromIntermediate<IntermediateDetails>,
+{
+    fn from_intermediate_exception(
+        exception: Exception<IntermediateDetails>,
+    ) -> Exception<Self::RootValue> {
+        T::from_intermediate_exception(exception)
+    }
+}

--- a/crates/lib/vm-value/src/exception.rs
+++ b/crates/lib/vm-value/src/exception.rs
@@ -30,3 +30,12 @@ impl FromException for ReadyValue {
         Self::Exception(Box::new(exception))
     }
 }
+
+impl waymark_vm_runtime_exception::ExceptionFromIntermediate<String> for ReadyValue {
+    fn from_intermediate_exception(exception: Exception<String>) -> Exception<Self::RootValue> {
+        Exception {
+            type_id: exception.type_id,
+            details: crate::Value::Ready(Self::String(exception.details)),
+        }
+    }
+}

--- a/example_app/src/example_app/web.py
+++ b/example_app/src/example_app/web.py
@@ -77,6 +77,9 @@ from example_app.workflows import (
     WhileLoopRequest,
     WhileLoopResult,
     WhileLoopWorkflow,
+    ZeroDivisionRequest,
+    ZeroDivisionResult,
+    ZeroDivisionWorkflow,
 )
 
 app = FastAPI(title="Waymark Example")
@@ -202,6 +205,15 @@ async def run_exception_metadata_workflow(payload: ErrorRequest) -> ErrorResult:
     """Run the exception metadata workflow demonstrating captured values."""
     workflow = ExceptionMetadataWorkflow()
     return await workflow.run(should_fail=payload.should_fail)
+
+
+@app.post("/api/zero-division", response_model=ZeroDivisionResult)
+async def run_zero_division_workflow(
+    payload: ZeroDivisionRequest,
+) -> ZeroDivisionResult:
+    """Run the zero division workflow demonstrating VM-raised exceptions."""
+    workflow = ZeroDivisionWorkflow()
+    return await workflow.run(denominator=payload.denominator)
 
 
 # =============================================================================
@@ -395,6 +407,7 @@ WORKFLOW_REGISTRY = {
     "LoopExceptionWorkflow": LoopExceptionWorkflow,
     "ErrorHandlingWorkflow": ErrorHandlingWorkflow,
     "ExceptionMetadataWorkflow": ExceptionMetadataWorkflow,
+    "ZeroDivisionWorkflow": ZeroDivisionWorkflow,
     "RetryCounterWorkflow": RetryCounterWorkflow,
     "TimeoutProbeWorkflow": TimeoutProbeWorkflow,
     "DurableSleepWorkflow": DurableSleepWorkflow,

--- a/example_app/src/example_app/workflows.py
+++ b/example_app/src/example_app/workflows.py
@@ -121,6 +121,17 @@ class ErrorRequest(BaseModel):
     should_fail: bool = Field(description="Whether the action should fail")
 
 
+class ZeroDivisionResult(BaseModel):
+    """Result from the zero division workflow."""
+
+    caught: bool
+    quotient: int
+
+
+class ZeroDivisionRequest(BaseModel):
+    denominator: int = Field(description="Denominator for the in-workflow division")
+
+
 class RetryCounterRequest(BaseModel):
     """Request for retry behavior workflow."""
 
@@ -483,6 +494,12 @@ async def build_error_result(
         error_code=error_code,
         error_detail=error_detail,
     )
+
+
+@action
+async def build_zero_division_result(caught: bool, quotient: int) -> ZeroDivisionResult:
+    """Build the zero division result."""
+    return ZeroDivisionResult(caught=caught, quotient=quotient)
 
 
 # =============================================================================
@@ -873,6 +890,29 @@ class ExceptionMetadataWorkflow(Workflow):
             error_code,
             error_detail,
         )
+
+
+@workflow
+class ZeroDivisionWorkflow(Workflow):
+    """
+    Demonstrate catching an exception raised by the VM itself.
+
+    The division happens in the workflow body rather than in an action, so
+    a zero denominator raises a catchable `ZeroDivisionError` from the VM
+    runtime instead of failing an action.
+    """
+
+    async def run(self, denominator: int) -> ZeroDivisionResult:
+        caught = False
+        quotient = 0
+
+        try:
+            quotient = 10 // denominator
+        except ZeroDivisionError:
+            caught = True
+            quotient = -1
+
+        return await build_zero_division_result(caught, quotient)
 
 
 @workflow

--- a/example_app/tests/test_web.py
+++ b/example_app/tests/test_web.py
@@ -81,6 +81,36 @@ def test_while_loop_workflow(monkeypatch: pytest.MonkeyPatch) -> None:
     assert payload["iterations"] == 4
 
 
+def test_zero_division_workflow_catches_the_vm_raised_exception(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A zero denominator raises `ZeroDivisionError` from the VM; the workflow catches it."""
+    _enable_real_cluster(monkeypatch)
+
+    client = TestClient(app)
+    response = client.post("/api/zero-division", json={"denominator": 0})
+    assert response.status_code == 200
+    payload = response.json()
+
+    assert payload["caught"] is True
+    assert payload["quotient"] == -1
+
+
+def test_zero_division_workflow_divides_normally_when_denominator_is_nonzero(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A nonzero denominator takes the ordinary division path."""
+    _enable_real_cluster(monkeypatch)
+
+    client = TestClient(app)
+    response = client.post("/api/zero-division", json={"denominator": 5})
+    assert response.status_code == 200
+    payload = response.json()
+
+    assert payload["caught"] is False
+    assert payload["quotient"] == 2
+
+
 def test_retry_counter_workflow_eventual_success(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
Goes in after #521.

---

This PR makes certain error conditions catchable via exceptions rather than exposing them via interpreter errors. The design removes the error conditions that are no longer present as errors from the interpreter error enums, and unifies the exception type-id definitions.

We also correct the overly-permissive behavior of the benchmarks/smoke/internal tests that allowed errors where they should've actually been not allowed (due to compile errors and VM runtime errors as opposed to caught exceptions).

---

We'd want to continue that work by sharing the exception types with compiler and maybe providing more exception details (i.e. exception-type-ids -> exception-types, and making the exception details compileable-into-bytecode-statics in addition to being runtime-constructable); but that's for later