### PR TITLE
Tighter CI checks

### DIFF
--- a/crates/bin/benchmark/src/registration.rs
+++ b/crates/bin/benchmark/src/registration.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
 
-use color_eyre::eyre::WrapErr as _;
+use color_eyre::eyre::{WrapErr as _, eyre};
 use rand::seq::SliceRandom;
 use waymark_backend_postgres::PostgresBackend;
 
@@ -33,24 +33,18 @@ pub async fn register_benchmark_vms(
 ) -> Result<usize, color_eyre::eyre::Report> {
     let mut compiled = HashMap::new();
     for (name, case) in cases {
-        match executables
+        let (executable_id, executable, metadata) = executables
             .compile_and_store(name, &case.ir_hash, &case.program)
             .await
-        {
-            Ok((executable_id, executable, metadata)) => {
-                compiled.insert(
-                    name.clone(),
-                    CompiledCase {
-                        executable_id,
-                        executable: Arc::new(executable),
-                        metadata,
-                    },
-                );
-            }
-            Err(err) => {
-                eprintln!("Skipping IR job '{name}': compilation failed: {err}");
-            }
-        }
+            .map_err(|err| eyre!("compile IR job '{name}': {err}"))?;
+        compiled.insert(
+            name.clone(),
+            CompiledCase {
+                executable_id,
+                executable: Arc::new(executable),
+                metadata,
+            },
+        );
     }
 
     let mut case_names = Vec::new();

--- a/crates/bin/benchmark/src/registration.rs
+++ b/crates/bin/benchmark/src/registration.rs
@@ -33,24 +33,18 @@ pub async fn register_benchmark_vms(
 ) -> Result<usize, color_eyre::eyre::Report> {
     let mut compiled = HashMap::new();
     for (name, case) in cases {
-        match executables
+        let (executable_id, executable, metadata) = executables
             .compile_and_store(name, &case.ir_hash, &case.program)
             .await
-        {
-            Ok((executable_id, executable, metadata)) => {
-                compiled.insert(
-                    name.clone(),
-                    CompiledCase {
-                        executable_id,
-                        executable: Arc::new(executable),
-                        metadata,
-                    },
-                );
-            }
-            Err(err) => {
-                eprintln!("Skipping IR job '{name}': compilation failed: {err}");
-            }
-        }
+            .wrap_err_with(|| format!("compile IR job '{name}'"))?;
+        compiled.insert(
+            name.clone(),
+            CompiledCase {
+                executable_id,
+                executable: Arc::new(executable),
+                metadata,
+            },
+        );
     }
 
     let mut case_names = Vec::new();

--- a/crates/bin/smoke/src/main.rs
+++ b/crates/bin/smoke/src/main.rs
@@ -101,6 +101,7 @@ async fn run_smoke(base: i64) -> i32 {
         return 1;
     }
 
+    let mut failures = 0;
     let mut cases = Vec::new();
     let examples = vec![
         ("smoke", Ok(build_program())),
@@ -114,6 +115,7 @@ async fn run_smoke(base: i64) -> i32 {
             Ok(value) => value,
             Err(err) => {
                 println!("Failed to build {name} program: {err}");
+                failures += 1;
                 continue;
             }
         };
@@ -121,6 +123,7 @@ async fn run_smoke(base: i64) -> i32 {
             Ok(value) => value,
             Err(err) => {
                 println!("Failed to convert {name} program to the AST: {err}");
+                failures += 1;
                 continue;
             }
         };
@@ -152,7 +155,6 @@ async fn run_smoke(base: i64) -> i32 {
         });
     }
 
-    let mut failures = 0;
     for case in &cases {
         if let Err(err) = run_program_smoke(case, Arc::clone(&worker_pool)).await {
             failures += 1;


### PR DESCRIPTION
Goes in after #522 

---

This PR makes even more places in our QA binaries more restrictive with respect to compile errors.

Note: this tightens the binaries' exit codes; CI starts observing them in #545-#547 (benchmark JSON report, direct benchmark invocation gating the job, smoke job).