### PR TITLE
Apply useful changes from the cancelled operations refactor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5589,12 +5589,10 @@ dependencies = [
  "waymark-vm-bytecode",
  "waymark-vm-instructions-extcallset",
  "waymark-vm-interpreter",
- "waymark-vm-interpreter-coreset",
  "waymark-vm-runtime",
  "waymark-vm-runtime-core",
  "waymark-vm-runtime-promise-core",
  "waymark-vm-runtime-test",
- "waymark-vm-runtime-value",
  "waymark-vm-runtime-view-capture",
 ]
 
@@ -5637,7 +5635,6 @@ dependencies = [
  "waymark-vm-exception-type-ids",
  "waymark-vm-instructions-pureset",
  "waymark-vm-interpreter",
- "waymark-vm-interpreter-coreset",
  "waymark-vm-interpreter-utils",
  "waymark-vm-runtime",
  "waymark-vm-runtime-core",
@@ -5756,7 +5753,6 @@ dependencies = [
  "waymark-vm-bytecode",
  "waymark-vm-bytecode-core",
  "waymark-vm-interpreter",
- "waymark-vm-interpreter-coreset",
  "waymark-vm-runtime",
  "waymark-vm-runtime-core",
  "waymark-vm-runtime-exception",

--- a/crates/lib/vm-interpreter-extcallset/Cargo.toml
+++ b/crates/lib/vm-interpreter-extcallset/Cargo.toml
@@ -18,7 +18,5 @@ thiserror = { workspace = true }
 
 [dev-dependencies]
 waymark-vm-bytecode = { workspace = true }
-waymark-vm-interpreter-coreset = { workspace = true }
 waymark-vm-runtime = { workspace = true }
 waymark-vm-runtime-test = { workspace = true }
-waymark-vm-runtime-value = { workspace = true }

--- a/crates/lib/vm-interpreter-extcallset/tests/support/mod.rs
+++ b/crates/lib/vm-interpreter-extcallset/tests/support/mod.rs
@@ -53,16 +53,6 @@ pub enum TestValue {
     Pending(PromiseStateId),
 }
 
-impl waymark_vm_runtime_value::RootValueAccess for TestValue {
-    type RootValue = Self;
-}
-
-impl waymark_vm_interpreter_coreset::value::CaptureCallArgument for TestValue {
-    fn capture_call_argument(&self) -> Self {
-        self.clone()
-    }
-}
-
 impl waymark_vm_interpreter_extcallset::value::CaptureActionCallArgument for TestValue {
     type ActionCallArgument = i32;
     type Error = UnresolvedPromiseError;

--- a/crates/lib/vm-interpreter-pureset/Cargo.toml
+++ b/crates/lib/vm-interpreter-pureset/Cargo.toml
@@ -18,7 +18,6 @@ derive-where = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
-waymark-vm-interpreter-coreset = { workspace = true }
 waymark-vm-runtime = { workspace = true }
 waymark-vm-runtime-test = { workspace = true }
 

--- a/crates/lib/vm-interpreter-pureset/tests/support/mod.rs
+++ b/crates/lib/vm-interpreter-pureset/tests/support/mod.rs
@@ -59,12 +59,6 @@ impl waymark_vm_runtime_value::RootValueAccess for TestValue {
 
 static_assertions::assert_impl_all!(TestValue: waymark_vm_interpreter_pureset::Value);
 
-impl waymark_vm_interpreter_coreset::value::CaptureCallArgument for TestValue {
-    fn capture_call_argument(&self) -> Self {
-        self.clone()
-    }
-}
-
 impl waymark_vm_interpreter_pureset::value::CaptureCopy for TestValue {
     fn capture_copy(&self) -> Self {
         self.clone()

--- a/crates/lib/vm-runtime-test/Cargo.toml
+++ b/crates/lib/vm-runtime-test/Cargo.toml
@@ -8,7 +8,6 @@ publish.workspace = true
 waymark-vm-bytecode = { workspace = true }
 waymark-vm-bytecode-core = { workspace = true, features = ["serde"] }
 waymark-vm-interpreter = { workspace = true }
-waymark-vm-interpreter-coreset = { workspace = true }
 waymark-vm-runtime = { workspace = true }
 waymark-vm-runtime-core = { workspace = true }
 waymark-vm-runtime-exception = { workspace = true }

--- a/crates/lib/vm-runtime-test/src/lib.rs
+++ b/crates/lib/vm-runtime-test/src/lib.rs
@@ -7,11 +7,10 @@
 //!
 //! Concretely, this crate may depend on the core runtime traits
 //! ([`waymark_vm_interpreter::Interpreter`],
-//! `waymark_vm_runtime_view_capture::CaptureRuntimeView`,
-//! [`waymark_vm_interpreter_coreset::value::CaptureCallArgument`], etc.) that
-//! every interpreter is expected to honor, but it must not depend on the
+//! `waymark_vm_runtime_view_capture::CaptureRuntimeView`, etc.) that every
+//! interpreter is expected to honor, but it must not depend on the
 //! per-instruction-set crates (e.g. `waymark-vm-instructions-pureset`,
-//! `waymark-vm-interpreter-extcallset`).
+//! `waymark-vm-interpreter-coreset`, `waymark-vm-interpreter-extcallset`).
 //!
 //! What belongs here:
 //!
@@ -96,12 +95,6 @@ impl waymark_vm_runtime_value::RootValueAccess for TestReadyValue {
 impl FromException for TestReadyValue {
     fn from_exception(exception: Exception<Self::RootValue>) -> Self {
         Self::Exception(Box::new(exception))
-    }
-}
-
-impl waymark_vm_interpreter_coreset::value::CaptureCallArgument for TestReadyValue {
-    fn capture_call_argument(&self) -> Self {
-        self.clone()
     }
 }
 


### PR DESCRIPTION
Goes in after #536

Supersedes #537 

---

The operations extraction from the value really serves no good purpose - cause the actual shape of the value has to change per-language. Not having values changing shape so has deep implications for the architecture flexibility - like the lack of the capability to represent certain per-language features.