### PR TITLE
Lock python tools versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ jobs:
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v7
+        with:
+          version-file: "pyproject.toml"
 
       - name: Install protoc
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
@@ -36,6 +38,8 @@ jobs:
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v7
+        with:
+          version-file: "pyproject.toml"
 
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}
@@ -115,6 +119,8 @@ jobs:
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v7
+        with:
+          version-file: "pyproject.toml"
 
       - name: Install protoc
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
@@ -226,6 +232,8 @@ jobs:
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v7
+        with:
+          version-file: "pyproject.toml"
 
       - name: Install protoc
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
@@ -280,6 +288,8 @@ jobs:
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v7
+        with:
+          version-file: "pyproject.toml"
 
       - name: Download Python coverage XML
         uses: actions/download-artifact@v4
@@ -366,6 +376,8 @@ jobs:
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v7
+        with:
+          version-file: "pyproject.toml"
 
       - name: Install protoc & clients
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler postgresql-client
@@ -410,6 +422,8 @@ jobs:
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v7
+        with:
+          version-file: "pyproject.toml"
 
       - name: Install protoc
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
@@ -439,6 +453,8 @@ jobs:
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v7
+        with:
+          version-file: "pyproject.toml"
 
       - name: Install protoc
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
@@ -482,6 +498,8 @@ jobs:
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v7
+        with:
+          version-file: "pyproject.toml"
 
       - name: Install protoc & clients
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler postgresql-client
@@ -581,6 +599,8 @@ jobs:
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v7
+        with:
+          version-file: "pyproject.toml"
 
       - name: Install protoc (Linux)
         if: runner.os == 'Linux'
@@ -641,6 +661,8 @@ jobs:
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v7
+        with:
+          version-file: "pyproject.toml"
 
       - name: Download Linux x86_64 wheel
         uses: actions/download-artifact@v4

--- a/example_app/Dockerfile
+++ b/example_app/Dockerfile
@@ -54,7 +54,7 @@ COPY . .
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,target=/root/.cache/uv \
-    uv run scripts/build_wheel.py --out-dir target/wheels
+    uv run --locked scripts/build_wheel.py --out-dir target/wheels
 
 # =============================================================================
 # Stage 4: Final runtime image

--- a/example_app/Dockerfile
+++ b/example_app/Dockerfile
@@ -56,6 +56,13 @@ RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cache/uv \
     uv run --locked scripts/build_wheel.py --out-dir target/wheels
 
+# Render the locked resolution for the runtime stage: everything
+# example_app needs (waymark's own entry excluded — the locally built
+# wheel provides it), exact versions + hashes from uv.lock.
+RUN uv export --locked --package example-app --extra tests --no-dev \
+    --no-emit-project --no-emit-package waymark \
+    -o target/example-app-requirements.txt
+
 # =============================================================================
 # Stage 4: Final runtime image
 # =============================================================================
@@ -76,10 +83,13 @@ ENV VIRTUAL_ENV=/opt/venv
 ENV PATH="/opt/venv/bin:${PATH}"
 
 COPY --from=wheel-builder /repo/target/wheels /tmp/wheels
+COPY --from=wheel-builder /repo/target/example-app-requirements.txt /tmp/example-app-requirements.txt
 RUN --mount=type=cache,target=/root/.cache/uv \
-    set -eux; wheel=$(ls /tmp/wheels/waymark-*.whl | head -n 1); uv pip install --no-cache-dir "$wheel"
+    uv pip install --no-cache-dir --require-hashes -r /tmp/example-app-requirements.txt
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv pip install --no-cache-dir --no-sources ".[tests]"
+    set -eux; wheel=$(ls /tmp/wheels/waymark-*.whl | head -n 1); uv pip install --no-cache-dir --no-deps "$wheel"
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip install --no-cache-dir --no-sources --no-deps .
 
 ENV WAYMARK_HTTP_PORT=24117 \
     WAYMARK_GRPC_PORT=24118

--- a/example_app/Dockerfile
+++ b/example_app/Dockerfile
@@ -1,5 +1,11 @@
 # syntax=docker/dockerfile:1.7
 
+# Mirrors `tool.uv.required-version` in the root pyproject.toml; a
+# mismatch fails loudly (uv refuses to run under required-version).
+ARG UV_VERSION=0.12.3
+
+FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv
+
 FROM rust:1.88-bookworm AS rust-base
 WORKDIR /repo
 COPY rust-toolchain.toml .
@@ -36,8 +42,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3-pip \
     curl \
     && rm -rf /var/lib/apt/lists/*
-RUN curl -LsSf https://astral.sh/uv/install.sh | sh
-ENV PATH="/root/.local/bin:${PATH}"
+COPY --from=uv /uv /uvx /usr/local/bin/
 
 # Copy cached dependencies from cacher stage
 COPY --from=rust-cacher /repo/target target
@@ -61,8 +66,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
     PYTHONUNBUFFERED=1
 
 RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
-RUN curl -LsSf https://astral.sh/uv/install.sh | sh
-ENV PATH="/root/.local/bin:${PATH}"
+COPY --from=uv /uv /uvx /usr/local/bin/
 
 WORKDIR /app
 COPY example_app /app

--- a/example_app/pyproject.toml
+++ b/example_app/pyproject.toml
@@ -20,7 +20,9 @@ tests = ["pytest>=8.3", "httpx>=0.27"]
 dev = ["pytest>=8.3", "httpx>=0.27"]
 
 [build-system]
-requires = ["setuptools>=68", "wheel"]
+# Exact pins: build-system requirements are not covered by uv.lock and
+# would otherwise float on every image build.
+requires = ["setuptools==84.0.0", "wheel==0.47.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,9 @@
+[tool.uv]
+# The single source of truth for the uv version: enforced by uv itself
+# on every invocation, read by CI via `setup-uv`'s `version-file`, and
+# mirrored by the Dockerfile's UV_VERSION arg (a mismatch there fails
+# loudly since the mismatched uv refuses to run).
+required-version = "==0.12.3"
+
 [tool.uv.workspace]
 members = ["python", "scripts", "example_app"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,5 +5,14 @@
 # loudly since the mismatched uv refuses to run).
 required-version = "==0.12.3"
 
+# Build-backend versions are not covered by uv.lock (they resolve in
+# isolated build environments); this constrains them everywhere a
+# member gets built — `uv sync`/`uv run` editable installs and
+# `uv build` wheel builds alike.
+#
+# hatchling 1.32.0 rejects the out-of-project readme path
+# (`readme = "../README.md"`).
+build-constraint-dependencies = ["hatchling==1.31.0"]
+
 [tool.uv.workspace]
 members = ["python", "scripts", "example_app"]

--- a/scripts/build_wheel.py
+++ b/scripts/build_wheel.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env -S uv run --script
 # /// script
+# requires-python = ">=3.10"
 # dependencies = ["click>=8", "rich>=13", "packaging>=23"]
 # ///
 """Build a distributable wheel that bundles Rust binaries and Python package."""

--- a/scripts/build_wheel.py.lock
+++ b/scripts/build_wheel.py.lock
@@ -1,0 +1,83 @@
+version = 1
+revision = 3
+requires-python = ">=3.10"
+
+[manifest]
+requirements = [
+    { name = "click", specifier = ">=8" },
+    { name = "packaging", specifier = ">=23" },
+    { name = "rich", specifier = ">=13" },
+]
+
+[[package]]
+name = "click"
+version = "8.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/fa/3944b40b07da9ce895c0e6303a5ab7d53da063554f534556b134a54d6093/packaging-26.3.tar.gz", hash = "sha256:94edc256424af38762eb31306eed28beb9f0efc50a8837492c9d6fd6004aed79", size = 313412, upload-time = "2026-08-04T18:15:28.737Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/34/ba1c580383c9eada3711951fef0795c80b829a078d72188184bcab9dd527/packaging-26.3-py3-none-any.whl", hash = "sha256:d7193f7c8e4e93f444fde0262bf90af30e16fa0ad0ad44cb553c87339b23cd1c", size = 129956, upload-time = "2026-08-04T18:15:27.159Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]

--- a/uv.lock
+++ b/uv.lock
@@ -12,6 +12,7 @@ members = [
     "waymark",
     "waymark-scripts",
 ]
+build-constraints = [{ name = "hatchling", specifier = "==1.31.0" }]
 
 [[package]]
 name = "annotated-doc"
@@ -318,7 +319,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -710,7 +711,7 @@ resolution-markers = [
     "python_full_version >= '3.12'",
 ]
 dependencies = [
-    { name = "pydantic", marker = "python_full_version >= '3.12'" },
+    { name = "pydantic" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/12/85/c2916fc2f76cc579038ab52b999e792d7fcb5a5dc7b3aba0f3270a1427d5/mountaineer_di-0.1.0.tar.gz", hash = "sha256:ad2e14c08b853eac2e26b1a4a6745adc729d534029b4cce1178e96102a7129a1", size = 29429, upload-time = "2026-03-30T03:22:45.746Z" }
 wheels = [
@@ -725,7 +726,7 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 dependencies = [
-    { name = "pydantic", marker = "python_full_version < '3.12'" },
+    { name = "pydantic" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c2/14/1990a29b4e945cb61ddee58d030dac0692a62c322d8d3facec3cb9932606/mountaineer_di-0.1.2.tar.gz", hash = "sha256:22e144e79d1aeefebd9989bcd7c63d2632396fdf5f7f6fa165343922a736260a", size = 30449, upload-time = "2026-03-30T03:36:20.36Z" }
 wheels = [


### PR DESCRIPTION
Fixes CI. Failures caused by updates in the python packages that we depend on but don't lock the version of.

We don't ever want to be in a position where our dependencies' versions are updated uncontrollably.