### PR TITLE
Add machine-readable JSON output to the benchmark

### DIFF
--- a/crates/bin/benchmark/src/cli.rs
+++ b/crates/bin/benchmark/src/cli.rs
@@ -22,6 +22,8 @@ pub struct BenchmarkArgs {
     pub dsn: SecretString,
     #[arg(long, default_value_t = false)]
     pub observe: bool,
+    #[arg(long, num_args = 0..=1, default_missing_value = "-")]
+    pub json: Option<String>,
     #[arg(long, num_args = 0..=1, default_missing_value = "target/benchmark-trace.json")]
     pub trace: Option<String>,
 }

--- a/crates/bin/benchmark/src/main.rs
+++ b/crates/bin/benchmark/src/main.rs
@@ -122,6 +122,7 @@ async fn run_benchmark(
     execution::shutdown_execution(execution_handles).await;
 
     Ok(BenchmarkStats {
+        total,
         elapsed,
         query_counts: backend.query_counts(),
         batch_counts: backend.batch_size_counts(),
@@ -163,7 +164,16 @@ fn main() -> Result<(), waymark_fn_main_common::Error> {
         registration_batch_max,
     ))?;
     println!("Benchmark completed in {:.2?}", stats.elapsed);
-    println!("{}", report::format_query_counts(stats.query_counts));
-    println!("{}", report::format_batch_size_counts(stats.batch_counts));
+    println!("{}", report::format_query_counts(&stats.query_counts));
+    println!("{}", report::format_batch_size_counts(&stats.batch_counts));
+    if let Some(json) = &args.json {
+        let report = report::format_json(&stats, args.count, args.base);
+        if json == "-" {
+            println!("{report}");
+        } else {
+            std::fs::write(json, format!("{report}\n"))
+                .wrap_err_with(|| format!("write the JSON report to {json}"))?;
+        }
+    }
     Ok(())
 }

--- a/crates/bin/benchmark/src/report.rs
+++ b/crates/bin/benchmark/src/report.rs
@@ -4,12 +4,13 @@ use std::collections::HashMap;
 use std::time::Duration;
 
 pub struct BenchmarkStats {
+    pub total: usize,
     pub elapsed: Duration,
     pub query_counts: HashMap<String, usize>,
     pub batch_counts: HashMap<String, HashMap<usize, usize>>,
 }
 
-pub fn format_query_counts(counts: HashMap<String, usize>) -> String {
+pub fn format_query_counts(counts: &HashMap<String, usize>) -> String {
     let mut keys: Vec<_> = counts.keys().cloned().collect();
     keys.sort();
     let mut lines = vec!["Postgres query counts:".to_string()];
@@ -38,7 +39,7 @@ fn median_from_counts(counts: &HashMap<usize, usize>) -> usize {
     0
 }
 
-pub fn format_batch_size_counts(batch_counts: HashMap<String, HashMap<usize, usize>>) -> String {
+pub fn format_batch_size_counts(batch_counts: &HashMap<String, HashMap<usize, usize>>) -> String {
     let mut keys: Vec<_> = batch_counts.keys().cloned().collect();
     keys.sort();
     let mut lines = vec!["Postgres batch size p50:".to_string()];
@@ -53,4 +54,37 @@ pub fn format_batch_size_counts(batch_counts: HashMap<String, HashMap<usize, usi
         }
     }
     lines.join("\n")
+}
+
+pub fn format_json(
+    stats: &BenchmarkStats,
+    count_per_case: std::num::NonZeroUsize,
+    base: i64,
+) -> String {
+    let elapsed_s = stats.elapsed.as_secs_f64();
+    let batch_p50: HashMap<&str, serde_json::Value> = stats
+        .batch_counts
+        .iter()
+        .filter(|(_, counts)| !counts.is_empty())
+        .map(|(key, counts)| {
+            let total: usize = counts.values().sum();
+            (
+                key.as_str(),
+                serde_json::json!({
+                    "p50": median_from_counts(counts),
+                    "batches": total,
+                }),
+            )
+        })
+        .collect();
+    serde_json::json!({
+        "count_per_case": count_per_case.get(),
+        "base": base,
+        "total": stats.total,
+        "elapsed_s": elapsed_s,
+        "throughput": stats.total as f64 / elapsed_s,
+        "query_counts": stats.query_counts,
+        "batch_p50": batch_p50,
+    })
+    .to_string()
 }


### PR DESCRIPTION
Goes in after #532

---

This was somehow slipped though the cracks, but there are traces of the infrastructure that'd use it. Idk, but it's a quick fix.