### PR TITLE
Add a smoke check job to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -397,6 +397,36 @@ jobs:
           name: benchmark-pr
           path: benchmark-pr.json
 
+  smoke:
+    runs-on: ubuntu-latest
+    needs: [rust-tests]
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version-file: "pyproject.toml"
+
+      - name: Install protoc
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
+      - name: Prepare Python worker environment
+        working-directory: python
+        run: uv sync
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2.8.2
+        with:
+          shared-key: waymark
+
+      - name: Run smoke check
+        run: cargo run --release --package waymark-smoke
+
   fuzz-sanity:
     runs-on: ubuntu-latest
     needs: [rust-tests]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4696,6 +4696,7 @@ dependencies = [
  "waymark-worker-python",
  "waymark-worker-remote-bringup",
  "waymark-worker-remote-pool",
+ "waymark-workflow-completion-core",
 ]
 
 [[package]]

--- a/crates/bin/smoke/Cargo.toml
+++ b/crates/bin/smoke/Cargo.toml
@@ -17,6 +17,7 @@ waymark-worker-core = { workspace = true }
 waymark-worker-python = { workspace = true }
 waymark-worker-remote-bringup = { workspace = true }
 waymark-worker-remote-pool = { workspace = true }
+waymark-workflow-completion-core = { workspace = true }
 
 clap = { workspace = true, features = ["derive"] }
 color-eyre = { workspace = true }

--- a/crates/bin/smoke/src/main.rs
+++ b/crates/bin/smoke/src/main.rs
@@ -63,7 +63,15 @@ where
     })?;
 
     println!("Workflow outcome ({}): {:?}", case.name, workflow_outcome);
-    Ok(())
+
+    match workflow_outcome {
+        waymark_workflow_completion_core::Outcome::Completion(_value) => Ok(()),
+        waymark_workflow_completion_core::Outcome::Exception(exception) => {
+            Err(color_eyre::eyre::eyre!(
+                "workflow terminated with an unhandled exception: {exception:?}"
+            ))
+        }
+    }
 }
 
 async fn run_smoke(base: i64) -> i32 {


### PR DESCRIPTION
Goes in after #546 

---

This PR adds smoke check invocation to CI. This was missing, but we actually want to have it.