### PR TITLE
Deliver the workflow outcome before waiting for VM to terminate at transient execution

### DIFF
--- a/crates/lib/transient-execution-worker-stream-bringup/src/lib.rs
+++ b/crates/lib/transient-execution-worker-stream-bringup/src/lib.rs
@@ -135,6 +135,8 @@ pub fn execute(runtime: waymark_system_vm::Runtime, skip_sleep: bool) -> Execute
             ActionCallCorrelation,
         >::new(action_result_rx);
 
+    let cancellation = tokio_util::sync::CancellationToken::new();
+
     let waymark_transient_execution_bringup::Execution {
         workflow_outcome_rx,
         driver_handle,
@@ -143,15 +145,10 @@ pub fn execute(runtime: waymark_system_vm::Runtime, skip_sleep: bool) -> Execute
         action_call_requester,
         action_call_completions_provider,
         skip_sleep,
-        tokio_util::sync::CancellationToken::new(),
+        cancellation.clone(),
     );
 
-    // Wait for the driver to finish, then await the workflow outcome
-    // and forward it to out_tx.
     tokio::spawn(async move {
-        let Err(err) = driver_handle.await;
-        tracing::warn!(?err, "vm driver exited");
-
         let response = match workflow_outcome_rx.await {
             Ok(workflow_outcome) => convert_workflow_outcome_to_stream_response(workflow_outcome),
             Err(_recv_error) => {
@@ -165,6 +162,11 @@ pub fn execute(runtime: waymark_system_vm::Runtime, skip_sleep: bool) -> Execute
         };
 
         let _ = out_tx.send(response).await;
+
+        cancellation.cancel();
+
+        let Err(err) = driver_handle.await;
+        tracing::warn!(?err, "vm driver exited");
     });
 
     ExecuteChannels {

--- a/python/tests/test_pytest_in_memory_runtime.py
+++ b/python/tests/test_pytest_in_memory_runtime.py
@@ -12,6 +12,11 @@ async def always_fails() -> None:
     raise ValueError("boom")
 
 
+@action
+async def instant(label: str) -> str:
+    return label
+
+
 @workflow
 class UnhandledFailureWorkflow(Workflow):
     async def run(self) -> None:
@@ -27,6 +32,15 @@ class SleepWorkflow(Workflow):
     async def run(self) -> str:
         await asyncio.sleep(20)
         return "done"
+
+
+@workflow
+class TimeoutPolicyWorkflow(Workflow):
+    async def run(self) -> str:
+        return await self.run_action(
+            instant("prompt"),
+            timeout=timedelta(seconds=30),
+        )
 
 
 @workflow
@@ -53,6 +67,15 @@ def test_pytest_runtime_skips_sleep_nodes() -> None:
     elapsed = time.monotonic() - started
 
     assert result == "done"
+    assert elapsed < 5.0
+
+
+def test_pytest_runtime_does_not_wait_out_action_timeouts() -> None:
+    started = time.monotonic()
+    result = asyncio.run(TimeoutPolicyWorkflow().run())
+    elapsed = time.monotonic() - started
+
+    assert result == "prompt"
     assert elapsed < 5.0
 
 


### PR DESCRIPTION
This PR changes the ordering in which we orchestrate the workflow outcome and VM driver termination during transient execution - it now semantically matching what's supposed to happen in production (more or less).

The underlying resource leak is still present, but it's not an issue for the transient execution specifically (this case) because the cancellation of the tasks at rust-side will take care of that; in production though, the resources will leak, and we need a proper cancellation routines support to do the resource cleanup.