### PR TITLE
Drop the WorkflowNodeResult and return the completion value as-is

### DIFF
--- a/crates/lib/workflow-completion-convert-proto/src/lib.rs
+++ b/crates/lib/workflow-completion-convert-proto/src/lib.rs
@@ -11,10 +11,6 @@ use waymark_vm_value_convert_core::PendingPromiseError;
 use waymark_workflow_completion_core::Outcome;
 
 /// Converter for workflow-completion results.
-///
-/// Completion results are wrapped in a
-/// [`BaseModelWorkflowArgument`](waymark_proto::messages::BaseModelWorkflowArgument)
-/// (`WorkflowNodeResult`) rather than plain primitive/dict/list values.
 pub struct Converter;
 
 impl TryConvert<Outcome<waymark_vm_value::ReadyValue>, waymark_proto::messages::WorkflowArguments>
@@ -77,41 +73,12 @@ fn exception_workflow_arguments(
 fn completion_workflow_arguments(
     json: serde_json::Value,
 ) -> waymark_proto::messages::WorkflowArguments {
-    use waymark_proto::messages::{
-        BaseModelWorkflowArgument, WorkflowArgument, WorkflowArguments, WorkflowDictArgument,
-        workflow_argument_value::Kind,
-    };
-
-    let variables_value = match &json {
-        serde_json::Value::Object(_) => json.clone(),
-        other => {
-            let mut map = serde_json::Map::new();
-            map.insert("result".to_string(), other.clone());
-            serde_json::Value::Object(map)
-        }
-    };
-
-    let variables_arg =
-        waymark_message_conversions::json_to_workflow_argument_value(&variables_value);
-    let dict = WorkflowDictArgument {
-        entries: vec![WorkflowArgument {
-            key: "variables".to_string(),
-            value: Some(variables_arg),
-        }],
-    };
-
-    let result_value = waymark_proto::messages::WorkflowArgumentValue {
-        kind: Some(Kind::Basemodel(BaseModelWorkflowArgument {
-            module: "waymark.workflow_runtime".to_string(),
-            name: "WorkflowNodeResult".to_string(),
-            data: Some(dict),
-        })),
-    };
+    use waymark_proto::messages::{WorkflowArgument, WorkflowArguments};
 
     WorkflowArguments {
         arguments: vec![WorkflowArgument {
             key: "result".to_string(),
-            value: Some(result_value),
+            value: Some(waymark_message_conversions::json_to_workflow_argument_value(&json)),
         }],
     }
 }

--- a/crates/lib/workflow-completion-convert-proto/tests/integration.rs
+++ b/crates/lib/workflow-completion-convert-proto/tests/integration.rs
@@ -5,7 +5,7 @@ use waymark_workflow_completion_convert_proto::Converter;
 use waymark_workflow_completion_core::Outcome;
 
 #[test]
-fn completion_wraps_primitive_in_workflow_node_result() {
+fn completion_produces_single_result_argument() {
     use waymark_proto::messages::{
         primitive_workflow_argument::Kind as PrimitiveKind, workflow_argument_value::Kind,
     };
@@ -17,43 +17,78 @@ fn completion_wraps_primitive_in_workflow_node_result() {
     let result_arg = &args.arguments[0];
     assert_eq!(result_arg.key, "result");
 
-    let Some(Kind::Basemodel(basemodel)) = result_arg
+    // The completion value travels as-is: no envelope around it.
+    let Some(Kind::Primitive(primitive)) = result_arg
         .value
         .as_ref()
         .and_then(|value| value.kind.as_ref())
     else {
-        panic!("expected a BaseModel-wrapped result, got {result_arg:?}");
-    };
-    assert_eq!(basemodel.module, "waymark.workflow_runtime");
-    assert_eq!(basemodel.name, "WorkflowNodeResult");
-
-    let variables = &basemodel
-        .data
-        .as_ref()
-        .expect("basemodel carries a dict")
-        .entries;
-    assert_eq!(variables.len(), 1);
-    assert_eq!(variables[0].key, "variables");
-
-    // A non-object completion value is nested under a `result` key.
-    let Some(Kind::DictValue(dict)) = variables[0]
-        .value
-        .as_ref()
-        .and_then(|value| value.kind.as_ref())
-    else {
-        panic!("expected variables to be a dict");
-    };
-    assert_eq!(dict.entries.len(), 1);
-    assert_eq!(dict.entries[0].key, "result");
-
-    let Some(Kind::Primitive(primitive)) = dict.entries[0]
-        .value
-        .as_ref()
-        .and_then(|value| value.kind.as_ref())
-    else {
-        panic!("expected the wrapped result to be a primitive");
+        panic!("expected the result to be a primitive, got {result_arg:?}");
     };
     assert_eq!(primitive.kind, Some(PrimitiveKind::IntValue(42)));
+}
+
+#[test]
+fn completion_dict_passes_through_verbatim() {
+    use waymark_proto::messages::{
+        primitive_workflow_argument::Kind as PrimitiveKind, workflow_argument_value::Kind,
+    };
+
+    // A dict completion is user data, even when its keys collide with the
+    // argument names of the completion plane (`result`).
+    let outcome = Outcome::Completion(waymark_vm_value::ReadyValue::Dict(
+        [
+            (
+                "result".to_string(),
+                waymark_vm_value::Value::Ready(waymark_vm_value::ReadyValue::String(
+                    "inner".to_string(),
+                )),
+            ),
+            (
+                "other".to_string(),
+                waymark_vm_value::Value::Ready(waymark_vm_value::ReadyValue::String(
+                    "kept".to_string(),
+                )),
+            ),
+        ]
+        .into_iter()
+        .collect(),
+    ));
+    let args = Converter::try_convert(outcome).expect("conversion is infallible for ready dicts");
+
+    assert_eq!(args.arguments.len(), 1);
+    let result_arg = &args.arguments[0];
+    assert_eq!(result_arg.key, "result");
+
+    let Some(Kind::DictValue(dict)) = result_arg
+        .value
+        .as_ref()
+        .and_then(|value| value.kind.as_ref())
+    else {
+        panic!("expected the result to be a dict, got {result_arg:?}");
+    };
+    let string_entry = |key: &str| {
+        let entry = dict
+            .entries
+            .iter()
+            .find(|entry| entry.key == key)
+            .unwrap_or_else(|| panic!("missing dict entry {key:?}"));
+        let Some(Kind::Primitive(primitive)) =
+            entry.value.as_ref().and_then(|value| value.kind.as_ref())
+        else {
+            panic!("expected the dict entry {key:?} to be a primitive");
+        };
+        primitive.kind.clone()
+    };
+    assert_eq!(dict.entries.len(), 2);
+    assert_eq!(
+        string_entry("result"),
+        Some(PrimitiveKind::StringValue("inner".to_string())),
+    );
+    assert_eq!(
+        string_entry("other"),
+        Some(PrimitiveKind::StringValue("kept".to_string())),
+    );
 }
 
 #[test]

--- a/python/src/waymark/workflow.py
+++ b/python/src/waymark/workflow.py
@@ -33,7 +33,7 @@ from .actions import deserialize_result_payload
 from .ir_builder import build_workflow_ir
 from .logger import configure as configure_logger
 from .serialization import build_arguments_from_kwargs
-from .workflow_runtime import WorkflowNodeResult, _coerce_value
+from .workflow_runtime import _coerce_value
 
 logger = configure_logger("waymark.workflow")
 
@@ -284,25 +284,6 @@ def _deserialize_workflow_result(
         raise RuntimeError(f"workflow failed: {result.error}")
 
     value = result.result
-
-    # Unwrap WorkflowNodeResult if present (internal worker representation)
-    if isinstance(value, WorkflowNodeResult):
-        variables = value.variables
-        program = workflow_cls.workflow_ir()
-        value = None
-        if program.functions:
-            outputs = list(program.functions[0].io.outputs)
-            for name in outputs:
-                if name in variables:
-                    value = variables[name]
-                    break
-        if value is None:
-            if "result" in variables:
-                value = variables["result"]
-            elif len(variables) == 1:
-                value = next(iter(variables.values()))
-            else:
-                value = variables
     target_type = _resolve_return_type(workflow_cls)
     if target_type is None:
         return value

--- a/python/src/waymark/workflow_runtime.py
+++ b/python/src/waymark/workflow_runtime.py
@@ -8,20 +8,12 @@ import asyncio
 from dataclasses import dataclass
 from typing import Any, Dict, get_type_hints
 
-from pydantic import BaseModel
-
 from waymark.proto import messages_pb2 as pb2
 
 from .dependencies import provide_dependencies
 from .registry import registry
 from .serialization import arguments_to_kwargs
 from .type_coercion import coerce_value as _coerce_value
-
-
-class WorkflowNodeResult(BaseModel):
-    """Result from a workflow node execution containing variable bindings."""
-
-    variables: Dict[str, Any]
 
 
 @dataclass

--- a/python/tests/test_pytest_in_memory_runtime.py
+++ b/python/tests/test_pytest_in_memory_runtime.py
@@ -54,6 +54,21 @@ class ListMergeSyntaxWorkflow(Workflow):
         return left
 
 
+@workflow
+class ResultKeyMappingWorkflow(Workflow):
+    async def run(self) -> dict[str, str]:
+        return {
+            "result": "inner",
+            "other": "must not be lost",
+        }
+
+
+@workflow
+class SingleKeyMappingWorkflow(Workflow):
+    async def run(self) -> dict[str, str]:
+        return {"only": "value"}
+
+
 def test_pytest_runtime_raises_for_unhandled_action_failure() -> None:
     with pytest.raises(RuntimeError, match="workflow failed") as exc_info:
         asyncio.run(UnhandledFailureWorkflow().run())
@@ -83,3 +98,20 @@ def test_pytest_runtime_executes_list_merge_syntax_variants() -> None:
     result = asyncio.run(ListMergeSyntaxWorkflow().run())
 
     assert result == [0, 1, 2, 3, 4, 5, 3, 4]
+
+
+def test_pytest_runtime_preserves_mapping_with_result_key() -> None:
+    """A returned mapping must not treat one user field as an envelope."""
+    result = asyncio.run(ResultKeyMappingWorkflow().run())
+
+    assert result == {
+        "result": "inner",
+        "other": "must not be lost",
+    }
+
+
+def test_pytest_runtime_preserves_single_key_mapping() -> None:
+    """A single-entry mapping must round-trip as a mapping, not its value."""
+    result = asyncio.run(SingleKeyMappingWorkflow().run())
+
+    assert result == {"only": "value"}

--- a/python/tests/test_workflow.py
+++ b/python/tests/test_workflow.py
@@ -420,7 +420,7 @@ def test_workflow_result_union_falls_back(monkeypatch: pytest.MonkeyPatch) -> No
 
 
 def test_workflow_result_direct_return(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Test that workflow results are returned directly when not using WorkflowNodeResult."""
+    """Test that workflow results are returned directly."""
     os.environ.pop("PYTEST_CURRENT_TEST", None)
 
     expected_result = "test_value"
@@ -432,7 +432,6 @@ def test_workflow_result_direct_return(monkeypatch: pytest.MonkeyPatch) -> None:
         )
 
     async def fake_wait_for_instance(*, instance_id: str, poll_interval_secs: float = 1.0) -> bytes:
-        # Return a direct result (not wrapped in WorkflowNodeResult)
         payload = serialize_result_payload(expected_result)
         return payload.SerializeToString()
 


### PR DESCRIPTION
The WorkflowNodeResult was a leftover of the DAG-originated workflow completion shape; VM doesn't have this restriction - and this legacy-compat logic just interferes with users trying to return their data in unexpected ways. So, we just drop it.