### PR TITLE
Classify terminal VM driver exits correctly

### DIFF
--- a/crates/lib/execution-driver/src/lib.rs
+++ b/crates/lib/execution-driver/src/lib.rs
@@ -232,7 +232,11 @@ async fn drive_one<
             tracing::debug!("VM evicted, parking workload");
             pinned.unpin(waymark_workload_pinning_core::UnpinMode::Park);
         }
-        Evicted::DriverError(_) | Evicted::HandledElsewhere => {
+        Evicted::DriverError(_) => {
+            tracing::error!("VM driver failed");
+            drop(pinned);
+        }
+        Evicted::HandledElsewhere => {
             tracing::debug!("VM evicted, unpinning");
             drop(pinned);
         }

--- a/crates/lib/vm-driver-thread/src/lib.rs
+++ b/crates/lib/vm-driver-thread/src/lib.rs
@@ -173,7 +173,7 @@ where
                     Error::Thread(error)
                 }
                 Ok(Err(error)) => {
-                    tracing::error!(?error, "vm driver terminated");
+                    tracing::debug!(?error, "vm driver terminated");
                     Error::Driver(error)
                 }
             })


### PR DESCRIPTION
Completed workflows currently emit an ERROR because the generic driver-thread wrapper logs Waymark’s expected terminal sentinel before the execution layer classifies it. This makes successful runs look unhealthy and obscures real driver failures.

- Downgrade generic driver-return logging to debug while preserving the returned error.
- Keep `NoReadyFramesOrWaitingPromises` as the expected parked-completion path.
- Emit an error only for genuinely unexpected persistent driver exits.