### PR TITLE
Verify Cargo.lock is in sync with the manifests during lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ rust-lint-base:
 
 rust-lint-base-verify:
 	cargo fmt -- --check
-	cargo clippy --all-targets --all-features -- -D warnings
+	cargo clippy --locked --all-targets --all-features -- -D warnings
 
 lint-extended: lint rust-lint-extended
 


### PR DESCRIPTION
This is a follow-up from #613  - will catch that at CI