### PR TITLE
A hotfix for postgres deadlocks

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -3,6 +3,10 @@
 typle = "typle"
 fullset = "fullset"
 
+[default.extend-identifiers]
+# Pluralized SQL keyword, as in "the DELETEs themselves"
+DELETEs = "DELETEs"
+
 
 [files]
 extend-exclude = [

--- a/crates/lib/backend-postgres-migrations/migrations/0023_canonical_row_lock_order.sql
+++ b/crates/lib/backend-postgres-migrations/migrations/0023_canonical_row_lock_order.sql
@@ -1,0 +1,84 @@
+-- Canonical row-lock order for the trigger-side multi-row writers.
+--
+-- Any two multi-row statements that take row locks on overlapping sets
+-- in different orders can deadlock; the 2026-08-31 production outage
+-- was the completion trigger's DELETE (transition-table order) against
+-- the batched lock-renewal UPDATE (input-array order) on the same
+-- action_call_requests rows.  The discipline that makes such cycles
+-- impossible is a single canonical acquisition order for every
+-- multi-row writer on the trigger-swept tables: lock the target rows
+-- via ORDER BY primary key FOR UPDATE, then mutate only the locked
+-- set.  Sorting is reliable here because locking happens above the
+-- sort in the plan and the sort key is the immutable primary key.
+--
+-- This migration installs the discipline in the two trigger functions;
+-- the statement-side writers get the same treatment in the backend's
+-- SQL.  The lock pass and the DELETE must be ONE statement — the
+-- locked-CTE form below: as two statements each would take its own
+-- READ COMMITTED snapshot, and a row committed into the target set
+-- between the snapshots would be deleted without ever passing through
+-- the ordered lock queue, reopening the cycle.  In the single
+-- statement a row committed after the snapshot is simply not seen; it
+-- survives the sweep as the already-accepted late-write orphan (see
+-- 0020).
+
+CREATE OR REPLACE FUNCTION action_call_requests_remove_on_completion() RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    WITH locked AS MATERIALIZED (
+        SELECT r.vm_id, r.promise_state_id
+        FROM action_call_requests r
+        JOIN inserted i
+            ON r.vm_id = i.vm_id AND r.promise_state_id = i.promise_state_id
+        ORDER BY r.vm_id, r.promise_state_id
+        FOR UPDATE OF r
+    )
+    DELETE FROM action_call_requests r
+    USING locked l
+    WHERE r.vm_id = l.vm_id AND r.promise_state_id = l.promise_state_id;
+
+    RETURN NULL;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION vm_runtime_snapshots_cleanup_on_delete() RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    WITH locked AS MATERIALIZED (
+        SELECT r.vm_id, r.promise_state_id
+        FROM action_call_requests r
+        JOIN deleted d ON r.vm_id = d.vm_id
+        ORDER BY r.vm_id, r.promise_state_id
+        FOR UPDATE OF r
+    )
+    DELETE FROM action_call_requests r
+    USING locked l
+    WHERE r.vm_id = l.vm_id AND r.promise_state_id = l.promise_state_id;
+
+    WITH locked AS MATERIALIZED (
+        SELECT c.vm_id, c.promise_state_id
+        FROM action_call_completions c
+        JOIN deleted d ON c.vm_id = d.vm_id
+        ORDER BY c.vm_id, c.promise_state_id
+        FOR UPDATE OF c
+    )
+    DELETE FROM action_call_completions c
+    USING locked l
+    WHERE c.vm_id = l.vm_id AND c.promise_state_id = l.promise_state_id;
+
+    WITH locked AS MATERIALIZED (
+        SELECT s.vm_id, s.promise_state_id
+        FROM sleep_requests s
+        JOIN deleted d ON s.vm_id = d.vm_id
+        ORDER BY s.vm_id, s.promise_state_id
+        FOR UPDATE OF s
+    )
+    DELETE FROM sleep_requests s
+    USING locked l
+    WHERE s.vm_id = l.vm_id AND s.promise_state_id = l.promise_state_id;
+
+    RETURN NULL;
+END;
+$$;

--- a/crates/lib/backend-postgres/src/action_call_completions/mod.rs
+++ b/crates/lib/backend-postgres/src/action_call_completions/mod.rs
@@ -84,6 +84,11 @@ impl waymark_action_completions_reconciler_backend::RecordCompletions for Postgr
                 (vm_id, promise_state_id, effect_number, outcome)
             SELECT * FROM UNNEST($1::uuid[], $2::bigint[], $3::bigint[], $4::bytea[])
                 AS t(vm_id, promise_state_id, effect_number, outcome)
+            -- Canonical lock order: replayed keys contend on existing
+            -- rows through the conflict arbiter, so insert in primary
+            -- key order like every other multi-row writer on the
+            -- trigger-swept tables.
+            ORDER BY t.vm_id, t.promise_state_id
             ON CONFLICT (vm_id, promise_state_id) DO NOTHING
             RETURNING vm_id, promise_state_id
             "#,
@@ -260,9 +265,20 @@ impl waymark_action_completions_reconciler_backend::AckCompletions for PostgresB
         );
         sqlx::query(
             r#"
+            -- Canonical lock order: take every target row lock in
+            -- primary key order before mutating, so multi-row writers
+            -- can never deadlock with each other on overlapping sets.
+            WITH locked AS MATERIALIZED (
+                SELECT c.vm_id, c.promise_state_id
+                FROM action_call_completions c
+                JOIN UNNEST($1::uuid[], $2::bigint[]) AS d(vm_id, promise_state_id)
+                    ON c.vm_id = d.vm_id AND c.promise_state_id = d.promise_state_id
+                ORDER BY c.vm_id, c.promise_state_id
+                FOR UPDATE OF c
+            )
             DELETE FROM action_call_completions c
-            USING UNNEST($1::uuid[], $2::bigint[]) AS d(vm_id, promise_state_id)
-            WHERE c.vm_id = d.vm_id AND c.promise_state_id = d.promise_state_id
+            USING locked l
+            WHERE c.vm_id = l.vm_id AND c.promise_state_id = l.promise_state_id
             "#,
         )
         .bind(&columns.vm_ids)

--- a/crates/lib/backend-postgres/src/action_call_completions/tests.rs
+++ b/crates/lib/backend-postgres/src/action_call_completions/tests.rs
@@ -1,4 +1,4 @@
-use nonempty_collections::NEVec;
+use nonempty_collections::{IntoNonEmptyIterator as _, NEVec, NonEmptyIterator as _, nev};
 use serial_test::serial;
 use waymark_action_completions_reconciler_backend::record_completions;
 use waymark_action_completions_reconciler_backend::record_completions::Error as _;
@@ -41,19 +41,18 @@ async fn record_then_poll_returns_only_demanded() {
     let vm_a = InstanceId::new_uuid_v4();
     let vm_b = InstanceId::new_uuid_v4();
 
-    let records = NEVec::try_from_vec(vec![
+    let records = nev![
         record(vm_a, 1, 10, b"a1"),
         record(vm_a, 2, 11, b"a2"),
-        record(vm_b, 1, 20, b"b1"),
-    ])
-    .unwrap();
+        record(vm_b, 1, 20, b"b1")
+    ];
     backend
         .record_completions(records.as_nonempty_slice())
         .await
         .expect("record");
 
     // Demand only one of vm_a's promises plus one that was never recorded.
-    let demand = NEVec::try_from_vec(vec![key(vm_a, 1), key(vm_a, 99)]).unwrap();
+    let demand = nev![key(vm_a, 1), key(vm_a, 99)];
     let polled = backend
         .poll_completions(demand.as_nonempty_slice())
         .await
@@ -168,18 +167,14 @@ async fn record_accepts_mixed_batch_of_new_and_identical_rows() {
         .expect("seed record");
 
     // One identical duplicate + one new row in the same batch.
-    let batch = NEVec::try_from_vec(vec![
-        record(vm_id, 1, 10, b"one"),
-        record(vm_id, 2, 11, b"two"),
-    ])
-    .unwrap();
+    let batch = nev![record(vm_id, 1, 10, b"one"), record(vm_id, 2, 11, b"two")];
     let success = backend
         .record_completions(batch.as_nonempty_slice())
         .await
         .expect("mixed batch is accepted");
     assert_eq!(success, record_completions::RecordingSuccess::AllRecorded);
 
-    let demand = NEVec::try_from_vec(vec![key(vm_id, 1), key(vm_id, 2)]).unwrap();
+    let demand = nev![key(vm_id, 1), key(vm_id, 2)];
     let polled = backend
         .poll_completions(demand.as_nonempty_slice())
         .await
@@ -193,11 +188,7 @@ async fn ack_removes_rows_and_is_idempotent() {
     let backend = setup_backend().await;
     let vm_id = InstanceId::new_uuid_v4();
 
-    let records = NEVec::try_from_vec(vec![
-        record(vm_id, 1, 10, b"one"),
-        record(vm_id, 2, 11, b"two"),
-    ])
-    .unwrap();
+    let records = nev![record(vm_id, 1, 10, b"one"), record(vm_id, 2, 11, b"two")];
     backend
         .record_completions(records.as_nonempty_slice())
         .await
@@ -209,13 +200,13 @@ async fn ack_removes_rows_and_is_idempotent() {
         .await
         .expect("ack");
     // Re-acking (crash recovery) and acking a never-recorded key are no-ops.
-    let re_acked = NEVec::try_from_vec(vec![key(vm_id, 1), key(vm_id, 99)]).unwrap();
+    let re_acked = nev![key(vm_id, 1), key(vm_id, 99)];
     backend
         .ack_completions(re_acked.as_nonempty_slice())
         .await
         .expect("re-ack is idempotent");
 
-    let demand = NEVec::try_from_vec(vec![key(vm_id, 1), key(vm_id, 2)]).unwrap();
+    let demand = nev![key(vm_id, 1), key(vm_id, 2)];
     let polled = backend
         .poll_completions(demand.as_nonempty_slice())
         .await
@@ -230,12 +221,11 @@ async fn snapshot_delete_sweeps_all_rows_of_the_vm_only() {
     let (vm_a, _) = register_test_vm(&backend).await;
     let (vm_b, _) = register_test_vm(&backend).await;
 
-    let records = NEVec::try_from_vec(vec![
+    let records = nev![
         record(vm_a, 1, 10, b"a1"),
         record(vm_a, 2, 11, b"a2"),
-        record(vm_b, 1, 20, b"b1"),
-    ])
-    .unwrap();
+        record(vm_b, 1, 20, b"b1")
+    ];
     backend
         .record_completions(records.as_nonempty_slice())
         .await
@@ -247,7 +237,7 @@ async fn snapshot_delete_sweeps_all_rows_of_the_vm_only() {
         .await
         .expect("delete vm_a snapshot");
 
-    let demand = NEVec::try_from_vec(vec![key(vm_a, 1), key(vm_a, 2), key(vm_b, 1)]).unwrap();
+    let demand = nev![key(vm_a, 1), key(vm_a, 2), key(vm_b, 1)];
     let polled = backend
         .poll_completions(demand.as_nonempty_slice())
         .await
@@ -269,11 +259,7 @@ async fn ack_and_sweep_across_a_staged_row(ack_order: [usize; 2]) {
     let backend = setup_backend().await;
     let (vm, _) = register_test_vm(&backend).await;
 
-    let records = NEVec::try_from_vec(vec![
-        record(vm, 1, 10, b"done-1"),
-        record(vm, 2, 11, b"done-2"),
-    ])
-    .unwrap();
+    let records = nev![record(vm, 1, 10, b"done-1"), record(vm, 2, 11, b"done-2")];
     backend
         .record_completions(records.as_nonempty_slice())
         .await
@@ -295,8 +281,10 @@ async fn ack_and_sweep_across_a_staged_row(ack_order: [usize; 2]) {
     // so releasing hands the row to it and not to the sweep queued later.
     let ack_backend = backend.clone();
     let ack_task = tokio::spawn(async move {
-        let keys = NEVec::try_from_vec(ack_order.iter().map(|&promise| key(vm, promise)).collect())
-            .unwrap();
+        let keys: NEVec<_> = ack_order
+            .into_nonempty_iter()
+            .map(|promise| key(vm, promise))
+            .collect();
         ack_backend.ack_completions(keys.as_nonempty_slice()).await
     });
     deadlock::contend_op_with_snapshot_sweep(

--- a/crates/lib/backend-postgres/src/action_call_completions/tests.rs
+++ b/crates/lib/backend-postgres/src/action_call_completions/tests.rs
@@ -10,7 +10,7 @@ use waymark_ids::InstanceId;
 use waymark_vm_runtime_effect::EffectNumber;
 use waymark_vm_runtime_promise_core::PromiseStateId;
 
-use super::super::test_helpers::{register_test_vm, setup_backend};
+use super::super::test_helpers::{deadlock, register_test_vm, setup_backend};
 use super::error::RecordError;
 
 fn record(
@@ -253,4 +253,79 @@ async fn snapshot_delete_sweeps_all_rows_of_the_vm_only() {
         .await
         .expect("poll");
     assert_eq!(polled[..], [record(vm_b, 1, 20, b"b1")]);
+}
+
+/// One choreographed collision of the completions-ack DELETE and the
+/// snapshot-cleanup trigger's completions sweep over the same two
+/// completion rows — the completions-table sweep pairing of the
+/// multi-row-writer class behind the 2026-08-31 deadlock outage.
+///
+/// The staging, plan-shape seeding, and contract are those of
+/// `complete_and_renew_across_a_staged_row` in
+/// `action_call_requests::tests`; the sweep's lock order is not
+/// input-driven — it walks the whole VM — so the mirroring axis is the
+/// ack batch's order plus which row is staged.
+async fn ack_and_sweep_across_a_staged_row(ack_order: [usize; 2]) {
+    let backend = setup_backend().await;
+    let (vm, _) = register_test_vm(&backend).await;
+
+    let records = NEVec::try_from_vec(vec![
+        record(vm, 1, 10, b"done-1"),
+        record(vm, 2, 11, b"done-2"),
+    ])
+    .unwrap();
+    backend
+        .record_completions(records.as_nonempty_slice())
+        .await
+        .expect("record completions");
+
+    deadlock::seed_filler_rows(backend.pool(), deadlock::SweptTable::ActionCallCompletions).await;
+
+    // Pre-hold the ack batch's first row.
+    let staged = ack_order[0];
+    let staging = deadlock::hold_row_for_update(
+        backend.pool(),
+        deadlock::SweptTable::ActionCallCompletions,
+        vm,
+        staged,
+    )
+    .await;
+
+    // The ack first: it must be the head of the staged row's wait queue,
+    // so releasing hands the row to it and not to the sweep queued later.
+    let ack_backend = backend.clone();
+    let ack_task = tokio::spawn(async move {
+        let keys = NEVec::try_from_vec(ack_order.iter().map(|&promise| key(vm, promise)).collect())
+            .unwrap();
+        ack_backend.ack_completions(keys.as_nonempty_slice()).await
+    });
+    deadlock::wait_until_lock_blocked(backend.pool(), "%DELETE FROM action_call_completions%")
+        .await;
+
+    // The sweep's completions pass contends the same two rows.
+    let sweep_task = deadlock::spawn_snapshot_sweep(backend.pool(), vec![vm]);
+    deadlock::wait_until_lock_blocked(backend.pool(), deadlock::SNAPSHOT_SWEEP_PATTERN).await;
+
+    staging.rollback().await.expect("release staged row");
+
+    ack_task
+        .await
+        .expect("join ack")
+        .expect("acking completions must not deadlock against the snapshot sweep");
+    sweep_task
+        .await
+        .expect("join sweep")
+        .expect("the snapshot sweep must not deadlock against completion acks");
+}
+
+#[serial(postgres)]
+#[tokio::test]
+async fn concurrent_ack_and_snapshot_sweep_do_not_deadlock() {
+    // Both ack orders, with the staged row tracking the ack's first key.
+    // These runs pin the ACK side's discipline only: a single-VM sweep
+    // locks its rows in primary-key order under every realizable plan,
+    // so the trigger side cannot regress visibly here — the multi-VM
+    // sweep test in `action_call_requests::tests` covers it.
+    ack_and_sweep_across_a_staged_row([2, 1]).await;
+    ack_and_sweep_across_a_staged_row([1, 2]).await;
 }

--- a/crates/lib/backend-postgres/src/action_call_completions/tests.rs
+++ b/crates/lib/backend-postgres/src/action_call_completions/tests.rs
@@ -299,23 +299,15 @@ async fn ack_and_sweep_across_a_staged_row(ack_order: [usize; 2]) {
             .unwrap();
         ack_backend.ack_completions(keys.as_nonempty_slice()).await
     });
-    deadlock::wait_until_lock_blocked(backend.pool(), "%DELETE FROM action_call_completions%")
-        .await;
-
-    // The sweep's completions pass contends the same two rows.
-    let sweep_task = deadlock::spawn_snapshot_sweep(backend.pool(), vec![vm]);
-    deadlock::wait_until_lock_blocked(backend.pool(), deadlock::SNAPSHOT_SWEEP_PATTERN).await;
-
-    staging.rollback().await.expect("release staged row");
-
-    ack_task
-        .await
-        .expect("join ack")
-        .expect("acking completions must not deadlock against the snapshot sweep");
-    sweep_task
-        .await
-        .expect("join sweep")
-        .expect("the snapshot sweep must not deadlock against completion acks");
+    deadlock::contend_op_with_snapshot_sweep(
+        backend.pool(),
+        staging,
+        "completions ack",
+        ack_task,
+        "%DELETE FROM action_call_completions%",
+        vm,
+    )
+    .await;
 }
 
 #[serial(postgres)]

--- a/crates/lib/backend-postgres/src/action_call_requests/mod.rs
+++ b/crates/lib/backend-postgres/src/action_call_requests/mod.rs
@@ -120,6 +120,11 @@ impl waymark_action_effect_reconciler_backend::RecordActionCallRequests for Post
             SELECT t.*, $5, NOW() + ($6 * interval '1 microsecond')
             FROM UNNEST($1::uuid[], $2::bigint[], $3::bigint[], $4::bytea[])
                 AS t(vm_id, promise_state_id, effect_number, request)
+            -- Canonical lock order: replayed keys contend on existing
+            -- rows through the conflict arbiter, so insert in primary
+            -- key order like every other multi-row writer on the
+            -- trigger-swept tables.
+            ORDER BY t.vm_id, t.promise_state_id
             ON CONFLICT (vm_id, promise_state_id) DO NOTHING
             RETURNING vm_id, promise_state_id
             "#,
@@ -239,10 +244,25 @@ impl waymark_action_effect_reconciler_backend::LockActionCallRequests for Postgr
         );
         let locked_rows = sqlx::query(
             r#"
-            UPDATE action_call_requests
+            -- Canonical lock order: take every target row lock in
+            -- primary key order before mutating, so multi-row writers
+            -- can never deadlock with each other on overlapping sets.
+            -- The FOR UPDATE requalifies the predicate on the current
+            -- row version after a lock wait, so a row renewed while we
+            -- waited correctly drops out.
+            WITH locked AS MATERIALIZED (
+                SELECT r.vm_id, r.promise_state_id
+                FROM action_call_requests r
+                WHERE r.vm_id = ANY($1)
+                    AND (r.locked_by IS NULL OR r.lock_expires_at <= NOW())
+                ORDER BY r.vm_id, r.promise_state_id
+                FOR UPDATE
+            )
+            UPDATE action_call_requests r
             SET locked_by = $2, lock_expires_at = NOW() + ($3 * interval '1 microsecond')
-            WHERE vm_id = ANY($1) AND (locked_by IS NULL OR lock_expires_at <= NOW())
-            RETURNING vm_id, promise_state_id, effect_number, request
+            FROM locked l
+            WHERE r.vm_id = l.vm_id AND r.promise_state_id = l.promise_state_id
+            RETURNING r.vm_id, r.promise_state_id, r.effect_number, r.request
             "#,
         )
         .bind(vm_ids.as_ref())
@@ -347,13 +367,31 @@ impl waymark_action_effect_reconciler_backend::RenewActionCallRequestLocks for P
             WITH input(vm_id, promise_state_id) AS (
                 SELECT * FROM UNNEST($1::uuid[], $2::bigint[])
             ),
+            -- Canonical lock order: take every target row lock in
+            -- primary key order before mutating, so multi-row writers
+            -- can never deadlock with each other on overlapping sets.
+            -- The ownership predicate lives here — a locked row is ours
+            -- as long as we hold its lock, so the update needs no
+            -- re-check.  FOR UPDATE is stronger than the FOR NO KEY
+            -- UPDATE a plain UPDATE takes implicitly; nothing references
+            -- these tables by foreign key (0020 rejects them), so
+            -- nothing can newly block — revisit the strength if an FK
+            -- ever appears.
+            locked AS MATERIALIZED (
+                SELECT r.vm_id, r.promise_state_id
+                FROM action_call_requests r
+                JOIN input i
+                    ON r.vm_id = i.vm_id AND r.promise_state_id = i.promise_state_id
+                WHERE r.locked_by = $3
+                ORDER BY r.vm_id, r.promise_state_id
+                FOR UPDATE OF r
+            ),
             renewed AS (
                 UPDATE action_call_requests r
                 SET lock_expires_at = NOW() + ($4 * interval '1 microsecond')
-                FROM input i
-                WHERE r.vm_id = i.vm_id
-                    AND r.promise_state_id = i.promise_state_id
-                    AND r.locked_by = $3
+                FROM locked l
+                WHERE r.vm_id = l.vm_id
+                    AND r.promise_state_id = l.promise_state_id
                 RETURNING r.vm_id, r.promise_state_id
             )
             SELECT i.vm_id, i.promise_state_id,
@@ -481,12 +519,21 @@ impl waymark_action_effect_reconciler_backend::UnlockActionCallRequests for Post
         );
         sqlx::query(
             r#"
+            -- Canonical lock order: see the renewal statement.
+            WITH locked AS MATERIALIZED (
+                SELECT r.vm_id, r.promise_state_id
+                FROM action_call_requests r
+                JOIN UNNEST($1::uuid[], $2::bigint[]) AS d(vm_id, promise_state_id)
+                    ON r.vm_id = d.vm_id AND r.promise_state_id = d.promise_state_id
+                WHERE r.locked_by = $3
+                ORDER BY r.vm_id, r.promise_state_id
+                FOR UPDATE OF r
+            )
             UPDATE action_call_requests r
             SET locked_by = NULL, lock_expires_at = NULL
-            FROM UNNEST($1::uuid[], $2::bigint[]) AS d(vm_id, promise_state_id)
-            WHERE r.vm_id = d.vm_id
-                AND r.promise_state_id = d.promise_state_id
-                AND r.locked_by = $3
+            FROM locked l
+            WHERE r.vm_id = l.vm_id
+                AND r.promise_state_id = l.promise_state_id
             "#,
         )
         .bind(&columns.vm_ids)

--- a/crates/lib/backend-postgres/src/action_call_requests/tests.rs
+++ b/crates/lib/backend-postgres/src/action_call_requests/tests.rs
@@ -446,3 +446,172 @@ async fn snapshot_delete_sweeps_only_the_vms_requests() {
     assert_eq!(status_of(vm_a, 1), RenewalStatus::Missing);
     assert_eq!(status_of(vm_b, 1), RenewalStatus::Renewed);
 }
+
+/// Wait until a backend whose current query matches `query_pattern` is
+/// blocked waiting on a lock, so the choreography below can stage each
+/// statement's position in the row-lock queues deterministically.
+async fn wait_until_lock_blocked(pool: &sqlx::PgPool, query_pattern: &str) {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    loop {
+        let waiting: i64 = sqlx::query_scalar(
+            r#"
+            SELECT COUNT(*) FROM pg_stat_activity
+            WHERE wait_event_type = 'Lock' AND query LIKE $1
+            "#,
+        )
+        .bind(query_pattern)
+        .fetch_one(pool)
+        .await
+        .expect("poll pg_stat_activity");
+        if waiting > 0 {
+            return;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "no statement matching {query_pattern:?} blocked on a lock — \
+             the staging assumptions no longer hold, see the choreography comment"
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+    }
+}
+
+/// One choreographed collision of the completion trigger's DELETE and
+/// the renewal UPDATE over the same two request rows.
+///
+/// Both statements take their row locks in input order — the trigger in
+/// transition-table (insert) order, the renewal in input-array order,
+/// verified empirically against the real plans at this scale — and
+/// neither imposes a canonical order, so opposite input orders form a
+/// deadlock cycle.  The staging makes the cycle deterministic instead of
+/// probabilistic: a helper transaction pre-holds the completion batch's
+/// FIRST row, which is the renewal batch's LAST row.  The completion
+/// blocks on it holding nothing; the renewal then locks every other row
+/// and queues behind the completion.  Releasing the staged row lets the
+/// completion advance into the renewal's rows while the renewal waits on
+/// the completion's — the deadlock, detected by Postgres within
+/// `deadlock_timeout`.
+///
+/// This is the production outage shape (2026-08-31): batched lock
+/// renewals and batched completion inserts deadlocking on the same
+/// `action_call_requests` rows, at batch sizes where overlap in
+/// conflicting orders is routine.  The test's contract is simply that
+/// both statements succeed: any ordering discipline that makes the
+/// deadlock impossible passes it, and disciplining only one side does
+/// not.
+async fn complete_and_renew_across_a_staged_row(
+    completion_order: [usize; 2],
+    renewal_order: [usize; 2],
+) {
+    let backend = setup_backend().await;
+    let vm = InstanceId::new_uuid_v4();
+    let owner = uuid::Uuid::new_v4();
+
+    let records = NEVec::try_from_vec(vec![
+        record(vm, 1, 10, b"call-1"),
+        record(vm, 2, 11, b"call-2"),
+    ])
+    .unwrap();
+    backend
+        .record_action_call_requests(Utc::now(), live_lock(owner), records.as_nonempty_slice())
+        .await
+        .expect("record requests");
+
+    // The input-order locking above holds for the production plan shape —
+    // small batches probing the primary key of a large table.  Against a
+    // freshly-truncated two-row table the planner walks both statements
+    // through the same seq scan instead, aligning their lock orders and
+    // hiding the bug, so give it the production shape: filler rows and
+    // fresh statistics.
+    sqlx::query(
+        r#"
+        INSERT INTO action_call_requests
+            (vm_id, promise_state_id, effect_number, request)
+        SELECT gen_random_uuid(), n, n, 'filler'
+        FROM generate_series(1, 10000) AS n
+        "#,
+    )
+    .execute(backend.pool())
+    .await
+    .expect("seed filler requests");
+    sqlx::query("ANALYZE action_call_requests, action_call_completions")
+        .execute(backend.pool())
+        .await
+        .expect("analyze");
+
+    // Pre-hold the row where the completion enters and the renewal exits.
+    let staged = completion_order[0];
+    assert_eq!(
+        staged, renewal_order[1],
+        "the staged row must be the completion's first and the renewal's last"
+    );
+    let mut staging = backend.pool().begin().await.expect("begin staging");
+    sqlx::query(
+        r#"
+        SELECT 1 FROM action_call_requests
+        WHERE vm_id = $1 AND promise_state_id = $2 FOR UPDATE
+        "#,
+    )
+    .bind(vm)
+    .bind(i64::try_from(staged).unwrap())
+    .execute(&mut *staging)
+    .await
+    .expect("hold staged row");
+
+    // The completion batch first: it must be the head of the staged
+    // row's wait queue, so releasing hands the row to it and not to the
+    // renewal queued second.
+    let completion_backend = backend.clone();
+    let completion_task = tokio::spawn(async move {
+        let completions = NEVec::try_from_vec(
+            completion_order
+                .iter()
+                .map(|&promise| CompletionRecord {
+                    vm_id: vm,
+                    promise_state_id: PromiseStateId(promise),
+                    effect_number: EffectNumber(promise + 9),
+                    outcome: b"done".to_vec(),
+                })
+                .collect(),
+        )
+        .unwrap();
+        completion_backend
+            .record_completions(completions.as_nonempty_slice())
+            .await
+    });
+    wait_until_lock_blocked(backend.pool(), "%INSERT INTO action_call_completions%").await;
+
+    let renewal_backend = backend.clone();
+    let renewal_task = tokio::spawn(async move {
+        let keys = NEVec::try_from_vec(
+            renewal_order
+                .iter()
+                .map(|&promise| key(vm, promise))
+                .collect(),
+        )
+        .unwrap();
+        renewal_backend
+            .renew_action_call_request_locks(Utc::now(), live_lock(owner), keys.as_nonempty_slice())
+            .await
+    });
+    wait_until_lock_blocked(backend.pool(), "%UPDATE action_call_requests%").await;
+
+    staging.rollback().await.expect("release staged row");
+
+    completion_task
+        .await
+        .expect("join completion")
+        .expect("recording completions must not deadlock against lock renewal");
+    renewal_task
+        .await
+        .expect("join renewal")
+        .expect("renewing locks must not deadlock against completion recording");
+}
+
+#[serial(postgres)]
+#[tokio::test]
+async fn concurrent_completion_and_renewal_batches_do_not_deadlock() {
+    // Both mirrored input orders: each run catches a discipline missing
+    // from one of the two statements.
+    complete_and_renew_across_a_staged_row([2, 1], [1, 2]).await;
+    complete_and_renew_across_a_staged_row([1, 2], [2, 1]).await;
+}

--- a/crates/lib/backend-postgres/src/action_call_requests/tests.rs
+++ b/crates/lib/backend-postgres/src/action_call_requests/tests.rs
@@ -14,7 +14,7 @@ use waymark_ids::InstanceId;
 use waymark_vm_runtime_effect::EffectNumber;
 use waymark_vm_runtime_promise_core::PromiseStateId;
 
-use super::super::test_helpers::{register_test_vm, setup_backend};
+use super::super::test_helpers::{register_test_vm, setup_backend, wait_until_lock_blocked};
 use super::error::RecordError;
 
 fn record(
@@ -445,34 +445,6 @@ async fn snapshot_delete_sweeps_only_the_vms_requests() {
     };
     assert_eq!(status_of(vm_a, 1), RenewalStatus::Missing);
     assert_eq!(status_of(vm_b, 1), RenewalStatus::Renewed);
-}
-
-/// Wait until a backend whose current query matches `query_pattern` is
-/// blocked waiting on a lock, so the choreography below can stage each
-/// statement's position in the row-lock queues deterministically.
-async fn wait_until_lock_blocked(pool: &sqlx::PgPool, query_pattern: &str) {
-    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
-    loop {
-        let waiting: i64 = sqlx::query_scalar(
-            r#"
-            SELECT COUNT(*) FROM pg_stat_activity
-            WHERE wait_event_type = 'Lock' AND query LIKE $1
-            "#,
-        )
-        .bind(query_pattern)
-        .fetch_one(pool)
-        .await
-        .expect("poll pg_stat_activity");
-        if waiting > 0 {
-            return;
-        }
-        assert!(
-            std::time::Instant::now() < deadline,
-            "no statement matching {query_pattern:?} blocked on a lock — \
-             the staging assumptions no longer hold, see the choreography comment"
-        );
-        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
-    }
 }
 
 /// One choreographed collision of the completion trigger's DELETE and

--- a/crates/lib/backend-postgres/src/action_call_requests/tests.rs
+++ b/crates/lib/backend-postgres/src/action_call_requests/tests.rs
@@ -757,23 +757,15 @@ async fn renew_and_sweep_across_a_staged_row(renewal_order: [usize; 2]) {
             .renew_action_call_request_locks(Utc::now(), live_lock(owner), keys.as_nonempty_slice())
             .await
     });
-    deadlock::wait_until_lock_blocked(backend.pool(), "%WITH input(vm_id, promise_state_id)%")
-        .await;
-
-    // The sweep's requests pass contends the same two rows.
-    let sweep_task = deadlock::spawn_snapshot_sweep(backend.pool(), vec![vm]);
-    deadlock::wait_until_lock_blocked(backend.pool(), deadlock::SNAPSHOT_SWEEP_PATTERN).await;
-
-    staging.rollback().await.expect("release staged row");
-
-    renewal_task
-        .await
-        .expect("join renewal")
-        .expect("renewing locks must not deadlock against the snapshot sweep");
-    sweep_task
-        .await
-        .expect("join sweep")
-        .expect("the snapshot sweep must not deadlock against lock renewal");
+    deadlock::contend_op_with_snapshot_sweep(
+        backend.pool(),
+        staging,
+        "renewal",
+        renewal_task,
+        "%WITH input(vm_id, promise_state_id)%",
+        vm,
+    )
+    .await;
 }
 
 #[serial(postgres)]

--- a/crates/lib/backend-postgres/src/action_call_requests/tests.rs
+++ b/crates/lib/backend-postgres/src/action_call_requests/tests.rs
@@ -14,7 +14,9 @@ use waymark_ids::InstanceId;
 use waymark_vm_runtime_effect::EffectNumber;
 use waymark_vm_runtime_promise_core::PromiseStateId;
 
-use super::super::test_helpers::{register_test_vm, setup_backend, wait_until_lock_blocked};
+use super::super::test_helpers::{
+    deadlock, register_test_vm, register_test_vm_with_id, setup_backend,
+};
 use super::error::RecordError;
 
 fn record(
@@ -470,10 +472,11 @@ async fn snapshot_delete_sweeps_only_the_vms_requests() {
 /// both statements succeed: any ordering discipline that makes the
 /// deadlock impossible passes it, and disciplining only one side does
 /// not.
-async fn complete_and_renew_across_a_staged_row(
-    completion_order: [usize; 2],
-    renewal_order: [usize; 2],
-) {
+async fn complete_and_renew_across_a_staged_row(completion_order: [usize; 2]) {
+    // The renewal walks the same rows in the opposite order, making the
+    // staged row the completion's first and the renewal's last.
+    let renewal_order = [completion_order[1], completion_order[0]];
+
     let backend = setup_backend().await;
     let vm = InstanceId::new_uuid_v4();
     let owner = uuid::Uuid::new_v4();
@@ -488,46 +491,17 @@ async fn complete_and_renew_across_a_staged_row(
         .await
         .expect("record requests");
 
-    // The input-order locking above holds for the production plan shape —
-    // small batches probing the primary key of a large table.  Against a
-    // freshly-truncated two-row table the planner walks both statements
-    // through the same seq scan instead, aligning their lock orders and
-    // hiding the bug, so give it the production shape: filler rows and
-    // fresh statistics.
-    sqlx::query(
-        r#"
-        INSERT INTO action_call_requests
-            (vm_id, promise_state_id, effect_number, request)
-        SELECT gen_random_uuid(), n, n, 'filler'
-        FROM generate_series(1, 10000) AS n
-        "#,
-    )
-    .execute(backend.pool())
-    .await
-    .expect("seed filler requests");
-    sqlx::query("ANALYZE action_call_requests, action_call_completions")
-        .execute(backend.pool())
-        .await
-        .expect("analyze");
+    deadlock::seed_filler_rows(backend.pool(), deadlock::SweptTable::ActionCallRequests).await;
 
     // Pre-hold the row where the completion enters and the renewal exits.
     let staged = completion_order[0];
-    assert_eq!(
-        staged, renewal_order[1],
-        "the staged row must be the completion's first and the renewal's last"
-    );
-    let mut staging = backend.pool().begin().await.expect("begin staging");
-    sqlx::query(
-        r#"
-        SELECT 1 FROM action_call_requests
-        WHERE vm_id = $1 AND promise_state_id = $2 FOR UPDATE
-        "#,
+    let staging = deadlock::hold_row_for_update(
+        backend.pool(),
+        deadlock::SweptTable::ActionCallRequests,
+        vm,
+        staged,
     )
-    .bind(vm)
-    .bind(i64::try_from(staged).unwrap())
-    .execute(&mut *staging)
-    .await
-    .expect("hold staged row");
+    .await;
 
     // The completion batch first: it must be the head of the staged
     // row's wait queue, so releasing hands the row to it and not to the
@@ -550,7 +524,8 @@ async fn complete_and_renew_across_a_staged_row(
             .record_completions(completions.as_nonempty_slice())
             .await
     });
-    wait_until_lock_blocked(backend.pool(), "%INSERT INTO action_call_completions%").await;
+    deadlock::wait_until_lock_blocked(backend.pool(), "%INSERT INTO action_call_completions%")
+        .await;
 
     let renewal_backend = backend.clone();
     let renewal_task = tokio::spawn(async move {
@@ -565,7 +540,8 @@ async fn complete_and_renew_across_a_staged_row(
             .renew_action_call_request_locks(Utc::now(), live_lock(owner), keys.as_nonempty_slice())
             .await
     });
-    wait_until_lock_blocked(backend.pool(), "%UPDATE action_call_requests%").await;
+    deadlock::wait_until_lock_blocked(backend.pool(), "%WITH input(vm_id, promise_state_id)%")
+        .await;
 
     staging.rollback().await.expect("release staged row");
 
@@ -582,8 +558,369 @@ async fn complete_and_renew_across_a_staged_row(
 #[serial(postgres)]
 #[tokio::test]
 async fn concurrent_completion_and_renewal_batches_do_not_deadlock() {
-    // Both mirrored input orders: each run catches a discipline missing
-    // from one of the two statements.
-    complete_and_renew_across_a_staged_row([2, 1], [1, 2]).await;
-    complete_and_renew_across_a_staged_row([1, 2], [2, 1]).await;
+    // Both mirrored input orders.  This pins the outage pair end to end;
+    // note the completion path is pinned as a whole — its two mechanisms
+    // (the INSERT's ORDER BY canonicalizing the transition table, the
+    // trigger's ordered lock pass) are mutually redundant here, so
+    // removing either one alone stays green.  The trigger body itself is
+    // pinned by the multi-VM sweep test below, and the INSERT's ORDER BY
+    // by the heap-order test below.
+    complete_and_renew_across_a_staged_row([2, 1]).await;
+    complete_and_renew_across_a_staged_row([1, 2]).await;
+}
+
+/// The individual pin on the batch INSERT's ORDER BY, whose independent
+/// job is canonicalizing conflict-arbiter waits between two overlapping
+/// replayed batches (an `ORDER BY` feeding `ON CONFLICT DO NOTHING`
+/// looks removable without it).  The arbiter cycle itself cannot be
+/// staged deterministically — waiters on an aborted speculative insert
+/// wake in no particular order, so a choreographed release resolves by
+/// coin flip — so this pins the mechanism directly instead: rows land in
+/// the heap in insertion order, `ctid` exposes that order, and a batch
+/// submitted out of order must still land in primary-key order.
+#[serial(postgres)]
+#[tokio::test]
+async fn record_batch_inserts_in_primary_key_order() {
+    let backend = setup_backend().await;
+    let vm = InstanceId::new_uuid_v4();
+
+    let records = NEVec::try_from_vec(vec![
+        record(vm, 2, 11, b"call-2"),
+        record(vm, 3, 12, b"call-3"),
+        record(vm, 1, 10, b"call-1"),
+    ])
+    .unwrap();
+    backend
+        .record_action_call_requests(
+            Utc::now(),
+            live_lock(uuid::Uuid::new_v4()),
+            records.as_nonempty_slice(),
+        )
+        .await
+        .expect("record requests");
+
+    let heap_order: Vec<i64> = sqlx::query_scalar(
+        r#"
+        SELECT promise_state_id FROM action_call_requests
+        WHERE vm_id = $1 ORDER BY ctid
+        "#,
+    )
+    .bind(vm)
+    .fetch_all(backend.pool())
+    .await
+    .expect("read heap order");
+    assert_eq!(
+        heap_order,
+        [1, 2, 3],
+        "the batch INSERT no longer writes in primary-key order — \
+         conflict-arbiter waits between overlapping replayed batches \
+         are back to input order and can cycle"
+    );
+}
+
+/// Premise canary for the UNNEST-join plan shape the op-side
+/// choreographies rely on: two hand-written PRE-discipline statements —
+/// plain input-order UNNEST-join UPDATE statements with opposite key
+/// orders — must still deadlock on this planner and schema.  The
+/// do-not-deadlock tests can only detect a lost discipline while the
+/// planner drives such statements' locks in input order; if plan shapes
+/// ever drift (a hash join over a seq scan aligns both sides' lock
+/// orders), this test goes red instead of those tests going silently
+/// vacuous.  The multi-VM sweep test guards its own, separate heap-order
+/// premise with an in-test plan assertion.
+#[serial(postgres)]
+#[tokio::test]
+async fn undisciplined_writers_still_deadlock_premise_canary() {
+    let backend = setup_backend().await;
+    let vm = InstanceId::new_uuid_v4();
+    let owner = uuid::Uuid::new_v4();
+
+    let records = NEVec::try_from_vec(vec![
+        record(vm, 1, 10, b"call-1"),
+        record(vm, 2, 11, b"call-2"),
+    ])
+    .unwrap();
+    backend
+        .record_action_call_requests(Utc::now(), live_lock(owner), records.as_nonempty_slice())
+        .await
+        .expect("record requests");
+
+    deadlock::seed_filler_rows(backend.pool(), deadlock::SweptTable::ActionCallRequests).await;
+
+    let staging = deadlock::hold_row_for_update(
+        backend.pool(),
+        deadlock::SweptTable::ActionCallRequests,
+        vm,
+        2,
+    )
+    .await;
+
+    let undisciplined_update = |tag: &'static str, order: [i64; 2]| {
+        let pool = backend.pool().clone();
+        tokio::spawn(async move {
+            sqlx::query(&format!(
+                r#"
+                /* premise canary {tag} */
+                UPDATE action_call_requests r
+                SET lock_expires_at = NOW() + interval '1 minute'
+                FROM UNNEST($1::uuid[], $2::bigint[]) AS i(vm_id, promise_state_id)
+                WHERE r.vm_id = i.vm_id AND r.promise_state_id = i.promise_state_id
+                "#
+            ))
+            .bind(vec![vm, vm])
+            .bind(order.to_vec())
+            .execute(&pool)
+            .await
+        })
+    };
+
+    // Descending first: it blocks on the staged row holding nothing, the
+    // ascending one locks row 1 and queues behind it — releasing forms
+    // the cycle.
+    let descending = undisciplined_update("descending", [2, 1]);
+    deadlock::wait_until_lock_blocked(backend.pool(), "%premise canary descending%").await;
+    let ascending = undisciplined_update("ascending", [1, 2]);
+    deadlock::wait_until_lock_blocked(backend.pool(), "%premise canary ascending%").await;
+
+    staging.rollback().await.expect("release staged row");
+
+    let results = [
+        descending.await.expect("join descending"),
+        ascending.await.expect("join ascending"),
+    ];
+    let deadlocked = results
+        .iter()
+        .filter(|result| {
+            result.as_ref().is_err_and(|error| {
+                error
+                    .as_database_error()
+                    .is_some_and(|db| db.code().as_deref() == Some("40P01"))
+            })
+        })
+        .count();
+    assert_eq!(
+        deadlocked, 1,
+        "input-order statements no longer deadlock — plan shapes drifted and the \
+         do-not-deadlock choreographies in this suite may be vacuous: {results:?}"
+    );
+}
+
+/// One choreographed collision of the renewal UPDATE and the
+/// snapshot-cleanup trigger's requests sweep over the same two request
+/// rows — the requests-table sweep pairing of the multi-row-writer
+/// class behind the 2026-08-31 deadlock outage (renewing a VM's locks
+/// while its terminal delete sweeps them).
+///
+/// The staging, plan-shape seeding, and contract are those of
+/// `complete_and_renew_across_a_staged_row` above; the sweep's lock
+/// order is not input-driven — it walks the whole VM — so the mirroring
+/// axis is the renewal batch's order plus which row is staged.
+async fn renew_and_sweep_across_a_staged_row(renewal_order: [usize; 2]) {
+    let backend = setup_backend().await;
+    let (vm, _) = register_test_vm(&backend).await;
+    let owner = uuid::Uuid::new_v4();
+
+    let records = NEVec::try_from_vec(vec![
+        record(vm, 1, 10, b"call-1"),
+        record(vm, 2, 11, b"call-2"),
+    ])
+    .unwrap();
+    backend
+        .record_action_call_requests(Utc::now(), live_lock(owner), records.as_nonempty_slice())
+        .await
+        .expect("record requests");
+
+    deadlock::seed_filler_rows(backend.pool(), deadlock::SweptTable::ActionCallRequests).await;
+
+    // Pre-hold the renewal batch's first row.
+    let staged = renewal_order[0];
+    let staging = deadlock::hold_row_for_update(
+        backend.pool(),
+        deadlock::SweptTable::ActionCallRequests,
+        vm,
+        staged,
+    )
+    .await;
+
+    // The renewal first: it must be the head of the staged row's wait
+    // queue, so releasing hands the row to it and not to the sweep.
+    let renewal_backend = backend.clone();
+    let renewal_task = tokio::spawn(async move {
+        let keys = NEVec::try_from_vec(
+            renewal_order
+                .iter()
+                .map(|&promise| key(vm, promise))
+                .collect(),
+        )
+        .unwrap();
+        renewal_backend
+            .renew_action_call_request_locks(Utc::now(), live_lock(owner), keys.as_nonempty_slice())
+            .await
+    });
+    deadlock::wait_until_lock_blocked(backend.pool(), "%WITH input(vm_id, promise_state_id)%")
+        .await;
+
+    // The sweep's requests pass contends the same two rows.
+    let sweep_task = deadlock::spawn_snapshot_sweep(backend.pool(), vec![vm]);
+    deadlock::wait_until_lock_blocked(backend.pool(), deadlock::SNAPSHOT_SWEEP_PATTERN).await;
+
+    staging.rollback().await.expect("release staged row");
+
+    renewal_task
+        .await
+        .expect("join renewal")
+        .expect("renewing locks must not deadlock against the snapshot sweep");
+    sweep_task
+        .await
+        .expect("join sweep")
+        .expect("the snapshot sweep must not deadlock against lock renewal");
+}
+
+#[serial(postgres)]
+#[tokio::test]
+async fn concurrent_renewal_and_snapshot_sweep_do_not_deadlock() {
+    // Both renewal orders, with the staged row tracking the renewal's
+    // first key.  These runs pin the RENEWAL side's discipline only: a
+    // single-VM sweep locks its rows in primary-key order under every
+    // realizable plan (index probe and fresh-heap seq scan alike), so
+    // the trigger side cannot regress visibly here — the multi-VM sweep
+    // test below covers it.
+    renew_and_sweep_across_a_staged_row([2, 1]).await;
+    renew_and_sweep_across_a_staged_row([1, 2]).await;
+}
+
+/// The multi-VM sweep choreography — the only shape that exercises the
+/// snapshot-cleanup trigger's OWN lock order.  A two-VM snapshot delete
+/// hands the trigger's requests pass rows spanning two VMs in heap
+/// (registration) order — arranged DESCENDING by vm_id below, so a
+/// trigger without the ordered lock pass provably inverts primary-key
+/// order — contended against the canonically-ordered revival lock.  No
+/// production multi-row snapshot delete exists yet, but 0020's design
+/// anticipates them; this pins the trigger body for that day.
+///
+/// `sweep_first` mirrors which statement leads: the leader's first
+/// contended row is staged so it blocks holding nothing, and the
+/// follower locks the other row and queues behind it — a discipline
+/// missing from the trigger fails the sweep-first run, one missing from
+/// the revival lock fails the other.
+async fn multi_vm_sweep_and_revival_lock_across_a_staged_row(sweep_first: bool) {
+    let backend = setup_backend().await;
+
+    // The snapshots table is tiny and fresh, so the sweep's scan order
+    // is heap order, which is registration order: mint the ids up
+    // front and register the HIGHER one first, so the sweep provably
+    // walks in descending vm_id order.
+    let mut vm_ids = [InstanceId::new_uuid_v4(), InstanceId::new_uuid_v4()];
+    vm_ids.sort();
+    let [vm_lo, vm_hi] = vm_ids;
+    register_test_vm_with_id(&backend, vm_hi).await;
+    register_test_vm_with_id(&backend, vm_lo).await;
+
+    // One expired-locked request row per VM, so the revival lock is
+    // eligible to take both.
+    let dead_owner = uuid::Uuid::new_v4();
+    let records = NEVec::try_from_vec(vec![
+        record(vm_lo, 1, 10, b"lo"),
+        record(vm_hi, 1, 11, b"hi"),
+    ])
+    .unwrap();
+    backend
+        .record_action_call_requests(
+            Utc::now(),
+            expired_lock(dead_owner),
+            records.as_nonempty_slice(),
+        )
+        .await
+        .expect("record requests");
+
+    deadlock::seed_filler_rows(backend.pool(), deadlock::SweptTable::ActionCallRequests).await;
+
+    // Premise guard: the descending arrangement above reaches the
+    // trigger only through a heap-order scan of the snapshot delete
+    // (seq or bitmap — both preserve heap order).  A plain index scan
+    // would hand the trigger ascending rows regardless, quietly
+    // blunting this test's only pin on the trigger body — fail here
+    // instead of passing vacuously.
+    let sweep_plan: Vec<String> =
+        sqlx::query_scalar("EXPLAIN DELETE FROM vm_runtime_snapshots WHERE vm_id = ANY($1)")
+            .bind(vec![vm_hi, vm_lo])
+            .fetch_all(backend.pool())
+            .await
+            .expect("explain the sweep");
+    assert!(
+        !sweep_plan
+            .iter()
+            .any(|line| line.contains("Index Scan using")),
+        "the snapshot sweep plans as a plain index scan, which emits \
+         ascending key order regardless of heap order — the sweep-first \
+         run can no longer detect a trigger-side regression: {sweep_plan:?}"
+    );
+
+    // The staged row is the leader's first contact: vm_hi's request row
+    // (heap-first for the sweep, input-first for the revival lock).
+    let staging = deadlock::hold_row_for_update(
+        backend.pool(),
+        deadlock::SweptTable::ActionCallRequests,
+        vm_hi,
+        1,
+    )
+    .await;
+
+    let spawn_revival_lock = |vm_ids: Vec<InstanceId>| {
+        let backend = backend.clone();
+        tokio::spawn(async move {
+            let vm_ids = NEVec::try_from_vec(vm_ids).unwrap();
+            backend
+                .lock_action_call_requests(
+                    Utc::now(),
+                    live_lock(uuid::Uuid::new_v4()),
+                    vm_ids.as_nonempty_slice(),
+                )
+                .await
+        })
+    };
+    let revival_pattern = "%locked_by IS NULL OR%";
+
+    if sweep_first {
+        let sweep = deadlock::spawn_snapshot_sweep(backend.pool(), vec![vm_hi, vm_lo]);
+        deadlock::wait_until_lock_blocked(backend.pool(), deadlock::SNAPSHOT_SWEEP_PATTERN).await;
+        let revival = spawn_revival_lock(vec![vm_lo, vm_hi]);
+        deadlock::wait_until_lock_blocked(backend.pool(), revival_pattern).await;
+
+        staging.rollback().await.expect("release staged row");
+
+        sweep
+            .await
+            .expect("join sweep")
+            .expect("the snapshot sweep must not deadlock against the revival lock");
+        revival
+            .await
+            .expect("join revival")
+            .expect("the revival lock must not deadlock against the snapshot sweep");
+    } else {
+        let revival = spawn_revival_lock(vec![vm_hi, vm_lo]);
+        deadlock::wait_until_lock_blocked(backend.pool(), revival_pattern).await;
+        let sweep = deadlock::spawn_snapshot_sweep(backend.pool(), vec![vm_lo, vm_hi]);
+        deadlock::wait_until_lock_blocked(backend.pool(), deadlock::SNAPSHOT_SWEEP_PATTERN).await;
+
+        staging.rollback().await.expect("release staged row");
+
+        revival
+            .await
+            .expect("join revival")
+            .expect("the revival lock must not deadlock against the snapshot sweep");
+        sweep
+            .await
+            .expect("join sweep")
+            .expect("the snapshot sweep must not deadlock against the revival lock");
+    }
+}
+
+#[serial(postgres)]
+#[tokio::test]
+async fn concurrent_multi_vm_sweep_and_revival_lock_do_not_deadlock() {
+    // Leader mirrored both ways: sweep-first pins the trigger's ordered
+    // lock pass, revival-first pins the revival lock's.
+    multi_vm_sweep_and_revival_lock_across_a_staged_row(true).await;
+    multi_vm_sweep_and_revival_lock_across_a_staged_row(false).await;
 }

--- a/crates/lib/backend-postgres/src/action_call_requests/tests.rs
+++ b/crates/lib/backend-postgres/src/action_call_requests/tests.rs
@@ -1,5 +1,5 @@
 use chrono::{Duration, Utc};
-use nonempty_collections::NEVec;
+use nonempty_collections::{IntoNonEmptyIterator as _, NEVec, NonEmptyIterator as _, nev};
 use serial_test::serial;
 use waymark_action_completions_reconciler_backend::{CompletionRecord, RecordCompletions as _};
 use waymark_action_effect_reconciler_backend::record_action_call_requests;
@@ -61,11 +61,7 @@ async fn record_fresh_then_identical_replay() {
     let vm = InstanceId::new_uuid_v4();
     let owner = uuid::Uuid::new_v4();
 
-    let records = NEVec::try_from_vec(vec![
-        record(vm, 1, 10, b"call-1"),
-        record(vm, 2, 11, b"call-2"),
-    ])
-    .unwrap();
+    let records = nev![record(vm, 1, 10, b"call-1"), record(vm, 2, 11, b"call-2")];
 
     let success = backend
         .record_action_call_requests(Utc::now(), live_lock(owner), records.as_nonempty_slice())
@@ -78,7 +74,7 @@ async fn record_fresh_then_identical_replay() {
 
     // A replayed effect re-inserts byte-identical rows: idempotently
     // accepted, reported, and the rows stay untouched.
-    let replay = NEVec::try_from_vec(vec![record(vm, 1, 10, b"call-1")]).unwrap();
+    let replay = nev![record(vm, 1, 10, b"call-1")];
     let success = backend
         .record_action_call_requests(
             Utc::now(),
@@ -89,9 +85,7 @@ async fn record_fresh_then_identical_replay() {
         .expect("replayed record");
     assert_eq!(
         success,
-        record_action_call_requests::RecordingSuccess::SomeAlreadyRecorded(
-            NEVec::try_from_vec(vec![key(vm, 1)]).unwrap()
-        )
+        record_action_call_requests::RecordingSuccess::SomeAlreadyRecorded(nev![key(vm, 1)])
     );
 
     // Untouched includes the lock: the original owner still renews.
@@ -99,9 +93,7 @@ async fn record_fresh_then_identical_replay() {
         .renew_action_call_request_locks(
             Utc::now(),
             live_lock(owner),
-            NEVec::try_from_vec(vec![key(vm, 1), key(vm, 2)])
-                .unwrap()
-                .as_nonempty_slice(),
+            nev![key(vm, 1), key(vm, 2)].as_nonempty_slice(),
         )
         .await
         .expect("renew");
@@ -118,7 +110,7 @@ async fn record_divergent_payload_fails_loudly() {
     let backend = setup_backend().await;
     let vm = InstanceId::new_uuid_v4();
 
-    let records = NEVec::try_from_vec(vec![record(vm, 1, 10, b"original")]).unwrap();
+    let records = nev![record(vm, 1, 10, b"original")];
     backend
         .record_action_call_requests(
             Utc::now(),
@@ -128,7 +120,7 @@ async fn record_divergent_payload_fails_loudly() {
         .await
         .expect("fresh record");
 
-    let divergent = NEVec::try_from_vec(vec![record(vm, 1, 10, b"DIFFERENT")]).unwrap();
+    let divergent = nev![record(vm, 1, 10, b"DIFFERENT")];
     let error = backend
         .record_action_call_requests(
             Utc::now(),
@@ -150,7 +142,7 @@ async fn record_divergent_payload_fails_loudly() {
     );
 
     // A diverging effect number alone is the same violation.
-    let divergent = NEVec::try_from_vec(vec![record(vm, 1, 99, b"original")]).unwrap();
+    let divergent = nev![record(vm, 1, 99, b"original")];
     let error = backend
         .record_action_call_requests(
             Utc::now(),
@@ -172,7 +164,7 @@ async fn lock_vm_takes_expired_and_reports_foreign() {
     let reviver = uuid::Uuid::new_v4();
 
     // One request whose lock expired (dead process), one still held live.
-    let expired = NEVec::try_from_vec(vec![record(vm, 1, 10, b"expired-call")]).unwrap();
+    let expired = nev![record(vm, 1, 10, b"expired-call")];
     backend
         .record_action_call_requests(
             Utc::now(),
@@ -181,7 +173,7 @@ async fn lock_vm_takes_expired_and_reports_foreign() {
         )
         .await
         .expect("record expired-locked");
-    let live = NEVec::try_from_vec(vec![record(vm, 2, 11, b"live-call")]).unwrap();
+    let live = nev![record(vm, 2, 11, b"live-call")];
     backend
         .record_action_call_requests(Utc::now(), live_lock(live_owner), live.as_nonempty_slice())
         .await
@@ -219,12 +211,12 @@ async fn renew_reports_per_key_status() {
     let owner = uuid::Uuid::new_v4();
     let other = uuid::Uuid::new_v4();
 
-    let mine = NEVec::try_from_vec(vec![record(vm, 1, 10, b"mine")]).unwrap();
+    let mine = nev![record(vm, 1, 10, b"mine")];
     backend
         .record_action_call_requests(Utc::now(), live_lock(owner), mine.as_nonempty_slice())
         .await
         .expect("record mine");
-    let theirs = NEVec::try_from_vec(vec![record(vm, 2, 11, b"theirs")]).unwrap();
+    let theirs = nev![record(vm, 2, 11, b"theirs")];
     backend
         .record_action_call_requests(Utc::now(), live_lock(other), theirs.as_nonempty_slice())
         .await
@@ -234,9 +226,7 @@ async fn renew_reports_per_key_status() {
         .renew_action_call_request_locks(
             Utc::now(),
             live_lock(owner),
-            NEVec::try_from_vec(vec![key(vm, 1), key(vm, 2), key(vm, 3)])
-                .unwrap()
-                .as_nonempty_slice(),
+            nev![key(vm, 1), key(vm, 2), key(vm, 3)].as_nonempty_slice(),
         )
         .await
         .expect("renew");
@@ -265,7 +255,7 @@ async fn renew_racing_a_row_removal_reports_missing() {
     let vm = InstanceId::new_uuid_v4();
     let owner = uuid::Uuid::new_v4();
 
-    let records = NEVec::try_from_vec(vec![record(vm, 1, 10, b"racing")]).unwrap();
+    let records = nev![record(vm, 1, 10, b"racing")];
     backend
         .record_action_call_requests(Utc::now(), live_lock(owner), records.as_nonempty_slice())
         .await
@@ -288,9 +278,7 @@ async fn renew_racing_a_row_removal_reports_missing() {
             .renew_action_call_request_locks(
                 Utc::now(),
                 live_lock(owner),
-                NEVec::try_from_vec(vec![key(vm, 1)])
-                    .unwrap()
-                    .as_nonempty_slice(),
+                nev![key(vm, 1)].as_nonempty_slice(),
             )
             .await
     });
@@ -312,24 +300,19 @@ async fn unlock_releases_own_locks_only() {
     let owner = uuid::Uuid::new_v4();
     let other = uuid::Uuid::new_v4();
 
-    let mine = NEVec::try_from_vec(vec![record(vm, 1, 10, b"mine")]).unwrap();
+    let mine = nev![record(vm, 1, 10, b"mine")];
     backend
         .record_action_call_requests(Utc::now(), live_lock(owner), mine.as_nonempty_slice())
         .await
         .expect("record mine");
-    let theirs = NEVec::try_from_vec(vec![record(vm, 2, 11, b"theirs")]).unwrap();
+    let theirs = nev![record(vm, 2, 11, b"theirs")];
     backend
         .record_action_call_requests(Utc::now(), live_lock(other), theirs.as_nonempty_slice())
         .await
         .expect("record theirs");
 
     backend
-        .unlock_action_call_requests(
-            &owner,
-            NEVec::try_from_vec(vec![key(vm, 1), key(vm, 2)])
-                .unwrap()
-                .as_nonempty_slice(),
-        )
+        .unlock_action_call_requests(&owner, nev![key(vm, 1), key(vm, 2)].as_nonempty_slice())
         .await
         .expect("unlock");
 
@@ -355,11 +338,7 @@ async fn recording_a_completion_removes_the_request() {
     let vm = InstanceId::new_uuid_v4();
     let owner = uuid::Uuid::new_v4();
 
-    let requests = NEVec::try_from_vec(vec![
-        record(vm, 1, 10, b"call-1"),
-        record(vm, 2, 11, b"call-2"),
-    ])
-    .unwrap();
+    let requests = nev![record(vm, 1, 10, b"call-1"), record(vm, 2, 11, b"call-2")];
     backend
         .record_action_call_requests(Utc::now(), live_lock(owner), requests.as_nonempty_slice())
         .await
@@ -367,13 +346,12 @@ async fn recording_a_completion_removes_the_request() {
 
     // Recording the completion for promise 1 removes exactly its request
     // row, atomically, via the schema trigger.
-    let completions = NEVec::try_from_vec(vec![CompletionRecord {
+    let completions = nev![CompletionRecord {
         vm_id: vm,
         promise_state_id: PromiseStateId(1),
         effect_number: EffectNumber(10),
         outcome: b"outcome-1".to_vec(),
-    }])
-    .unwrap();
+    }];
     backend
         .record_completions(completions.as_nonempty_slice())
         .await
@@ -383,9 +361,7 @@ async fn recording_a_completion_removes_the_request() {
         .renew_action_call_request_locks(
             Utc::now(),
             live_lock(owner),
-            NEVec::try_from_vec(vec![key(vm, 1), key(vm, 2)])
-                .unwrap()
-                .as_nonempty_slice(),
+            nev![key(vm, 1), key(vm, 2)].as_nonempty_slice(),
         )
         .await
         .expect("renew");
@@ -415,8 +391,7 @@ async fn snapshot_delete_sweeps_only_the_vms_requests() {
     let (vm_b, _) = register_test_vm(&backend).await;
     let owner = uuid::Uuid::new_v4();
 
-    let records =
-        NEVec::try_from_vec(vec![record(vm_a, 1, 10, b"a1"), record(vm_b, 1, 20, b"b1")]).unwrap();
+    let records = nev![record(vm_a, 1, 10, b"a1"), record(vm_b, 1, 20, b"b1")];
     backend
         .record_action_call_requests(Utc::now(), live_lock(owner), records.as_nonempty_slice())
         .await
@@ -432,9 +407,7 @@ async fn snapshot_delete_sweeps_only_the_vms_requests() {
         .renew_action_call_request_locks(
             Utc::now(),
             live_lock(owner),
-            NEVec::try_from_vec(vec![key(vm_a, 1), key(vm_b, 1)])
-                .unwrap()
-                .as_nonempty_slice(),
+            nev![key(vm_a, 1), key(vm_b, 1)].as_nonempty_slice(),
         )
         .await
         .expect("renew");
@@ -481,11 +454,7 @@ async fn complete_and_renew_across_a_staged_row(completion_order: [usize; 2]) {
     let vm = InstanceId::new_uuid_v4();
     let owner = uuid::Uuid::new_v4();
 
-    let records = NEVec::try_from_vec(vec![
-        record(vm, 1, 10, b"call-1"),
-        record(vm, 2, 11, b"call-2"),
-    ])
-    .unwrap();
+    let records = nev![record(vm, 1, 10, b"call-1"), record(vm, 2, 11, b"call-2")];
     backend
         .record_action_call_requests(Utc::now(), live_lock(owner), records.as_nonempty_slice())
         .await
@@ -529,13 +498,10 @@ async fn complete_and_renew_across_a_staged_row(completion_order: [usize; 2]) {
 
     let renewal_backend = backend.clone();
     let renewal_task = tokio::spawn(async move {
-        let keys = NEVec::try_from_vec(
-            renewal_order
-                .iter()
-                .map(|&promise| key(vm, promise))
-                .collect(),
-        )
-        .unwrap();
+        let keys: NEVec<_> = renewal_order
+            .into_nonempty_iter()
+            .map(|promise| key(vm, promise))
+            .collect();
         renewal_backend
             .renew_action_call_request_locks(Utc::now(), live_lock(owner), keys.as_nonempty_slice())
             .await
@@ -584,12 +550,11 @@ async fn record_batch_inserts_in_primary_key_order() {
     let backend = setup_backend().await;
     let vm = InstanceId::new_uuid_v4();
 
-    let records = NEVec::try_from_vec(vec![
+    let records = nev![
         record(vm, 2, 11, b"call-2"),
         record(vm, 3, 12, b"call-3"),
-        record(vm, 1, 10, b"call-1"),
-    ])
-    .unwrap();
+        record(vm, 1, 10, b"call-1")
+    ];
     backend
         .record_action_call_requests(
             Utc::now(),
@@ -635,11 +600,7 @@ async fn undisciplined_writers_still_deadlock_premise_canary() {
     let vm = InstanceId::new_uuid_v4();
     let owner = uuid::Uuid::new_v4();
 
-    let records = NEVec::try_from_vec(vec![
-        record(vm, 1, 10, b"call-1"),
-        record(vm, 2, 11, b"call-2"),
-    ])
-    .unwrap();
+    let records = nev![record(vm, 1, 10, b"call-1"), record(vm, 2, 11, b"call-2")];
     backend
         .record_action_call_requests(Utc::now(), live_lock(owner), records.as_nonempty_slice())
         .await
@@ -720,11 +681,7 @@ async fn renew_and_sweep_across_a_staged_row(renewal_order: [usize; 2]) {
     let (vm, _) = register_test_vm(&backend).await;
     let owner = uuid::Uuid::new_v4();
 
-    let records = NEVec::try_from_vec(vec![
-        record(vm, 1, 10, b"call-1"),
-        record(vm, 2, 11, b"call-2"),
-    ])
-    .unwrap();
+    let records = nev![record(vm, 1, 10, b"call-1"), record(vm, 2, 11, b"call-2")];
     backend
         .record_action_call_requests(Utc::now(), live_lock(owner), records.as_nonempty_slice())
         .await
@@ -746,13 +703,10 @@ async fn renew_and_sweep_across_a_staged_row(renewal_order: [usize; 2]) {
     // queue, so releasing hands the row to it and not to the sweep.
     let renewal_backend = backend.clone();
     let renewal_task = tokio::spawn(async move {
-        let keys = NEVec::try_from_vec(
-            renewal_order
-                .iter()
-                .map(|&promise| key(vm, promise))
-                .collect(),
-        )
-        .unwrap();
+        let keys: NEVec<_> = renewal_order
+            .into_nonempty_iter()
+            .map(|promise| key(vm, promise))
+            .collect();
         renewal_backend
             .renew_action_call_request_locks(Utc::now(), live_lock(owner), keys.as_nonempty_slice())
             .await
@@ -811,11 +765,7 @@ async fn multi_vm_sweep_and_revival_lock_across_a_staged_row(sweep_first: bool) 
     // One expired-locked request row per VM, so the revival lock is
     // eligible to take both.
     let dead_owner = uuid::Uuid::new_v4();
-    let records = NEVec::try_from_vec(vec![
-        record(vm_lo, 1, 10, b"lo"),
-        record(vm_hi, 1, 11, b"hi"),
-    ])
-    .unwrap();
+    let records = nev![record(vm_lo, 1, 10, b"lo"), record(vm_hi, 1, 11, b"hi")];
     backend
         .record_action_call_requests(
             Utc::now(),

--- a/crates/lib/backend-postgres/src/lib.rs
+++ b/crates/lib/backend-postgres/src/lib.rs
@@ -1,4 +1,26 @@
 //! Postgres backend for persisting VM execution state and action results.
+//!
+//! # Invariant: canonical row-lock order for multi-row writers
+//!
+//! Any two multi-row statements that take row locks on overlapping sets
+//! in different orders can deadlock; the 2026-08-31 production outage
+//! was exactly that (the batched lock renewal against the completion
+//! trigger's removal DELETE).  Every multi-row UPDATE/DELETE in this
+//! crate therefore locks its target rows in primary-key order first —
+//! a `locked AS MATERIALIZED (SELECT … ORDER BY <pk> FOR UPDATE)` CTE
+//! in the same statement as the mutation (never a separate statement:
+//! each statement snapshots independently under READ COMMITTED, and a
+//! row committed between snapshots would bypass the ordered queue) —
+//! and every batch INSERT orders its source rows the same way so
+//! conflict-arbiter waits queue canonically too.  The trigger functions
+//! (migration `0023`) follow the identical form.
+//!
+//! **When adding a multi-row writer**, follow the pattern (the renewal
+//! statement in `action_call_requests` is the canonical example) and
+//! add a staged-row deadlock choreography for its contended pairing —
+//! see `test_helpers::deadlock` and the existing
+//! `*_do_not_deadlock` tests.  No mechanical check enforces this; the
+//! reviewed convention is the enforcement.
 
 mod action_call_completions;
 mod action_call_requests;

--- a/crates/lib/backend-postgres/src/scheduler/mod.rs
+++ b/crates/lib/backend-postgres/src/scheduler/mod.rs
@@ -130,6 +130,23 @@ impl waymark_scheduler_backend::RegisterScheduledVmRuntimes for PostgresBackend 
                     WITH ORDINALITY
                     AS t(schedule_name, expected_next_run_at, vm_id, new_next_run_at, check_overlap, input_position)
             ),
+            -- Canonical lock order (see the renewal statement in
+            -- action_call_requests): concurrent registrars with
+            -- overlapping due batches are the DESIGNED normal case, so
+            -- take the row locks in primary-key order before the fenced
+            -- update.  A row whose fence moved while we waited is
+            -- requalified out of `locked` but its lock is still held, so
+            -- `advanced`'s own re-check below never acquires out of
+            -- order.
+            locked AS MATERIALIZED (
+                SELECT schedules.schedule_name
+                FROM schedules
+                JOIN input ON schedules.schedule_name = input.schedule_name
+                WHERE schedules.status = 'active'
+                  AND schedules.next_run_at = input.expected_next_run_at
+                ORDER BY schedules.schedule_name
+                FOR UPDATE
+            ),
             gated AS (
                 SELECT input.input_position,
                        input.schedule_name,
@@ -152,6 +169,7 @@ impl waymark_scheduler_backend::RegisterScheduledVmRuntimes for PostgresBackend 
                        ) AS blocked
                 FROM schedules
                 JOIN input ON schedules.schedule_name = input.schedule_name
+                JOIN locked ON locked.schedule_name = schedules.schedule_name
                 WHERE schedules.status = 'active'
                   AND schedules.next_run_at = input.expected_next_run_at
             ),

--- a/crates/lib/backend-postgres/src/scheduler/tests.rs
+++ b/crates/lib/backend-postgres/src/scheduler/tests.rs
@@ -11,7 +11,7 @@ use waymark_scheduler_backend::register_scheduled_vm_runtimes::{Item, Outcome};
 use waymark_scheduler_backend::{PollDueSchedules, RegisterScheduledVmRuntimes};
 use waymark_workflow_service_scheduler_backend::{UpsertSchedule, upsert_schedule};
 
-use super::super::test_helpers::{setup_backend, upsert_test_executable};
+use super::super::test_helpers::{deadlock, setup_backend, upsert_test_executable};
 
 const TEST_DEFINITION: &[u8] = b"test-definition";
 const TEST_INITIAL_SNAPSHOT: &[u8] = b"test-initial-snapshot";
@@ -282,4 +282,119 @@ async fn a_batch_reports_per_row_outcomes_in_input_order() {
     assert_eq!(outcomes, nev![Outcome::Registered, Outcome::Superseded]);
     assert!(vm_runtime_registered(&backend, fresh_vm_id).await);
     assert!(!vm_runtime_registered(&backend, stale_vm_id).await);
+}
+
+/// One choreographed collision of two concurrent registrar batches over
+/// the same two due schedules — the schedules-table member of the
+/// multi-row-writer class behind the 2026-08-31 deadlock outage.
+/// Racing registrars are the DESIGNED normal case here (the loser's
+/// rows come back Superseded), so opposite batch orders must queue, not
+/// cycle.
+///
+/// The staging, plan-shape seeding, and contract follow
+/// `complete_and_renew_across_a_staged_row` in
+/// `action_call_requests::tests`: the leader's first key is pre-held so
+/// it blocks holding nothing, the follower locks the other row and
+/// queues behind it.  Both batches run the same statement text, so the
+/// follower's blocked state is staged by waiter count.
+async fn register_against_register_across_a_staged_row(leader_order: [&'static str; 2]) {
+    let backend = setup_backend().await;
+    let executable_id = upsert_test_executable(&backend, "choreography").await;
+    upsert(&backend, "sched-a", &executable_id, at(1)).await;
+    upsert(&backend, "sched-b", &executable_id, at(1)).await;
+
+    // Plan shape, as in the swept-table choreographies: enough analyzed
+    // rows that the registrar statement probes the primary key in input
+    // order instead of seq-scanning both contenders into one order.
+    sqlx::query(
+        r#"
+        INSERT INTO schedules
+            (schedule_name, executable_id, definition, initial_snapshot, status, next_run_at)
+        SELECT 'filler-' || n, $1, 'd', 's', 'active', NOW() + interval '1 hour'
+        FROM generate_series(1, 10000) AS n
+        "#,
+    )
+    .bind(executable_id)
+    .execute(backend.pool())
+    .await
+    .expect("seed filler schedules");
+    sqlx::query("ANALYZE schedules")
+        .execute(backend.pool())
+        .await
+        .expect("analyze");
+
+    // Pre-hold the leader batch's first schedule row.
+    let mut staging = backend.pool().begin().await.expect("begin staging");
+    let held = sqlx::query("SELECT 1 FROM schedules WHERE schedule_name = $1 FOR UPDATE")
+        .bind(leader_order[0])
+        .execute(&mut *staging)
+        .await
+        .expect("hold staged row");
+    assert_eq!(held.rows_affected(), 1, "the staged schedule must exist");
+
+    fn spawn_register(
+        backend: &crate::PostgresBackend,
+        order: [&'static str; 2],
+    ) -> tokio::task::JoinHandle<
+        Result<
+            nonempty_collections::NEVec<Outcome>,
+            <crate::PostgresBackend as RegisterScheduledVmRuntimes>::Error,
+        >,
+    > {
+        let backend = backend.clone();
+        tokio::spawn(async move {
+            let items = nev![
+                Item {
+                    schedule_name: Cow::Borrowed(order[0]),
+                    expected_next_run_at: Cow::Owned(at(1)),
+                    vm_id: Cow::Owned(InstanceId::new_uuid_v4()),
+                    new_next_run_at: Cow::Owned(at(2)),
+                    check_overlap: false,
+                },
+                Item {
+                    schedule_name: Cow::Borrowed(order[1]),
+                    expected_next_run_at: Cow::Owned(at(1)),
+                    vm_id: Cow::Owned(InstanceId::new_uuid_v4()),
+                    new_next_run_at: Cow::Owned(at(2)),
+                    check_overlap: false,
+                },
+            ];
+            backend
+                .register_scheduled_vm_runtimes(items.as_nonempty_slice())
+                .await
+        })
+    }
+    // `input_position` appears only in the registrar statement.
+    let register_pattern = "%input_position%";
+
+    let leader = spawn_register(&backend, leader_order);
+    deadlock::wait_until_lock_blocked(backend.pool(), register_pattern).await;
+    let follower = spawn_register(&backend, [leader_order[1], leader_order[0]]);
+    deadlock::wait_until_lock_blocked_at_least(
+        backend.pool(),
+        register_pattern,
+        std::num::NonZeroI64::new(2).unwrap(),
+    )
+    .await;
+
+    staging.rollback().await.expect("release staged row");
+
+    leader
+        .await
+        .expect("join leader")
+        .expect("a registrar batch must not deadlock against a competing registrar");
+    follower
+        .await
+        .expect("join follower")
+        .expect("a registrar batch must not deadlock against a competing registrar");
+}
+
+#[serial(postgres)]
+#[tokio::test]
+async fn concurrent_registrar_batches_do_not_deadlock() {
+    // Both leader orders, with the staged row tracking the leader's
+    // first key, so an ordering discipline missing from the registrar
+    // statement fails one of the runs.
+    register_against_register_across_a_staged_row(["sched-b", "sched-a"]).await;
+    register_against_register_across_a_staged_row(["sched-a", "sched-b"]).await;
 }

--- a/crates/lib/backend-postgres/src/sleep_requests/mod.rs
+++ b/crates/lib/backend-postgres/src/sleep_requests/mod.rs
@@ -91,6 +91,11 @@ impl waymark_sleep_reconciler_backend::RecordSleeps for PostgresBackend {
                    NOW() + (t.wake_micros * interval '1 microsecond')
             FROM UNNEST($1::uuid[], $2::bigint[], $3::bigint[], $4::bigint[])
                 AS t(vm_id, promise_state_id, effect_number, wake_micros)
+            -- Canonical lock order: replayed keys contend on existing
+            -- rows through the conflict arbiter, so insert in primary
+            -- key order like every other multi-row writer on the
+            -- trigger-swept tables.
+            ORDER BY t.vm_id, t.promise_state_id
             ON CONFLICT (vm_id, promise_state_id) DO NOTHING
             RETURNING vm_id, promise_state_id
             "#,
@@ -240,9 +245,20 @@ impl waymark_sleep_reconciler_backend::AckSleeps for PostgresBackend {
         );
         sqlx::query(
             r#"
+            -- Canonical lock order: take every target row lock in
+            -- primary key order before mutating, so multi-row writers
+            -- can never deadlock with each other on overlapping sets.
+            WITH locked AS MATERIALIZED (
+                SELECT s.vm_id, s.promise_state_id
+                FROM sleep_requests s
+                JOIN UNNEST($1::uuid[], $2::bigint[]) AS d(vm_id, promise_state_id)
+                    ON s.vm_id = d.vm_id AND s.promise_state_id = d.promise_state_id
+                ORDER BY s.vm_id, s.promise_state_id
+                FOR UPDATE OF s
+            )
             DELETE FROM sleep_requests s
-            USING UNNEST($1::uuid[], $2::bigint[]) AS d(vm_id, promise_state_id)
-            WHERE s.vm_id = d.vm_id AND s.promise_state_id = d.promise_state_id
+            USING locked l
+            WHERE s.vm_id = l.vm_id AND s.promise_state_id = l.promise_state_id
             "#,
         )
         .bind(&columns.vm_ids)

--- a/crates/lib/backend-postgres/src/sleep_requests/tests.rs
+++ b/crates/lib/backend-postgres/src/sleep_requests/tests.rs
@@ -10,7 +10,7 @@ use waymark_sleep_reconciler_backend::{
 use waymark_vm_runtime_effect::EffectNumber;
 use waymark_vm_runtime_promise_core::PromiseStateId;
 
-use super::super::test_helpers::{register_test_vm, setup_backend};
+use super::super::test_helpers::{deadlock, register_test_vm, setup_backend};
 use super::error::RecordError;
 
 fn record(
@@ -246,4 +246,76 @@ async fn snapshot_delete_sweeps_all_rows_of_the_vm_only() {
         .await
         .expect("poll");
     assert_eq!(polled[..], [key(vm_b, 1)]);
+}
+
+/// One choreographed collision of the sleep-ack DELETE and the
+/// snapshot-cleanup trigger's sleep sweep over the same two sleep rows —
+/// the sleeps-table sweep pairing of the multi-row-writer class behind
+/// the 2026-08-31 deadlock outage.
+///
+/// The staging, plan-shape seeding, and contract are those of
+/// `complete_and_renew_across_a_staged_row` in
+/// `action_call_requests::tests`; the sweep's lock order is not
+/// input-driven — it walks the whole VM — so the mirroring axis is the
+/// ack batch's order plus which row is staged.
+async fn ack_and_sweep_across_a_staged_row(ack_order: [usize; 2]) {
+    let backend = setup_backend().await;
+    let (vm, _) = register_test_vm(&backend).await;
+    let wake = Utc::now() - Duration::hours(1);
+
+    let records =
+        NEVec::try_from_vec(vec![record(vm, 1, 10, wake), record(vm, 2, 11, wake)]).unwrap();
+    backend
+        .record_sleeps(records.as_nonempty_slice())
+        .await
+        .expect("record sleeps");
+
+    deadlock::seed_filler_rows(backend.pool(), deadlock::SweptTable::SleepRequests).await;
+
+    // Pre-hold the ack batch's first row.
+    let staged = ack_order[0];
+    let staging = deadlock::hold_row_for_update(
+        backend.pool(),
+        deadlock::SweptTable::SleepRequests,
+        vm,
+        staged,
+    )
+    .await;
+
+    // The ack first: it must be the head of the staged row's wait queue,
+    // so releasing hands the row to it and not to the sweep queued later.
+    let ack_backend = backend.clone();
+    let ack_task = tokio::spawn(async move {
+        let keys = NEVec::try_from_vec(ack_order.iter().map(|&promise| key(vm, promise)).collect())
+            .unwrap();
+        ack_backend.ack_sleeps(keys.as_nonempty_slice()).await
+    });
+    deadlock::wait_until_lock_blocked(backend.pool(), "%DELETE FROM sleep_requests%").await;
+
+    // The sweep's sleep-table pass contends the same two rows.
+    let sweep_task = deadlock::spawn_snapshot_sweep(backend.pool(), vec![vm]);
+    deadlock::wait_until_lock_blocked(backend.pool(), deadlock::SNAPSHOT_SWEEP_PATTERN).await;
+
+    staging.rollback().await.expect("release staged row");
+
+    ack_task
+        .await
+        .expect("join ack")
+        .expect("acking sleeps must not deadlock against the snapshot sweep");
+    sweep_task
+        .await
+        .expect("join sweep")
+        .expect("the snapshot sweep must not deadlock against sleep acks");
+}
+
+#[serial(postgres)]
+#[tokio::test]
+async fn concurrent_ack_and_snapshot_sweep_do_not_deadlock() {
+    // Both ack orders, with the staged row tracking the ack's first key.
+    // These runs pin the ACK side's discipline only: a single-VM sweep
+    // locks its rows in primary-key order under every realizable plan,
+    // so the trigger side cannot regress visibly here — the multi-VM
+    // sweep test in `action_call_requests::tests` covers it.
+    ack_and_sweep_across_a_staged_row([2, 1]).await;
+    ack_and_sweep_across_a_staged_row([1, 2]).await;
 }

--- a/crates/lib/backend-postgres/src/sleep_requests/tests.rs
+++ b/crates/lib/backend-postgres/src/sleep_requests/tests.rs
@@ -1,5 +1,5 @@
 use chrono::{Duration, Utc};
-use nonempty_collections::NEVec;
+use nonempty_collections::{IntoNonEmptyIterator as _, NEVec, NonEmptyIterator as _, nev};
 use serial_test::serial;
 use waymark_ids::InstanceId;
 use waymark_sleep_reconciler_backend::record_sleeps;
@@ -44,12 +44,11 @@ async fn record_then_poll_returns_only_demanded_and_due() {
     let past = now - Duration::hours(1);
     let future = now + Duration::hours(1);
 
-    let records = NEVec::try_from_vec(vec![
+    let records = nev![
         record(vm_a, 1, 10, past),
         record(vm_a, 2, 11, future),
-        record(vm_b, 1, 20, past),
-    ])
-    .unwrap();
+        record(vm_b, 1, 20, past)
+    ];
     backend
         .record_sleeps(records.as_nonempty_slice())
         .await
@@ -57,7 +56,7 @@ async fn record_then_poll_returns_only_demanded_and_due() {
 
     // Demand vm_a's promises plus one that was never recorded: only the
     // due one comes back — not the future one, not the undemanded vm_b.
-    let demand = NEVec::try_from_vec(vec![key(vm_a, 1), key(vm_a, 2), key(vm_a, 99)]).unwrap();
+    let demand = nev![key(vm_a, 1), key(vm_a, 2), key(vm_a, 99)];
     let polled = backend
         .poll_due_sleeps(now, demand.as_nonempty_slice())
         .await
@@ -161,17 +160,16 @@ async fn record_accepts_mixed_batch_of_new_and_replayed_rows() {
         .expect("seed record");
 
     // One replayed duplicate + one new row in the same batch.
-    let batch = NEVec::try_from_vec(vec![
+    let batch = nev![
         record(vm_id, 1, 10, now + Duration::hours(1)),
-        record(vm_id, 2, 11, wake),
-    ])
-    .unwrap();
+        record(vm_id, 2, 11, wake)
+    ];
     backend
         .record_sleeps(batch.as_nonempty_slice())
         .await
         .expect("mixed batch is accepted");
 
-    let demand = NEVec::try_from_vec(vec![key(vm_id, 1), key(vm_id, 2)]).unwrap();
+    let demand = nev![key(vm_id, 1), key(vm_id, 2)];
     let polled = backend
         .poll_due_sleeps(now, demand.as_nonempty_slice())
         .await
@@ -187,8 +185,7 @@ async fn ack_removes_rows_and_is_idempotent() {
     let now = Utc::now();
     let wake = now - Duration::hours(1);
 
-    let records =
-        NEVec::try_from_vec(vec![record(vm_id, 1, 10, wake), record(vm_id, 2, 11, wake)]).unwrap();
+    let records = nev![record(vm_id, 1, 10, wake), record(vm_id, 2, 11, wake)];
     backend
         .record_sleeps(records.as_nonempty_slice())
         .await
@@ -200,13 +197,13 @@ async fn ack_removes_rows_and_is_idempotent() {
         .await
         .expect("ack");
     // Re-acking (crash recovery) and acking a never-recorded key are no-ops.
-    let re_acked = NEVec::try_from_vec(vec![key(vm_id, 1), key(vm_id, 99)]).unwrap();
+    let re_acked = nev![key(vm_id, 1), key(vm_id, 99)];
     backend
         .ack_sleeps(re_acked.as_nonempty_slice())
         .await
         .expect("re-ack is idempotent");
 
-    let demand = NEVec::try_from_vec(vec![key(vm_id, 1), key(vm_id, 2)]).unwrap();
+    let demand = nev![key(vm_id, 1), key(vm_id, 2)];
     let polled = backend
         .poll_due_sleeps(now, demand.as_nonempty_slice())
         .await
@@ -223,12 +220,11 @@ async fn snapshot_delete_sweeps_all_rows_of_the_vm_only() {
     let now = Utc::now();
     let wake = now - Duration::hours(1);
 
-    let records = NEVec::try_from_vec(vec![
+    let records = nev![
         record(vm_a, 1, 10, wake),
         record(vm_a, 2, 11, wake),
-        record(vm_b, 1, 20, wake),
-    ])
-    .unwrap();
+        record(vm_b, 1, 20, wake)
+    ];
     backend
         .record_sleeps(records.as_nonempty_slice())
         .await
@@ -240,7 +236,7 @@ async fn snapshot_delete_sweeps_all_rows_of_the_vm_only() {
         .await
         .expect("delete vm_a snapshot");
 
-    let demand = NEVec::try_from_vec(vec![key(vm_a, 1), key(vm_a, 2), key(vm_b, 1)]).unwrap();
+    let demand = nev![key(vm_a, 1), key(vm_a, 2), key(vm_b, 1)];
     let polled = backend
         .poll_due_sleeps(now, demand.as_nonempty_slice())
         .await
@@ -263,8 +259,7 @@ async fn ack_and_sweep_across_a_staged_row(ack_order: [usize; 2]) {
     let (vm, _) = register_test_vm(&backend).await;
     let wake = Utc::now() - Duration::hours(1);
 
-    let records =
-        NEVec::try_from_vec(vec![record(vm, 1, 10, wake), record(vm, 2, 11, wake)]).unwrap();
+    let records = nev![record(vm, 1, 10, wake), record(vm, 2, 11, wake)];
     backend
         .record_sleeps(records.as_nonempty_slice())
         .await
@@ -286,8 +281,10 @@ async fn ack_and_sweep_across_a_staged_row(ack_order: [usize; 2]) {
     // so releasing hands the row to it and not to the sweep queued later.
     let ack_backend = backend.clone();
     let ack_task = tokio::spawn(async move {
-        let keys = NEVec::try_from_vec(ack_order.iter().map(|&promise| key(vm, promise)).collect())
-            .unwrap();
+        let keys: NEVec<_> = ack_order
+            .into_nonempty_iter()
+            .map(|promise| key(vm, promise))
+            .collect();
         ack_backend.ack_sleeps(keys.as_nonempty_slice()).await
     });
     deadlock::contend_op_with_snapshot_sweep(

--- a/crates/lib/backend-postgres/src/sleep_requests/tests.rs
+++ b/crates/lib/backend-postgres/src/sleep_requests/tests.rs
@@ -290,22 +290,15 @@ async fn ack_and_sweep_across_a_staged_row(ack_order: [usize; 2]) {
             .unwrap();
         ack_backend.ack_sleeps(keys.as_nonempty_slice()).await
     });
-    deadlock::wait_until_lock_blocked(backend.pool(), "%DELETE FROM sleep_requests%").await;
-
-    // The sweep's sleep-table pass contends the same two rows.
-    let sweep_task = deadlock::spawn_snapshot_sweep(backend.pool(), vec![vm]);
-    deadlock::wait_until_lock_blocked(backend.pool(), deadlock::SNAPSHOT_SWEEP_PATTERN).await;
-
-    staging.rollback().await.expect("release staged row");
-
-    ack_task
-        .await
-        .expect("join ack")
-        .expect("acking sleeps must not deadlock against the snapshot sweep");
-    sweep_task
-        .await
-        .expect("join sweep")
-        .expect("the snapshot sweep must not deadlock against sleep acks");
+    deadlock::contend_op_with_snapshot_sweep(
+        backend.pool(),
+        staging,
+        "sleep ack",
+        ack_task,
+        "%DELETE FROM sleep_requests%",
+        vm,
+    )
+    .await;
 }
 
 #[serial(postgres)]

--- a/crates/lib/backend-postgres/src/test_helpers/deadlock.rs
+++ b/crates/lib/backend-postgres/src/test_helpers/deadlock.rs
@@ -26,6 +26,18 @@ pub(crate) enum SweptTable {
 /// (~1KB), so match on text near the FRONT of the statement, never on a
 /// fragment that sits past the first kilobyte.
 pub(crate) async fn wait_until_lock_blocked(pool: &sqlx::PgPool, query_pattern: &str) {
+    wait_until_lock_blocked_at_least(pool, query_pattern, std::num::NonZeroI64::new(1).unwrap())
+        .await;
+}
+
+/// [`wait_until_lock_blocked`] for `count` concurrently blocked
+/// statements matching the pattern — for choreographies whose two
+/// contenders run the same statement text.
+pub(crate) async fn wait_until_lock_blocked_at_least(
+    pool: &sqlx::PgPool,
+    query_pattern: &str,
+    count: std::num::NonZeroI64,
+) {
     let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
     loop {
         let waiting: i64 = sqlx::query_scalar(
@@ -40,7 +52,7 @@ pub(crate) async fn wait_until_lock_blocked(pool: &sqlx::PgPool, query_pattern: 
         .fetch_one(pool)
         .await
         .expect("poll pg_stat_activity");
-        if waiting > 0 {
+        if waiting >= count.get() {
             return;
         }
         assert!(
@@ -159,4 +171,33 @@ pub(crate) fn spawn_snapshot_sweep(
             .execute(&pool)
             .await
     })
+}
+
+/// The shared tail of the single-VM op-versus-sweep choreographies: the
+/// caller has spawned the op task with the staged row as its first
+/// contact; this waits for it to become the staged row's first waiter,
+/// queues the VM's snapshot sweep behind it, releases the staged row so
+/// the two advance into each other, and requires both to succeed.
+pub(crate) async fn contend_op_with_snapshot_sweep<T, OpError: core::fmt::Debug>(
+    pool: &sqlx::PgPool,
+    staging: sqlx::Transaction<'_, sqlx::Postgres>,
+    op_name: &str,
+    op_task: tokio::task::JoinHandle<Result<T, OpError>>,
+    op_pattern: &str,
+    sweep_vm: InstanceId,
+) {
+    wait_until_lock_blocked(pool, op_pattern).await;
+
+    let sweep_task = spawn_snapshot_sweep(pool, vec![sweep_vm]);
+    wait_until_lock_blocked(pool, SNAPSHOT_SWEEP_PATTERN).await;
+
+    staging.rollback().await.expect("release staged row");
+
+    if let Err(error) = op_task.await.expect("join the op") {
+        panic!("the {op_name} must not deadlock against the snapshot sweep: {error:?}");
+    }
+    sweep_task
+        .await
+        .expect("join the sweep")
+        .expect("the snapshot sweep must not deadlock against the op");
 }

--- a/crates/lib/backend-postgres/src/test_helpers/deadlock.rs
+++ b/crates/lib/backend-postgres/src/test_helpers/deadlock.rs
@@ -1,0 +1,162 @@
+//! Shared machinery for the lock-order deadlock choreographies.
+//!
+//! The choreography tests (see `complete_and_renew_across_a_staged_row`
+//! in `action_call_requests::tests` for the canonical write-up) stage
+//! two multi-row statements into a would-be deadlock cycle around a
+//! pre-held row and assert both succeed under the canonical row-lock
+//! order.  These helpers carry the pieces every choreography shares —
+//! and the load-bearing constants (the filler-row count, the wait
+//! deadline) live here so no test copy can drift on its own.
+
+use waymark_ids::InstanceId;
+
+/// A trigger-swept table a lock-order choreography stages rows in.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum SweptTable {
+    ActionCallRequests,
+    ActionCallCompletions,
+    SleepRequests,
+}
+
+/// Wait until a backend whose current query matches `query_pattern` is
+/// blocked waiting on a lock, so lock-order choreographies can stage
+/// each statement's position in the row-lock queues deterministically.
+///
+/// `pg_stat_activity.query` is truncated at `track_activity_query_size`
+/// (~1KB), so match on text near the FRONT of the statement, never on a
+/// fragment that sits past the first kilobyte.
+pub(crate) async fn wait_until_lock_blocked(pool: &sqlx::PgPool, query_pattern: &str) {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    loop {
+        let waiting: i64 = sqlx::query_scalar(
+            r#"
+            SELECT COUNT(*) FROM pg_stat_activity
+            WHERE wait_event_type = 'Lock'
+                AND datname = current_database()
+                AND query LIKE $1
+            "#,
+        )
+        .bind(query_pattern)
+        .fetch_one(pool)
+        .await
+        .expect("poll pg_stat_activity");
+        if waiting > 0 {
+            return;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "no statement matching {query_pattern:?} became lock-blocked within the \
+             deadline — the statement the caller staged either never ran, finished \
+             without contending the pre-held row, its plan no longer takes row \
+             locks in the order the caller's choreography assumes, or the match \
+             fragment fell past pg_stat_activity's ~1KB query truncation"
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+    }
+}
+
+/// Seed filler rows and refresh statistics so a lock-order choreography
+/// gets the production plan shape: against a large analyzed table the
+/// planner drives the contending statements through per-key primary-key
+/// probes, making their lock order follow their input; a tiny
+/// unanalyzed table walks both statements through the same seq scan,
+/// aligning their lock orders and silently neutering the test.  The row
+/// count lives here so no test copy can drift below the plan-flip
+/// threshold on its own.
+pub(crate) async fn seed_filler_rows(pool: &sqlx::PgPool, table: SweptTable) {
+    let insert = match table {
+        SweptTable::ActionCallRequests => {
+            r#"
+            INSERT INTO action_call_requests
+                (vm_id, promise_state_id, effect_number, request)
+            SELECT gen_random_uuid(), n, n, 'filler'
+            FROM generate_series(1, 10000) AS n
+            "#
+        }
+        SweptTable::ActionCallCompletions => {
+            r#"
+            INSERT INTO action_call_completions
+                (vm_id, promise_state_id, effect_number, outcome)
+            SELECT gen_random_uuid(), n, n, 'filler'
+            FROM generate_series(1, 10000) AS n
+            "#
+        }
+        SweptTable::SleepRequests => {
+            r#"
+            INSERT INTO sleep_requests
+                (vm_id, promise_state_id, effect_number, wake_at)
+            SELECT gen_random_uuid(), n, n, NOW()
+            FROM generate_series(1, 10000) AS n
+            "#
+        }
+    };
+    sqlx::query(insert)
+        .execute(pool)
+        .await
+        .expect("seed filler rows");
+    sqlx::query(
+        "ANALYZE action_call_requests, action_call_completions, \
+         sleep_requests, vm_runtime_snapshots",
+    )
+    .execute(pool)
+    .await
+    .expect("analyze");
+}
+
+/// Open a transaction holding a `FOR UPDATE` lock on one choreography
+/// row; dropping or rolling back the returned transaction releases it.
+pub(crate) async fn hold_row_for_update(
+    pool: &sqlx::PgPool,
+    table: SweptTable,
+    vm_id: InstanceId,
+    promise_state_id: usize,
+) -> sqlx::Transaction<'_, sqlx::Postgres> {
+    let select = match table {
+        SweptTable::ActionCallRequests => {
+            "SELECT 1 FROM action_call_requests \
+             WHERE vm_id = $1 AND promise_state_id = $2 FOR UPDATE"
+        }
+        SweptTable::ActionCallCompletions => {
+            "SELECT 1 FROM action_call_completions \
+             WHERE vm_id = $1 AND promise_state_id = $2 FOR UPDATE"
+        }
+        SweptTable::SleepRequests => {
+            "SELECT 1 FROM sleep_requests \
+             WHERE vm_id = $1 AND promise_state_id = $2 FOR UPDATE"
+        }
+    };
+    let mut staging = pool.begin().await.expect("begin staging");
+    let held = sqlx::query(select)
+        .bind(vm_id)
+        .bind(i64::try_from(promise_state_id).expect("promise state id fits"))
+        .execute(&mut *staging)
+        .await
+        .expect("hold staged row");
+    assert_eq!(
+        held.rows_affected(),
+        1,
+        "the staged row ({table:?}, {vm_id:?}, {promise_state_id}) does not exist — \
+         the choreography would hold nothing and time out blaming plan shapes"
+    );
+    staging
+}
+
+/// The `pg_stat_activity` match pattern for a blocked [`spawn_snapshot_sweep`]
+/// statement.
+pub(crate) const SNAPSHOT_SWEEP_PATTERN: &str = "%DELETE FROM vm_runtime_snapshots%";
+
+/// Spawn the VMs' terminal snapshot delete, firing the cleanup trigger
+/// whose per-table sweeps the choreographies contend with; wait for its
+/// blocked state via [`SNAPSHOT_SWEEP_PATTERN`].
+pub(crate) fn spawn_snapshot_sweep(
+    pool: &sqlx::PgPool,
+    vm_ids: Vec<InstanceId>,
+) -> tokio::task::JoinHandle<Result<sqlx::postgres::PgQueryResult, sqlx::Error>> {
+    let pool = pool.clone();
+    tokio::spawn(async move {
+        sqlx::query("DELETE FROM vm_runtime_snapshots WHERE vm_id = ANY($1)")
+            .bind(vm_ids)
+            .execute(&pool)
+            .await
+    })
+}

--- a/crates/lib/backend-postgres/src/test_helpers/mod.rs
+++ b/crates/lib/backend-postgres/src/test_helpers/mod.rs
@@ -1,3 +1,5 @@
+pub(super) mod deadlock;
+
 use super::PostgresBackend;
 use waymark_ids::{InstanceId, WorkflowVersionId};
 use waymark_support_test::postgres_setup;
@@ -37,6 +39,15 @@ pub(super) async fn upsert_test_executable(
 /// share exactly the registration behavior they exercise.
 pub(super) async fn register_test_vm(backend: &PostgresBackend) -> (InstanceId, WorkflowVersionId) {
     let vm_id = InstanceId::new_uuid_v4();
+    register_test_vm_with_id(backend, vm_id).await
+}
+
+/// [`register_test_vm`] with a caller-chosen VM id, for tests whose
+/// choreography depends on the registration (heap) order of specific ids.
+pub(super) async fn register_test_vm_with_id(
+    backend: &PostgresBackend,
+    vm_id: InstanceId,
+) -> (InstanceId, WorkflowVersionId) {
     let executable_id = WorkflowVersionId::new_uuid_v4();
     let item = waymark_workflow_service_vm_runtimes_backend::register_vm_runtimes::RegisterVmRuntimesItem {
         vm_id: &vm_id,

--- a/crates/lib/backend-postgres/src/vm_runtimes/mod.rs
+++ b/crates/lib/backend-postgres/src/vm_runtimes/mod.rs
@@ -47,9 +47,23 @@ impl waymark_state_vm_runtimes_backend::StoreSnapshots for PostgresBackend {
         // a benign no-op, so `rows_affected` is not inspected.
         sqlx::query(
             r#"
+            -- Canonical lock order (see the renewal statement in
+            -- action_call_requests): overlapping snapshot writes are only
+            -- reachable cross-node in the post-steal dual-ownership
+            -- window, but the day a batched snapshot delete lands this
+            -- table gains a second multi-row writer — locked in primary
+            -- key order now so that day needs no retrofit.
+            WITH locked AS MATERIALIZED (
+                SELECT s.vm_id
+                FROM vm_runtime_snapshots s
+                JOIN UNNEST($1::uuid[]) AS b(vm_id) ON s.vm_id = b.vm_id
+                ORDER BY s.vm_id
+                FOR UPDATE OF s
+            )
             UPDATE vm_runtime_snapshots AS s
             SET snapshot = b.snapshot, updated_at = NOW()
             FROM UNNEST($1::uuid[], $2::bytea[]) AS b(vm_id, snapshot)
+            JOIN locked l ON l.vm_id = b.vm_id
             WHERE s.vm_id = b.vm_id
             "#,
         )

--- a/crates/lib/backend-postgres/src/vm_runtimes/tests.rs
+++ b/crates/lib/backend-postgres/src/vm_runtimes/tests.rs
@@ -1,6 +1,8 @@
 use serial_test::serial;
 
-use super::super::test_helpers::{TEST_VM_SNAPSHOT, register_test_vm, setup_backend};
+use super::super::test_helpers::{
+    TEST_VM_SNAPSHOT, deadlock, register_test_vm, register_test_vm_with_id, setup_backend,
+};
 use waymark_ids::InstanceId;
 
 #[serial(postgres)]
@@ -126,4 +128,116 @@ async fn load_for_revive_unknown_vm_returns_error() {
         result,
         Err(super::error::LoadForReviveError::NotFound(_))
     ));
+}
+
+/// One choreographed collision of two concurrent snapshot-store batches
+/// over the same two VMs — the vm_runtime_snapshots member of the
+/// multi-row-writer class behind the 2026-08-31 deadlock outage
+/// (reachable cross-node in the post-steal dual-ownership window, and
+/// this table's second writer arrives the day a batched snapshot delete
+/// lands).  Opposite batch orders must queue, not cycle.
+///
+/// The staging, plan-shape seeding, and contract follow
+/// `complete_and_renew_across_a_staged_row` in
+/// `action_call_requests::tests`: the leader's first VM row is pre-held
+/// so it blocks holding nothing, the follower locks the other row and
+/// queues behind it.  Both batches run the same statement text, so the
+/// follower's blocked state is staged by waiter count.
+async fn store_against_store_across_a_staged_row(leader_first: bool) {
+    let backend = setup_backend().await;
+    let mut vm_ids = [InstanceId::new_uuid_v4(), InstanceId::new_uuid_v4()];
+    vm_ids.sort();
+    let [vm_lo, vm_hi] = vm_ids;
+    register_test_vm_with_id(&backend, vm_lo).await;
+    register_test_vm_with_id(&backend, vm_hi).await;
+
+    // Plan shape, as in the swept-table choreographies: enough analyzed
+    // rows that the store statement probes the primary key in input
+    // order instead of seq-scanning both contenders into one order.
+    sqlx::query(
+        r#"
+        INSERT INTO vm_runtime_snapshots (vm_id, executable_id, snapshot)
+        SELECT gen_random_uuid(), gen_random_uuid(), 'filler'
+        FROM generate_series(1, 10000) AS n
+        "#,
+    )
+    .execute(backend.pool())
+    .await
+    .expect("seed filler snapshots");
+    sqlx::query("ANALYZE vm_runtime_snapshots")
+        .execute(backend.pool())
+        .await
+        .expect("analyze");
+
+    let (leader_order, follower_order) = if leader_first {
+        ([vm_hi, vm_lo], [vm_lo, vm_hi])
+    } else {
+        ([vm_lo, vm_hi], [vm_hi, vm_lo])
+    };
+
+    // Pre-hold the leader batch's first VM row.
+    let mut staging = backend.pool().begin().await.expect("begin staging");
+    let held = sqlx::query("SELECT 1 FROM vm_runtime_snapshots WHERE vm_id = $1 FOR UPDATE")
+        .bind(leader_order[0])
+        .execute(&mut *staging)
+        .await
+        .expect("hold staged row");
+    assert_eq!(
+        held.rows_affected(),
+        1,
+        "the staged snapshot row must exist"
+    );
+
+    let spawn_store = |order: [InstanceId; 2]| {
+        let backend = backend.clone();
+        tokio::spawn(async move {
+            waymark_state_vm_runtimes_backend::StoreSnapshots::store_snapshots(
+                &backend,
+                &[
+                    waymark_state_vm_runtimes_backend::StoreSnapshotsItem {
+                        vm_id: &order[0],
+                        snapshot: b"stored",
+                    },
+                    waymark_state_vm_runtimes_backend::StoreSnapshotsItem {
+                        vm_id: &order[1],
+                        snapshot: b"stored",
+                    },
+                ],
+            )
+            .await
+        })
+    };
+    // `SET snapshot` appears only in the store statement.
+    let store_pattern = "%SET snapshot = b.snapshot%";
+
+    let leader = spawn_store(leader_order);
+    deadlock::wait_until_lock_blocked(backend.pool(), store_pattern).await;
+    let follower = spawn_store(follower_order);
+    deadlock::wait_until_lock_blocked_at_least(
+        backend.pool(),
+        store_pattern,
+        std::num::NonZeroI64::new(2).unwrap(),
+    )
+    .await;
+
+    staging.rollback().await.expect("release staged row");
+
+    leader
+        .await
+        .expect("join leader")
+        .expect("a snapshot-store batch must not deadlock against a competing store");
+    follower
+        .await
+        .expect("join follower")
+        .expect("a snapshot-store batch must not deadlock against a competing store");
+}
+
+#[serial(postgres)]
+#[tokio::test]
+async fn concurrent_snapshot_store_batches_do_not_deadlock() {
+    // Both leader orders, with the staged row tracking the leader's
+    // first key, so an ordering discipline missing from the store
+    // statement fails one of the runs.
+    store_against_store_across_a_staged_row(true).await;
+    store_against_store_across_a_staged_row(false).await;
 }


### PR DESCRIPTION
The deadlock in postgres occurs because of the row lock ordering in batch transactions. The solution is simple, as for any mutex-caused deadlocks - make the locking order consistent, this is what we do here.

The deadlock was triggered in actions, but it pulls in the VM cleanup on deletion, which pull in sleeps. The order should be consistent across all of them, or it won't work.

I don't particularly like how much "magic" there now is the in database layer - both just SQL-wise and architecturally - there is a spread of properties across the whole backend that are very hard to keep track of unless you know about them.

Benchmark doesn't show any substantial degradation in performance (that said - we're now much slower than we were at #515 - before it had defensive deduplication applied at the rust side; that deduplication wasn't benched, and might be the slowdown that we see now - so it could be that #515 was fast only while it was in-development, but at the time it got merged was slow - and `main` could've been slow all along... to research later).

---

UPD: I've looks deeper into the backend operations, and applied same tweaks (as this deadlock hotfix) to the operations across the board - and it *improves* the performance slightly (~20%). The row lock contention also leads to slowdown in our synthetic benchmark loads - and having a well-defined canonical order of locking rows for update/delete actually helps performance. The perf degradation from above still applies though - chances are that if we fix that one we'll beat the legacy DAG impl twice over.